### PR TITLE
Update GitHub Actions CI

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -38,9 +38,9 @@ jobs:
   #       os: [ubuntu-latest]
   #       python-version: [3.8, 3.9, 3.10, 3.11, 3.12]
   #   steps:
-  #     - uses: actions/checkout@v2
+  #     - uses: actions/checkout@v4
   #     - name: Set up Python ${{ matrix.python-version }}
-  #       uses: actions/setup-python@v2
+  #       uses: actions/setup-python@v5
   #       with:
   #         python-version: ${{ matrix.python-version }}
   #     - name: Install dependencies
@@ -58,9 +58,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test-rust] # TODO: Add test-python when implemented
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python 3.12
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.12
       - name: Install dependencies


### PR DESCRIPTION
The following updates are performed:
* update [`actions/checkout`](https://github.com/actions/checkout) to v4
* update [`actions/setup-python`](https://github.com/actions/setup-python) to v5

Still using the outdated / unmaintained actions will generate several warnings in CI runs, for example in https://github.com/duncaneddy/brahe/actions/runs/7457261161:

> The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, actions/setup-python@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

The PR will get rid of those warnings.