### PR TITLE
Add nalgebra-lapack dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,16 @@ version = "0.27.1"
 # "abi3-py38" tells pyo3 (and maturin) to build using the stable ABI with minimum Python version 3.8
 features = ["extension-module"]
 
+[target.'cfg(target_os = "macos")'.dependencies]
+nalgebra-lapack = { version = "0.26", features = ["accelerate"] , default-features = false }
+
+# Linux + Windows: use some other backend (e.g., OpenBLAS)
+[target.'cfg(target_os = "linux")'.dependencies]
+nalgebra-lapack = { version = "0.26", features = ["openblas"] , default-features = false }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+nalgebra-lapack = { version = "0.26", features = ["netlib"] , default-features = false }
+
 [dev-dependencies]
 approx = "0.5.1"
 rstest = "0.26.1"


### PR DESCRIPTION
# Pull Request

## Description

This PR adds nalgebra-lapack as a crate dependency with different built backends depending on platform. This PR is primarily experimental to confirm that the library still builds on all platforms with the dependency added.

## Changelog

### Added
- Added dependency on nalgebra-lapack to enable usage of linear algebra routines in crate.