### PR TITLE
Update CHANGELOG for v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## [1.3.1] - 2026-03-29
+### Added
+
+- Added retry logic and exponential back-off to Celestrak client
+  Added process-based rate-limiting to Celestrak client [#244](https://github.com/duncaneddy/brahe/pull/244)
+
+### Changed
+
+- Set default celestrak client cache age to 2 hours. [#244](https://github.com/duncaneddy/brahe/pull/244)
+- Bump version for `v1.3.1` [#248](https://github.com/duncaneddy/brahe/pull/248)
+
+### Fixed
+
+- Pointed `mike` documentation deployment to use `properdocs.yml` [#244](https://github.com/duncaneddy/brahe/pull/244)
+- Fix `mike set-default` invocation to use `properdocs.yml` config [#246](https://github.com/duncaneddy/brahe/pull/246)
+
 ## [1.3.0] - 2026-03-29
 ### Added
 

--- a/news/244.added.md
+++ b/news/244.added.md
@@ -1,2 +1,0 @@
-Added retry logic and exponential back-off to Celestrak client
-Added process-based rate-limiting to Celestrak client

--- a/news/244.changed.md
+++ b/news/244.changed.md
@@ -1,1 +1,0 @@
-Set default celestrak client cache age to 2 hours.

--- a/news/244.fixed.md
+++ b/news/244.fixed.md
@@ -1,1 +1,0 @@
-Pointed `mike` documentation deployment to use `properdocs.yml`

--- a/news/246.fixed.md
+++ b/news/246.fixed.md
@@ -1,1 +1,0 @@
-Fix `mike set-default` invocation to use `properdocs.yml` config

--- a/news/248.changed.md
+++ b/news/248.changed.md
@@ -1,1 +1,0 @@
-Bump version for `v1.3.1`


### PR DESCRIPTION
Auto-generated CHANGELOG update for release v1.3.1

This PR updates the CHANGELOG and removes consumed changelog fragments.

This PR can be auto-merged.