### PR TITLE
Add JD_J2000 constant to python bindings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brahe"
-version = "1.3.2"
+version = "1.3.3"
 authors = ["Duncan Eddy <duncan.eddy@gmail.com>"]
 edition = "2024"
 description = "Brahe is a modern satellite dynamics library for research and engineering applications designed to be easy-to-learn, high-performance, and quick-to-deploy. The north-star of the development is enabling users to solve meaningful problems and answer questions quickly, easily, and correctly."

--- a/brahe/constants.py
+++ b/brahe/constants.py
@@ -20,6 +20,7 @@ from brahe._brahe import (
     # Time constants
     MJD_ZERO,
     MJD_J2000,
+    JD_J2000,
     GPS_TAI,
     TAI_GPS,
     TT_TAI,
@@ -73,6 +74,7 @@ __all__ = [
     # Time constants
     "MJD_ZERO",
     "MJD_J2000",
+    "JD_J2000",
     "GPS_TAI",
     "TAI_GPS",
     "TT_TAI",

--- a/src/pymodule/mod.rs
+++ b/src/pymodule/mod.rs
@@ -581,6 +581,7 @@ pub fn _brahe(py: Python<'_>, module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add("RAD2AS", constants::RAD2AS)?;
     module.add("MJD_ZERO", constants::MJD_ZERO)?;
     module.add("MJD_J2000", constants::MJD_J2000)?;
+    module.add("JD_J2000", constants::JD_J2000)?;
     module.add("GPS_TAI", constants::GPS_TAI)?;
     module.add("TAI_GPS", constants::TAI_GPS)?;
     module.add("TT_TAI", constants::TT_TAI)?;

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -30,6 +30,10 @@ def test_MJD_J2000():
     assert brahe.MJD_J2000 == 51544.5
 
 
+def test_JD_J2000():
+    assert brahe.JD_J2000 == 2451545.0
+
+
 def test_GPS_TAI():
     assert brahe.GPS_TAI == -19.0
 


### PR DESCRIPTION
# Pull Request

## Description

Add `JD_J2000` constant to python bindings

## Changelog

### Added
- Add JD_J2000 constant to python bindings