### PR TITLE
Package Blue Marble texture for wheel installs

### DIFF
--- a/brahe/plots/data/__init__.py
+++ b/brahe/plots/data/__init__.py
@@ -1,0 +1,1 @@
+"""Packaged plot resources."""

--- a/brahe/plots/texture_utils.py
+++ b/brahe/plots/texture_utils.py
@@ -5,6 +5,7 @@ Handles loading packaged textures and downloading/caching external texture data.
 """
 
 import zipfile
+from importlib.resources import files
 from pathlib import Path
 from typing import Optional
 import httpx
@@ -44,21 +45,17 @@ def get_blue_marble_texture_path() -> Path:
     Raises:
         FileNotFoundError: If the packaged texture is not found
     """
-    # Get the package root directory
-    import brahe
-
-    package_root = Path(brahe.__file__).parent.parent
-    texture_path = (
-        package_root / "data" / "textures" / "world.topo.200410.3x5400x2700.png"
+    texture_resource = files("brahe.plots.data").joinpath(
+        "world.topo.200410.3x5400x2700.png"
     )
 
-    if not texture_path.exists():
+    if not texture_resource.is_file():
         raise FileNotFoundError(
-            f"Blue Marble texture not found at {texture_path}. "
+            f"Blue Marble texture not found at {texture_resource}. "
             "This may indicate a corrupted installation."
         )
 
-    return texture_path
+    return Path(str(texture_resource))
 
 
 def download_natural_earth_texture(resolution: str = "50m") -> Path:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,12 @@ module-name = "brahe._brahe"
 # "extension-module" tells pyo3 we want to build an extension module (skips linking against libpython.so)
 features = ["pyo3/extension-module", "python"]
 # Include type stub file in distribution
-include = ["brahe/_brahe.pyi", "brahe/py.typed"]
+include = [
+    "brahe/_brahe.pyi",
+    "brahe/py.typed",
+    "brahe/plots/data/__init__.py",
+    "brahe/plots/data/world.topo.200410.3x5400x2700.png",
+]
 
 [tool.pytest.ini_options]
 markers = [

--- a/tests/plots/test_textures.py
+++ b/tests/plots/test_textures.py
@@ -1,5 +1,6 @@
 """Tests for texture utility functions."""
 
+from importlib.resources import files
 import pytest
 from pathlib import Path
 from PIL import Image
@@ -34,6 +35,15 @@ def test_get_blue_marble_texture_path():
     assert texture_path.is_file()
     assert texture_path.suffix == ".png"
     assert "world.topo" in texture_path.name
+
+
+def test_blue_marble_resource_is_packaged():
+    """Test that the Blue Marble texture is present as a package resource."""
+    texture_resource = files("brahe.plots.data").joinpath(
+        "world.topo.200410.3x5400x2700.png"
+    )
+
+    assert texture_resource.is_file()
 
 
 def test_load_earth_texture_simple():


### PR DESCRIPTION
# Pull Request

## Description

This change updates the texture lookup in `brahe.plots.texture_utils` to load the asset via `importlib.resources`, adds the packaged data module and image to the distribution configuration, and adds a test that checks the resource is present as an installed package asset.

## Changelog
- Package the Blue Marble texture in Python distributions so `get_blue_marble_texture_path()` works from installed wheels
- Load the bundled texture via `importlib.resources`

## Changed
- Add `brahe.plots.data` as the home for packaged plotting resources
- Add a test covering Blue Marble resource packaging

## Related Issue

#268 

## Note to Reviewers

The Blue Marble resource seems to be a quite unusual case that sits in the middle:
- it's not protected by Rust's embedding pattern, so it's not in `brahe/_brahe.so` (and it shouldn't)
- it's meant to be a built-in asset, not user-supplied or cache-download

It's probably the only instance of this specific failure mode, but I didn't check too closely.
