### PR TITLE
Move from celestrak.com to celestrak.org

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brahe"
-version = "1.3.3"
+version = "1.3.4"
 authors = ["Duncan Eddy <duncan.eddy@gmail.com>"]
 edition = "2024"
 description = "Brahe is a modern satellite dynamics library for research and engineering applications designed to be easy-to-learn, high-performance, and quick-to-deploy. The north-star of the development is enabling users to solve meaningful problems and answer questions quickly, easily, and correctly."

--- a/docs/learn/orbits/anomalies.md
+++ b/docs/learn/orbits/anomalies.md
@@ -201,4 +201,4 @@ provided for convenience. These methods simply wrap successive calls to two
     ```
 
 [^1]: D. Vallado, *Fundamentals of Astrodynamics and Applications (4th Ed.)*, 2010  
-[https://celestrak.com/software/vallado-sw.php](https://celestrak.com/software/vallado-sw.php)
+[https://celestrak.org/software/vallado-sw.php](https://celestrak.org/software/vallado-sw.php)

--- a/docs/learn/space_weather/index.md
+++ b/docs/learn/space_weather/index.md
@@ -42,7 +42,7 @@ The approximately 11-year solar cycle is clearly visible in the data, with peaks
 **Kp** and **Ap** indices measure geomagnetic activity caused by solar wind interactions with Earth's magnetosphere.
 ## Data Source
 
-Brahe uses CSSI space weather data files provided by [CelesTrak](https://celestrak.com/SpaceData/). The data includes:
+Brahe uses CSSI space weather data files provided by [CelesTrak](https://celestrak.org/SpaceData/). The data includes:
 
 - **Historical observations** from October 1957 to present
 - **Daily predictions** for the near term

--- a/joss/paper.bib
+++ b/joss/paper.bib
@@ -38,7 +38,7 @@
   title = {{Celestrak} {Active} {Satellite} {Database}},
   note = {{A}ccessed: November 7, 2025},
   year = {2025},
-  url = {https://celestrak.com/}
+  url = {https://celestrak.org/}
 }
 
 @misc{spacetrack,

--- a/scripts/update-data.sh
+++ b/scripts/update-data.sh
@@ -13,5 +13,5 @@ curl -L https://datacenter.iers.org/data/latestVersion/finals.all.iau2000.txt -o
 curl -L https://datacenter.iers.org/data/latestVersion/EOP_20_C04_one_file_1962-now.txt -o ./data/eop/EOP_20_C04_one_file_1962-now.txt
 
 # Space Weather Data
-curl -L https://celestrak.com/SpaceData/sw19571001.txt -o ./data/space_weather/sw19571001.txt
+curl -L https://celestrak.org/SpaceData/sw19571001.txt -o ./data/space_weather/sw19571001.txt
 curl -L https://www.spaceweather.gc.ca/solar_flux_data/daily_flux_values/fluxtable.txt -o ./data/space_weather/fluxtable.txt

--- a/src/space_weather/caching_provider.rs
+++ b/src/space_weather/caching_provider.rs
@@ -16,7 +16,7 @@ use crate::utils::atomic_write;
 use crate::utils::cache::get_space_weather_cache_dir;
 
 /// Default URL for downloading space weather data from CelesTrak
-const DEFAULT_SW_URL: &str = "https://celestrak.com/SpaceData/sw19571001.txt";
+const DEFAULT_SW_URL: &str = "https://celestrak.org/SpaceData/sw19571001.txt";
 
 /// Default filename for cached space weather data
 const DEFAULT_SW_FILENAME: &str = "sw19571001.txt";


### PR DESCRIPTION
# Pull Request

## Description

Celestrak queries were failing in CI due to an outdated certificate. The queries were hitting celestrak.com however the website has since moved to celestrak.org

## Changelog

### Fixed
- Fix failing celestrak queries by migrating from celestrak.com to celestrak.org