### PR TITLE
Update CHANGELOG for v1.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## [1.3.4] - 2026-04-15
+### Fixed
+
+- Fix failing celestrak queries by migrating from celestrak.com to celestrak.org [#272](https://github.com/duncaneddy/brahe/pull/272)
+
 ## [1.3.3] - 2026-04-10
 ### Added
 

--- a/news/272.fixed.md
+++ b/news/272.fixed.md
@@ -1,1 +1,0 @@
-Fix failing celestrak queries by migrating from celestrak.com to celestrak.org


### PR DESCRIPTION
Auto-generated CHANGELOG update for release v1.3.4

This PR updates the CHANGELOG and removes consumed changelog fragments.

This PR can be auto-merged.