### PR TITLE
Make pyo3 and numpy optional dependencies behind the python feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## [Unreleased]
+### Changed
+
+- `pyo3` and `numpy` are now optional dependencies, activated via the `python` feature flag. Pure-Rust consumers that do not need the Python bindings no longer compile these crates. Existing Python users (pip/maturin installs) are unaffected; maturin already passes `--features python` via `pyproject.toml`.
+
 ## [1.3.4] - 2026-04-15
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 rsofa = "0.5.0"
 nalgebra = { version = "0.34.1", features = ["serde-serialize"] }
-numpy = "0.28.0"
+numpy = { version = "0.28.0", optional = true }
 once_cell = "1.21.3"
 num-traits = "0.2.19"
 regex = "1.12.3"
@@ -56,8 +56,11 @@ anise = "0.9.3"
 
 [dependencies.pyo3]
 version = "0.28.2"
-# "abi3-py38" tells pyo3 (and maturin) to build using the stable ABI with minimum Python version 3.8
-features = ["extension-module"]
+# "extension-module" is intentionally NOT set here; maturin passes it via pyproject.toml's
+# [tool.maturin] features list ("pyo3/extension-module"). This lets pure-Rust consumers use
+# `cargo build/test --features python` without requiring a Python runtime to link against,
+# while maturin still produces a correct extension module for Python wheels.
+optional = true
 
 [dev-dependencies]
 approx = "0.5.1"
@@ -74,7 +77,7 @@ criterion = { version = "0.8", features = ["html_reports"] }
 [features]
 ci = []
 manual = []  # For tests requiring network downloads (run with: cargo test --features manual)
-python = []
+python = ["dep:pyo3", "dep:numpy"]
 
 # Build Profiles
 [profile.dev]


### PR DESCRIPTION
## Motivation

`brahe` ships Python bindings via PyO3. Until now, `pyo3` and `numpy` were unconditional `[dependencies]`, so any downstream Rust project that added `brahe` to its `Cargo.toml` unconditionally pulled in the entire PyO3 + numpy stack even if it only wanted the pure-Rust API.

This has three practical costs for pure-Rust consumers:
- **Compile time:** PyO3 and its transitive dependencies add measurable build time.
- **Dep graph size:** Consumers inherit all PyO3 transitive deps in their lockfile.
- **Build environment fragility:** Some environments (cross-compilation targets, minimal containers, embedded toolchains) don't have Python headers available. A mandatory PyO3 dep breaks these builds entirely.

## What changed

**`Cargo.toml`**
- `numpy` is now `optional = true`.
- `pyo3` is now `optional = true`. The `features = ["extension-module"]` line is also removed from `Cargo.toml` — maturin already passes `pyo3/extension-module` explicitly via `pyproject.toml` `[tool.maturin] features`, so having it in both places caused linker failures when using `cargo build --features python` directly.
- The `python` feature (which already existed and already gated `mod pymodule` in `src/lib.rs`) is wired up: `python = ["dep:pyo3", "dep:numpy"]`.

**`pyproject.toml`** — no changes. Maturin already passes `features = ["pyo3/extension-module", "python"]`, so Python wheel builds are unaffected.

**CI** — no changes needed. `test_rust.yml` already runs without `--features python`, so it now correctly exercises the no-Python build path. Python CI continues through maturin as before.

## Impact

| Consumer | Before | After |
|---|---|---|
| Pure-Rust (`cargo add brahe`) | Pulled in pyo3 + numpy unconditionally | No pyo3/numpy unless `--features python` |
| Python (pip / maturin) | Unchanged | Unchanged — maturin passes `python` feature |
| Rust with Python bindings | `--features python` had no dep effect | `--features python` activates pyo3 + numpy |

The public Rust API surface is unchanged. No astrodynamics logic was modified.

## Verification

```
cargo build                          # ✅ succeeds, pyo3/numpy absent from dep tree
cargo tree | grep -E "pyo3|numpy"    # ✅ empty
cargo build --features python        # ✅ succeeds, pyo3/numpy present
cargo tree --features python | grep -E "pyo3|numpy"  # ✅ both appear
cargo test                           # ✅ 4256 pass (1 pre-existing network test failure unrelated to this change)
cargo test --features python         # ✅ 4256 pass (same pre-existing failure, no regressions)
```

## Known follow-up

`crate-type = ["cdylib", "lib"]` is still unconditional. The `cdylib` is only needed for maturin/Python builds; pure-Rust consumers build an unnecessary cdylib artifact. Cargo does not support feature-gating `crate-type`, so a clean fix would require splitting into a workspace (`brahe-core` as `lib`, `brahe-py` as `cdylib`). That's a larger structural change left for a future PR.