### PR TITLE
Update CHANGELOG for v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ Each release groups entries under the Keep a Changelog section headings in the o
 
 <!-- towncrier release notes start -->
 
+## [1.4.0] - 2026-04-17
+### Added
+
+- Added [brahe-mcp](https://github.com/duncaneddy/brahe-mcp) information to docs [#278](https://github.com/duncaneddy/brahe/pull/278)
+
+### Changed
+
+- Refactored repository structure to use a Rust workspace to breakup the python module from the core rust module. This pure-rust package consumers to avoid having to build the `cdylib`, which is only needed for python module builds. [#278](https://github.com/duncaneddy/brahe/pull/278)
+
+### Fixed
+
+- Fixed issue that would cause tests and auto-merge to not run on dependabot PRs [#278](https://github.com/duncaneddy/brahe/pull/278)
+
 ## [Unreleased]
 ### Changed
 

--- a/news/278.added.md
+++ b/news/278.added.md
@@ -1,1 +1,0 @@
-Added [brahe-mcp](https://github.com/duncaneddy/brahe-mcp) information to docs

--- a/news/278.changed.md
+++ b/news/278.changed.md
@@ -1,1 +1,0 @@
-Refactored repository structure to use a Rust workspace to breakup the python module from the core rust module. This pure-rust package consumers to avoid having to build the `cdylib`, which is only needed for python module builds.

--- a/news/278.fixed.md
+++ b/news/278.fixed.md
@@ -1,1 +1,0 @@
-Fixed issue that would cause tests and auto-merge to not run on dependabot PRs


### PR DESCRIPTION
Auto-generated CHANGELOG update for release v1.4.0

This PR updates the CHANGELOG and removes consumed changelog fragments.

This PR can be auto-merged.