### PR TITLE
Refactor repository structure and update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,16 +17,13 @@ Each release groups entries under the Keep a Changelog section headings in the o
 ### Changed
 
 - Refactored repository structure to use a Rust workspace to breakup the python module from the core rust module. This pure-rust package consumers to avoid having to build the `cdylib`, which is only needed for python module builds. [#278](https://github.com/duncaneddy/brahe/pull/278)
+- `pyo3` and `numpy` are now optional dependencies, activated via the `python` feature flag. Pure-Rust consumers that do not need the Python bindings no longer compile these crates.
+- Split the repository into a Cargo workspace so the PyO3 bindings live in a dedicated `brahe-py` member crate at `crates/brahe-py/`. The published `brahe` crate now builds only an `rlib`, eliminating the unnecessary `cdylib` artifact previously produced for every pure-Rust consumer. Rust downstream (`use brahe::*`) and Python downstream (`import brahe`) are unchanged.
+
 
 ### Fixed
 
 - Fixed issue that would cause tests and auto-merge to not run on dependabot PRs [#278](https://github.com/duncaneddy/brahe/pull/278)
-
-## [Unreleased]
-### Changed
-
-- `pyo3` and `numpy` are now optional dependencies, activated via the `python` feature flag. Pure-Rust consumers that do not need the Python bindings no longer compile these crates.
-- Split the repository into a Cargo workspace so the PyO3 bindings live in a dedicated `brahe-py` member crate at `crates/brahe-py/`. The published `brahe` crate now builds only an `rlib`, eliminating the unnecessary `cdylib` artifact previously produced for every pure-Rust consumer. Rust downstream (`use brahe::*`) and Python downstream (`import brahe`) are unchanged.
 
 ## [1.3.4] - 2026-04-15
 ### Fixed


### PR DESCRIPTION
Refactor repository structure to use a Rust workspace, making `pyo3` and `numpy` optional dependencies. Split into a Cargo workspace for better organization.

# Pull Request

## Description

<!-- Provide a brief description of the changes in this PR -->

## Changelog

**Fill in at least one section below.** Entries will be automatically converted to changelog fragments when this PR is merged. Sections follow the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) convention; see the [versioning policy](https://duncaneddy.github.io/brahe/latest/about/versioning/) for how deprecations and removals flow across releases.

### Added
- <!-- New features added in this PR -->

### Changed
- <!-- Changes to existing functionality -->

### Deprecated / Future Warning
- <!-- APIs still present in this release but now scheduled for removal. Each entry must emit a `DeprecationWarning` (or `FutureWarning` for behavior changes) pointing users at the replacement. -->

### Removed
- <!-- Previously deprecated APIs that have now been removed. Each entry should reference the release in which it was deprecated. -->

### Fixed
- <!-- Bug fixes -->

## Related Issue
<!-- If this PR addresses a specific issue, please provide the issue number here -->

## Note to Reviewers
<!-- Any special instructions for reviewers, such as testing steps or areas of focus -->