### PR TITLE
Fix CHANGELOG validation failing to run on fork PRs

### DIFF
--- a/.github/workflows/validate_pr_changelog.yml
+++ b/.github/workflows/validate_pr_changelog.yml
@@ -1,7 +1,7 @@
 name: Validate PR Changelog
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, edited, reopened]
 
 permissions:


### PR DESCRIPTION
# Pull Request

## Description

Fix a permissions issue that pervented CHANGELOG validation from running on fork PRs

## Changelog

### Fixed
- Fix a permissions issue that pervented CHANGELOG validation from running on fork PRs