### PR TITLE
Update CHANGELOG for v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Each release groups entries under the Keep a Changelog section headings in the o
 
 <!-- towncrier release notes start -->
 
+## [1.4.1] - 2026-04-21
+### Changed
+
+- Improve documentation around versioning practices. [#282](https://github.com/duncaneddy/brahe/pull/282)
+- Add deprecation section to changelog [#284](https://github.com/duncaneddy/brahe/pull/284)
+- Bump version for v1.4.1 release [#295](https://github.com/duncaneddy/brahe/pull/295)
+
+### Fixed
+
+- Fix a permissions issue that pervented CHANGELOG validation from running on fork PRs [#293](https://github.com/duncaneddy/brahe/pull/293)
+
 ## [1.4.0] - 2026-04-17
 ### Added
 

--- a/news/282.changed.md
+++ b/news/282.changed.md
@@ -1,1 +1,0 @@
-Improve documentation around versioning practices.

--- a/news/284.changed.md
+++ b/news/284.changed.md
@@ -1,1 +1,0 @@
-Add deprecation section to changelog

--- a/news/293.fixed.md
+++ b/news/293.fixed.md
@@ -1,1 +1,0 @@
-Fix a permissions issue that pervented CHANGELOG validation from running on fork PRs

--- a/news/295.changed.md
+++ b/news/295.changed.md
@@ -1,1 +1,0 @@
-Bump version for v1.4.1 release


### PR DESCRIPTION
Auto-generated CHANGELOG update for release v1.4.1

This PR updates the CHANGELOG and removes consumed changelog fragments.

This PR can be auto-merged.