### PR TITLE
Fix how package versioning works

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,15 @@
 [workspace]
 members = ["crates/brahe-py"]
 
+# Single source of truth for the release version. Workspace members inherit via
+# `version.workspace = true` so `brahe-py` (the Python extension) stays in sync
+# with the root `brahe` crate.
+[workspace.package]
+version = "1.4.2"
+
 [package]
 name = "brahe"
-version = "1.4.1"
+version.workspace = true
 authors = ["Duncan Eddy <duncan.eddy@gmail.com>"]
 edition = "2024"
 description = "Brahe is a modern satellite dynamics library for research and engineering applications designed to be easy-to-learn, high-performance, and quick-to-deploy. The north-star of the development is enabling users to solve meaningful problems and answer questions quickly, easily, and correctly."

--- a/crates/brahe-py/Cargo.toml
+++ b/crates/brahe-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brahe-py"
-version = "1.4.0"
+version.workspace = true
 authors = ["Duncan Eddy <duncan.eddy@gmail.com>"]
 edition = "2024"
 description = "PyO3 bindings for the brahe astrodynamics library. Built by maturin into the `brahe._brahe` Python extension module; not published to crates.io."


### PR DESCRIPTION
# Pull Request

## Description

When the python crate was separated out there was a regression in single-source-of-truth package versioning. This PR fixes it so the root `Cargo.toml` remains the source of truth.

## Changelog

### Fixed
- Fix `brahe-py` Crate not using root `Cargo.toml` as single-source-of-truth for package version.