### PR TITLE
Add changelog fragments for PR #298

### DIFF
--- a/news/298.fixed.md
+++ b/news/298.fixed.md
@@ -1,0 +1,1 @@
+Fix `brahe-py` Crate not using root `Cargo.toml` as single-source-of-truth for package version.


### PR DESCRIPTION
Auto-generated changelog fragments from PR #298

Created fragments: news/298.fixed.md

This PR can be auto-merged.