### PR TITLE
Update CHANGELOG for v1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Each release groups entries under the Keep a Changelog section headings in the o
 
 <!-- towncrier release notes start -->
 
+## [1.4.2] - 2026-04-23
+### Fixed
+
+- Fix `brahe-py` Crate not using root `Cargo.toml` as single-source-of-truth for package version. [#298](https://github.com/duncaneddy/brahe/pull/298)
+
 ## [1.4.1] - 2026-04-21
 ### Changed
 

--- a/news/298.fixed.md
+++ b/news/298.fixed.md
@@ -1,1 +1,0 @@
-Fix `brahe-py` Crate not using root `Cargo.toml` as single-source-of-truth for package version.


### PR DESCRIPTION
Auto-generated CHANGELOG update for release v1.4.2

This PR updates the CHANGELOG and removes consumed changelog fragments.

This PR can be auto-merged.