### PR TITLE
Update CHANGELOG for v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ Each release groups entries under the Keep a Changelog section headings in the o
 
 <!-- towncrier release notes start -->
 
+## [1.5.0] - 2026-05-06
+### Changed
+
+- Update package lockfile [#306](https://github.com/duncaneddy/brahe/pull/306)
+
+### Removed
+
+- Removed rust artifact caching from CI since existing rust environment already provides (working) caching. [#315](https://github.com/duncaneddy/brahe/pull/315)
+
+### Fixed
+
+- Add missing `CHANGELOG.md` release entries
+  Fix error with release note generation step of release workflow
+  Fix issue with awk-based release-note generation step of release workflow not populating release note contents. [#306](https://github.com/duncaneddy/brahe/pull/306)
+- Fix 3rd party changes PRs not generating changelog fragments. [#317](https://github.com/duncaneddy/brahe/pull/317)
+
 ## [1.4.2] - 2026-04-23
 ### Fixed
 

--- a/news/306.changed.md
+++ b/news/306.changed.md
@@ -1,1 +1,0 @@
-Update package lockfile

--- a/news/306.fixed.md
+++ b/news/306.fixed.md
@@ -1,3 +1,0 @@
-Add missing `CHANGELOG.md` release entries
-Fix error with release note generation step of release workflow
-Fix issue with awk-based release-note generation step of release workflow not populating release note contents.

--- a/news/315.removed.md
+++ b/news/315.removed.md
@@ -1,1 +1,0 @@
-Removed rust artifact caching from CI since existing rust environment already provides (working) caching.

--- a/news/317.fixed.md
+++ b/news/317.fixed.md
@@ -1,1 +1,0 @@
-Fix 3rd party changes PRs not generating changelog fragments.


### PR DESCRIPTION
Auto-generated CHANGELOG update for release v1.5.0

This PR updates the CHANGELOG and removes consumed changelog fragments.

This PR can be auto-merged.