### PR TITLE
Disable propagator default acceleration storage, update quintic hermite usage validation

### DIFF
--- a/crates/brahe-py/src/propagators.rs
+++ b/crates/brahe-py/src/propagators.rs
@@ -4067,6 +4067,21 @@ impl PyNumericalPropagationConfig {
         self.config.interpolation_method = value.method;
     }
 
+    /// Validate that the configuration is internally consistent.
+    ///
+    /// Called automatically by the propagator constructors. Can also be called
+    /// directly to pre-flight a configuration before propagation.
+    ///
+    /// Raises:
+    ///     RuntimeError: If interpolation_method is HermiteQuintic but
+    ///         store_accelerations is False. The message names the two fixes
+    ///         (enable acceleration storage, or pick a different method).
+    fn validate(&self) -> PyResult<()> {
+        self.config
+            .validate()
+            .map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))
+    }
+
     fn __repr__(&self) -> String {
         format!("NumericalPropagationConfig(method={:?}, abs_tol={}, rel_tol={})",
                 self.config.method, self.config.integrator.abs_tol, self.config.integrator.rel_tol)

--- a/crates/brahe-py/src/trajectories.rs
+++ b/crates/brahe-py/src/trajectories.rs
@@ -43,8 +43,8 @@ impl PyInterpolationMethod {
     /// Quintic Hermite interpolation method.
     ///
     /// Uses position, velocity, and acceleration at two bracketing points for C2
-    /// continuous interpolation. Uses stored accelerations if available, otherwise
-    /// estimates via finite differences.
+    /// continuous interpolation. Requires the trajectory to carry per-sample
+    /// accelerations — interpolation fails if accelerations are not stored.
     ///
     /// Returns:
     ///     InterpolationMethod: Quintic Hermite interpolation constant

--- a/src/math/interpolation.rs
+++ b/src/math/interpolation.rs
@@ -41,8 +41,9 @@ pub enum InterpolationMethod {
     HermiteCubic,
 
     /// Quintic Hermite interpolation using position, velocity, and acceleration at 2 points.
-    /// Provides C2 continuity (smooth second derivative). Uses stored accelerations
-    /// if available, otherwise estimates via finite differences.
+    /// Provides C2 continuity (smooth second derivative). Requires the trajectory to
+    /// carry per-sample accelerations — interpolation fails if accelerations are not
+    /// stored.
     HermiteQuintic,
 }
 
@@ -53,7 +54,7 @@ impl InterpolationMethod {
             Self::Linear => 2,
             Self::Lagrange { degree } => degree + 1,
             Self::HermiteCubic => 2,
-            Self::HermiteQuintic => 2, // or 3 for finite difference fallback
+            Self::HermiteQuintic => 2,
         }
     }
 
@@ -728,80 +729,6 @@ pub fn interpolate_hermite_quintic_svector6(
     result
 }
 
-/// Quintic Hermite interpolation with finite difference acceleration estimation.
-///
-/// Uses three neighboring points to estimate accelerations via central differences,
-/// then applies quintic Hermite interpolation.
-///
-/// # Arguments
-/// * `times` - Array of 3 sample times [t0, t1, t2]
-/// * `states` - Array of 3 states at those times
-/// * `t` - Query time for interpolation (must be between times[0] and times[2])
-///
-/// # Returns
-/// Interpolated 6D state at time t
-pub fn interpolate_hermite_quintic_fd_svector6(
-    times: &[f64; 3],
-    states: &[SVector<f64, 6>; 3],
-    t: f64,
-) -> SVector<f64, 6> {
-    // Estimate accelerations via finite differences from velocities
-    // acc[i] ≈ (v[i+1] - v[i-1]) / (t[i+1] - t[i-1])
-    // For endpoints, use forward/backward differences
-
-    let v0 = states[0].fixed_rows::<3>(3);
-    let v1 = states[1].fixed_rows::<3>(3);
-    let v2 = states[2].fixed_rows::<3>(3);
-
-    // Central difference for middle point
-    let acc1: SVector<f64, 3> = (v2 - v0) / (times[2] - times[0]);
-
-    // Forward/backward differences for endpoints
-    let acc0: SVector<f64, 3> = (v1 - v0) / (times[1] - times[0]);
-    let acc2: SVector<f64, 3> = (v2 - v1) / (times[2] - times[1]);
-
-    // Determine which interval to use
-    if t <= times[1] {
-        interpolate_hermite_quintic_svector6(
-            times[0], times[1], states[0], states[1], acc0, acc1, t,
-        )
-    } else {
-        interpolate_hermite_quintic_svector6(
-            times[1], times[2], states[1], states[2], acc1, acc2, t,
-        )
-    }
-}
-
-/// Quintic Hermite interpolation for dynamic vectors using finite difference acceleration.
-///
-/// Uses three states to estimate accelerations via finite differences from velocities.
-/// This allows quintic interpolation without requiring explicitly stored accelerations.
-///
-/// # Arguments
-/// * `times` - Array of three sample times [t0, t1, t2]
-/// * `states` - Array of three 6D states at the sample times
-/// * `t` - Query time for interpolation (should be within [t0, t2])
-///
-/// # Returns
-/// Interpolated 6D state at time t
-///
-/// # Panics
-/// Panics if any state is not 6D
-pub fn interpolate_hermite_quintic_fd_dvector6(
-    times: &[f64; 3],
-    states: &[DVector<f64>; 3],
-    t: f64,
-) -> DVector<f64> {
-    // Convert to static vectors and use existing implementation
-    let s0 = SVector::<f64, 6>::from_iterator(states[0].iter().copied());
-    let s1 = SVector::<f64, 6>::from_iterator(states[1].iter().copied());
-    let s2 = SVector::<f64, 6>::from_iterator(states[2].iter().copied());
-
-    let static_states = [s0, s1, s2];
-    let result = interpolate_hermite_quintic_fd_svector6(times, &static_states, t);
-    DVector::from_iterator(6, result.iter().copied())
-}
-
 /// Quintic Hermite interpolation for dynamic vectors with explicit accelerations.
 ///
 /// # Arguments
@@ -1405,67 +1332,4 @@ mod tests {
         interpolate_hermite_quintic_dvector6(t0, t1, &state0, &state1, &acc0, &acc1, 0.5);
     }
 
-    // =========================================================================
-    // Hermite Quintic with Finite Difference Tests
-    // =========================================================================
-
-    #[test]
-    fn test_hermite_quintic_fd_svector6_constant_velocity() {
-        // With constant velocity, acceleration should be zero and result should be linear
-        let times = [0.0, 1.0, 2.0];
-        let v = SVector::<f64, 3>::new(10.0, 20.0, 30.0);
-        let states = [
-            SVector::<f64, 6>::new(0.0, 0.0, 0.0, v[0], v[1], v[2]),
-            SVector::<f64, 6>::new(v[0], v[1], v[2], v[0], v[1], v[2]),
-            SVector::<f64, 6>::new(2.0 * v[0], 2.0 * v[1], 2.0 * v[2], v[0], v[1], v[2]),
-        ];
-
-        // At t=0.5, position should be 0.5 * v
-        let result = interpolate_hermite_quintic_fd_svector6(&times, &states, 0.5);
-        assert_abs_diff_eq!(result[0], 5.0, epsilon = 1e-6);
-        assert_abs_diff_eq!(result[1], 10.0, epsilon = 1e-6);
-        assert_abs_diff_eq!(result[2], 15.0, epsilon = 1e-6);
-    }
-
-    #[test]
-    fn test_hermite_quintic_fd_svector6_constant_acceleration() {
-        // Constant acceleration motion
-        let times = [0.0, 1.0, 2.0];
-        // Acceleration in x direction: a = 2.0
-        let states = [
-            // t=0: pos=0, vel=0
-            SVector::<f64, 6>::new(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
-            // t=1: pos=0.5*a*1^2=1, vel=a*1=2
-            SVector::<f64, 6>::new(1.0, 0.0, 0.0, 2.0, 0.0, 0.0),
-            // t=2: pos=0.5*a*2^2=4, vel=a*2=4
-            SVector::<f64, 6>::new(4.0, 0.0, 0.0, 4.0, 0.0, 0.0),
-        ];
-
-        // At t=0.5, pos should be 0.5*a*0.5^2=0.25, vel should be a*0.5=1.0
-        let result = interpolate_hermite_quintic_fd_svector6(&times, &states, 0.5);
-        assert_abs_diff_eq!(result[0], 0.25, epsilon = 1e-4);
-        assert_abs_diff_eq!(result[3], 1.0, epsilon = 1e-4);
-    }
-
-    #[test]
-    fn test_hermite_quintic_fd_svector6_endpoint_values() {
-        let times = [0.0, 1.0, 2.0];
-        let states = [
-            SVector::<f64, 6>::new(1.0, 2.0, 3.0, 4.0, 5.0, 6.0),
-            SVector::<f64, 6>::new(7.0, 8.0, 9.0, 10.0, 11.0, 12.0),
-            SVector::<f64, 6>::new(13.0, 14.0, 15.0, 16.0, 17.0, 18.0),
-        ];
-
-        // At first endpoint, should return first state (approximately)
-        let result = interpolate_hermite_quintic_fd_svector6(&times, &states, 0.0);
-        for i in 0..6 {
-            assert_abs_diff_eq!(result[i], states[0][i], epsilon = 1e-6);
-        }
-
-        // At last endpoint, should return last state (approximately)
-        let result = interpolate_hermite_quintic_fd_svector6(&times, &states, 2.0);
-        for i in 0..6 {
-            assert_abs_diff_eq!(result[i], states[2][i], epsilon = 1e-6);
-        }
-    }
 }

--- a/src/propagators/dnumerical_orbit_propagator.rs
+++ b/src/propagators/dnumerical_orbit_propagator.rs
@@ -540,6 +540,9 @@ impl DNumericalOrbitPropagator {
         control_input: DControlInput,
         initial_covariance: Option<DMatrix<f64>>,
     ) -> Result<Self, BraheError> {
+        // Validate propagation config (e.g. HermiteQuintic requires stored accelerations)
+        propagation_config.validate()?;
+
         // Validate parameters against force model requirements
         force_config.validate_params(params.as_ref())?;
 
@@ -4017,6 +4020,40 @@ mod tests {
     // =========================================================================
     // InterpolationConfig Trait Tests
     // =========================================================================
+
+    #[test]
+    fn test_dnumericalorbitpropagator_rejects_hermite_quintic_without_accelerations() {
+        // Propagator construction must surface the config-validation error to the user.
+        setup_global_test_eop();
+
+        let epoch = Epoch::from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+        let state = DVector::from_vec(vec![R_EARTH + 500e3, 0.0, 0.0, 0.0, 7500.0, 0.0]);
+
+        let config = NumericalPropagationConfig::default()
+            .with_interpolation_method(InterpolationMethod::HermiteQuintic);
+        // store_accelerations stays false (the new default)
+
+        let result = DNumericalOrbitPropagator::new(
+            epoch,
+            state,
+            config,
+            ForceModelConfig::earth_gravity(),
+            None,
+            None,
+            None,
+            None,
+        );
+        let err = result.err().expect("expected propagator construction to fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("HermiteQuintic interpolation requires store_accelerations = true"),
+            "unexpected error message: {msg}"
+        );
+        assert!(
+            msg.contains("with_store_accelerations(true)"),
+            "error should mention the fix: {msg}"
+        );
+    }
 
     #[test]
     fn test_dnumericalorbitpropagator_interpolationconfig_with_method() {

--- a/src/propagators/dnumerical_propagator.rs
+++ b/src/propagators/dnumerical_propagator.rs
@@ -292,6 +292,9 @@ impl DNumericalPropagator {
         control_input: DControlInput,
         initial_covariance: Option<DMatrix<f64>>,
     ) -> Result<Self, BraheError> {
+        // Validate propagation config (e.g. HermiteQuintic requires stored accelerations)
+        propagation_config.validate()?;
+
         // Use provided params or create empty vector (only valid if force config doesn't need params)
         let params = params.unwrap_or_else(|| DVector::zeros(0));
 
@@ -2808,9 +2811,11 @@ mod tests {
         assert!(err_msg.contains("HermiteCubic"));
         assert!(err_msg.contains("6D states"));
 
-        // HermiteQuintic should also fail for 2D state
+        // HermiteQuintic should also fail for 2D state. Enable acceleration storage
+        // so the config passes config-level validation and the dimension check fires.
         let config_quintic = NumericalPropagationConfig::default()
-            .with_interpolation_method(InterpolationMethod::HermiteQuintic);
+            .with_interpolation_method(InterpolationMethod::HermiteQuintic)
+            .with_store_accelerations(true);
         let result = DNumericalPropagator::new(
             epoch,
             state,
@@ -2825,6 +2830,33 @@ mod tests {
         let err_msg = err.to_string();
         assert!(err_msg.contains("HermiteQuintic"));
         assert!(err_msg.contains("6D states"));
+    }
+
+    #[test]
+    fn test_dnumericalpropagator_rejects_hermite_quintic_without_accelerations() {
+        // Propagator construction must surface the config-validation error to the user.
+        let epoch = Epoch::from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+        let state = DVector::from_vec(vec![1.0, 0.0, 0.0, 0.0, 1.0, 0.0]);
+
+        let config = NumericalPropagationConfig::default()
+            .with_interpolation_method(InterpolationMethod::HermiteQuintic);
+        // store_accelerations stays false (the new default)
+
+        let result = DNumericalPropagator::new(
+            epoch,
+            state,
+            sho_dynamics(1.0),
+            config,
+            None,
+            None,
+            None,
+        );
+        let err = result.err().expect("expected propagator construction to fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("HermiteQuintic interpolation requires store_accelerations = true"),
+            "unexpected error message: {msg}"
+        );
     }
 
     // =============================================================================

--- a/src/propagators/numerical_propagation_config.rs
+++ b/src/propagators/numerical_propagation_config.rs
@@ -27,6 +27,7 @@ use serde::{Deserialize, Serialize};
 use crate::integrators::IntegratorConfig;
 use crate::math::interpolation::InterpolationMethod;
 use crate::math::jacobian::DifferenceMethod;
+use crate::utils::BraheError;
 
 // =============================================================================
 // Integrator Method Selection
@@ -307,7 +308,7 @@ pub struct NumericalPropagationConfig {
     /// at each trajectory point. This enables higher-order interpolation
     /// methods like Hermite quintic that use acceleration data.
     ///
-    /// Default: `true`
+    /// Default: `false`
     pub store_accelerations: bool,
 
     /// Interpolation method for trajectory queries
@@ -331,14 +332,14 @@ impl Default for NumericalPropagationConfig {
     /// - Dormand-Prince 5(4) integrator
     /// - Default tolerances (abs=1e-6, rel=1e-3)
     /// - No variational matrix propagation (central differences when enabled)
-    /// - Acceleration storage enabled
+    /// - Acceleration storage disabled
     /// - Linear interpolation (safe for any state dimension)
     fn default() -> Self {
         Self {
             method: IntegratorMethod::default(),
             integrator: IntegratorConfig::default(),
             variational: VariationalConfig::default(),
-            store_accelerations: true,
+            store_accelerations: false,
             interpolation_method: InterpolationMethod::Linear,
         }
     }
@@ -402,8 +403,7 @@ impl NumericalPropagationConfig {
             method,
             integrator,
             variational,
-            store_accelerations: true,
-            interpolation_method: InterpolationMethod::Linear,
+            ..Default::default()
         }
     }
 
@@ -455,6 +455,35 @@ impl NumericalPropagationConfig {
     pub fn with_interpolation_method(mut self, method: InterpolationMethod) -> Self {
         self.interpolation_method = method;
         self
+    }
+
+    /// Validate that the configuration is internally consistent.
+    ///
+    /// Called automatically by `DNumericalPropagator::new` and
+    /// `DNumericalOrbitPropagator::new` before construction. Can also be
+    /// called directly to pre-flight a configuration before propagation.
+    ///
+    /// # Errors
+    ///
+    /// Returns `BraheError::PropagatorError` if:
+    /// - `interpolation_method` is `HermiteQuintic` but `store_accelerations`
+    ///   is `false`. Quintic Hermite interpolation requires the trajectory
+    ///   to carry per-sample accelerations; enable storage with
+    ///   `.with_store_accelerations(true)` or switch to `HermiteCubic`,
+    ///   `Lagrange`, or `Linear` interpolation.
+    pub fn validate(&self) -> Result<(), BraheError> {
+        if matches!(self.interpolation_method, InterpolationMethod::HermiteQuintic)
+            && !self.store_accelerations
+        {
+            return Err(BraheError::PropagatorError(
+                "HermiteQuintic interpolation requires store_accelerations = true, \
+                 but the propagation config has store_accelerations = false. \
+                 Either call .with_store_accelerations(true) on the config, or use \
+                 a different interpolation method (HermiteCubic, Lagrange, or Linear)."
+                    .to_string(),
+            ));
+        }
+        Ok(())
     }
 }
 
@@ -583,7 +612,7 @@ mod tests {
         assert!(config.variational.enable_stm);
         assert!(!config.variational.enable_sensitivity);
         // New fields should have defaults
-        assert!(config.store_accelerations);
+        assert!(!config.store_accelerations);
         assert_eq!(config.interpolation_method, InterpolationMethod::Linear);
     }
 
@@ -591,8 +620,8 @@ mod tests {
     fn test_numerical_propagation_config_default_accelerations() {
         let config = NumericalPropagationConfig::default();
 
-        // Acceleration storage should be enabled by default
-        assert!(config.store_accelerations);
+        // Acceleration storage should be disabled by default
+        assert!(!config.store_accelerations);
         // Default interpolation is Linear (safe for any state dimension)
         assert_eq!(config.interpolation_method, InterpolationMethod::Linear);
     }
@@ -651,5 +680,43 @@ mod tests {
         assert!(config.store_accelerations);
         // Default interpolation is Linear (safe for any state dimension)
         assert_eq!(config.interpolation_method, InterpolationMethod::Linear);
+    }
+
+    #[test]
+    fn test_numerical_propagation_config_validate_default_ok() {
+        // Default config is valid (Linear interpolation, accelerations off)
+        assert!(NumericalPropagationConfig::default().validate().is_ok());
+    }
+
+    #[test]
+    fn test_numerical_propagation_config_validate_hermite_quintic_without_accelerations() {
+        let config = NumericalPropagationConfig::default()
+            .with_interpolation_method(InterpolationMethod::HermiteQuintic);
+        let err = config.validate().unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("HermiteQuintic interpolation requires store_accelerations = true"),
+            "unexpected error message: {msg}"
+        );
+        assert!(
+            msg.contains("with_store_accelerations(true)"),
+            "error should mention the fix: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_numerical_propagation_config_validate_hermite_quintic_with_accelerations_ok() {
+        let config = NumericalPropagationConfig::default()
+            .with_interpolation_method(InterpolationMethod::HermiteQuintic)
+            .with_store_accelerations(true);
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_numerical_propagation_config_validate_hermite_cubic_without_accelerations_ok() {
+        // HermiteCubic does not require accelerations, so it should validate fine.
+        let config = NumericalPropagationConfig::default()
+            .with_interpolation_method(InterpolationMethod::HermiteCubic);
+        assert!(config.validate().is_ok());
     }
 }

--- a/src/trajectories/dorbit_trajectory.rs
+++ b/src/trajectories/dorbit_trajectory.rs
@@ -95,8 +95,7 @@ use crate::frames::{
 use crate::math::{
     CovarianceInterpolationConfig, interpolate_covariance_sqrt_dmatrix,
     interpolate_covariance_two_wasserstein_dmatrix, interpolate_hermite_cubic_dvector6,
-    interpolate_hermite_quintic_dvector6, interpolate_hermite_quintic_fd_dvector6,
-    interpolate_lagrange_dvector,
+    interpolate_hermite_quintic_dvector6, interpolate_lagrange_dvector,
 };
 use crate::relative_motion::rotation_eci_to_rtn;
 use crate::time::Epoch;
@@ -1438,11 +1437,9 @@ impl InterpolatableTrajectory for DOrbitTrajectory {
     ///
     /// # Returns
     /// * `Ok(state)` - Interpolated state vector
-    /// * `Err(BraheError)` - If interpolation fails or epoch is out of range
-    ///
-    /// # Panics
-    /// - HermiteCubic/HermiteQuintic panic if state dimension is not 6
-    /// - HermiteQuintic panics if no accelerations stored AND fewer than 3 points
+    /// * `Err(BraheError)` - If interpolation fails or epoch is out of range. In
+    ///   particular: HermiteCubic/HermiteQuintic require 6D states, and
+    ///   HermiteQuintic additionally requires that acceleration storage is enabled.
     fn interpolate(&self, epoch: &Epoch) -> Result<DVector<f64>, BraheError> {
         // Bounds checking
         if let Some(start) = self.start_epoch()
@@ -1542,47 +1539,35 @@ impl InterpolatableTrajectory for DOrbitTrajectory {
                     )));
                 }
 
-                // Check if we have stored accelerations
-                if let Some(ref accs) = self.accelerations {
-                    // Use explicit accelerations
-                    let t0 = self.epochs[idx1] - ref_epoch;
-                    let t1 = self.epochs[idx2] - ref_epoch;
-                    let t = *epoch - ref_epoch;
+                // HermiteQuintic requires per-sample accelerations. Enable them via
+                // `enable_acceleration_storage()` on the trajectory, or pass a
+                // `NumericalPropagationConfig` with `store_accelerations = true` to
+                // the propagator that produced this trajectory.
+                let Some(ref accs) = self.accelerations else {
+                    return Err(BraheError::Error(
+                        "HermiteQuintic interpolation requires per-sample accelerations, \
+                         but this trajectory has no acceleration storage. Either call \
+                         `enable_acceleration_storage()` on the trajectory before adding \
+                         states, configure the propagator with \
+                         `NumericalPropagationConfig::with_store_accelerations(true)`, \
+                         or switch to HermiteCubic, Lagrange, or Linear interpolation."
+                            .to_string(),
+                    ));
+                };
 
-                    Ok(interpolate_hermite_quintic_dvector6(
-                        t0,
-                        t1,
-                        &self.states[idx1],
-                        &self.states[idx2],
-                        &accs[idx1],
-                        &accs[idx2],
-                        t,
-                    ))
-                } else if self.len() >= 3 {
-                    // Use finite difference approximation
-                    let (i0, i1, i2) = self.compute_fd_window(idx1, idx2)?;
+                let t0 = self.epochs[idx1] - ref_epoch;
+                let t1 = self.epochs[idx2] - ref_epoch;
+                let t = *epoch - ref_epoch;
 
-                    let times = [
-                        self.epochs[i0] - ref_epoch,
-                        self.epochs[i1] - ref_epoch,
-                        self.epochs[i2] - ref_epoch,
-                    ];
-                    let states = [
-                        self.states[i0].clone(),
-                        self.states[i1].clone(),
-                        self.states[i2].clone(),
-                    ];
-                    let t = *epoch - ref_epoch;
-
-                    Ok(interpolate_hermite_quintic_fd_dvector6(&times, &states, t))
-                } else {
-                    Err(BraheError::Error(format!(
-                        "HermiteQuintic interpolation requires either stored accelerations \
-                         or at least 3 trajectory points. This trajectory has {} points \
-                         and no stored accelerations.",
-                        self.len()
-                    )))
-                }
+                Ok(interpolate_hermite_quintic_dvector6(
+                    t0,
+                    t1,
+                    &self.states[idx1],
+                    &self.states[idx2],
+                    &accs[idx1],
+                    &accs[idx2],
+                    t,
+                ))
             }
         }
     }
@@ -1617,22 +1602,6 @@ impl DOrbitTrajectory {
         Ok((start_idx, end_idx))
     }
 
-    /// Compute the 3-point window for finite difference acceleration estimation.
-    fn compute_fd_window(
-        &self,
-        idx1: usize,
-        idx2: usize,
-    ) -> Result<(usize, usize, usize), BraheError> {
-        if idx1 > 0 {
-            Ok((idx1 - 1, idx1, idx2))
-        } else if idx2 + 1 < self.len() {
-            Ok((idx1, idx2, idx2 + 1))
-        } else {
-            Err(BraheError::Error(
-                "Cannot compute finite difference window with available points".to_string(),
-            ))
-        }
-    }
 }
 
 impl STMStorage for DOrbitTrajectory {
@@ -4623,13 +4592,13 @@ mod tests {
     }
 
     #[test]
-    fn test_dorbittrajectory_interpolate_hermite_quintic_fd_fallback() {
-        // Without accelerations, uses finite difference with 3+ points
+    fn test_dorbittrajectory_interpolate_hermite_quintic_without_accelerations_errors() {
+        // Without enabled acceleration storage, HermiteQuintic must error — even
+        // when many points are available — since the FD fallback has been removed.
         let mut traj =
             DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .with_interpolation_method(InterpolationMethod::HermiteQuintic);
 
-        // Add 3 points for FD fallback
         for i in 0..3 {
             let epoch = Epoch::from_datetime(2024, 1, 1, 12, i * 10, 0.0, 0.0, TimeSystem::UTC);
             let state =
@@ -4638,30 +4607,19 @@ mod tests {
         }
 
         let mid = Epoch::from_datetime(2024, 1, 1, 12, 5, 0.0, 0.0, TimeSystem::UTC);
-        let result = traj.interpolate(&mid);
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_dorbittrajectory_interpolate_hermite_quintic_error_insufficient() {
-        let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
-                .with_interpolation_method(InterpolationMethod::HermiteQuintic);
-
-        // Only 2 points and no accelerations
-        let epoch1 = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
-        let epoch2 = Epoch::from_datetime(2024, 1, 1, 12, 10, 0.0, 0.0, TimeSystem::UTC);
-        let state1 = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
-        let state2 = DVector::from_vec(vec![7100e3, 0.0, 0.0, 0.0, 7.4e3, 0.0]);
-        traj.add(epoch1, state1);
-        traj.add(epoch2, state2);
-
-        let mid = Epoch::from_datetime(2024, 1, 1, 12, 5, 0.0, 0.0, TimeSystem::UTC);
-        let result = traj.interpolate(&mid);
-        assert!(result.is_err());
-        let err_msg = result.unwrap_err().to_string();
+        let err = traj.interpolate(&mid).unwrap_err();
+        let msg = err.to_string();
         assert!(
-            err_msg.contains("HermiteQuintic interpolation requires either stored accelerations")
+            msg.contains("HermiteQuintic interpolation requires per-sample accelerations"),
+            "unexpected error message: {msg}"
+        );
+        assert!(
+            msg.contains("enable_acceleration_storage"),
+            "error should mention the trajectory-level fix: {msg}"
+        );
+        assert!(
+            msg.contains("with_store_accelerations(true)"),
+            "error should mention the propagator-level fix: {msg}"
         );
     }
 

--- a/src/trajectories/sorbit_trajectory.rs
+++ b/src/trajectories/sorbit_trajectory.rs
@@ -53,8 +53,7 @@ use crate::frames::{
 use crate::math::{
     CovarianceInterpolationConfig, interpolate_covariance_sqrt_smatrix,
     interpolate_covariance_two_wasserstein_smatrix, interpolate_hermite_cubic_svector6,
-    interpolate_hermite_quintic_fd_svector6, interpolate_hermite_quintic_svector6,
-    interpolate_lagrange_svector,
+    interpolate_hermite_quintic_svector6, interpolate_lagrange_svector,
 };
 use crate::propagators::traits::{
     SCovarianceProvider, SOrbitCovarianceProvider, SOrbitStateProvider, SStateProvider,
@@ -1396,11 +1395,9 @@ impl InterpolatableTrajectory for SOrbitTrajectory {
     ///
     /// # Returns
     /// * `Ok(state)` - Interpolated state vector
-    /// * `Err(BraheError)` - If interpolation fails or epoch is out of range
-    ///
-    /// # Panics
-    /// - HermiteCubic/HermiteQuintic panic if states are not 6D (always true for SOrbitTrajectory)
-    /// - HermiteQuintic panics if no accelerations stored AND fewer than 3 points
+    /// * `Err(BraheError)` - If interpolation fails or epoch is out of range. In
+    ///   particular, HermiteQuintic requires that acceleration storage is enabled
+    ///   on the trajectory.
     fn interpolate(&self, epoch: &Epoch) -> Result<SVector<f64, 6>, BraheError> {
         // Bounds checking
         if let Some(start) = self.start_epoch()
@@ -1479,42 +1476,33 @@ impl InterpolatableTrajectory for SOrbitTrajectory {
             }
 
             InterpolationMethod::HermiteQuintic => {
-                // Check if we have stored accelerations
-                if let Some(ref accs) = self.accelerations {
-                    // Use explicit accelerations
-                    let t0 = self.epochs[idx1] - ref_epoch;
-                    let t1 = self.epochs[idx2] - ref_epoch;
-                    let state0 = self.states[idx1];
-                    let state1 = self.states[idx2];
-                    let acc0 = accs[idx1];
-                    let acc1 = accs[idx2];
-                    let t = *epoch - ref_epoch;
+                // HermiteQuintic requires per-sample accelerations. Enable them via
+                // `enable_acceleration_storage()` on the trajectory, or pass a
+                // `NumericalPropagationConfig` with `store_accelerations = true` to
+                // the propagator that produced this trajectory.
+                let Some(ref accs) = self.accelerations else {
+                    return Err(BraheError::Error(
+                        "HermiteQuintic interpolation requires per-sample accelerations, \
+                         but this trajectory has no acceleration storage. Either call \
+                         `enable_acceleration_storage()` on the trajectory before adding \
+                         states, configure the propagator with \
+                         `NumericalPropagationConfig::with_store_accelerations(true)`, \
+                         or switch to HermiteCubic, Lagrange, or Linear interpolation."
+                            .to_string(),
+                    ));
+                };
 
-                    Ok(interpolate_hermite_quintic_svector6(
-                        t0, t1, state0, state1, acc0, acc1, t,
-                    ))
-                } else if self.len() >= 3 {
-                    // Use finite difference approximation
-                    // Need 3 points: find center and surrounding indices
-                    let (i0, i1, i2) = self.compute_fd_window(idx1, idx2)?;
+                let t0 = self.epochs[idx1] - ref_epoch;
+                let t1 = self.epochs[idx2] - ref_epoch;
+                let state0 = self.states[idx1];
+                let state1 = self.states[idx2];
+                let acc0 = accs[idx1];
+                let acc1 = accs[idx2];
+                let t = *epoch - ref_epoch;
 
-                    let times = [
-                        self.epochs[i0] - ref_epoch,
-                        self.epochs[i1] - ref_epoch,
-                        self.epochs[i2] - ref_epoch,
-                    ];
-                    let states = [self.states[i0], self.states[i1], self.states[i2]];
-                    let t = *epoch - ref_epoch;
-
-                    Ok(interpolate_hermite_quintic_fd_svector6(&times, &states, t))
-                } else {
-                    panic!(
-                        "HermiteQuintic interpolation requires either stored accelerations \
-                         or at least 3 trajectory points. This trajectory has {} points \
-                         and no stored accelerations.",
-                        self.len()
-                    );
-                }
+                Ok(interpolate_hermite_quintic_svector6(
+                    t0, t1, state0, state1, acc0, acc1, t,
+                ))
             }
         }
     }
@@ -1556,30 +1544,6 @@ impl SOrbitTrajectory {
         Ok((start_idx, end_idx))
     }
 
-    /// Compute the 3-point window for finite difference acceleration estimation.
-    ///
-    /// Returns indices (i0, i1, i2) where the query point falls between i0-i1 or i1-i2.
-    fn compute_fd_window(
-        &self,
-        idx1: usize,
-        idx2: usize,
-    ) -> Result<(usize, usize, usize), BraheError> {
-        // We need 3 consecutive points. The query is between idx1 and idx2.
-        // Try to use [idx1-1, idx1, idx2] or [idx1, idx2, idx2+1]
-
-        if idx1 > 0 {
-            // Use point before idx1
-            Ok((idx1 - 1, idx1, idx2))
-        } else if idx2 + 1 < self.len() {
-            // Use point after idx2
-            Ok((idx1, idx2, idx2 + 1))
-        } else {
-            // Edge case: only 2 points (shouldn't happen if len >= 3)
-            Err(BraheError::Error(
-                "Cannot compute finite difference window with available points".to_string(),
-            ))
-        }
-    }
 }
 
 // Implementation of CovarianceInterpolationConfig trait
@@ -6204,30 +6168,29 @@ mod tests {
     }
 
     #[test]
-    fn test_orbittrajectory_interpolation_hermite_quintic_finite_difference() {
+    fn test_orbittrajectory_interpolation_hermite_quintic_without_accelerations_errors() {
+        // Without enabled acceleration storage, HermiteQuintic must error — even
+        // when many points are available — since the FD fallback has been removed.
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let mut traj = SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None);
-        // No acceleration storage - will use finite differences
         traj.set_interpolation_method(InterpolationMethod::HermiteQuintic);
 
-        // Add 3 points for finite difference approximation
-        // Use parabolic motion in x: x = 7000e3 + 100*t + 0.5*t^2
         for i in 0..3 {
             let dt = (i as f64) * 30.0;
-            let x = 7000e3 + 100.0 * dt + 0.5 * dt * dt;
-            let vx = 100.0 + dt; // velocity = derivative = 100 + t
-            traj.add(t0 + dt, Vector6::new(x, 0.0, 0.0, vx, 7500.0, 0.0));
+            traj.add(t0 + dt, Vector6::new(7000e3, 0.0, 0.0, 100.0, 7500.0, 0.0));
         }
 
-        // Interpolate at t = 45s
-        let t_query = t0 + 45.0;
-        let result = traj.interpolate(&t_query).unwrap();
-
-        // Expected position: 7000e3 + 100*45 + 0.5*45^2 = 7005512.5
-        let expected_x = 7000e3 + 100.0 * 45.0 + 0.5 * 45.0 * 45.0;
-        // Finite difference Hermite quintic should be close to exact value
-        assert_abs_diff_eq!(result[0], expected_x, epsilon = 100.0);
+        let err = traj.interpolate(&(t0 + 45.0)).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("HermiteQuintic interpolation requires per-sample accelerations"),
+            "unexpected error message: {msg}"
+        );
+        assert!(
+            msg.contains("enable_acceleration_storage"),
+            "error should mention the trajectory-level fix: {msg}"
+        );
     }
 
     #[test]
@@ -6374,22 +6337,23 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(
-        expected = "HermiteQuintic interpolation requires either stored accelerations or at least 3 trajectory points"
-    )]
-    fn test_orbittrajectory_hermite_quintic_panics_without_accelerations_or_points() {
+    fn test_orbittrajectory_hermite_quintic_errors_with_only_two_points() {
+        // Even with 2 points, HermiteQuintic without acceleration storage must error
+        // (previously this branch panicked; now it returns a structured error).
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let mut traj = SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None);
         traj.set_interpolation_method(InterpolationMethod::HermiteQuintic);
 
-        // Add only 2 points - not enough for finite difference
         traj.add(t0, Vector6::new(7000e3, 0.0, 0.0, 0.0, 7500.0, 0.0));
         traj.add(t0 + 60.0, Vector6::new(7006e3, 0.0, 0.0, 0.0, 7500.0, 0.0));
 
-        // This should panic
-        let t_mid = t0 + 30.0;
-        let _ = traj.interpolate(&t_mid);
+        let err = traj.interpolate(&(t0 + 30.0)).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("HermiteQuintic interpolation requires per-sample accelerations"),
+            "unexpected error message: {err}"
+        );
     }
 
     // ========================

--- a/tests/propagators/test_numerical_propagation_config.py
+++ b/tests/propagators/test_numerical_propagation_config.py
@@ -4,6 +4,8 @@ Tests for NumericalPropagationConfig and related types Python bindings
 These tests mirror the Rust tests from src/propagators/numerical_propagation_config.rs
 """
 
+import pytest
+
 from brahe import (
     IntegrationMethod,
     IntegratorConfig,
@@ -104,8 +106,8 @@ def test_numericalpropagationconfig_new_with_variational():
 def test_numericalpropagationconfig_default_accelerations():
     """Test NumericalPropagationConfig default acceleration settings"""
     config = NumericalPropagationConfig.default()
-    # store_accelerations defaults to True
-    assert config.store_accelerations is True
+    # store_accelerations defaults to False
+    assert config.store_accelerations is False
     # interpolation_method defaults to Linear (safe for any state dimension)
     assert config.interpolation_method == InterpolationMethod.LINEAR
 
@@ -174,3 +176,45 @@ def test_numericalpropagationconfig_interpolation_method_setter():
     assert config.interpolation_method.degree == 8
     config.interpolation_method = InterpolationMethod.LINEAR
     assert config.interpolation_method == InterpolationMethod.LINEAR
+
+
+# =============================================================================
+# validate() Tests
+# =============================================================================
+
+
+def test_numericalpropagationconfig_validate_default_ok():
+    """Default config is internally consistent."""
+    NumericalPropagationConfig.default().validate()  # no exception
+
+
+def test_numericalpropagationconfig_validate_hermite_quintic_without_accelerations():
+    """HermiteQuintic requires store_accelerations=True."""
+    config = NumericalPropagationConfig.default().with_interpolation_method(
+        InterpolationMethod.HERMITE_QUINTIC
+    )
+    with pytest.raises(
+        Exception,
+        match="HermiteQuintic interpolation requires store_accelerations = true",
+    ) as exc_info:
+        config.validate()
+    # Error should also point users at the fix
+    assert "with_store_accelerations(true)" in str(exc_info.value)
+
+
+def test_numericalpropagationconfig_validate_hermite_quintic_with_accelerations_ok():
+    """HermiteQuintic + store_accelerations=True is valid."""
+    config = (
+        NumericalPropagationConfig.default()
+        .with_interpolation_method(InterpolationMethod.HERMITE_QUINTIC)
+        .with_store_accelerations(True)
+    )
+    config.validate()  # no exception
+
+
+def test_numericalpropagationconfig_validate_hermite_cubic_without_accelerations_ok():
+    """HermiteCubic does not require stored accelerations."""
+    config = NumericalPropagationConfig.default().with_interpolation_method(
+        InterpolationMethod.HERMITE_CUBIC
+    )
+    config.validate()  # no exception

--- a/tests/trajectories/test_orbit_trajectory.py
+++ b/tests/trajectories/test_orbit_trajectory.py
@@ -3580,29 +3580,23 @@ def test_orbittrajectory_hermite_quintic_with_accelerations():
     assert result[0] > 7000e3 and result[0] < 7008e3
 
 
-def test_orbittrajectory_hermite_quintic_finite_difference():
-    """Test HermiteQuintic interpolation with finite difference fallback."""
+def test_orbittrajectory_hermite_quintic_without_accelerations_errors():
+    """HermiteQuintic must error if acceleration storage is not enabled."""
     t0 = Epoch.from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, brahe.UTC)
 
     traj = OrbitTrajectory(6, OrbitFrame.ECI, OrbitRepresentation.CARTESIAN, None)
-    # No acceleration storage - will use finite differences
+    # Acceleration storage NOT enabled
     traj.set_interpolation_method(InterpolationMethod.HERMITE_QUINTIC)
 
-    # Add 3 points for finite difference approximation
-    # Use parabolic motion in x: x = 7000e3 + 100*t + 0.5*t^2
     for i in range(3):
         dt = i * 30.0
-        x = 7000e3 + 100.0 * dt + 0.5 * dt * dt
-        vx = 100.0 + dt  # velocity = derivative = 100 + t
-        traj.add(t0 + dt, np.array([x, 0.0, 0.0, vx, 7500.0, 0.0]))
+        traj.add(t0 + dt, np.array([7000e3, 0.0, 0.0, 100.0, 7500.0, 0.0]))
 
-    # Interpolate at t = 45s
-    t_query = t0 + 45.0
-    result = traj.interpolate(t_query)
-
-    # Expected position: 7000e3 + 100*45 + 0.5*45^2 = 7005512.5
-    expected_x = 7000e3 + 100.0 * 45.0 + 0.5 * 45.0 * 45.0
-    assert result[0] == pytest.approx(expected_x, abs=100.0)
+    with pytest.raises(
+        Exception,
+        match="HermiteQuintic interpolation requires per-sample accelerations",
+    ):
+        traj.interpolate(t0 + 45.0)
 
 
 def test_orbittrajectory_add_with_acceleration_requires_enabled():


### PR DESCRIPTION
# Pull Request

## Description

This PR changes the default behavior for orbit propagators to no longer store acceleration by default. As such we also needed to change how interpolation selection is validated as quintic hermite interpolation might no longer have the necessary accelerations present. If those accelerations are not present. Throw an error.

## Changelog

### Changed
- `NumericalOrbitPropagator` and `NumericalPropagator` now no longer store accelerations by default to save space and improve performance.
- The FD fallback for HermiteQuintic is removed. Previously, calling HermiteQuintic on a trajectory without stored accelerations would silently degrade to finite-difference acceleration estimation if 3+ points were available; now it errors. Combined with the earlier store_accelerations: false default flip, any code path that today uses HermiteQuintic either needs NumericalPropagationConfig::with_store_accelerations(true) (propagator path) or trajectory.enable_acceleration_storage() (direct path).
