### PR TITLE
De/add missing python bindings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["crates/brahe-py"]
 # `version.workspace = true` so `brahe-py` (the Python extension) stays in sync
 # with the root `brahe` crate.
 [workspace.package]
-version = "1.5.0"
+version = "1.5.1"
 
 [package]
 name = "brahe"

--- a/brahe/plots/estimation_state.py
+++ b/brahe/plots/estimation_state.py
@@ -28,7 +28,7 @@ from brahe.plots.estimation_common import (
 def _sigma_band_label(series_label, sigma_level):
     """Format the legend label for a covariance band."""
     level = sigma_level if sigma_level is not None else 3
-    return f"{series_label} ±{level}σ"
+    return rf"{series_label} ±{level}$\sigma$"
 
 
 # =============================================================================

--- a/crates/brahe-py/src/propagators.rs
+++ b/crates/brahe-py/src/propagators.rs
@@ -508,6 +508,20 @@ impl PySGPPropagator {
         Ok(states.iter().map(|s: &Vector6<f64>| s.as_slice().to_pyarray(py).to_owned()).collect())
     }
 
+    /// Compute states at multiple epochs in ECEF coordinates.
+    ///
+    /// Args:
+    ///     epochs (list[Epoch]): List of epochs for state computation.
+    ///
+    /// Returns:
+    ///     list[numpy.ndarray]: List of ECEF state vectors.
+    #[pyo3(text_signature = "(epochs)")]
+    pub fn states_ecef<'a>(&self, py: Python<'a>, epochs: Vec<PyRef<PyEpoch>>) -> PyResult<Vec<Bound<'a, PyArray<f64, Ix1>>>> {
+        let epoch_vec: Vec<_> = epochs.iter().map(|e| e.obj).collect();
+        let states = SOrbitStateProvider::states_ecef(&self.propagator, &epoch_vec)?;
+        Ok(states.iter().map(|s: &Vector6<f64>| s.as_slice().to_pyarray(py).to_owned()).collect())
+    }
+
     /// Compute states at multiple epochs in GCRF coordinates.
     ///
     /// Args:
@@ -533,6 +547,20 @@ impl PySGPPropagator {
     pub fn states_itrf<'a>(&self, py: Python<'a>, epochs: Vec<PyRef<PyEpoch>>) -> PyResult<Vec<Bound<'a, PyArray<f64, Ix1>>>> {
         let epoch_vec: Vec<_> = epochs.iter().map(|e| e.obj).collect();
         let states = SOrbitStateProvider::states_itrf(&self.propagator, &epoch_vec)?;
+        Ok(states.iter().map(|s: &Vector6<f64>| s.as_slice().to_pyarray(py).to_owned()).collect())
+    }
+
+    /// Compute states at multiple epochs in EME2000 coordinates.
+    ///
+    /// Args:
+    ///     epochs (list[Epoch]): List of epochs for state computation.
+    ///
+    /// Returns:
+    ///     list[numpy.ndarray]: List of EME2000 state vectors.
+    #[pyo3(text_signature = "(epochs)")]
+    pub fn states_eme2000<'a>(&self, py: Python<'a>, epochs: Vec<PyRef<PyEpoch>>) -> PyResult<Vec<Bound<'a, PyArray<f64, Ix1>>>> {
+        let epoch_vec: Vec<_> = epochs.iter().map(|e| e.obj).collect();
+        let states = SOrbitStateProvider::states_eme2000(&self.propagator, &epoch_vec)?;
         Ok(states.iter().map(|s: &Vector6<f64>| s.as_slice().to_pyarray(py).to_owned()).collect())
     }
 
@@ -2241,6 +2269,20 @@ impl PyKeplerianPropagator {
     pub fn states_itrf<'a>(&self, py: Python<'a>, epochs: Vec<PyRef<PyEpoch>>) -> PyResult<Vec<Bound<'a, PyArray<f64, Ix1>>>> {
         let epoch_vec: Vec<_> = epochs.iter().map(|e| e.obj).collect();
         let states = DOrbitStateProvider::states_itrf(&self.propagator, &epoch_vec)?;
+        Ok(states.iter().map(|s: &Vector6<f64>| s.as_slice().to_pyarray(py).to_owned()).collect())
+    }
+
+    /// Compute states at multiple epochs in EME2000 coordinates.
+    ///
+    /// Args:
+    ///     epochs (list[Epoch]): List of epochs for state computation.
+    ///
+    /// Returns:
+    ///     list[numpy.ndarray]: List of EME2000 state vectors.
+    #[pyo3(text_signature = "(epochs)")]
+    pub fn states_eme2000<'a>(&self, py: Python<'a>, epochs: Vec<PyRef<PyEpoch>>) -> PyResult<Vec<Bound<'a, PyArray<f64, Ix1>>>> {
+        let epoch_vec: Vec<_> = epochs.iter().map(|e| e.obj).collect();
+        let states = DOrbitStateProvider::states_eme2000(&self.propagator, &epoch_vec)?;
         Ok(states.iter().map(|s: &Vector6<f64>| s.as_slice().to_pyarray(py).to_owned()).collect())
     }
 
@@ -4781,6 +4823,81 @@ impl PyNumericalOrbitPropagator {
         Ok(state.as_slice().to_pyarray(py).to_owned())
     }
 
+    /// Compute states at multiple epochs in ECI coordinates.
+    ///
+    /// Args:
+    ///     epochs (list[Epoch]): List of epochs for state computation.
+    ///
+    /// Returns:
+    ///     list[numpy.ndarray]: List of ECI state vectors.
+    #[pyo3(text_signature = "(epochs)")]
+    pub fn states_eci<'a>(&self, py: Python<'a>, epochs: Vec<PyRef<PyEpoch>>) -> PyResult<Vec<Bound<'a, PyArray<f64, Ix1>>>> {
+        let epoch_vec: Vec<_> = epochs.iter().map(|e| e.obj).collect();
+        let states = DOrbitStateProvider::states_eci(&self.propagator, &epoch_vec)
+            .map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))?;
+        Ok(states.iter().map(|s: &Vector6<f64>| s.as_slice().to_pyarray(py).to_owned()).collect())
+    }
+
+    /// Compute states at multiple epochs in ECEF coordinates.
+    ///
+    /// Args:
+    ///     epochs (list[Epoch]): List of epochs for state computation.
+    ///
+    /// Returns:
+    ///     list[numpy.ndarray]: List of ECEF state vectors.
+    #[pyo3(text_signature = "(epochs)")]
+    pub fn states_ecef<'a>(&self, py: Python<'a>, epochs: Vec<PyRef<PyEpoch>>) -> PyResult<Vec<Bound<'a, PyArray<f64, Ix1>>>> {
+        let epoch_vec: Vec<_> = epochs.iter().map(|e| e.obj).collect();
+        let states = DOrbitStateProvider::states_ecef(&self.propagator, &epoch_vec)
+            .map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))?;
+        Ok(states.iter().map(|s: &Vector6<f64>| s.as_slice().to_pyarray(py).to_owned()).collect())
+    }
+
+    /// Compute states at multiple epochs in GCRF coordinates.
+    ///
+    /// Args:
+    ///     epochs (list[Epoch]): List of epochs for state computation.
+    ///
+    /// Returns:
+    ///     list[numpy.ndarray]: List of GCRF state vectors.
+    #[pyo3(text_signature = "(epochs)")]
+    pub fn states_gcrf<'a>(&self, py: Python<'a>, epochs: Vec<PyRef<PyEpoch>>) -> PyResult<Vec<Bound<'a, PyArray<f64, Ix1>>>> {
+        let epoch_vec: Vec<_> = epochs.iter().map(|e| e.obj).collect();
+        let states = DOrbitStateProvider::states_gcrf(&self.propagator, &epoch_vec)
+            .map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))?;
+        Ok(states.iter().map(|s: &Vector6<f64>| s.as_slice().to_pyarray(py).to_owned()).collect())
+    }
+
+    /// Compute states at multiple epochs in ITRF coordinates.
+    ///
+    /// Args:
+    ///     epochs (list[Epoch]): List of epochs for state computation.
+    ///
+    /// Returns:
+    ///     list[numpy.ndarray]: List of ITRF state vectors.
+    #[pyo3(text_signature = "(epochs)")]
+    pub fn states_itrf<'a>(&self, py: Python<'a>, epochs: Vec<PyRef<PyEpoch>>) -> PyResult<Vec<Bound<'a, PyArray<f64, Ix1>>>> {
+        let epoch_vec: Vec<_> = epochs.iter().map(|e| e.obj).collect();
+        let states = DOrbitStateProvider::states_itrf(&self.propagator, &epoch_vec)
+            .map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))?;
+        Ok(states.iter().map(|s: &Vector6<f64>| s.as_slice().to_pyarray(py).to_owned()).collect())
+    }
+
+    /// Compute states at multiple epochs in EME2000 coordinates.
+    ///
+    /// Args:
+    ///     epochs (list[Epoch]): List of epochs for state computation.
+    ///
+    /// Returns:
+    ///     list[numpy.ndarray]: List of EME2000 state vectors.
+    #[pyo3(text_signature = "(epochs)")]
+    pub fn states_eme2000<'a>(&self, py: Python<'a>, epochs: Vec<PyRef<PyEpoch>>) -> PyResult<Vec<Bound<'a, PyArray<f64, Ix1>>>> {
+        let epoch_vec: Vec<_> = epochs.iter().map(|e| e.obj).collect();
+        let states = DOrbitStateProvider::states_eme2000(&self.propagator, &epoch_vec)
+            .map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))?;
+        Ok(states.iter().map(|s: &Vector6<f64>| s.as_slice().to_pyarray(py).to_owned()).collect())
+    }
+
     /// Compute state as osculating Keplerian elements at a specific epoch.
     ///
     /// Args:
@@ -5999,6 +6116,21 @@ impl PyNumericalPropagator {
         let state = DStateProvider::state(&self.propagator, epoch.obj)
             .map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))?;
         Ok(state.as_slice().to_pyarray(py).to_owned())
+    }
+
+    /// Compute states at multiple epochs.
+    ///
+    /// Args:
+    ///     epochs (list[Epoch]): List of epochs for state computation.
+    ///
+    /// Returns:
+    ///     list[numpy.ndarray]: List of state vectors in the propagator's current output format.
+    #[pyo3(text_signature = "(epochs)")]
+    pub fn states<'a>(&self, py: Python<'a>, epochs: Vec<PyRef<PyEpoch>>) -> PyResult<Vec<Bound<'a, PyArray<f64, Ix1>>>> {
+        let epoch_vec: Vec<_> = epochs.iter().map(|e| e.obj).collect();
+        let states = DStateProvider::states(&self.propagator, &epoch_vec)
+            .map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))?;
+        Ok(states.iter().map(|s| s.as_slice().to_pyarray(py).to_owned()).collect())
     }
 
     // =========================================================================

--- a/tests/propagators/test_keplerian_propagator.py
+++ b/tests/propagators/test_keplerian_propagator.py
@@ -836,6 +836,98 @@ def test_keplerianpropagator_analyticpropagator_states_ecef():
             assert abs(computed_elements[j] - elements[j]) < 1e-6
 
 
+def test_keplerianpropagator_analyticpropagator_states_gcrf():
+    """Test states_gcrf() method"""
+    epoch = Epoch.from_jd(TEST_EPOCH_JD, TimeSystem.UTC)
+    elements = create_test_elements()
+
+    propagator = KeplerianPropagator.from_keplerian(
+        epoch,
+        elements,
+        AngleFormat.DEGREES,
+        60.0,
+    )
+
+    epochs = [
+        epoch,
+        epoch + orbital_period(elements[0]),
+        epoch + 2.0 * orbital_period(elements[0]),
+    ]
+
+    states = propagator.states_gcrf(epochs)
+    assert len(states) == 3
+    # GCRF is the modern realization of ECI; round-trip via KOE should match
+    for state in states:
+        computed_elements = state_eci_to_koe(state, angle_format=AngleFormat.DEGREES)
+        for i in range(6):
+            assert abs(computed_elements[i] - elements[i]) < 1e-6
+
+
+def test_keplerianpropagator_analyticpropagator_states_itrf():
+    """Test states_itrf() method"""
+    epoch = Epoch.from_jd(TEST_EPOCH_JD, TimeSystem.UTC)
+    elements = create_test_elements()
+
+    propagator = KeplerianPropagator.from_keplerian(
+        epoch,
+        elements,
+        AngleFormat.DEGREES,
+        60.0,
+    )
+
+    epochs = [
+        epoch,
+        epoch + orbital_period(elements[0]),
+        epoch + 2.0 * orbital_period(elements[0]),
+    ]
+
+    states = propagator.states_itrf(epochs)
+    assert len(states) == 3
+    for i, state in enumerate(states):
+        # ITRF == ECEF; round-trip through ECI and confirm round-trip preserves elements
+        eci_state = state_ecef_to_eci(epochs[i], state)
+        computed_elements = state_eci_to_koe(
+            eci_state, angle_format=AngleFormat.DEGREES
+        )
+        for j in range(6):
+            assert abs(computed_elements[j] - elements[j]) < 1e-6
+
+
+def test_keplerianpropagator_analyticpropagator_states_eme2000():
+    """Test states_eme2000() method"""
+    epoch = Epoch.from_jd(TEST_EPOCH_JD, TimeSystem.UTC)
+    elements = create_test_elements()
+
+    propagator = KeplerianPropagator.from_keplerian(
+        epoch,
+        elements,
+        AngleFormat.DEGREES,
+        60.0,
+    )
+
+    epochs = [
+        epoch,
+        epoch + orbital_period(elements[0]),
+        epoch + 2.0 * orbital_period(elements[0]),
+    ]
+
+    states = propagator.states_eme2000(epochs)
+    assert len(states) == 3
+    for state in states:
+        # Convert EME2000 -> GCRF (small frame bias rotation, ~mas), then to KOE
+        gcrf_state = state_eme2000_to_gcrf(state)
+        computed_elements = state_eci_to_koe(
+            gcrf_state, angle_format=AngleFormat.DEGREES
+        )
+        for i in range(6):
+            assert abs(computed_elements[i] - elements[i]) < 1e-6
+
+    # Verify per-epoch parity with state_eme2000 single-state method
+    for i, state in enumerate(states):
+        single = propagator.state_eme2000(epochs[i])
+        np.testing.assert_allclose(state, single, rtol=1e-12)
+
+
 def test_keplerianpropagator_analyticpropagator_states_koe_osc():
     """Test states_koe_osc() method"""
     epoch = Epoch.from_jd(TEST_EPOCH_JD, TimeSystem.UTC)

--- a/tests/propagators/test_numerical_orbit_propagator.py
+++ b/tests/propagators/test_numerical_orbit_propagator.py
@@ -1137,6 +1137,114 @@ def test_numericalorbitpropagator_dorbitstateprovider_state_eme2000():
     assert pos_mag > R_EARTH and pos_mag < R_EARTH + 1000e3
 
 
+# =============================================================================
+# NumericalOrbitPropagator states_* (bulk frame conversion) Tests
+# =============================================================================
+
+
+@pytest.fixture
+def propagated_orbit_prop():
+    """Create a NumericalOrbitPropagator that has propagated through one full orbit."""
+    epoch = create_test_epoch()
+    state = create_leo_state()
+
+    prop = NumericalOrbitPropagator(
+        epoch,
+        state,
+        NumericalPropagationConfig.default(),
+        ForceModelConfig.two_body(),
+        None,
+    )
+
+    prop.propagate_to(epoch + orbital_period(R_EARTH + 500e3))
+    return prop, epoch
+
+
+def test_numericalorbitpropagator_dorbitstateprovider_states_eci(propagated_orbit_prop):
+    """Test states_eci() returns ECI state vectors at multiple epochs."""
+    prop, epoch = propagated_orbit_prop
+    epochs = [epoch + i * 120.0 for i in range(5)]
+
+    states = prop.states_eci(epochs)
+
+    assert len(states) == 5
+    for i, state in enumerate(states):
+        assert len(state) == 6
+        assert all(np.isfinite(state))
+        # LEO altitude check
+        pos_norm = np.linalg.norm(state[:3])
+        assert R_EARTH < pos_norm < R_EARTH + 1000e3
+        # Bulk must match single-epoch result
+        single = prop.state_eci(epochs[i])
+        np.testing.assert_allclose(state, single, rtol=1e-10)
+
+
+def test_numericalorbitpropagator_dorbitstateprovider_states_ecef(propagated_orbit_prop):
+    """Test states_ecef() returns ECEF state vectors at multiple epochs."""
+    prop, epoch = propagated_orbit_prop
+    epochs = [epoch + i * 120.0 for i in range(5)]
+
+    states = prop.states_ecef(epochs)
+
+    assert len(states) == 5
+    for i, state in enumerate(states):
+        assert len(state) == 6
+        assert all(np.isfinite(state))
+        pos_norm = np.linalg.norm(state[:3])
+        assert R_EARTH < pos_norm < R_EARTH + 1000e3
+        single = prop.state_ecef(epochs[i])
+        np.testing.assert_allclose(state, single, rtol=1e-10)
+
+
+def test_numericalorbitpropagator_dorbitstateprovider_states_gcrf(propagated_orbit_prop):
+    """Test states_gcrf() returns GCRF state vectors at multiple epochs."""
+    prop, epoch = propagated_orbit_prop
+    epochs = [epoch + i * 120.0 for i in range(5)]
+
+    states = prop.states_gcrf(epochs)
+
+    assert len(states) == 5
+    for i, state in enumerate(states):
+        single = prop.state_gcrf(epochs[i])
+        np.testing.assert_allclose(state, single, rtol=1e-10)
+
+
+def test_numericalorbitpropagator_dorbitstateprovider_states_itrf(propagated_orbit_prop):
+    """Test states_itrf() returns ITRF state vectors at multiple epochs."""
+    prop, epoch = propagated_orbit_prop
+    epochs = [epoch + i * 120.0 for i in range(5)]
+
+    states = prop.states_itrf(epochs)
+
+    assert len(states) == 5
+    for i, state in enumerate(states):
+        single = prop.state_itrf(epochs[i])
+        np.testing.assert_allclose(state, single, rtol=1e-10)
+
+
+def test_numericalorbitpropagator_dorbitstateprovider_states_eme2000(propagated_orbit_prop):
+    """Test states_eme2000() returns EME2000 state vectors at multiple epochs."""
+    prop, epoch = propagated_orbit_prop
+    epochs = [epoch + i * 120.0 for i in range(5)]
+
+    states = prop.states_eme2000(epochs)
+
+    assert len(states) == 5
+    for i, state in enumerate(states):
+        single = prop.state_eme2000(epochs[i])
+        np.testing.assert_allclose(state, single, rtol=1e-10)
+
+
+def test_numericalorbitpropagator_states_empty_epochs(propagated_orbit_prop):
+    """Bulk state methods should return an empty list when given no epochs."""
+    prop, _ = propagated_orbit_prop
+    assert prop.states_eci([]) == []
+    assert prop.states_ecef([]) == []
+    assert prop.states_gcrf([]) == []
+    assert prop.states_itrf([]) == []
+    assert prop.states_eme2000([]) == []
+
+
 def test_numericalorbitpropagator_dorbitstateprovider_osculating_elements_radians():
     """Test state_koe_osc() with radians (mirrors Rust test)"""
     epoch = create_test_epoch()

--- a/tests/propagators/test_numerical_propagator.py
+++ b/tests/propagators/test_numerical_propagator.py
@@ -315,6 +315,38 @@ def test_dstateprovider_state_interpolation():
     assert len(result) == 2
 
 
+def test_dstateprovider_states_bulk():
+    """Test states() returns the state vector at every requested epoch."""
+    epoch = create_test_epoch()
+    state = np.array([1.0, 0.0])
+
+    config = NumericalPropagationConfig.default()
+    config.interpolation_method = InterpolationMethod.LINEAR
+
+    prop = NumericalPropagator(epoch, state, sho_dynamics, config)
+    prop.propagate_to(epoch + 2.0)
+
+    epochs = [epoch + 0.0, epoch + 0.5, epoch + 1.0, epoch + 1.5, epoch + 2.0]
+    states = prop.states(epochs)
+
+    assert len(states) == len(epochs)
+    for i, s in enumerate(states):
+        assert len(s) == 2
+        assert all(np.isfinite(s))
+        # Bulk must match single-epoch query
+        np.testing.assert_allclose(s, prop.state(epochs[i]), rtol=1e-12)
+
+
+def test_dstateprovider_states_empty():
+    """states() should accept an empty list and return an empty list."""
+    epoch = create_test_epoch()
+    state = np.array([1.0, 0.0])
+    prop = NumericalPropagator(
+        epoch, state, sho_dynamics, NumericalPropagationConfig.default()
+    )
+    assert prop.states([]) == []
+
+
 # =============================================================================
 # Trajectory Tests
 # =============================================================================

--- a/tests/propagators/test_sgp_propagator.py
+++ b/tests/propagators/test_sgp_propagator.py
@@ -1729,3 +1729,40 @@ class TestSGPPropagatorAdditionalMethods:
         for i in range(3):
             assert mean_list_rad[i][0] == pytest.approx(mean_list[i][0], rel=1e-10)
             assert mean_list_rad[i][1] == pytest.approx(mean_list[i][1], rel=1e-10)
+
+    def test_states_ecef(self, iss_tle):
+        """Test states_ecef returns ECEF state vectors at multiple epochs."""
+        prop = brahe.SGPPropagator.from_tle(iss_tle[0], iss_tle[1], 60.0)
+        initial_epoch = prop.epoch
+        epochs = [initial_epoch + i * 60.0 for i in range(5)]
+
+        states = prop.states_ecef(epochs)
+
+        assert len(states) == 5
+        for i, state in enumerate(states):
+            assert len(state) == 6
+            assert all(np.isfinite(state))
+            # Verify magnitude is roughly LEO altitude
+            r_mag = np.linalg.norm(state[:3])
+            assert 6.3e6 < r_mag < 7.0e6
+            # Verify states_ecef matches state_ecef at each epoch
+            single = prop.state_ecef(epochs[i])
+            assert state == pytest.approx(single, rel=1e-10)
+
+    def test_states_eme2000(self, iss_tle):
+        """Test states_eme2000 returns EME2000 state vectors at multiple epochs."""
+        prop = brahe.SGPPropagator.from_tle(iss_tle[0], iss_tle[1], 60.0)
+        initial_epoch = prop.epoch
+        epochs = [initial_epoch + i * 60.0 for i in range(3)]
+
+        states = prop.states_eme2000(epochs)
+
+        assert len(states) == 3
+        for i, state in enumerate(states):
+            assert len(state) == 6
+            assert all(np.isfinite(state))
+            r_mag = np.linalg.norm(state[:3])
+            assert 6.3e6 < r_mag < 7.0e6
+            # Verify states_eme2000 matches state_eme2000 at each epoch
+            single = prop.state_eme2000(epochs[i])
+            assert state == pytest.approx(single, rel=1e-10)


### PR DESCRIPTION
# Pull Request

## Description

Expose missing python `*.state*` bindings to different propagators.

## Changelog

### Added
- Added `states_ecef` and `states_eme2000` to `SGPPropagator`
- Added `states_eme2000` to `KeplerianPropagator`
- Added `states_eci`, `states_ecef`, `states_gcrf`, `states_itrf`, and `states_eme2000` to `NumericalOrbitPropagator`
- Added `states` to `NumericalPropagator`

### Fixed
- Some estimation plots used unicode sigma instead of `$\sigma$`. When latex is installed and defaults to pdfLaTeX compiler, this causes an error. Switch to `$\sigma$` everywhere

## Related Issues
- Resolves: https://github.com/duncaneddy/brahe/issues/329