### PR TITLE
Update CHANGELOG generation flow to avoid dirty releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,16 @@ jobs:
           fi
           echo "Cargo.toml version matches: $CARGO_VERSION"
 
+      - name: Validate CHANGELOG entry for this version
+        run: |
+          VERSION="${{ steps.extract.outputs.version }}"
+          if ! grep -q "^## \[${VERSION}\]" CHANGELOG.md; then
+            echo "ERROR: CHANGELOG.md has no '## [${VERSION}]' entry."
+            echo "Run 'just generate-changelog' locally before tagging, then commit and re-tag."
+            exit 1
+          fi
+          echo "CHANGELOG.md contains entry for v${VERSION}"
+
       - name: Validate pyproject.toml version
         run: |
           # pyproject.toml version is dynamic, synced to Cargo.toml, so just verify Cargo.toml is correct
@@ -51,62 +61,27 @@ jobs:
     needs: [validate-version]
     secrets: inherit
 
-  # Generate release notes from PRs merged since the previous release tag, update
-  # CHANGELOG.md if needed, and publish artifacts consumed by downstream jobs.
-  generate-release-notes:
+  # Extract this release's notes from the CHANGELOG.md committed in the tag.
+  # The maintainer runs `just generate-changelog` locally before tagging, so the
+  # CHANGELOG entry is already part of the tagged commit. This job only reads
+  # the file — it does not mutate or push anything, keeping the working tree
+  # clean for downstream publish steps.
+  prepare-release-notes:
     runs-on: ubuntu-latest
     needs: [validate-version, test-rust, test-python, test-examples]
-    permissions:
-      contents: write
     steps:
       - name: Checkout code
-        # WORKFLOW_TOKEN so the subsequent push to main is allowed by branch
-        # protection. The default GITHUB_TOKEN cannot bypass required reviews.
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.WORKFLOW_TOKEN }}
 
-      - name: Determine previous release tag
-        id: prev-tag
+      - name: Extract release notes from CHANGELOG
         run: |
           VERSION=${{ needs.validate-version.outputs.version }}
-          PREV=$(git describe --tags --abbrev=0 "v${VERSION}^" 2>/dev/null || true)
-          if [ -z "$PREV" ]; then
-            echo "ERROR: Could not determine previous release tag preceding v${VERSION}"
-            exit 1
-          fi
-          echo "Previous release tag: $PREV"
-          echo "prev_tag=$PREV" >> "$GITHUB_OUTPUT"
-
-      - name: Generate release notes and update CHANGELOG
-        env:
-          GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
-        run: |
-          VERSION=${{ needs.validate-version.outputs.version }}
-          python3 scripts/generate_release_notes.py \
+          python3 scripts/extract_release_notes.py \
             --version "$VERSION" \
-            --prev-tag "${{ steps.prev-tag.outputs.prev_tag }}" \
-            --release-notes release_notes.md \
-            --changelog CHANGELOG.md
+            --changelog CHANGELOG.md \
+            --output release_notes.md
           echo "----- release_notes.md -----"
           cat release_notes.md
-
-      - name: Commit CHANGELOG update to main
-        run: |
-          VERSION=${{ needs.validate-version.outputs.version }}
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          if git diff --quiet -- CHANGELOG.md; then
-            echo "CHANGELOG.md already up to date for v${VERSION}; nothing to commit."
-            exit 0
-          fi
-          git add CHANGELOG.md
-          git commit -m "Update CHANGELOG for v${VERSION}"
-          # The tag points at the previous tip; push the CHANGELOG commit to main
-          # so the live history stays in sync. The released artifacts use the
-          # in-job CHANGELOG.md content via the uploaded artifact below.
-          git push origin HEAD:main
 
       - name: Upload release notes artifact
         uses: actions/upload-artifact@v7
@@ -114,15 +89,9 @@ jobs:
           name: release-notes
           path: release_notes.md
 
-      - name: Upload CHANGELOG artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: changelog
-          path: CHANGELOG.md
-
   # Generate type stubs once (platform-independent) for inclusion in all packages
   generate-stubs:
-    needs: [generate-release-notes]
+    needs: [prepare-release-notes]
     runs-on: ubuntu-latest
     env:
       RUST_TOOLCHAIN: stable
@@ -167,7 +136,7 @@ jobs:
         path: brahe/_brahe.pyi
 
   python-build-source:
-    needs: [generate-release-notes, generate-stubs]
+    needs: [prepare-release-notes, generate-stubs]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -178,11 +147,6 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
-
-    - name: Download CHANGELOG
-      uses: actions/download-artifact@v8
-      with:
-        name: changelog
 
     - name: Download type stubs
       uses: actions/download-artifact@v8
@@ -227,7 +191,7 @@ jobs:
         name: brahe-${{ github.ref_name }}-${{ runner.os }}-source
 
   python-build-wheels:
-    needs: [generate-release-notes, generate-stubs]
+    needs: [prepare-release-notes, generate-stubs]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -307,10 +271,6 @@ jobs:
       RUST_TOOLCHAIN: stable
     steps:
       - uses: actions/checkout@v6
-      - name: Download CHANGELOG
-        uses: actions/download-artifact@v8
-        with:
-          name: changelog
       - name: Set up Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1.16.1
         with:
@@ -324,7 +284,7 @@ jobs:
 
   update-docs:
     uses: ./.github/workflows/update_docs.yml
-    needs: [generate-release-notes, release-python, release-rust]
+    needs: [prepare-release-notes, release-python, release-rust]
     with:
       version: ${{ github.ref_name }}
 
@@ -353,13 +313,13 @@ jobs:
         with:
           name: release-notes
 
-      - name: Create draft GitHub Release
+      - name: Publish GitHub Release
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}
           name: Release ${{ github.ref_name }}
           body_path: release_notes.md
-          draft: true
+          draft: false
           prerelease: false
           files: release-artifacts/*
 

--- a/docs/development_guide.md
+++ b/docs/development_guide.md
@@ -409,24 +409,32 @@ This requires the `gh` CLI to be authenticated (`gh auth status`).
 
 ## Release Process
 
+CHANGELOG generation and version bumps happen **locally before tagging**, so the tagged commit contains everything the published artifacts ship. CI never mutates the repository during a release.
+
 ### Initiating a Release
 
-Before creating a release:
-
-1. **Update version** in `Cargo.toml`:
+1. **Bump the workspace version**:
    ```bash
-   # Edit version in Cargo.toml
-   vim Cargo.toml  # Update version = "1.2.3"
+   just set-version 1.2.3
+   ```
+   This updates `[workspace.package].version` in `Cargo.toml` (inherited by `brahe` and `brahe-py`) and refreshes `Cargo.lock`.
+
+2. **Regenerate the CHANGELOG entry** for this release:
+   ```bash
+   just generate-changelog
+   ```
+   By default, the version is read from `Cargo.toml` and the previous tag from `git describe --tags --abbrev=0`. Override either with `just generate-changelog 1.2.3 v1.2.2`. The script aggregates `### Section` blocks from PR bodies merged since the previous tag — `gh` must be authenticated (`gh auth status`).
+
+   Review the diff to `CHANGELOG.md` and edit if needed; it is the canonical source of release notes.
+
+3. **Run quality checks**:
+   ```bash
+   just check
    ```
 
-2. **Run quality checks**:
+4. **Commit and tag**:
    ```bash
-   ruff check && cargo fmt -- --check && cargo test && uv pip install -e ".[all]" && uv run pytest && just test-examples && just make-plots && uv run properdocs build --strict
-   ```
-
-3. **Push version tag**:
-   ```bash
-   git add Cargo.toml
+   git add Cargo.toml Cargo.lock CHANGELOG.md
    git commit -m "Prepare release v1.2.3"
    git push origin main
    git tag v1.2.3
@@ -437,24 +445,14 @@ Before creating a release:
 
 Once the tag is pushed, GitHub Actions automatically:
 
-1. Validates version matches between tag and `Cargo.toml`
-2. Runs all tests (Rust, Python, examples)
-3. Generates `release_notes.md` and updates `CHANGELOG.md` from PRs merged since the previous tag (via `scripts/generate_release_notes.py`), then pushes the CHANGELOG update directly to `main`
-4. Builds documentation and deploys to GitHub Pages
-5. Builds Python wheels and source distribution
-6. Publishes to PyPI and crates.io
-7. Creates **draft** GitHub Release with artifacts and release notes
-8. Updates "latest" tag and release
-
-### Completing the Release
-
-After automation completes:
-
-1. **Review draft release** at `https://github.com/duncaneddy/brahe/releases`
-2. **Edit release notes** (optional):
-   - Add highlights or breaking changes
-   - Include migration notes if needed
-3. **Publish release** by clicking "Publish release"
+1. Validates the tag version matches `Cargo.toml` **and** that `CHANGELOG.md` contains a `## [1.2.3]` entry (fails fast if `just generate-changelog` was skipped).
+2. Runs all tests (Rust, Python, examples).
+3. Extracts `release_notes.md` from the committed `CHANGELOG.md` (via `scripts/extract_release_notes.py`) for use as the GitHub Release body — no commits or pushes from CI.
+4. Builds documentation and deploys to GitHub Pages.
+5. Builds Python wheels and source distribution.
+6. Publishes to PyPI and crates.io.
+7. Publishes the GitHub Release (non-draft) with artifacts and release notes.
+8. Updates the "latest" tag and release.
 
 ### Verification
 

--- a/justfile
+++ b/justfile
@@ -251,6 +251,62 @@ list-plots *args: _setup
 stats: _setup
     @PYTHONPATH={{scripts_dir}} {{python}} {{scripts_dir}}/stats.py
 
+# ───── Release ─────
+
+# Set the workspace version in Cargo.toml (single source of truth for all crates)
+set-version version:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if ! [[ "{{version}}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        echo "error: version must be MAJOR.MINOR.PATCH (got '{{version}}')" >&2
+        exit 1
+    fi
+    # Update the [workspace.package] version. The brahe and brahe-py crates
+    # inherit it via `version.workspace = true`.
+    python3 -c "
+    import re, pathlib
+    p = pathlib.Path('Cargo.toml')
+    text = p.read_text()
+    new = re.sub(
+        r'(\[workspace\.package\][^\[]*?\nversion = )\"[^\"]+\"',
+        r'\\g<1>\"{{version}}\"',
+        text,
+        count=1,
+        flags=re.DOTALL,
+    )
+    if new == text:
+        raise SystemExit('error: could not find [workspace.package] version in Cargo.toml')
+    p.write_text(new)
+    "
+    # Refresh Cargo.lock so the workspace version bump is reflected there too.
+    cargo update --workspace --quiet
+    echo "✓ Set workspace version to {{version}}"
+
+# Regenerate the CHANGELOG.md entry for an upcoming release.
+# Defaults: version from Cargo.toml, prev-tag from `git describe --tags`.
+generate-changelog version="" prev_tag="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    VERSION="{{version}}"
+    PREV_TAG="{{prev_tag}}"
+    if [ -z "$VERSION" ]; then
+        VERSION=$(grep -E '^version = ' Cargo.toml | head -1 | sed -E 's/version = "(.*)"/\1/')
+        echo "Using version from Cargo.toml: $VERSION"
+    fi
+    if [ -z "$PREV_TAG" ]; then
+        PREV_TAG=$(git describe --tags --abbrev=0)
+        echo "Using previous tag from git: $PREV_TAG"
+    fi
+    if ! command -v gh > /dev/null 2>&1; then
+        echo "error: gh CLI is required (https://cli.github.com/)" >&2
+        exit 1
+    fi
+    python3 scripts/generate_release_notes.py \
+        --version "$VERSION" \
+        --prev-tag "$PREV_TAG" \
+        --changelog CHANGELOG.md
+    echo "✓ CHANGELOG.md updated for v$VERSION. Review the diff, then commit and tag."
+
 # ───── Full Quality Check ─────
 
 # Run full quality check (test + lint + format + stubs + docs)

--- a/scripts/extract_release_notes.py
+++ b/scripts/extract_release_notes.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Extract a single version's release-notes block from CHANGELOG.md.
+
+Used by CI at release time to produce `release_notes.md` for the GitHub Release
+body, sourced from the CHANGELOG that the maintainer already committed and
+tagged. This keeps the published release notes consistent with the file users
+read in the repo, and avoids re-querying the GitHub API in CI.
+
+Typical usage in CI:
+
+    python3 scripts/extract_release_notes.py \
+        --version 1.5.2 \
+        --changelog CHANGELOG.md \
+        --output release_notes.md
+
+The extracted block excludes the `## [version] - date` heading itself, so it
+renders as the body of a GitHub Release whose title is "Release v1.5.2".
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+def extract_version_block(changelog_text: str, version: str) -> str:
+    """Return the body of the `## [<version>] - <date>` block from <changelog_text>.
+
+    The returned text excludes the version heading itself and any leading or
+    trailing whitespace, so it can be used directly as a GitHub Release body.
+
+    Raises ValueError if no `## [<version>] - YYYY-MM-DD` heading is present, or
+    if the matched block has an empty body. CI uses these failures to catch
+    "forgot to run `just generate-changelog`" or a malformed entry.
+    """
+    pattern = rf"^## \[{re.escape(version)}\] - \d{{4}}-\d{{2}}-\d{{2}}\s*$"
+    lines = changelog_text.splitlines()
+    start = next((i for i, l in enumerate(lines) if re.match(pattern, l)), None)
+    if start is None:
+        raise ValueError(f"no '## [{version}] - <date>' heading in changelog")
+    end = next((i for i in range(start + 1, len(lines))
+                if lines[i].startswith("## [")), len(lines))
+    body = "\n".join(lines[start + 1:end]).strip("\n")
+    if not body.strip():
+        raise ValueError(f"version {version} has empty body")
+    return body
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--version", required=True,
+                        help="Release version to extract, e.g. 1.5.2")
+    parser.add_argument("--changelog", default="CHANGELOG.md",
+                        help="Path to the CHANGELOG.md file (default: %(default)s)")
+    parser.add_argument("--output", default=None,
+                        help="Write the extracted block to this path. "
+                             "If omitted, prints to stdout.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    changelog = Path(args.changelog)
+    if not changelog.exists():
+        print(f"error: CHANGELOG not found at {changelog}", file=sys.stderr)
+        return 1
+
+    try:
+        block = extract_version_block(changelog.read_text(), args.version)
+    except ValueError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+
+    if args.output:
+        Path(args.output).write_text(block + "\n")
+        print(f"Wrote {args.output} ({len(block.splitlines())} lines)")
+    else:
+        print(block)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/generate_release_notes.py
+++ b/scripts/generate_release_notes.py
@@ -178,7 +178,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--prev-tag", required=True, help="Previous release tag, e.g. v1.4.2")
     parser.add_argument("--repo", default="duncaneddy/brahe")
     parser.add_argument("--changelog", default="CHANGELOG.md")
-    parser.add_argument("--release-notes", default="release_notes.md")
+    parser.add_argument("--release-notes", default=None,
+                        help="Optional path to also write the release section to "
+                             "(e.g. release_notes.md). Omit to only update the CHANGELOG.")
     parser.add_argument("--date", default=date.today().isoformat(),
                         help="Release date in ISO format (default: today, UTC)")
     parser.add_argument("--dry-run", action="store_true",
@@ -200,9 +202,10 @@ def main() -> int:
         print(section, end="")
         return 0
 
-    Path(args.release_notes).write_text(section)
+    if args.release_notes:
+        Path(args.release_notes).write_text(section)
+        print(f"Wrote {args.release_notes} ({len(section.splitlines())} lines)")
     inserted = update_changelog(Path(args.changelog), section)
-    print(f"Wrote {args.release_notes} ({len(section.splitlines())} lines)")
     if inserted:
         print(f"Inserted v{args.version} block into {args.changelog}")
     else:


### PR DESCRIPTION
# Pull Request

## Description

This PR contains a minor fix to the release process to avoid an error in building the rust-crate due to the uncommitted CHANGELOG.

## Changelog

### Fixed
- Fix issue with new release workflow `CHANGELOG` generation that would result in an error causing the release to fail. Release notes now must be manually generated and committed _prior_ to running the release action.