### PR TITLE
Align EulerAngleOrder naming to wider aerospace industry conventions

### DIFF
--- a/.github/workflows/validate_pr_changelog.yml
+++ b/.github/workflows/validate_pr_changelog.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, edited, reopened]
 
 permissions:
-  pull-requests: read
+  pull-requests: write
   issues: write
 
 jobs:
@@ -28,17 +28,19 @@ jobs:
             const foundEntries = [];
 
             for (const section of sections) {
-              // Match section header followed by list items (not HTML comments).
+              // Capture the section body: everything from the `### Section` header
+              // up to (but not including) the next heading or the end of the body.
               // `[^\\n]*` tolerates header suffixes like "Deprecated / Future Warning".
-              const pattern = new RegExp(`###\\s+${section}[^\\n]*\\n((?:- (?!<!--).*\\n?)*)`, 'i');
+              // This is intentionally forgiving — blank lines between the header and
+              // the first bullet, or prose preceding the list, do not break validation.
+              const pattern = new RegExp(`###\\s+${section}[^\\n]*\\n([\\s\\S]*?)(?=\\n#{1,6}\\s|$)`, 'i');
               const match = prBody.match(pattern);
 
               if (match) {
-                const content = match[1].trim();
-                // Filter out empty lines and HTML comments
-                const lines = content.split('\n').filter(line => {
+                // Count bullets that aren't HTML-comment placeholders from the template.
+                const lines = match[1].split('\n').filter(line => {
                   const trimmed = line.trim();
-                  return trimmed && !trimmed.startsWith('<!--');
+                  return trimmed.startsWith('- ') && !trimmed.startsWith('- <!--');
                 });
 
                 if (lines.length > 0) {

--- a/docs/learn/attitude_representations/euler_angles.md
+++ b/docs/learn/attitude_representations/euler_angles.md
@@ -6,6 +6,14 @@ Euler angles represent rotations as three sequential rotations about coordinate 
 
 Euler angles describe orientation using three angles representing sequential rotations about specified axes. Brahe supports all 12 possible Euler angle sequences (e.g., XYZ, ZYX, ZYZ).
 
+!!! info "Euler Angle Application Order Conventions"
+
+    Brahe follows standard aerospace engineering conventions for the naming of Euler angle sequences with the application of rotation matrices being applied from _left_ to _right_.
+
+    A 3-2-1 (Z-Y-X) Euler angle sequence is equivalent to the multication by $R$ where $R = R_x(\psi)R_y(\theta)R_z(\phi)$. Note the "3" (Z) is the first rotation applied when a vector $\vec{x}$ is rotated: $R\vec{x}$. Then the "2" (Y) is applied, and finally the "1" (X) is applied.
+
+    This is slightly at odds with the as-written Diebel convention, but is consistent with the aerospace engineering convention. Brahe internally transforms between the aerospace convention to the Diebel convention.
+
 ## Mathematical Representation
 
 An Euler angle rotation is specified by:

--- a/src/attitude/attitude_types.rs
+++ b/src/attitude/attitude_types.rs
@@ -91,6 +91,29 @@ pub enum EulerAngleOrder {
     ZYZ = 323,
 }
 
+impl EulerAngleOrder {
+    /// Returns this order with its axis letters reversed:
+    /// `XYZ ↔ ZYX`, `XZY ↔ YZX`, `YXZ ↔ ZXY`. Symmetric (palindromic) orders
+    /// like `XYX`, `ZYZ`, etc. are fixed points.
+    ///
+    /// Used internally to translate between the convention in which the
+    /// per-order quaternion and rotation-matrix formulas were originally written
+    /// (Diebel 2006, where the label indexes matrix-product position) and the
+    /// convention brahe exposes to users (aerospace standard, where the label
+    /// indexes the rotation *sequence* — first letter applied first).
+    pub(crate) fn reversed(self) -> Self {
+        match self {
+            EulerAngleOrder::XYZ => EulerAngleOrder::ZYX,
+            EulerAngleOrder::ZYX => EulerAngleOrder::XYZ,
+            EulerAngleOrder::XZY => EulerAngleOrder::YZX,
+            EulerAngleOrder::YZX => EulerAngleOrder::XZY,
+            EulerAngleOrder::YXZ => EulerAngleOrder::ZXY,
+            EulerAngleOrder::ZXY => EulerAngleOrder::YXZ,
+            sym => sym,
+        }
+    }
+}
+
 impl fmt::Display for EulerAngleOrder {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {

--- a/src/attitude/euler_angle.rs
+++ b/src/attitude/euler_angle.rs
@@ -429,12 +429,14 @@ mod tests {
         assert_abs_diff_eq!(q[2], 0.0, epsilon = 1e-12);
         assert_abs_diff_eq!(q[3], 0.0, epsilon = 1e-12);
 
+        // Aerospace XYZ(30°, 45°, 60°) = rotate 30° about X first, 45° about new Y',
+        // then 60° about newest Z''. Equivalent quaternion: q_x(30°) ⊗ q_y(45°) ⊗ q_z(60°).
         let e = EulerAngle::new(EulerAngleOrder::XYZ, 30.0, 45.0, 60.0, DEGREES);
         let q = e.to_quaternion();
-        assert_abs_diff_eq!(q[0], 0.8223631719059994, epsilon = 1e-12);
-        assert_abs_diff_eq!(q[1], 0.022260026714733844, epsilon = 1e-12);
-        assert_abs_diff_eq!(q[2], 0.43967973954090955, epsilon = 1e-12);
-        assert_abs_diff_eq!(q[3], 0.3604234056503559, epsilon = 1e-12);
+        assert_abs_diff_eq!(q[0], 0.7233174113647118, epsilon = 1e-12);
+        assert_abs_diff_eq!(q[1], 0.39190383732911993, epsilon = 1e-12);
+        assert_abs_diff_eq!(q[2], 0.20056212114657512, epsilon = 1e-12);
+        assert_abs_diff_eq!(q[3], 0.5319756951821668, epsilon = 1e-12);
     }
 
     #[test]

--- a/src/attitude/quaternion.rs
+++ b/src/attitude/quaternion.rs
@@ -393,15 +393,32 @@ impl FromAttitude for Quaternion {
     }
 
     fn from_euler_angle(e: EulerAngle) -> Self {
-        // Precompute common trigonometric values
-        let cos_phi2 = (e.phi / 2.0).cos();
-        let cos_theta2 = (e.theta / 2.0).cos();
-        let cos_psi2 = (e.psi / 2.0).cos();
-        let sin_phi2 = (e.phi / 2.0).sin();
-        let sin_theta2 = (e.theta / 2.0).sin();
-        let sin_psi2 = (e.psi / 2.0).sin();
+        // Aerospace-convention shim. The per-order quaternion formulas below are
+        // transcribed from Diebel 2006 (eq. 458-469), where `EulerAngleOrder::ABC`
+        // labels the matrix-product *position* of each elementary rotation
+        // (R_A · R_B · R_C) and the angles (phi, theta, psi) bind to that product
+        // by position — phi to the leftmost matrix.
+        //
+        // brahe exposes the aerospace standard, where `EulerAngleOrder::ABC`
+        // labels the rotation *sequence*: phi is applied about A first, theta
+        // about B' second, psi about C'' third. The two conventions are related by
+        //     aerospace_ABC(phi, theta, psi)  ==  Diebel q_CBA(psi, theta, phi)
+        // so we re-express the input here (reverse the order label, swap
+        // phi <-> psi) and feed the existing Diebel formulas unchanged.
+        let order = e.order.reversed();
+        let phi = e.psi;
+        let theta = e.theta;
+        let psi = e.phi;
 
-        let data = match e.order {
+        // Precompute common trigonometric values
+        let cos_phi2 = (phi / 2.0).cos();
+        let cos_theta2 = (theta / 2.0).cos();
+        let cos_psi2 = (psi / 2.0).cos();
+        let sin_phi2 = (phi / 2.0).sin();
+        let sin_theta2 = (theta / 2.0).sin();
+        let sin_psi2 = (psi / 2.0).sin();
+
+        let data = match order {
             EulerAngleOrder::XYX => Vector4::new(
                 cos_phi2 * cos_theta2 * cos_psi2 - sin_phi2 * cos_theta2 * sin_psi2,
                 cos_phi2 * cos_theta2 * sin_psi2 + cos_theta2 * cos_psi2 * sin_phi2,

--- a/src/attitude/rotation_matrix.rs
+++ b/src/attitude/rotation_matrix.rs
@@ -516,7 +516,20 @@ impl ToAttitude for RotationMatrix {
     /// let e = r.to_euler_angle(EulerAngleOrder::XYZ);
     /// ```
     fn to_euler_angle(&self, order: EulerAngleOrder) -> EulerAngle {
-        // The Euler angles from the rotation matrix per the order specific and the equations in Diebel section 8.
+        // Aerospace-convention shim. The per-order extraction formulas below come
+        // from Diebel 2006 (section 8), where `EulerAngleOrder::ABC` labels the
+        // matrix-product *position* of each elementary rotation in the passive
+        // DCM (R_A · R_B · R_C) and the extracted (phi, theta, psi) bind to that
+        // product by position.
+        //
+        // brahe exposes the aerospace standard, where `EulerAngleOrder::ABC`
+        // labels the rotation *sequence* — first letter applied first. The two
+        // are related by
+        //     aerospace_ABC(phi, theta, psi)  ==  Diebel q_CBA(psi, theta, phi)
+        // so we dispatch on the letter-reversed order to pick the right Diebel
+        // extraction, then swap phi <-> psi and stamp the user's original order
+        // on the result.
+        let diebel_order = order.reversed();
 
         // Extract matrix components for easier-to-read correspondence to Diebel's equations
         let r11 = self.data[(0, 0)];
@@ -529,56 +542,24 @@ impl ToAttitude for RotationMatrix {
         let r32 = self.data[(2, 1)];
         let r33 = self.data[(2, 2)];
 
-        match order {
-            EulerAngleOrder::XYX => {
-                EulerAngle::new(order, r21.atan2(r31), r11.acos(), r12.atan2(-r13), RADIANS)
-            }
-            EulerAngleOrder::XYZ => {
-                EulerAngle::new(order, r23.atan2(r33), -r13.asin(), r12.atan2(r11), RADIANS)
-            }
-            EulerAngleOrder::XZX => {
-                EulerAngle::new(order, r31.atan2(-r21), r11.acos(), r13.atan2(r12), RADIANS)
-            }
-            EulerAngleOrder::XZY => EulerAngle::new(
-                order,
-                (-r32).atan2(r22),
-                r12.asin(),
-                (-r13).atan2(r11),
-                RADIANS,
-            ),
-            EulerAngleOrder::YXY => {
-                EulerAngle::new(order, r12.atan2(-r32), r22.acos(), r21.atan2(r23), RADIANS)
-            }
-            EulerAngleOrder::YXZ => EulerAngle::new(
-                order,
-                (-r13).atan2(r33),
-                r23.asin(),
-                (-r21).atan2(r22),
-                RADIANS,
-            ),
-            EulerAngleOrder::YZX => {
-                EulerAngle::new(order, r31.atan2(r11), -r21.asin(), r23.atan2(r22), RADIANS)
-            }
-            EulerAngleOrder::YZY => {
-                EulerAngle::new(order, r32.atan2(r12), r22.acos(), r23.atan2(-r21), RADIANS)
-            }
-            EulerAngleOrder::ZXY => {
-                EulerAngle::new(order, r12.atan2(r22), -r32.asin(), r31.atan2(r33), RADIANS)
-            }
-            EulerAngleOrder::ZXZ => {
-                EulerAngle::new(order, r13.atan2(r23), r33.acos(), r31.atan2(-r32), RADIANS)
-            }
-            EulerAngleOrder::ZYX => EulerAngle::new(
-                order,
-                (-r21).atan2(r11),
-                r31.asin(),
-                (-r32).atan2(r33),
-                RADIANS,
-            ),
-            EulerAngleOrder::ZYZ => {
-                EulerAngle::new(order, r23.atan2(-r13), r33.acos(), r32.atan2(r31), RADIANS)
-            }
-        }
+        let (phi_d, theta_d, psi_d) = match diebel_order {
+            EulerAngleOrder::XYX => (r21.atan2(r31), r11.acos(), r12.atan2(-r13)),
+            EulerAngleOrder::XYZ => (r23.atan2(r33), -r13.asin(), r12.atan2(r11)),
+            EulerAngleOrder::XZX => (r31.atan2(-r21), r11.acos(), r13.atan2(r12)),
+            EulerAngleOrder::XZY => ((-r32).atan2(r22), r12.asin(), (-r13).atan2(r11)),
+            EulerAngleOrder::YXY => (r12.atan2(-r32), r22.acos(), r21.atan2(r23)),
+            EulerAngleOrder::YXZ => ((-r13).atan2(r33), r23.asin(), (-r21).atan2(r22)),
+            EulerAngleOrder::YZX => (r31.atan2(r11), -r21.asin(), r23.atan2(r22)),
+            EulerAngleOrder::YZY => (r32.atan2(r12), r22.acos(), r23.atan2(-r21)),
+            EulerAngleOrder::ZXY => (r12.atan2(r22), -r32.asin(), r31.atan2(r33)),
+            EulerAngleOrder::ZXZ => (r13.atan2(r23), r33.acos(), r31.atan2(-r32)),
+            EulerAngleOrder::ZYX => ((-r21).atan2(r11), r31.asin(), (-r32).atan2(r33)),
+            EulerAngleOrder::ZYZ => (r23.atan2(-r13), r33.acos(), r32.atan2(r31)),
+        };
+
+        // Aerospace: swap phi <-> psi from the Diebel matrix-position labeling,
+        // and stamp the user's original order on the result.
+        EulerAngle::new(order, psi_d, theta_d, phi_d, RADIANS)
     }
 
     /// Convert the `RotationMatrix` to a `RotationMatrix`. This is equivalent to cloning the

--- a/tests/attitude/test_euler_angle.py
+++ b/tests/attitude/test_euler_angle.py
@@ -123,12 +123,14 @@ def test_euler_angle_to_quaternion():
     assert q[2] == approx(0.0, abs=1e-12)
     assert q[3] == approx(0.0, abs=1e-12)
 
+    # Aerospace XYZ(30°, 45°, 60°) = rotate 30° about X first, 45° about new Y',
+    # then 60° about newest Z''. Equivalent quaternion: q_x(30°) ⊗ q_y(45°) ⊗ q_z(60°).
     e = EulerAngle(EulerAngleOrder.XYZ, 30.0, 45.0, 60.0, AngleFormat.DEGREES)
     q = e.to_quaternion()
-    assert q[0] == approx(0.8223631719059994, abs=1e-12)
-    assert q[1] == approx(0.022260026714733844, abs=1e-12)
-    assert q[2] == approx(0.43967973954090955, abs=1e-12)
-    assert q[3] == approx(0.3604234056503559, abs=1e-12)
+    assert q[0] == approx(0.7233174113647118, abs=1e-12)
+    assert q[1] == approx(0.39190383732911993, abs=1e-12)
+    assert q[2] == approx(0.20056212114657512, abs=1e-12)
+    assert q[3] == approx(0.5319756951821668, abs=1e-12)
 
 
 def test_euler_angle_to_euler_axis():


### PR DESCRIPTION
# Pull Request

## Description

Realigns EulerAngleOrder semantics with the aerospace-standard intrinsic rotation sequence convention used by OreKit, GMAT, Basilisk, Wertz, Schaub & Junkins, and others. Prior to this change, brahe's per-order Euler ↔ quaternion rotation-matrix conversions implemented the matrix-product-position labeling from Diebel 2006 (eq. 458–469): the literal formula match brahe was transcribing from is faithful to Diebel, but Diebel uses the label as an index into a passive DCM written `R_A · R_B · R_C` rather than as a rotation sequence — so `EulerAngleOrder::ZYX(phi, theta, psi)` in brahe corresponded to `R_z_p(phi) · R_y_p(theta) · R_x_p(psi)` rather than the aerospace yaw-pitch-roll the docs claimed ("rotate phi about z first, theta about y', psi about x''"). For the same `(phi, theta, psi)` triplet these are genuinely different rotations.

The fix maps aerospace input to the existing Diebel-correct formulas at the two conversion boundaries (Quaternion::from_euler_angle and RotationMatrix::to_euler_angle) via the identity aerospace_ABC(phi, theta, psi) ≡ Diebel q_CBA(psi, theta, phi). The shim adds EulerAngleOrder::reversed() (a letter-reversal helper; symmetric orders are fixed points), reverses the order label, and swaps phi ↔ psi before the existing 12-arm match dispatches.

This is a behavioral breaking change for any caller previously relying on Diebel semantics - the same code path, same input, will now describe a different rotation.

## Changelog

### Fixed
- `EulerAngleOrder` semantics now match what brahe's documentation always described and what the comparative benchmark expects. Prior to this fix, `attitude.euler_angle_to_quaternion` disagreed with OreKit, GMAT, and Basilisk. The discrepancy was traced through to a convention mismatch between the per-order formulas (faithfully transcribed from Diebel 2006) and the aerospace rotation-sequence interpretation users (and the docs) assumed.
- Fixed issue with CHANGELOG parsing in PRs where a blank line after a section header would fail to validate.