### PR TITLE
Add ICGEM Model download capabilities

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ is_close = "0.1.3"
 ureq = { version = "3.2.0", features = ["cookies", "multipart"] }
 strum = "0.28.0"
 strum_macros = "0.28.0"
+scraper = "0.20"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 quick-xml = { version = "0.40", features = ["serialize"] }

--- a/brahe/cli/datasets/__init__.py
+++ b/brahe/cli/datasets/__init__.py
@@ -3,7 +3,8 @@ CLI commands for datasets module
 """
 
 import typer
-from brahe.cli.datasets import groundstations
+from brahe.cli.datasets import groundstations, icgem
 
 app = typer.Typer()
 app.add_typer(groundstations.app, name="groundstations")
+app.add_typer(icgem.app, name="icgem")

--- a/brahe/cli/datasets/icgem.py
+++ b/brahe/cli/datasets/icgem.py
@@ -1,0 +1,109 @@
+"""CLI commands for ICGEM gravity model datasets."""
+
+from typing import Optional
+
+import typer
+from loguru import logger
+from rich.console import Console
+from rich.table import Table
+from typing_extensions import Annotated
+
+import brahe.datasets as datasets
+
+
+app = typer.Typer()
+
+
+_KNOWN_BODIES = ["earth", "moon", "mars", "venus", "ceres"]
+
+
+@app.command("list")
+def list_models(
+    body: Annotated[
+        str, typer.Option("--body", "-b", help="Body name or 'all'.")
+    ] = "earth",
+    table_view: Annotated[
+        bool, typer.Option("--table", "-t", help="Display as a Rich table.")
+    ] = False,
+):
+    """List ICGEM gravity models for a body (or all bodies)."""
+    multi_body = body.lower() == "all"
+    bodies = _KNOWN_BODIES if multi_body else [body]
+
+    rows = []
+    for b in bodies:
+        try:
+            entries = datasets.icgem.list_models(b)
+        except Exception as e:
+            # In --body all mode, an individual body's failure shouldn't doom
+            # the whole listing — log and continue. In single-body mode, the
+            # user asked about THAT body specifically, so propagate the error
+            # rather than silently returning an empty list.
+            if multi_body:
+                logger.warning(f"Skipping {b}: {e}")
+                continue
+            typer.echo(f"Error: {e}", err=True)
+            raise typer.Exit(code=1) from e
+        for e in entries:
+            rows.append((e.body, e.name, e.degree, e.year))
+
+    if not table_view:
+        for body_, name, degree, year in rows:
+            typer.echo(f"{body_:8s} {name:40s} degree={degree:<6d} year={year}")
+        typer.echo(f"\n{len(rows)} model(s)")
+        return
+
+    console = Console()
+    rich_table = Table(show_header=True, header_style="bold cyan")
+    rich_table.add_column("Body", style="cyan")
+    rich_table.add_column("Model", style="green")
+    rich_table.add_column("Degree", justify="right", style="yellow")
+    rich_table.add_column("Year", justify="right")
+    for body_, name, degree, year in rows:
+        rich_table.add_row(body_, name, str(degree), str(year if year else ""))
+    console.print(rich_table)
+
+
+@app.command("download")
+def download(
+    name: Annotated[str, typer.Argument(help="Model name (optionally NAME-DEGREE).")],
+    body: Annotated[
+        str, typer.Option("--body", "-b", help="Body name.")
+    ] = "earth",
+    output: Annotated[
+        Optional[str],
+        typer.Option("--output", "-o", help="Copy the file to this path."),
+    ] = None,
+):
+    """Download an ICGEM gravity model into the local cache."""
+    if body.lower() == "all":
+        raise typer.BadParameter("`--body all` is not valid for `download`")
+    try:
+        path = datasets.icgem.download_model(body, name, output)
+    except Exception as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(code=1)
+    typer.echo(path)
+
+
+@app.command("refresh")
+def refresh(
+    body: Annotated[
+        Optional[str], typer.Option("--body", "-b", help="Body to refresh.")
+    ] = None,
+    all_bodies: Annotated[
+        bool, typer.Option("--all", help="Refresh both Earth and celestial indexes.")
+    ] = False,
+):
+    """Force-refresh the ICGEM index files."""
+    if body and all_bodies:
+        raise typer.BadParameter("Pass either `--body` or `--all`, not both.")
+    if not body and not all_bodies:
+        raise typer.BadParameter("Pass either `--body` or `--all`.")
+
+    if all_bodies:
+        datasets.icgem.refresh_all_indexes()
+        typer.echo("Refreshed all ICGEM indexes.")
+    else:
+        datasets.icgem.refresh_index(body)
+        typer.echo(f"Refreshed ICGEM index for body '{body}'.")

--- a/brahe/cli/datasets/icgem.py
+++ b/brahe/cli/datasets/icgem.py
@@ -101,7 +101,7 @@ def refresh(
     if not body and not all_bodies:
         raise typer.BadParameter("Pass either `--body` or `--all`.")
 
-    if all_bodies:
+    if all_bodies or (body and body.lower() == "all"):
         datasets.icgem.refresh_all_indexes()
         typer.echo("Refreshed all ICGEM indexes.")
     else:

--- a/brahe/datasets.py
+++ b/brahe/datasets.py
@@ -2,12 +2,14 @@
 Datasets Module
 
 Provides access to groundstation location data, NAIF ephemeris kernels,
-and GCAT (General Catalog of Artificial Space Objects) satellite catalogs.
+GCAT (General Catalog of Artificial Space Objects) satellite catalogs,
+and ICGEM spherical harmonic gravity models.
 
 This module provides a source-specific API organized by data provider:
 - groundstations: Curated groundstation location datasets
 - naif: NASA JPL NAIF ephemeris kernels (DE series)
 - gcat: Jonathan McDowell's GCAT satellite catalogs (SATCAT, PSATCAT)
+- icgem: ICGEM spherical harmonic gravity model catalog (Earth + celestial bodies)
 
 For CelestrakClient satellite catalog data, use the `brahe.celestrak` module instead.
 
@@ -25,6 +27,10 @@ Example:
     # GCAT satellite catalogs
     satcat = datasets.gcat.get_satcat()
     iss = satcat.get_by_satcat("25544")
+
+    # ICGEM gravity models
+    earth_models = datasets.icgem.list_models("earth")
+    path = datasets.icgem.download_model("earth", "JGM3")
     ```
 """
 
@@ -43,6 +49,12 @@ from brahe._brahe import (
     GCATPsatcatRecord,
     GCATSatcat,
     GCATPsatcat,
+    # ICGEM functions and types
+    icgem_list_models,
+    icgem_refresh_index,
+    icgem_refresh_all_indexes,
+    icgem_download_model,
+    ICGEMIndexEntry,
 )
 
 
@@ -86,8 +98,24 @@ class _GcatNamespace:
 # Create GCAT namespace instance
 gcat = _GcatNamespace()
 
+
+# Create an ICGEM namespace object
+class _ICGEMNamespace:
+    """ICGEM gravity model dataset namespace."""
+
+    list_models = staticmethod(icgem_list_models)
+    refresh_index = staticmethod(icgem_refresh_index)
+    refresh_all_indexes = staticmethod(icgem_refresh_all_indexes)
+    download_model = staticmethod(icgem_download_model)
+    IndexEntry = ICGEMIndexEntry
+
+
+# Create ICGEM namespace instance
+icgem = _ICGEMNamespace()
+
 __all__ = [
     "groundstations",
     "naif",
     "gcat",
+    "icgem",
 ]

--- a/crates/brahe-py/src/icgem.rs
+++ b/crates/brahe-py/src/icgem.rs
@@ -1,0 +1,114 @@
+// Python bindings for the ICGEM datasets module.
+
+use brahe::datasets::icgem::{
+    self, ICGEMBody as RustICGEMBody, IndexEntry as RustIndexEntry,
+};
+
+fn body_from_str(s: &str) -> RustICGEMBody {
+    RustICGEMBody::from_name(s)
+}
+
+/// One ICGEM model index row.
+#[pyclass(name = "ICGEMIndexEntry")]
+#[derive(Clone)]
+pub struct PyIndexEntry {
+    inner: RustIndexEntry,
+}
+
+#[pymethods]
+impl PyIndexEntry {
+    /// Body string (e.g. "Earth", "Moon", "pluto").
+    #[getter]
+    fn body(&self) -> String { self.inner.body.as_name().to_string() }
+
+    /// Model name.
+    #[getter]
+    fn name(&self) -> String { self.inner.name.clone() }
+
+    /// Publication year, if known.
+    #[getter]
+    fn year(&self) -> Option<u16> { self.inner.year }
+
+    /// Maximum spherical harmonic degree.
+    #[getter]
+    fn degree(&self) -> u32 { self.inner.degree }
+
+    /// ICGEM relative download path (includes the opaque hash).
+    #[getter]
+    fn download_path(&self) -> String { self.inner.download_path.clone() }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "ICGEMIndexEntry(body='{}', name='{}', degree={}, year={:?})",
+            self.inner.body.as_name(),
+            self.inner.name,
+            self.inner.degree,
+            self.inner.year
+        )
+    }
+}
+
+/// List ICGEM models for a body.
+///
+/// Args:
+///     body (str): Body name. Known: "earth", "moon", "mars", "venus", "ceres".
+///         Any other name is treated as a custom celestial body and matched
+///         against the ICGEM celestial catalog.
+///
+/// Returns:
+///     list[ICGEMIndexEntry]
+#[pyfunction]
+#[pyo3(name = "icgem_list_models")]
+fn py_icgem_list_models(body: &str) -> PyResult<Vec<PyIndexEntry>> {
+    let body = body_from_str(body);
+    let entries = icgem::list_icgem_models(body)
+        .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+    Ok(entries.into_iter().map(|e| PyIndexEntry { inner: e }).collect())
+}
+
+/// Force-refresh the ICGEM index file for a single body.
+#[pyfunction]
+#[pyo3(name = "icgem_refresh_index")]
+fn py_icgem_refresh_index(body: &str) -> PyResult<()> {
+    icgem::refresh_icgem_index(body_from_str(body))
+        .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))
+}
+
+/// Force-refresh both Earth and celestial index files.
+#[pyfunction]
+#[pyo3(name = "icgem_refresh_all_indexes")]
+fn py_icgem_refresh_all_indexes() -> PyResult<()> {
+    icgem::refresh_all_icgem_indexes()
+        .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))
+}
+
+/// Download a `.gfc` file from ICGEM (with caching).
+///
+/// Args:
+///     body (str): Body name.
+///     name (str): Model name, optionally suffixed with -DEGREE.
+///     output_path (str, optional): Optional copy destination.
+///
+/// Returns:
+///     str: Path to the resulting `.gfc` file.
+#[pyfunction]
+#[pyo3(name = "icgem_download_model", signature = (body, name, output_path=None))]
+fn py_icgem_download_model(
+    body: &str,
+    name: &str,
+    output_path: Option<&str>,
+) -> PyResult<String> {
+    let body = body_from_str(body);
+    let out = output_path.map(std::path::PathBuf::from);
+    let path = icgem::download_icgem_model(body, name, out)
+        .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+    path.to_str()
+        .ok_or_else(|| {
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
+                "Path contains invalid UTF-8 characters",
+            )
+        })
+        .map(|s| s.to_string())
+}
+
+// Functions are registered in lib.rs via add_function() calls.

--- a/crates/brahe-py/src/icgem.rs
+++ b/crates/brahe-py/src/icgem.rs
@@ -9,7 +9,7 @@ fn body_from_str(s: &str) -> RustICGEMBody {
 }
 
 /// One ICGEM model index row.
-#[pyclass(name = "ICGEMIndexEntry")]
+#[pyclass(name = "ICGEMIndexEntry", skip_from_py_object)]
 #[derive(Clone)]
 pub struct PyIndexEntry {
     inner: RustIndexEntry,

--- a/crates/brahe-py/src/lib.rs
+++ b/crates/brahe-py/src/lib.rs
@@ -534,6 +534,7 @@ impl PyAngleFormat {
 
 include!("datasets.rs");
 include!("py_gcat.rs");
+include!("icgem.rs");
 include!("eop.rs");
 include!("space_weather.rs");
 include!("time.rs");
@@ -970,6 +971,13 @@ pub fn _brahe(py: Python<'_>, module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_class::<PyGCATPsatcat>()?;
     module.add_function(wrap_pyfunction!(py_gcat_get_satcat, module)?)?;
     module.add_function(wrap_pyfunction!(py_gcat_get_psatcat, module)?)?;
+
+    //* ICGEM *//
+    module.add_class::<PyIndexEntry>()?;
+    module.add_function(wrap_pyfunction!(py_icgem_list_models, module)?)?;
+    module.add_function(wrap_pyfunction!(py_icgem_refresh_index, module)?)?;
+    module.add_function(wrap_pyfunction!(py_icgem_refresh_all_indexes, module)?)?;
+    module.add_function(wrap_pyfunction!(py_icgem_download_model, module)?)?;
 
     //* Orbit Dynamics - Ephemerides *//
     module.add_class::<PyEphemerisSource>()?;

--- a/crates/brahe-py/src/orbit_dynamics.rs
+++ b/crates/brahe-py/src/orbit_dynamics.rs
@@ -1174,6 +1174,33 @@ impl PyGravityModelType {
         })
     }
 
+    /// Build a GravityModelType referencing an ICGEM model.
+    ///
+    /// Args:
+    ///     body (str): Body name ("earth", "moon", "mars", "venus", "ceres", or other).
+    ///     name (str): Model name, optionally with `-DEGREE` suffix.
+    ///
+    /// Returns:
+    ///     GravityModelType: A new GravityModelType referencing the ICGEM model.
+    ///
+    /// Example:
+    ///     ```python
+    ///     import brahe as bh
+    ///
+    ///     model_type = bh.GravityModelType.icgem("earth", "JGM3")
+    ///     model = bh.GravityModel.from_model_type(model_type)
+    ///     ```
+    #[staticmethod]
+    fn icgem(body: &str, name: &str) -> PyResult<Self> {
+        let body = brahe::datasets::icgem::ICGEMBody::from_name(body);
+        Ok(PyGravityModelType {
+            model: orbit_dynamics::GravityModelType::ICGEMModel {
+                body,
+                name: name.to_string(),
+            },
+        })
+    }
+
     fn __str__(&self) -> String {
         match &self.model {
             orbit_dynamics::GravityModelType::FromFile(path) => format!("FromFile({})", path),
@@ -1189,15 +1216,14 @@ impl PyGravityModelType {
     }
 
     fn __richcmp__(&self, other: &Self, op: CompareOp) -> PyResult<bool> {
+        // `GravityModelType` derives `PartialEq + Eq`, so a direct `==`
+        // correctly compares all variants — including data-carrying ones like
+        // `FromFile(path)` and `ICGEMModel { body, name }`. Discriminant-only
+        // comparison would collapse every ICGEMModel into a single equivalence
+        // class regardless of body or name.
         match op {
-            CompareOp::Eq => Ok(match (&self.model, &other.model) {
-                (orbit_dynamics::GravityModelType::FromFile(a), orbit_dynamics::GravityModelType::FromFile(b)) => a == b,
-                _ => std::mem::discriminant(&self.model) == std::mem::discriminant(&other.model),
-            }),
-            CompareOp::Ne => Ok(match (&self.model, &other.model) {
-                (orbit_dynamics::GravityModelType::FromFile(a), orbit_dynamics::GravityModelType::FromFile(b)) => a != b,
-                _ => std::mem::discriminant(&self.model) != std::mem::discriminant(&other.model),
-            }),
+            CompareOp::Eq => Ok(self.model == other.model),
+            CompareOp::Ne => Ok(self.model != other.model),
             _ => Err(exceptions::PyNotImplementedError::new_err("Comparison not supported")),
         }
     }

--- a/docs/learn/cli/datasets.md
+++ b/docs/learn/cli/datasets.md
@@ -1,12 +1,13 @@
 # Datasets Commands
 
-Download and query satellite ephemeris data and ground station information.
+Download and query satellite ephemeris data, ground station information, and spherical harmonic gravity models.
 
 ## Overview
 
 The `datasets` command group provides access to:
 - **CelesTrak** - Satellite TLE (Two-Line Element) data
 - **Ground Stations** - Commercial ground station network databases
+- **ICGEM** - Spherical harmonic gravity models from the International Centre for Global Earth Models
 
 ## CelesTrak Commands
 
@@ -340,6 +341,132 @@ Output:
 
 ---
 
+## ICGEM Commands
+
+Browse, download, and refresh spherical harmonic gravity models from the [ICGEM catalog](https://icgem.gfz.de). Downloads are cached under `$BRAHE_CACHE/icgem/` and reused on subsequent invocations.
+
+### `icgem list`
+
+List ICGEM gravity models for a given body (or for all known bodies).
+
+**Syntax:**
+```bash
+brahe datasets icgem list [OPTIONS]
+```
+
+**Options:**
+- `--body`, `-b <name>` - Body name: `earth`, `moon`, `mars`, `venus`, `ceres`, `all`, or any custom celestial body in the ICGEM catalog. Default: `earth`.
+- `--table`, `-t` - Display results as a Rich table.
+
+**Examples:**
+
+List Earth models (default body):
+```bash
+brahe datasets icgem list
+```
+Output (truncated):
+```bash
+# Earth    EGM2008                                  degree=2190   year=2008
+# Earth    GGM05S                                   degree=180    year=2014
+# Earth    JGM3                                     degree=70     year=1996
+# ...
+# 200+ model(s)
+```
+
+List lunar models as a table:
+```bash
+brahe datasets icgem list --body moon --table
+```
+
+List models across all known bodies:
+```bash
+brahe datasets icgem list --body all
+```
+
+In `--body all` mode, an individual body's index failure is logged and the listing continues with the remaining bodies; in single-body mode the failure is surfaced as an error.
+
+---
+
+### `icgem download`
+
+Download a single `.gfc` gravity model file into the local cache.
+
+**Syntax:**
+```bash
+brahe datasets icgem download <NAME> [OPTIONS]
+```
+
+**Arguments:**
+- `NAME` - Model name (e.g. `EGM2008`). Append `-<DEGREE>` to pin a specific variant, e.g. `EGM2008-2190`.
+
+**Options:**
+- `--body`, `-b <name>` - Body name. Default: `earth`. `--body all` is not valid for `download`.
+- `--output`, `-o <path>` - In addition to caching, copy the file to this path. The command prints the resulting path on success.
+
+**Examples:**
+
+Cache the largest published variant of EGM2008:
+```bash
+brahe datasets icgem download EGM2008
+```
+Output:
+```bash
+# /Users/.../.cache/brahe/icgem/models/earth/EGM2008-2190-<hash>.gfc
+```
+
+Pin a specific degree:
+```bash
+brahe datasets icgem download EGM2008-360
+```
+
+Download a lunar model and also drop a copy beside your analysis:
+```bash
+brahe datasets icgem download GRGM1200B --body moon --output ./gravity/moon.gfc
+```
+
+If the requested name doesn't match any model for the body, the command prints a "did you mean…" hint listing the three nearest names by edit distance. If the name matches but the requested `-DEGREE` doesn't, it lists the available degree variants.
+
+---
+
+### `icgem refresh`
+
+Force-refresh one or both cached ICGEM index files, ignoring the 30-day TTL.
+
+**Syntax:**
+```bash
+brahe datasets icgem refresh [OPTIONS]
+```
+
+**Options:**
+- `--body`, `-b <name>` - Refresh the listing for a single body.
+- `--all` - Refresh both the Earth (`tom_longtime`) and celestial (`tom_celestial`) index files.
+
+Exactly one of `--body` or `--all` must be supplied.
+
+**Examples:**
+
+Refresh just the Earth index:
+```bash
+brahe datasets icgem refresh --body earth
+```
+Output:
+```bash
+# Refreshed ICGEM index for body 'earth'.
+```
+
+Refresh both index files in one call:
+```bash
+brahe datasets icgem refresh --all
+```
+Output:
+```bash
+# Refreshed all ICGEM indexes.
+```
+
+Reach for `refresh` when ICGEM has published a new model and you don't want to wait for the next normal cache miss to pick it up.
+
+---
+
 ## Ground Station Commands
 
 ### `groundstations list-providers`
@@ -411,7 +538,9 @@ Output:
 ## See Also
 
 - [CelesTrak](https://celestrak.org) - Official TLE data source
+- [ICGEM Website](https://icgem.gfz.de) - Official ICGEM gravity model catalog
 - [Two-Line Elements](../orbits/two_line_elements.md) - Understanding Two-Line Elements
 - [SGP Propagation](../orbit_propagation/sgp_propagation.md) - TLE-based orbit propagation
 - [Access CLI](access.md) - Compute satellite passes (uses TLE data)
+- [ICGEM Dataset Guide](../datasets/icgem.md) - Programmatic ICGEM interface and cache behavior
 - [Datasets API](../../library_api/datasets/index.md) - Python dataset functions

--- a/docs/learn/datasets/icgem.md
+++ b/docs/learn/datasets/icgem.md
@@ -1,0 +1,181 @@
+# ICGEM Gravity Models
+
+The [International Centre for Global Earth Models (ICGEM)](https://icgem.gfz.de), hosted at GFZ Potsdam, maintains the de facto catalog of published spherical harmonic gravity models for Earth and other solar system bodies. Brahe's `brahe.datasets.icgem` interface mirrors that catalog in code: list the available models for a body, download a specific `.gfc` file into a local cache, and refresh stale indexes on demand.
+
+!!! info "Why a download interface?"
+    Brahe ships three packaged Earth models (EGM2008 truncated to 360, GGM05S, JGM3). The ICGEM catalog publishes hundreds more — newer high-degree Earth fields, lunar models like GRGM1200B, planetary models for Mars/Venus/Ceres, and asteroid fields. The dataset interface gives access to any of them without bundling tens of megabytes of model data into the library.
+
+## Supported Bodies
+
+The `body` argument accepts case-insensitive names. The five known bodies have dedicated routing:
+
+<div class="center-table" markdown="1">
+| Body     | Source page                | Example model |
+|----------|----------------------------|---------------|
+| `earth`  | `tom_longtime` (Earth list) | `EGM2008`, `JGM3`, `GGM05S` |
+| `moon`   | `tom_celestial`             | `GRGM1200B`   |
+| `mars`   | `tom_celestial`             | `MRO120F`     |
+| `venus`  | `tom_celestial`             | `MGNP180U`    |
+| `ceres`  | `tom_celestial`             | `sphericalRFM_CERES_2519`     |
+</div>
+
+Any other name (e.g. `"pluto"`, `"bennu"`) is treated as a custom celestial body and matched case-insensitively against ICGEM's celestial catalog. This keeps the catalog open-ended: ICGEM can add new bodies and they remain reachable without a Brahe release.
+
+## Caching Behavior
+
+ICGEM downloads are cached under the Brahe cache directory:
+
+<div class="center-table" markdown="1">
+| Path                                                | Contents                                   |
+|-----------------------------------------------------|--------------------------------------------|
+| `$BRAHE_CACHE/icgem/index_earth.json`               | Parsed listing of Earth models             |
+| `$BRAHE_CACHE/icgem/index_celestial.json`           | Parsed listing of all non-Earth bodies     |
+| `$BRAHE_CACHE/icgem/models/<body>/<name>-<degree>-<hashprefix>.gfc` | Downloaded `.gfc` files |
+</div>
+
+- **Index TTL**: 30 days. After expiry, `list_models()` and `download_model()` transparently refresh the listing on the next call.
+- **Stale-cache fallback**: if a refresh attempt fails (no network, ICGEM down), the previous cached index is reused and a warning is printed. This keeps offline use working from a populated cache.
+- **Hash-suffixed filenames**: each cached `.gfc` carries a short prefix of the ICGEM URL hash, so a republished model with the same `(name, degree)` but a fresh upstream URL is fetched cleanly instead of being shadowed by the old cache entry.
+- **Model files**: downloads are permanent — `.gfc` coefficient sets do not change after publication.
+
+## Listing Available Models
+
+`datasets.icgem.list_models(body)` returns a list of `ICGEMIndexEntry` records. Each entry has `body`, `name`, `degree`, `year`, and the opaque `download_path` ICGEM uses internally.
+
+=== "Python"
+
+    ``` python
+    --8<-- "./examples/datasets/icgem_list_models.py:12"
+    ```
+
+=== "Rust"
+
+    ``` rust
+    --8<-- "./examples/datasets/icgem_list_models.rs:8"
+    ```
+
+??? example "Output"
+    === "Python"
+        ```
+        --8<-- "./docs/outputs/datasets/icgem_list_models.py.txt"
+        ```
+
+    === "Rust"
+        ```
+        --8<-- "./docs/outputs/datasets/icgem_list_models.rs.txt"
+        ```
+
+The first call hits ICGEM and writes the index to disk. Subsequent calls within 30 days read straight from the cached JSON.
+
+## Downloading a Model
+
+`datasets.icgem.download_model(body, name, output_path=None)` returns the path to the resulting `.gfc` file. Behaviors worth knowing:
+
+- **Largest-degree resolution**: passing just a name like `"EGM2008"` selects the largest-degree variant ICGEM publishes for that name.
+- **Explicit degree**: append `-<DEGREE>` (e.g. `"EGM2008-2190"`) to pin a specific variant.
+- **Cache reuse**: if the model is already on disk for that `(name, degree, hash)`, no network call is made.
+- **Optional copy**: pass `output_path` to additionally copy the file to a chosen location; the return value then points at that copy.
+
+=== "Python"
+
+    ``` python
+    --8<-- "./examples/datasets/icgem_download_model.py:17"
+    ```
+
+=== "Rust"
+
+    ``` rust
+    --8<-- "./examples/datasets/icgem_download_model.rs:11"
+    ```
+
+??? example "Output"
+    === "Python"
+        ```
+        --8<-- "./docs/outputs/datasets/icgem_download_model.py.txt"
+        ```
+
+    === "Rust"
+        ```
+        --8<-- "./docs/outputs/datasets/icgem_download_model.rs.txt"
+        ```
+
+### Error messages
+
+`download_model` resolves the requested name against the cached index and gives a useful hint when something doesn't match:
+
+- Unknown name → suggests the three nearest names by edit distance.
+- Known name but missing degree → lists the available degrees for that name.
+
+This makes typos and degree mismatches cheap to debug without consulting the website.
+
+## Refreshing the Index
+
+`datasets.icgem.refresh_index(body)` forces a fresh fetch of the listing page for a single body, regardless of TTL. `datasets.icgem.refresh_all_indexes()` refreshes both the Earth listing and the celestial listing (which covers all non-Earth bodies in one file).
+
+=== "Python"
+
+    ``` python
+    --8<-- "./examples/datasets/icgem_refresh_index.py:13"
+    ```
+
+=== "Rust"
+
+    ``` rust
+    --8<-- "./examples/datasets/icgem_refresh_index.rs:9"
+    ```
+
+??? example "Output"
+    === "Python"
+        ```
+        --8<-- "./docs/outputs/datasets/icgem_refresh_index.py.txt"
+        ```
+
+    === "Rust"
+        ```
+        --8<-- "./docs/outputs/datasets/icgem_refresh_index.rs.txt"
+        ```
+
+Reach for these when ICGEM publishes a new model and you don't want to wait for the 30-day TTL to expire.
+
+## Offline & Stale Cache Behavior
+
+The dataset interface is designed to remain useful with no network:
+
+1. **Cold start, no network**: `list_models()` returns the error from the failed fetch — there is nothing cached to fall back on yet.
+2. **Populated cache, no network, within TTL**: served straight from cache, no fetch attempted.
+3. **Populated cache, no network, past TTL**: refresh fails, the existing (stale) entries are returned, and a warning is logged. This is the key offline-friendly path — once a deployment has populated the cache, it keeps working.
+4. **`download_model` for a previously downloaded model**: served from disk; no network call.
+
+Setting the `BRAHE_CACHE` environment variable to a checked-in or shipped cache directory is a clean way to make the ICGEM interface fully offline-capable from the first call.
+
+## Using a Downloaded Model in a Propagator
+
+The `brahe.datasets.icgem` API focuses on *fetching* gravity models. To *use* one as the central-body field in a numerical propagator, build a `GravityModelType` that points at the same body/name pair and wire it through `GravityConfiguration` into a `ForceModelConfig`:
+
+=== "Python"
+
+    ``` python
+    --8<-- "./examples/numerical_propagation/force_model_gravity_icgem.py:13"
+    ```
+
+=== "Rust"
+
+    ``` rust
+    --8<-- "./examples/numerical_propagation/force_model_gravity_icgem.rs:10"
+    ```
+
+The first `GravityModel.from_model_type` call backing this configuration will download the file if it isn't already cached, then load and cache the parsed `GravityModel` in memory. See the [Force Models guide](../orbit_propagation/numerical_propagation/force_models.md#using-an-icgem-gravity-model) for the full propagator wiring.
+
+## Command Line
+
+The same operations are exposed via the CLI under `brahe datasets icgem`. See the [Datasets CLI guide](../cli/datasets.md#icgem-commands) for `list`, `download`, and `refresh` subcommands.
+
+---
+
+## See Also
+
+- [ICGEM Website](https://icgem.gfz.de) - Official ICGEM model catalog
+- [Gravity Models (Learn)](../orbital_dynamics/gravity.md) - Geopotential theory and dominant terms
+- [Force Models (Learn)](../orbit_propagation/numerical_propagation/force_models.md) - Configuring gravity in a numerical propagator
+- [ICGEM API Reference](../../library_api/datasets/icgem.md) - `brahe.datasets.icgem` function reference
+- [GravityModelType (API)](../../library_api/orbit_dynamics/gravity.md#gravity-model-type) - All constructors for selecting a gravity model

--- a/docs/learn/datasets/index.md
+++ b/docs/learn/datasets/index.md
@@ -11,6 +11,7 @@ Working with satellite and planetary data typically requires gathering informati
 
 - **Planetary ephemeris** (DE kernels) for high-precision solar system body positions
 - **Groundstation locations** for computing contact opportunities
+- **Spherical harmonic gravity models** for high-fidelity central-body force modeling
 
 Brahe's datasets module centralizes access to these data sources, handling the details of fetching, parsing, and caching so you can focus on analysis rather than data wrangling.
 
@@ -36,6 +37,17 @@ Brahe's datasets module centralizes access to these data sources, handling the d
 - **Search and filtering**: Name search, type/status/owner filters, orbital range filters
 
 **Best for**: Satellite catalog research, constellation analysis, historical studies
+
+### [ICGEM Gravity Models](icgem.md)
+
+The [International Centre for Global Earth Models (ICGEM)](https://icgem.gfz.de) hosts spherical harmonic gravity models for Earth and other solar system bodies (Moon, Mars, Venus, Ceres, asteroids, …). The brahe interface supports:
+
+- **Catalog listing**: Discover available models per body, with degree and publication year
+- **On-demand download**: Fetch `.gfc` files into a local cache on first use
+- **Index TTL + stale fallback**: 30-day index refresh with graceful degradation when offline
+- **Propagator integration**: Reference a downloaded model directly from `GravityModelType.icgem(body, name)`
+
+**Best for**: High-fidelity gravity modeling beyond the three packaged Earth models, gravity fields for other bodies, and pinning a specific published model version
 
 ### [Groundstations](groundstations.md)
 
@@ -67,5 +79,6 @@ Brahe's datasets module aims to:
 - [Ephemeris Data Sources](../ephemeris/index.md) - CelesTrak and Space-Track API clients
 - [NAIF Ephemeris Kernels](naif.md) - Planetary ephemeris data
 - [GCAT Satellite Catalogs](gcat.md) - GCAT SATCAT and PSATCAT catalogs
+- [ICGEM Gravity Models](icgem.md) - Spherical harmonic gravity model catalog
 - [Groundstation Datasets](groundstations.md) - Ground facility locations
 - [Datasets API Reference](../../library_api/datasets/index.md) - Complete function documentation

--- a/docs/learn/orbit_propagation/numerical_propagation/force_models.md
+++ b/docs/learn/orbit_propagation/numerical_propagation/force_models.md
@@ -104,7 +104,7 @@ $$
         --8<-- "./docs/outputs/numerical_propagation/force_model_gravity_pointmass.rs.txt"
         ```
 
-**Spherical Harmonics**: High-fidelity gravity using EGM2008, GGM05S, or user-defined `.gfc` model. Degree and order control accuracy vs computation time.
+**Spherical Harmonics**: High-fidelity gravity using a packaged model (EGM2008, GGM05S, JGM3), a user-supplied `.gfc` file, or any model fetched from the [ICGEM catalog](../../datasets/icgem.md). Degree and order control accuracy vs computation time.
 
 $$
 \mathbf{a} = -\nabla V, \quad V(r, \phi, \lambda) = \frac{GM}{r} \sum_{n=0}^{N} \sum_{m=0}^{n} \left(\frac{R_E}{r}\right)^n \bar{P}_{nm}(\sin\phi) \left(\bar{C}_{nm}\cos(m\lambda) + \bar{S}_{nm}\sin(m\lambda)\right)
@@ -132,6 +132,74 @@ $$
         ```
         --8<-- "./docs/outputs/numerical_propagation/force_model_gravity_spherical.rs.txt"
         ```
+
+#### Selecting a Gravity Model
+
+`GravityConfiguration.spherical_harmonic(...)` accepts a `model_type` argument
+that selects which spherical harmonic field is loaded. Four sources are
+available:
+
+<div class="center-table" markdown="1">
+| Constructor                                  | Source                                                  |
+|----------------------------------------------|---------------------------------------------------------|
+| `GravityModelType.EGM2008_360`               | Packaged with Brahe (Earth, 360×360)                    |
+| `GravityModelType.GGM05S`                    | Packaged with Brahe (Earth, 180×180)                    |
+| `GravityModelType.JGM3`                      | Packaged with Brahe (Earth, 70×70)                      |
+| `GravityModelType.from_file("path.gfc")`     | Any `.gfc` file on disk                                 |
+| `GravityModelType.icgem(body, name)`         | Any model from the [ICGEM catalog](../../datasets/icgem.md) (downloaded on first use) |
+</div>
+
+All four are interchangeable at the `GravityConfiguration` boundary. The same
+`degree` / `order` truncation rules apply: they must satisfy `degree ≤ model.n_max`
+and `order ≤ min(degree, model.m_max)`.
+
+#### Using an ICGEM Gravity Model
+
+`GravityModelType.icgem(body, name)` lets you reference any model from the
+[ICGEM catalog](../../datasets/icgem.md) without manually managing the
+download. The first time a propagator backed by this configuration is built,
+brahe downloads the matching `.gfc` file into
+`$BRAHE_CACHE/icgem/models/<body>/` and caches the parsed `GravityModel` in
+memory. Subsequent propagators referencing the same model reuse both caches.
+
+=== "Python"
+
+    ``` python
+    --8<-- "./examples/numerical_propagation/force_model_gravity_icgem.py:13"
+    ```
+
+=== "Rust"
+
+    ``` rust
+    --8<-- "./examples/numerical_propagation/force_model_gravity_icgem.rs:10"
+    ```
+
+??? example "Output"
+    === "Python"
+        ```
+        --8<-- "./docs/outputs/numerical_propagation/force_model_gravity_icgem.py.txt"
+        ```
+
+    === "Rust"
+        ```
+        --8<-- "./docs/outputs/numerical_propagation/force_model_gravity_icgem.rs.txt"
+        ```
+
+!!! tip "Pre-fetching models for offline runs"
+    Call `bh.datasets.icgem.download_model(body, name)` once during setup to
+    warm the cache. Subsequent `GravityModelType.icgem(body, name)` references
+    then resolve entirely from disk, with no network dependency at propagator
+    construction time.
+
+!!! note "Equality of `ICGEMModel` types"
+    Two `GravityModelType.icgem(body, name)` instances compare equal only when
+    both `body` and `name` match. This is what lets the in-process
+    `GravityModel` cache de-duplicate across configurations — multiple
+    propagators that request the same ICGEM model share a single parsed
+    coefficient set in memory.
+
+For the discovery, refresh, and cache mechanics around ICGEM downloads, see
+the [ICGEM dataset guide](../../datasets/icgem.md).
 
 ### Atmospheric Drag
 

--- a/docs/learn/orbital_dynamics/gravity.md
+++ b/docs/learn/orbital_dynamics/gravity.md
@@ -56,7 +56,7 @@ The most significant non-spherical terms are:
 
 ### Gravity Models
 
-Brahe includes several standard geopotential models with different degrees and orders of expansion:
+Brahe includes several standard geopotential models with different degrees and orders of expansion, packaged with the library:
 
 - **EGM2008**: Earth Gravitational Model 2008, high-fidelity model to degree/order 360
 - **GGM05S**: GRACE Gravity Model, degree/order 180
@@ -68,7 +68,46 @@ Higher degree/order models provide more accuracy but require more computation. F
 - **Medium/Geostationary Orbit**: Degree/order 4-8 usually adequate
 - **High-precision applications**: Degree/order 50+ may be needed
 
-Additional gravity models (`.gfc` files) can be downloaded from the [International Centre for Global Earth Models (ICGEM)](https://icgem.gfz-potsdam.de/tom_longtime) repository and used with Brahe.
+#### Loading Models From ICGEM
+
+For anything beyond the three packaged Earth models — newer high-degree Earth
+fields, lunar models, Mars/Venus/Ceres fields, or a specific published
+revision — Brahe's [ICGEM dataset interface](../datasets/icgem.md) downloads
+the corresponding `.gfc` file from the [International Centre for Global Earth
+Models](https://icgem.gfz.de) and caches it under `$BRAHE_CACHE/icgem/`.
+
+Use `GravityModelType.icgem(body, name)` to slot an ICGEM-sourced model into
+the same `GravityModel` / `GravityConfiguration` machinery as the packaged
+models. The download happens transparently on first use:
+
+=== "Python"
+
+    ``` python
+    --8<-- "./examples/orbit_dynamics/gravity_icgem_load.py:17"
+    ```
+
+=== "Rust"
+
+    ``` rust
+    --8<-- "./examples/orbit_dynamics/gravity_icgem_load.rs:12"
+    ```
+
+??? example "Output"
+    === "Python"
+        ```
+        --8<-- "./docs/outputs/orbit_dynamics/gravity_icgem_load.py.txt"
+        ```
+
+    === "Rust"
+        ```
+        --8<-- "./docs/outputs/orbit_dynamics/gravity_icgem_load.rs.txt"
+        ```
+
+To wire the same model into a numerical propagator, see
+[Force Models → Using an ICGEM Gravity Model](../orbit_propagation/numerical_propagation/force_models.md#using-an-icgem-gravity-model).
+
+You can also load any `.gfc` file already on disk via
+`GravityModelType.from_file(path)`.
 
 ## Computational Considerations
 
@@ -135,6 +174,8 @@ For high-fidelity Earth gravity modeling, use the spherical harmonic expansion w
 ## See Also
 
 - [Library API Reference: Gravity](../../library_api/orbit_dynamics/gravity.md)
+- [ICGEM Dataset Interface](../datasets/icgem.md) - Discovering and downloading ICGEM models
+- [Force Models](../orbit_propagation/numerical_propagation/force_models.md) - Wiring a gravity model into a numerical propagator
 - [Orbital Dynamics Overview](index.md)
 - [Constants: Physical Parameters](../constants.md#physical-constants)
 

--- a/docs/library_api/datasets/icgem.md
+++ b/docs/library_api/datasets/icgem.md
@@ -1,0 +1,43 @@
+# ICGEM Functions
+
+Functions and types for discovering and downloading spherical harmonic gravity models from the [International Centre for Global Earth Models (ICGEM)](https://icgem.gfz.de).
+
+All functions are available via `brahe.datasets.icgem.<function_name>`.
+
+!!! tip "Loading a downloaded model into a propagator"
+    To use an ICGEM model as the central-body field in a numerical propagator,
+    build a `GravityModelType` from the same `(body, name)` pair via
+    [`GravityModelType.icgem`](../orbit_dynamics/gravity.md#icgem-gravity-models).
+    The download and cache happen transparently on first use.
+
+## list_models
+
+::: brahe._brahe.icgem_list_models
+
+## download_model
+
+::: brahe._brahe.icgem_download_model
+
+## refresh_index
+
+::: brahe._brahe.icgem_refresh_index
+
+## refresh_all_indexes
+
+::: brahe._brahe.icgem_refresh_all_indexes
+
+## ICGEMIndexEntry
+
+::: brahe._brahe.ICGEMIndexEntry
+    options:
+      show_root_heading: true
+      show_root_full_path: false
+
+---
+
+## See Also
+
+- [ICGEM Gravity Models (Learn)](../../learn/datasets/icgem.md) - Overview, caching, and usage guide
+- [Gravity Models (Learn)](../../learn/orbital_dynamics/gravity.md) - Geopotential theory and Brahe's gravity API
+- [Force Models (Learn)](../../learn/orbit_propagation/numerical_propagation/force_models.md) - Wiring an ICGEM model into a numerical propagator
+- [ICGEM Website](https://icgem.gfz.de) - Official ICGEM model catalog

--- a/docs/library_api/datasets/index.md
+++ b/docs/library_api/datasets/index.md
@@ -12,12 +12,14 @@ The module is organized by data source:
 - **`brahe.datasets.groundstations`**: Curated groundstation location datasets
 - **`brahe.datasets.naif`**: NASA JPL NAIF planetary ephemeris kernels
 - **`brahe.datasets.gcat`**: GCAT satellite catalogs (SATCAT, PSATCAT)
+- **`brahe.datasets.icgem`**: ICGEM spherical harmonic gravity models (Earth + celestial bodies)
 
 ## Submodules
 
 - [Groundstation Functions](groundstations.md) - Groundstation location datasets
 - [NAIF Functions](naif.md) - Planetary ephemeris kernels from NASA JPL
 - [GCAT Functions](gcat.md) - GCAT satellite catalog access
+- [ICGEM Functions](icgem.md) - ICGEM spherical harmonic gravity models
 
 ---
 

--- a/docs/library_api/orbit_dynamics/gravity.md
+++ b/docs/library_api/orbit_dynamics/gravity.md
@@ -17,7 +17,33 @@ Gravity acceleration functions including point-mass and spherical harmonic model
 
 ::: brahe.GravityModel
 
+## Gravity Model Type
+
+`GravityModelType` selects which spherical harmonic field is loaded into a
+[`GravityModel`](#gravity-model-class) (or wired into a
+[`GravityConfiguration`](../propagators/force_model_config.md)). In addition to
+the packaged constants `EGM2008_360`, `GGM05S`, and `JGM3`, two constructors
+load external models:
+
+- `GravityModelType.from_file(path)` — load any `.gfc` file from disk.
+- `GravityModelType.icgem(body, name)` — reference any model from the
+  [ICGEM catalog](../../learn/datasets/icgem.md); the matching `.gfc` file is
+  downloaded into `$BRAHE_CACHE/icgem/models/<body>/` on first use and cached
+  permanently.
+
+The same `GravityModelType` can be passed to
+[`GravityConfiguration.spherical_harmonic(model_type=...)`](../propagators/force_model_config.md)
+to use the model as the central-body field in a `NumericalOrbitPropagator`.
+For end-to-end usage examples see the
+[ICGEM dataset guide](../../learn/datasets/icgem.md) and the
+[Gravity Models user guide](../../learn/orbital_dynamics/gravity.md#loading-models-from-icgem).
+
+::: brahe.GravityModelType
+
 ## See Also
 
 - [Gravity Models (Learn)](../../learn/orbital_dynamics/gravity.md) - Conceptual explanation and examples
+- [ICGEM Dataset Interface (Learn)](../../learn/datasets/icgem.md) - Discovering and downloading ICGEM models
+- [ICGEM Functions API](../datasets/icgem.md) - `brahe.datasets.icgem` API reference
+- [Force Models (Learn)](../../learn/orbit_propagation/numerical_propagation/force_models.md) - Using a gravity model in a numerical propagator
 - [Orbital Dynamics Module](index.md) - Complete orbit dynamics API reference

--- a/examples/datasets/icgem_download_model.py
+++ b/examples/datasets/icgem_download_model.py
@@ -1,0 +1,32 @@
+# /// script
+# dependencies = ["brahe"]
+# FLAGS = ["CI-ONLY"]
+# ///
+"""
+Download a spherical harmonic gravity model from ICGEM.
+
+Downloads are cached under $BRAHE_CACHE/icgem/models/<body>/ keyed on
+(name, degree, hash-prefix). Subsequent calls for the same model are
+served from disk.
+
+To pin a specific degree variant — when ICGEM publishes more than one
+truncation of the same model — append "-<DEGREE>" to the name argument,
+e.g. download_model("earth", "XGM2019e_2159-760").
+"""
+
+import brahe.datasets as datasets
+
+# JGM3 is small (~70x70) and stable — a good demonstration target.
+# Passing just the name selects the largest published degree variant.
+path = datasets.icgem.download_model("earth", "JGM3")
+print(f"Cached at: {path}")
+
+# Optionally also copy the file to a chosen location (cache still populated)
+copied = datasets.icgem.download_model(
+    "earth", "JGM3", output_path="/tmp/icgem_jgm3.gfc"
+)
+print(f"Copied to: {copied}")
+
+# Lunar model — body name routes to the celestial catalog
+moon_path = datasets.icgem.download_model("moon", "GLGM-1")
+print(f"Lunar model cached at: {moon_path}")

--- a/examples/datasets/icgem_download_model.rs
+++ b/examples/datasets/icgem_download_model.rs
@@ -1,0 +1,34 @@
+//! Download a spherical harmonic gravity model from ICGEM.
+//!
+//! FLAGS = ["CI-ONLY"]
+//!
+//! Downloads are cached under $BRAHE_CACHE/icgem/models/<body>/ keyed on
+//! (name, degree, hash-prefix). To pin a specific degree variant — when
+//! ICGEM publishes more than one truncation of the same model — append
+//! "-<DEGREE>" to the name argument, e.g. download_icgem_model(
+//! ICGEMBody::Earth, "XGM2019e_2159-760", None).
+
+use std::path::PathBuf;
+
+use brahe as bh;
+use bh::datasets::icgem::{ICGEMBody, download_icgem_model};
+
+fn main() {
+    // JGM3 is small (~70x70) and stable — a good demonstration target.
+    // Passing just the name selects the largest published degree variant.
+    let path = download_icgem_model(ICGEMBody::Earth, "JGM3", None).unwrap();
+    println!("Cached at: {}", path.display());
+
+    // Optionally also copy the file to a chosen location (cache still populated)
+    let copied = download_icgem_model(
+        ICGEMBody::Earth,
+        "JGM3",
+        Some(PathBuf::from("/tmp/icgem_jgm3.gfc")),
+    )
+    .unwrap();
+    println!("Copied to: {}", copied.display());
+
+    // Lunar model — body name routes to the celestial catalog
+    let moon_path = download_icgem_model(ICGEMBody::Moon, "GLGM-1", None).unwrap();
+    println!("Lunar model cached at: {}", moon_path.display());
+}

--- a/examples/datasets/icgem_list_models.py
+++ b/examples/datasets/icgem_list_models.py
@@ -1,0 +1,29 @@
+# /// script
+# dependencies = ["brahe"]
+# FLAGS = ["CI-ONLY"]
+# ///
+"""
+List spherical harmonic gravity models from the ICGEM catalog.
+
+The first call fetches the listing from ICGEM and caches it under
+$BRAHE_CACHE/icgem/. Subsequent calls within the 30-day TTL read from disk.
+"""
+
+import brahe.datasets as datasets
+
+# List all Earth gravity models in the catalog
+earth_models = datasets.icgem.list_models("earth")
+print(f"Earth models available: {len(earth_models)}")
+for entry in earth_models[:3]:
+    print(f"  {entry.name:30s} degree={entry.degree:<6d} year={entry.year}")
+
+# Each entry is a plain ICGEMIndexEntry, so standard Python filtering works
+egm_family = [e for e in earth_models if e.name.startswith("EGM")]
+print(f"\nEGM-family Earth models: {len(egm_family)}")
+
+# The same call works for other bodies — Moon, Mars, Venus, Ceres, or any
+# custom celestial body present in the ICGEM celestial catalog.
+moon_models = datasets.icgem.list_models("moon")
+print(f"\nLunar models available: {len(moon_models)}")
+for entry in moon_models[:3]:
+    print(f"  {entry.name:30s} degree={entry.degree:<6d} year={entry.year}")

--- a/examples/datasets/icgem_list_models.rs
+++ b/examples/datasets/icgem_list_models.rs
@@ -1,0 +1,39 @@
+//! List spherical harmonic gravity models from the ICGEM catalog.
+//!
+//! The first call fetches the listing from ICGEM and caches it under
+//! $BRAHE_CACHE/icgem/. Subsequent calls within the 30-day TTL read from disk.
+//!
+//! FLAGS = ["CI-ONLY"]
+
+use brahe as bh;
+use bh::datasets::icgem::{ICGEMBody, list_icgem_models};
+
+fn main() {
+    // List all Earth gravity models in the catalog
+    let earth_models = list_icgem_models(ICGEMBody::Earth).unwrap();
+    println!("Earth models available: {}", earth_models.len());
+    for entry in earth_models.iter().take(3) {
+        println!(
+            "  {:30} degree={:<6} year={:?}",
+            entry.name, entry.degree, entry.year
+        );
+    }
+
+    // Each entry is a plain IndexEntry, so standard iterator filtering works
+    let egm_family = earth_models
+        .iter()
+        .filter(|e| e.name.starts_with("EGM"))
+        .count();
+    println!("\nEGM-family Earth models: {egm_family}");
+
+    // The same call works for other bodies — Moon, Mars, Venus, Ceres, or any
+    // custom celestial body present in the ICGEM celestial catalog.
+    let moon_models = list_icgem_models(ICGEMBody::Moon).unwrap();
+    println!("\nLunar models available: {}", moon_models.len());
+    for entry in moon_models.iter().take(3) {
+        println!(
+            "  {:30} degree={:<6} year={:?}",
+            entry.name, entry.degree, entry.year
+        );
+    }
+}

--- a/examples/datasets/icgem_refresh_index.py
+++ b/examples/datasets/icgem_refresh_index.py
@@ -1,0 +1,27 @@
+# /// script
+# dependencies = ["brahe"]
+# FLAGS = ["CI-ONLY"]
+# ///
+"""
+Force-refresh the cached ICGEM index files.
+
+Indexes auto-refresh every 30 days, so this is only needed when ICGEM has
+published a new model and you don't want to wait for the next normal cache
+miss to pick it up.
+"""
+
+import brahe.datasets as datasets
+
+# Refresh a single body's listing. The Earth listing comes from ICGEM's
+# `tom_longtime` page; all non-Earth bodies share the `tom_celestial` index.
+datasets.icgem.refresh_index("earth")
+print("Refreshed Earth index")
+
+# Refresh both index files in one call — equivalent to refreshing Earth plus
+# any non-Earth body (since the celestial listing covers Moon/Mars/Venus/Ceres/...).
+datasets.icgem.refresh_all_indexes()
+print("Refreshed all ICGEM indexes")
+
+# Confirm the refresh took effect by listing a known body
+earth_models = datasets.icgem.list_models("earth")
+print(f"\n{len(earth_models)} Earth models after refresh")

--- a/examples/datasets/icgem_refresh_index.rs
+++ b/examples/datasets/icgem_refresh_index.rs
@@ -1,0 +1,28 @@
+//! Force-refresh the cached ICGEM index files.
+//!
+//! Indexes auto-refresh every 30 days, so this is only needed when ICGEM has
+//! published a new model and you don't want to wait for the next normal cache
+//! miss to pick it up.
+//!
+//! FLAGS = ["CI-ONLY"]
+
+use brahe as bh;
+use bh::datasets::icgem::{
+    ICGEMBody, list_icgem_models, refresh_all_icgem_indexes, refresh_icgem_index,
+};
+
+fn main() {
+    // Refresh a single body's listing. The Earth listing comes from ICGEM's
+    // `tom_longtime` page; all non-Earth bodies share the `tom_celestial` index.
+    refresh_icgem_index(ICGEMBody::Earth).unwrap();
+    println!("Refreshed Earth index");
+
+    // Refresh both index files in one call — equivalent to refreshing Earth plus
+    // any non-Earth body (since the celestial listing covers Moon/Mars/Venus/Ceres/...).
+    refresh_all_icgem_indexes().unwrap();
+    println!("Refreshed all ICGEM indexes");
+
+    // Confirm the refresh took effect by listing a known body
+    let earth_models = list_icgem_models(ICGEMBody::Earth).unwrap();
+    println!("\n{} Earth models after refresh", earth_models.len());
+}

--- a/examples/numerical_propagation/force_model_gravity_icgem.py
+++ b/examples/numerical_propagation/force_model_gravity_icgem.py
@@ -1,0 +1,59 @@
+# /// script
+# dependencies = ["brahe", "numpy"]
+# FLAGS = ["CI-ONLY"]
+# ///
+"""
+Configure a NumericalOrbitPropagator with an ICGEM-sourced gravity model.
+
+GravityModelType.icgem(body, name) slots into the same model_type slot as
+the packaged JGM3/GGM05S/EGM2008_360 constants. The .gfc file is downloaded
+into $BRAHE_CACHE/icgem/ on first use of the resulting GravityModel.
+"""
+
+import brahe as bh
+import numpy as np
+
+# Initialize EOP data (required for any numerical propagation)
+bh.initialize_eop()
+
+# Reference an ICGEM Earth model. Use bh.datasets.icgem.list_models("earth")
+# to discover the full catalog. Append "-<DEGREE>" to pin a specific variant.
+grav_type = bh.GravityModelType.icgem("earth", "JGM3")
+
+gravity_cfg = bh.GravityConfiguration.spherical_harmonic(
+    degree=20, order=20, model_type=grav_type
+)
+
+# Minimal force model: ICGEM-sourced spherical-harmonic gravity only
+force_cfg = bh.ForceModelConfig(gravity=gravity_cfg)
+
+# Build an initial state for a LEO satellite
+epoch = bh.Epoch.from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, bh.TimeSystem.UTC)
+oe = np.array(
+    [
+        bh.R_EARTH + 500e3,    # a (m)
+        0.001,                  # e
+        np.radians(97.8),       # i (rad)
+        np.radians(15.0),       # RAAN (rad)
+        np.radians(30.0),       # arg perigee (rad)
+        np.radians(45.0),       # true anomaly (rad)
+    ]
+)
+state0 = bh.state_koe_to_eci(oe, bh.AngleFormat.RADIANS)
+
+# Construct the propagator — this is where the ICGEM model is downloaded
+# (if not cached) and loaded into the force evaluator.
+prop = bh.NumericalOrbitPropagator(
+    epoch,
+    state0,
+    bh.NumericalPropagationConfig.default(),
+    force_cfg,
+    None,
+)
+
+# Step one minute forward
+prop.step_by(60.0)
+state1 = prop.current_state()
+
+drift = float(np.linalg.norm(np.asarray(state1[:3]) - np.asarray(state0[:3])))
+print(f"Propagated 60 s with JGM3 (ICGEM source); position drift = {drift:.1f} m")

--- a/examples/numerical_propagation/force_model_gravity_icgem.rs
+++ b/examples/numerical_propagation/force_model_gravity_icgem.rs
@@ -1,0 +1,38 @@
+//! Configure a force model with an ICGEM-sourced spherical-harmonic gravity field.
+//!
+//! `GravityModelType::ICGEMModel { body, name }` slots into the same
+//! `GravityModelSource::ModelType(...)` slot as the packaged JGM3 / GGM05S /
+//! EGM2008_360 variants. The .gfc file is downloaded into `$BRAHE_CACHE/icgem/`
+//! on first use of the resulting `GravityModel`.
+//!
+//! FLAGS = ["CI-ONLY"]
+
+use brahe as bh;
+use bh::GravityModelType;
+use bh::datasets::icgem::ICGEMBody;
+
+fn main() {
+    // Reference an ICGEM Earth model. Use
+    // `bh::datasets::icgem::list_icgem_models(ICGEMBody::Earth)` to discover
+    // the full catalog. Append "-<DEGREE>" to pin a specific variant.
+    let grav_type = GravityModelType::ICGEMModel {
+        body: ICGEMBody::Earth,
+        name: "JGM3".to_string(),
+    };
+
+    let _force_config = bh::ForceModelConfig {
+        gravity: bh::GravityConfiguration::SphericalHarmonic {
+            source: bh::GravityModelSource::ModelType(grav_type),
+            degree: 20,
+            order: 20,
+        },
+        drag: None,
+        srp: None,
+        third_body: None,
+        relativity: false,
+        mass: None,
+        frame_transform: bh::FrameTransformationModel::default(),
+    };
+
+    println!("Built ForceModelConfig with ICGEM gravity source: Earth/JGM3 (20x20)");
+}

--- a/examples/orbit_dynamics/gravity_icgem_load.py
+++ b/examples/orbit_dynamics/gravity_icgem_load.py
@@ -1,0 +1,29 @@
+# /// script
+# dependencies = ["brahe"]
+# FLAGS = ["CI-ONLY"]
+# ///
+"""
+Load a GravityModel sourced from the ICGEM catalog.
+
+GravityModelType.icgem(body, name) is interchangeable with the packaged
+GravityModelType constants. The .gfc file is downloaded on first use and
+cached under $BRAHE_CACHE/icgem/.
+
+To pin a specific degree variant (when ICGEM publishes multiple), append
+"-<DEGREE>" to the name argument, e.g. GravityModelType.icgem("earth",
+"XGM2019e_2159-760").
+"""
+
+import brahe as bh
+
+# Earth — JGM3 (~70x70), small and stable
+earth_type = bh.GravityModelType.icgem("earth", "JGM3")
+earth_model = bh.GravityModel.from_model_type(earth_type)
+print(
+    f"Loaded {earth_model.model_name} "
+    f"({earth_model.n_max}x{earth_model.m_max}, GM={earth_model.gm:.6e} m^3/s^2)"
+)
+
+# Inspect a coefficient — normalized C_{2,0} (J2 term) from the Earth model
+c20, s20 = earth_model.get(2, 0)
+print(f"\nEarth normalized C(2,0) = {c20:.6e}")

--- a/examples/orbit_dynamics/gravity_icgem_load.rs
+++ b/examples/orbit_dynamics/gravity_icgem_load.rs
@@ -1,0 +1,31 @@
+//! Load a GravityModel sourced from the ICGEM catalog.
+//!
+//! `GravityModelType::ICGEMModel { body, name }` is interchangeable with the
+//! packaged `GravityModelType` variants. The .gfc file is downloaded on first
+//! use and cached under `$BRAHE_CACHE/icgem/`.
+//!
+//! To pin a specific degree variant (when ICGEM publishes multiple), append
+//! "-<DEGREE>" to the name, e.g. `name: "XGM2019e_2159-760".to_string()`.
+//!
+//! FLAGS = ["CI-ONLY"]
+
+use brahe as bh;
+use bh::GravityModelType;
+use bh::datasets::icgem::ICGEMBody;
+
+fn main() {
+    // Earth — JGM3 (~70x70), small and stable
+    let earth_type = GravityModelType::ICGEMModel {
+        body: ICGEMBody::Earth,
+        name: "JGM3".to_string(),
+    };
+    let earth_model = bh::GravityModel::from_model_type(&earth_type).unwrap();
+    println!(
+        "Loaded {} ({}x{}, GM={:.6e} m^3/s^2)",
+        earth_model.model_name, earth_model.n_max, earth_model.m_max, earth_model.gm
+    );
+
+    // Inspect a coefficient — normalized C_{2,0} (J2 term) from the Earth model
+    let (c20, _s20) = earth_model.get(2, 0).unwrap();
+    println!("\nEarth normalized C(2,0) = {c20:.6e}");
+}

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -284,6 +284,7 @@ nav:
           - NAIF: learn/datasets/naif.md
           - Groundstations: learn/datasets/groundstations.md
           - GCAT: learn/datasets/gcat.md
+          - ICGEM: learn/datasets/icgem.md
       - Utilities:
           - learn/utilities/index.md
           - Caching: learn/utilities/caching.md
@@ -443,6 +444,7 @@ nav:
           - Groundstations: library_api/datasets/groundstations.md
           - NAIF: library_api/datasets/naif.md
           - GCAT: library_api/datasets/gcat.md
+          - ICGEM: library_api/datasets/icgem.md
       - Ephemeris Data Sources:
           - library_api/ephemeris/index.md
           - Shared Types: library_api/ephemeris/shared_types.md

--- a/src/datasets/icgem/body.rs
+++ b/src/datasets/icgem/body.rs
@@ -1,0 +1,114 @@
+//! ICGEM body enum and string-form conversion.
+
+use serde::{Deserialize, Serialize};
+
+/// A celestial body cataloged on ICGEM.
+///
+/// Known bodies map to specific enum variants; arbitrary bodies fall back to
+/// `Other(name)` so the catalog stays useful if ICGEM adds new bodies before
+/// Brahe is updated. Names stored in `Other` are normalized to lowercase to
+/// give case-insensitive matching against the ICGEM "Object" column.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ICGEMBody {
+    /// Earth — uses the ICGEM `tom_longtime` listing page.
+    Earth,
+    /// Earth's Moon.
+    Moon,
+    /// Mars.
+    Mars,
+    /// Venus.
+    Venus,
+    /// Dwarf planet Ceres.
+    Ceres,
+    /// Any other body present in the ICGEM celestial catalog, stored as a
+    /// lowercase name (e.g. `Other("pluto")`).
+    Other(String),
+}
+
+impl ICGEMBody {
+    /// Parse a body name (case-insensitive). Known bodies map to their
+    /// dedicated variants; anything else becomes `Other(lowercased)`.
+    ///
+    /// The ICGEM celestial catalog labels the Moon as "Moon (of the Earth)";
+    /// any name that is exactly "moon" or starts with "moon " (with a trailing
+    /// space) is mapped to `ICGEMBody::Moon`. The trailing-space guard prevents
+    /// a hypothetical body like "moonlet-x" from being misclassified.
+    pub fn from_name(s: &str) -> Self {
+        let lower = s.trim().to_lowercase();
+        match lower.as_str() {
+            "earth" => ICGEMBody::Earth,
+            "mars" => ICGEMBody::Mars,
+            "venus" => ICGEMBody::Venus,
+            "ceres" => ICGEMBody::Ceres,
+            other if other == "moon" || other.starts_with("moon ") => ICGEMBody::Moon,
+            other => ICGEMBody::Other(other.to_string()),
+        }
+    }
+
+    /// Canonical display name (capitalized for known bodies, lowercase for `Other`).
+    pub fn as_name(&self) -> &str {
+        match self {
+            ICGEMBody::Earth => "Earth",
+            ICGEMBody::Moon => "Moon",
+            ICGEMBody::Mars => "Mars",
+            ICGEMBody::Venus => "Venus",
+            ICGEMBody::Ceres => "Ceres",
+            ICGEMBody::Other(name) => name.as_str(),
+        }
+    }
+
+    /// True for Earth, which uses the `tom_longtime` listing page. Everything
+    /// else uses `tom_celestial`.
+    pub fn is_earth(&self) -> bool {
+        matches!(self, ICGEMBody::Earth)
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_name_known_bodies_case_insensitive() {
+        assert_eq!(ICGEMBody::from_name("Earth"), ICGEMBody::Earth);
+        assert_eq!(ICGEMBody::from_name("earth"), ICGEMBody::Earth);
+        assert_eq!(ICGEMBody::from_name("  MOON "), ICGEMBody::Moon);
+        assert_eq!(ICGEMBody::from_name("Mars"), ICGEMBody::Mars);
+        assert_eq!(ICGEMBody::from_name("Venus"), ICGEMBody::Venus);
+        assert_eq!(ICGEMBody::from_name("Ceres"), ICGEMBody::Ceres);
+    }
+
+    #[test]
+    fn test_from_name_unknown_falls_through_to_other_lowercased() {
+        assert_eq!(
+            ICGEMBody::from_name("Pluto"),
+            ICGEMBody::Other("pluto".to_string())
+        );
+        assert_eq!(
+            ICGEMBody::from_name("Bennu"),
+            ICGEMBody::Other("bennu".to_string())
+        );
+    }
+
+    #[test]
+    fn test_as_name_round_trip() {
+        for body in [
+            ICGEMBody::Earth,
+            ICGEMBody::Moon,
+            ICGEMBody::Mars,
+            ICGEMBody::Venus,
+            ICGEMBody::Ceres,
+            ICGEMBody::Other("pluto".to_string()),
+        ] {
+            assert_eq!(ICGEMBody::from_name(body.as_name()), body);
+        }
+    }
+
+    #[test]
+    fn test_is_earth() {
+        assert!(ICGEMBody::Earth.is_earth());
+        assert!(!ICGEMBody::Moon.is_earth());
+        assert!(!ICGEMBody::Other("earth-like".to_string()).is_earth());
+    }
+}

--- a/src/datasets/icgem/download.rs
+++ b/src/datasets/icgem/download.rs
@@ -1,0 +1,481 @@
+//! ICGEM model name → entry resolution and download.
+
+use crate::datasets::icgem::body::ICGEMBody;
+use crate::datasets::icgem::index::IndexEntry;
+use crate::utils::BraheError;
+
+/// Resolve `name` (optionally with `-<degree>` suffix) against `entries` for
+/// `body`. Returns the matched `IndexEntry`, or an error with a helpful hint.
+///
+/// Algorithm:
+/// 1. Filter entries to `body`.
+/// 2. Exact name match → return that variant (largest degree if multiple).
+/// 3. Strip a trailing `-<digits>` suffix and retry exact-name match; if name
+///    matches but the requested degree does not, error listing available degrees.
+/// 4. No match → error listing the 3 nearest names by edit distance.
+pub fn resolve_icgem_model<'a>(
+    body: &ICGEMBody,
+    name: &str,
+    entries: &'a [IndexEntry],
+) -> Result<&'a IndexEntry, BraheError> {
+    let body_entries: Vec<&IndexEntry> =
+        entries.iter().filter(|e| &e.body == body).collect();
+
+    // Step 2: exact-name match.
+    let exact: Vec<&IndexEntry> = body_entries
+        .iter()
+        .copied()
+        .filter(|e| e.name == name)
+        .collect();
+    if !exact.is_empty() {
+        let best = exact.iter().copied().max_by_key(|e| e.degree).unwrap();
+        return Ok(best);
+    }
+
+    // Step 3: strip `-<digits>` suffix.
+    if let Some((base, suffix)) = name.rsplit_once('-')
+        && let Ok(req_degree) = suffix.parse::<u32>()
+    {
+        let base_matches: Vec<&IndexEntry> = body_entries
+            .iter()
+            .copied()
+            .filter(|e| e.name == base)
+            .collect();
+        if !base_matches.is_empty() {
+            if let Some(match_with_degree) = base_matches
+                .iter()
+                .copied()
+                .find(|e| e.degree == req_degree)
+            {
+                return Ok(match_with_degree);
+            }
+            let degrees: Vec<u32> = base_matches.iter().map(|e| e.degree).collect();
+            return Err(BraheError::Error(format!(
+                "ICGEM model '{}' has no variant at degree {}. Available: {:?}",
+                base, req_degree, degrees
+            )));
+        }
+    }
+
+    // Step 4: typo hint.
+    let nearest = nearest_names(name, &body_entries, 3);
+    Err(BraheError::Error(format!(
+        "ICGEM model '{}' not found for body '{}'. Did you mean: {}?",
+        name,
+        body.as_name(),
+        nearest.join(", ")
+    )))
+}
+
+fn nearest_names(target: &str, entries: &[&IndexEntry], k: usize) -> Vec<String> {
+    let mut seen = std::collections::HashSet::new();
+    let mut unique: Vec<&IndexEntry> = Vec::new();
+    for e in entries {
+        if seen.insert(e.name.clone()) {
+            unique.push(e);
+        }
+    }
+    let mut scored: Vec<(usize, String)> = unique
+        .iter()
+        .map(|e| (levenshtein(target, &e.name), e.name.clone()))
+        .collect();
+    scored.sort_by_key(|(d, _)| *d);
+    scored.into_iter().take(k).map(|(_, n)| n).collect()
+}
+
+fn levenshtein(a: &str, b: &str) -> usize {
+    let (a, b) = (a.as_bytes(), b.as_bytes());
+    let (n, m) = (a.len(), b.len());
+    if n == 0 { return m; }
+    if m == 0 { return n; }
+    let mut prev: Vec<usize> = (0..=m).collect();
+    let mut curr = vec![0usize; m + 1];
+    for i in 1..=n {
+        curr[0] = i;
+        for j in 1..=m {
+            let cost = if a[i - 1] == b[j - 1] { 0 } else { 1 };
+            curr[j] = (curr[j - 1] + 1)
+                .min(prev[j] + 1)
+                .min(prev[j - 1] + cost);
+        }
+        std::mem::swap(&mut prev, &mut curr);
+    }
+    prev[m]
+}
+
+use crate::datasets::icgem::index::{ICGEM_BASE_URL, list_icgem_models_with_url};
+use crate::utils::cache::get_icgem_cache_dir;
+use crate::utils::fs::atomic_write;
+use std::path::PathBuf;
+
+/// Number of leading hex characters of the ICGEM download hash to embed in
+/// the cache filename. Twelve characters gives 48 bits of entropy — collisions
+/// are astronomically unlikely across a single model's variants, while keeping
+/// filenames human-readable.
+const ICGEM_CACHE_HASH_LEN: usize = 12;
+
+/// Extract ICGEM's opaque hash segment from a download path of the form
+/// `/getmodel/gfc/<hash>/<name>.gfc`. Returns `None` if the path doesn't
+/// match the expected shape.
+fn extract_icgem_hash(download_path: &str) -> Option<&str> {
+    download_path
+        .strip_prefix("/getmodel/gfc/")
+        .and_then(|s| s.split('/').next())
+        .filter(|h| !h.is_empty())
+}
+
+/// Build the local cache filename for an index entry.
+///
+/// Format: `<name>-<degree>-<hashprefix>.gfc`. Embedding the hash means that
+/// if ICGEM republishes a model under the same name+degree but a new hashed
+/// URL (e.g. a corrected coefficient set), the cache path changes and the new
+/// file is fetched on next access — rather than serving the stale local copy
+/// forever.
+fn cache_filename_for_entry(entry: &IndexEntry) -> String {
+    let hash = extract_icgem_hash(&entry.download_path).unwrap_or("nohash");
+    let short = &hash[..hash.len().min(ICGEM_CACHE_HASH_LEN)];
+    format!("{}-{}-{}.gfc", entry.name, entry.degree, short)
+}
+
+/// Download (or load from cache) a `.gfc` file for the named ICGEM model.
+///
+/// If `output_path` is `Some`, also copies the cached file there and returns
+/// that path. Otherwise returns the cache path.
+pub fn download_icgem_model(
+    body: ICGEMBody,
+    name: &str,
+    output_path: Option<PathBuf>,
+) -> Result<PathBuf, BraheError> {
+    download_icgem_model_with_url(&body, name, output_path, ICGEM_BASE_URL)
+}
+
+pub(crate) fn download_icgem_model_with_url(
+    body: &ICGEMBody,
+    name: &str,
+    output_path: Option<PathBuf>,
+    base_url: &str,
+) -> Result<PathBuf, BraheError> {
+    let entries = list_icgem_models_with_url(body, base_url)?;
+    let entry = resolve_icgem_model(body, name, &entries)?.clone();
+
+    let cache_root = PathBuf::from(get_icgem_cache_dir()?);
+    let body_subdir = match body {
+        ICGEMBody::Earth => "earth".to_string(),
+        ICGEMBody::Moon => "moon".to_string(),
+        ICGEMBody::Mars => "mars".to_string(),
+        ICGEMBody::Venus => "venus".to_string(),
+        ICGEMBody::Ceres => "ceres".to_string(),
+        ICGEMBody::Other(n) => format!("other/{}", n),
+    };
+    let cache_dir = cache_root.join("models").join(&body_subdir);
+    let cache_file = cache_dir.join(cache_filename_for_entry(&entry));
+
+    if !cache_file.exists() {
+        let url = format!("{}{}", base_url, entry.download_path);
+        let response = ureq::get(&url).call().map_err(|e| {
+            BraheError::Error(format!(
+                "Failed to download ICGEM model '{}': {}",
+                entry.name, e
+            ))
+        })?;
+        use std::io::Read;
+        let mut buf = Vec::new();
+        response
+            .into_body()
+            .into_reader()
+            .read_to_end(&mut buf)
+            .map_err(|e| {
+                BraheError::Error(format!(
+                    "Failed to read ICGEM model '{}' body: {}",
+                    entry.name, e
+                ))
+            })?;
+        if buf.is_empty() {
+            return Err(BraheError::Error(format!(
+                "Empty response for ICGEM model '{}'",
+                entry.name
+            )));
+        }
+        atomic_write(&cache_file, &buf).map_err(|e| {
+            BraheError::Error(format!(
+                "Failed to write ICGEM model cache {}: {}",
+                cache_file.display(),
+                e
+            ))
+        })?;
+    }
+
+    if let Some(out) = output_path {
+        if let Some(parent) = out.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                BraheError::Error(format!(
+                    "Failed to create output directory {}: {}",
+                    parent.display(),
+                    e
+                ))
+            })?;
+        }
+        std::fs::copy(&cache_file, &out).map_err(|e| {
+            BraheError::Error(format!(
+                "Failed to copy ICGEM model from {} to {}: {}",
+                cache_file.display(),
+                out.display(),
+                e
+            ))
+        })?;
+        Ok(out)
+    } else {
+        Ok(cache_file)
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    fn entry(body: ICGEMBody, name: &str, degree: u32) -> IndexEntry {
+        IndexEntry {
+            body,
+            name: name.into(),
+            year: None,
+            degree,
+            download_path: format!("/getmodel/gfc/h/{}.gfc", name),
+        }
+    }
+
+    fn earth_fixture() -> Vec<IndexEntry> {
+        vec![
+            entry(ICGEMBody::Earth, "JGM3", 70),
+            entry(ICGEMBody::Earth, "EGM2008", 2190),
+            entry(ICGEMBody::Earth, "WHU-CASM-UGM2025_2159", 760),
+            entry(ICGEMBody::Earth, "WHU-CASM-UGM2025_2159", 2190),
+            entry(ICGEMBody::Earth, "WHU-CASM-UGM2025_2159", 11000),
+            entry(ICGEMBody::Moon, "GRGM1200B", 1200),
+        ]
+    }
+
+    #[test]
+    fn test_resolve_exact_single_variant() {
+        let entries = earth_fixture();
+        let got = resolve_icgem_model(&ICGEMBody::Earth, "JGM3", &entries).unwrap();
+        assert_eq!(got.name, "JGM3");
+        assert_eq!(got.degree, 70);
+    }
+
+    #[test]
+    fn test_resolve_largest_degree_when_ambiguous() {
+        let entries = earth_fixture();
+        let got = resolve_icgem_model(
+            &ICGEMBody::Earth,
+            "WHU-CASM-UGM2025_2159",
+            &entries,
+        )
+        .unwrap();
+        assert_eq!(got.degree, 11000);
+    }
+
+    #[test]
+    fn test_resolve_with_explicit_degree_suffix() {
+        let entries = earth_fixture();
+        let got = resolve_icgem_model(
+            &ICGEMBody::Earth,
+            "WHU-CASM-UGM2025_2159-2190",
+            &entries,
+        )
+        .unwrap();
+        assert_eq!(got.degree, 2190);
+    }
+
+    #[test]
+    fn test_resolve_missing_degree_errors_with_available_list() {
+        let entries = earth_fixture();
+        let err = resolve_icgem_model(
+            &ICGEMBody::Earth,
+            "WHU-CASM-UGM2025_2159-99",
+            &entries,
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("no variant at degree 99"));
+        assert!(msg.contains("760") && msg.contains("2190") && msg.contains("11000"));
+    }
+
+    #[test]
+    fn test_resolve_typo_returns_nearest_names() {
+        let entries = earth_fixture();
+        let err = resolve_icgem_model(&ICGEMBody::Earth, "EGM200", &entries).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("EGM2008"));
+    }
+
+    #[test]
+    fn test_resolve_other_body_does_not_leak_earth_results() {
+        let entries = earth_fixture();
+        let err = resolve_icgem_model(&ICGEMBody::Mars, "EGM2008", &entries).unwrap_err();
+        assert!(err.to_string().contains("not found for body 'Mars'"));
+    }
+
+    #[test]
+    fn test_resolve_exact_match_takes_precedence_over_suffix_split() {
+        let mut entries = earth_fixture();
+        entries.push(entry(ICGEMBody::Earth, "MODEL-X-2020", 200));
+        let got = resolve_icgem_model(&ICGEMBody::Earth, "MODEL-X-2020", &entries).unwrap();
+        assert_eq!(got.name, "MODEL-X-2020");
+        assert_eq!(got.degree, 200);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_download_end_to_end_with_mock_server() {
+        use httpmock::prelude::*;
+
+        let dir = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("BRAHE_CACHE", dir.path()); }
+
+        let html = std::fs::read_to_string("test_assets/icgem/tom_longtime_sample.html").unwrap();
+        let gfc = std::fs::read_to_string("data/gravity_models/JGM3.gfc").unwrap();
+
+        let server = MockServer::start();
+        let _list = server.mock(|when, then| {
+            when.method(GET).path_includes("/tom_longtime");
+            then.status(200).body(&html);
+        });
+        let _file = server.mock(|when, then| {
+            when.method(GET).path_includes("/getmodel/gfc/");
+            then.status(200).body(&gfc);
+        });
+
+        // Discover a model name from the fixture dynamically.
+        let entries = crate::datasets::icgem::parser::parse_earth_catalog(&html).unwrap();
+        let target = entries.first().expect("fixture has at least one entry").name.clone();
+
+        let path = download_icgem_model_with_url(
+            &ICGEMBody::Earth,
+            &target,
+            None,
+            &server.base_url(),
+        )
+        .unwrap();
+        assert!(path.exists());
+        assert!(path.to_string_lossy().contains("models"));
+        assert!(path.to_string_lossy().contains("earth"));
+
+        unsafe { std::env::remove_var("BRAHE_CACHE"); }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_download_uses_cache_on_second_call() {
+        use httpmock::prelude::*;
+
+        let dir = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("BRAHE_CACHE", dir.path()); }
+
+        let html = std::fs::read_to_string("test_assets/icgem/tom_longtime_sample.html").unwrap();
+        let gfc = std::fs::read_to_string("data/gravity_models/JGM3.gfc").unwrap();
+
+        let server = MockServer::start();
+        let list_mock = server.mock(|when, then| {
+            when.method(GET).path_includes("/tom_longtime");
+            then.status(200).body(&html);
+        });
+        let download_mock = server.mock(|when, then| {
+            when.method(GET).path_includes("/getmodel/gfc/");
+            then.status(200).body(&gfc);
+        });
+
+        let entries = crate::datasets::icgem::parser::parse_earth_catalog(&html).unwrap();
+        let target = entries.first().unwrap().name.clone();
+
+        let _ = download_icgem_model_with_url(
+            &ICGEMBody::Earth, &target, None, &server.base_url(),
+        ).unwrap();
+        let _ = download_icgem_model_with_url(
+            &ICGEMBody::Earth, &target, None, &server.base_url(),
+        ).unwrap();
+
+        // Only one HTTP fetch for the file itself.
+        download_mock.assert_calls(1);
+        // The index listing is fetched only once: the first call writes it to
+        // disk with fetched_at = now, so the second call finds a fresh cache
+        // and skips the network entirely.
+        list_mock.assert_calls(1);
+
+        unsafe { std::env::remove_var("BRAHE_CACHE"); }
+    }
+
+    #[test]
+    #[cfg_attr(not(feature = "ci"), ignore)]
+    #[serial_test::serial]
+    fn test_download_live_jgm3_network() {
+        // Smoke test against real ICGEM. Skipped unless `--features ci`.
+        let dir = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("BRAHE_CACHE", dir.path()); }
+
+        let path = download_icgem_model(ICGEMBody::Earth, "JGM3", None);
+        // JGM3 is small and stable; if ICGEM is reachable, this must succeed.
+        assert!(path.is_ok(), "live download failed: {:?}", path.err());
+
+        unsafe { std::env::remove_var("BRAHE_CACHE"); }
+    }
+
+    #[test]
+    fn test_extract_icgem_hash_well_formed() {
+        let h = extract_icgem_hash("/getmodel/gfc/abc123def456/EGM2008.gfc");
+        assert_eq!(h, Some("abc123def456"));
+    }
+
+    #[test]
+    fn test_extract_icgem_hash_malformed_returns_none() {
+        assert_eq!(extract_icgem_hash(""), None);
+        assert_eq!(extract_icgem_hash("/wrong/prefix/abc/x.gfc"), None);
+        assert_eq!(extract_icgem_hash("/getmodel/gfc//x.gfc"), None);
+    }
+
+    #[test]
+    fn test_cache_filename_includes_hash_so_republished_models_get_new_path() {
+        // Two index entries for the same body/name/degree but with different
+        // ICGEM download hashes (e.g. the model was republished) must produce
+        // distinct cache filenames so the new file is fetched on the next
+        // download rather than being shadowed by the stale cached copy.
+        let old = IndexEntry {
+            body: ICGEMBody::Earth,
+            name: "EGM2008".into(),
+            year: Some(2008),
+            degree: 2190,
+            download_path: "/getmodel/gfc/old_hash_aaaaaaaaaaa/EGM2008.gfc".into(),
+        };
+        let new = IndexEntry {
+            body: ICGEMBody::Earth,
+            name: "EGM2008".into(),
+            year: Some(2008),
+            degree: 2190,
+            download_path: "/getmodel/gfc/new_hash_bbbbbbbbbbb/EGM2008.gfc".into(),
+        };
+        let old_name = cache_filename_for_entry(&old);
+        let new_name = cache_filename_for_entry(&new);
+        assert_ne!(
+            old_name, new_name,
+            "republished model under a new hash must not collide with the old cache file"
+        );
+        assert!(old_name.starts_with("EGM2008-2190-"));
+        assert!(new_name.starts_with("EGM2008-2190-"));
+        assert!(old_name.ends_with(".gfc"));
+    }
+
+    #[test]
+    fn test_cache_filename_falls_back_when_hash_missing() {
+        // Defensive: if download_path doesn't match the /getmodel/gfc/<hash>/...
+        // pattern (shouldn't happen in practice), we still produce a stable
+        // filename rather than panicking.
+        let entry = IndexEntry {
+            body: ICGEMBody::Earth,
+            name: "X".into(),
+            year: None,
+            degree: 70,
+            download_path: "unexpected".into(),
+        };
+        assert_eq!(cache_filename_for_entry(&entry), "X-70-nohash.gfc");
+    }
+}

--- a/src/datasets/icgem/index.rs
+++ b/src/datasets/icgem/index.rs
@@ -1,0 +1,456 @@
+//! ICGEM index file: read/write, TTL, and list query.
+
+use crate::datasets::icgem::body::ICGEMBody;
+use crate::utils::BraheError;
+use crate::utils::cache::get_icgem_cache_dir;
+use crate::utils::fs::atomic_write;
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// One ICGEM model row: a specific (body, name, degree) triple with its
+/// opaque download path.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct IndexEntry {
+    /// Celestial body this model is for.
+    pub body: ICGEMBody,
+    /// Model name as listed on ICGEM (e.g. "EGM2008", "GRGM1200B").
+    pub name: String,
+    /// Publication year, if parseable from the listing page.
+    pub year: Option<u16>,
+    /// Maximum spherical harmonic degree of this variant.
+    pub degree: u32,
+    /// Relative URL path including the opaque ICGEM hash, e.g.
+    /// `/getmodel/gfc/<hash>/EGM2008.gfc`.
+    pub download_path: String,
+}
+
+/// On-disk shape of an index cache file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct IndexFile {
+    /// Unix timestamp (seconds since epoch) when this index was fetched.
+    pub fetched_at: u64,
+    /// All entries parsed from the listing page at fetch time.
+    pub entries: Vec<IndexEntry>,
+}
+
+/// Default TTL before an index file is considered stale (30 days, in seconds).
+pub(crate) const DEFAULT_INDEX_TTL_SECONDS: u64 = 30 * 24 * 60 * 60;
+
+/// Filename for the Earth index file.
+pub(crate) const EARTH_INDEX_FILE: &str = "index_earth.json";
+
+/// Filename for the celestial (non-Earth) index file.
+pub(crate) const CELESTIAL_INDEX_FILE: &str = "index_celestial.json";
+
+/// Resolve the on-disk path for a body's index file.
+pub(crate) fn index_path_for(body: &ICGEMBody) -> Result<PathBuf, BraheError> {
+    let dir = get_icgem_cache_dir()?;
+    let filename = if body.is_earth() {
+        EARTH_INDEX_FILE
+    } else {
+        CELESTIAL_INDEX_FILE
+    };
+    Ok(PathBuf::from(dir).join(filename))
+}
+
+/// Current Unix time in seconds.
+pub(crate) fn now_unix_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Read an index file from disk. Returns `Ok(None)` if the file does not exist.
+pub(crate) fn read_index_file(path: &Path) -> Result<Option<IndexFile>, BraheError> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let data = std::fs::read_to_string(path).map_err(|e| {
+        BraheError::Error(format!(
+            "Failed to read ICGEM index file {}: {}",
+            path.display(),
+            e
+        ))
+    })?;
+    let parsed: IndexFile = serde_json::from_str(&data).map_err(|e| {
+        BraheError::Error(format!(
+            "Failed to parse ICGEM index file {}: {}",
+            path.display(),
+            e
+        ))
+    })?;
+    Ok(Some(parsed))
+}
+
+/// Write an index file to disk atomically.
+pub(crate) fn write_index_file(path: &Path, file: &IndexFile) -> Result<(), BraheError> {
+    let data = serde_json::to_string_pretty(file).map_err(|e| {
+        BraheError::Error(format!("Failed to serialize ICGEM index: {}", e))
+    })?;
+    atomic_write(path, data.as_bytes()).map_err(|e| {
+        BraheError::Error(format!(
+            "Failed to write ICGEM index to {}: {}",
+            path.display(),
+            e
+        ))
+    })
+}
+
+/// Production ICGEM base URL. All fetch functions take an explicit base URL
+/// (private `_with_url` variants) so tests can redirect to a local mock.
+pub(crate) const ICGEM_BASE_URL: &str = "https://icgem.gfz.de";
+
+/// Listing page path for Earth models.
+pub(crate) const EARTH_PATH: &str = "/tom_longtime";
+
+/// Listing page path for celestial models.
+pub(crate) const CELESTIAL_PATH: &str = "/tom_celestial";
+
+/// Fetch and parse a listing page from a given base URL.
+pub(crate) fn fetch_index_with_url(
+    body: &ICGEMBody,
+    base_url: &str,
+) -> Result<IndexFile, BraheError> {
+    use std::io::Read;
+    let path = if body.is_earth() { EARTH_PATH } else { CELESTIAL_PATH };
+    let url = format!("{}{}", base_url, path);
+
+    let response = ureq::get(&url).call().map_err(|e| {
+        BraheError::Error(format!("Failed to fetch ICGEM index from {}: {}", url, e))
+    })?;
+    let mut buf = String::new();
+    response
+        .into_body()
+        .into_reader()
+        .read_to_string(&mut buf)
+        .map_err(|e| {
+            BraheError::Error(format!("Failed to read ICGEM index from {}: {}", url, e))
+        })?;
+
+    let entries = if body.is_earth() {
+        crate::datasets::icgem::parser::parse_earth_catalog(&buf)?
+    } else {
+        crate::datasets::icgem::parser::parse_celestial_catalog(&buf)?
+    };
+
+    Ok(IndexFile {
+        fetched_at: now_unix_seconds(),
+        entries,
+    })
+}
+
+/// List models for a body, refreshing the index transparently if stale or
+/// missing. On a TTL miss with no network, falls back to the stale cache and
+/// logs a warning.
+pub fn list_icgem_models(body: ICGEMBody) -> Result<Vec<IndexEntry>, BraheError> {
+    list_icgem_models_with_url(&body, ICGEM_BASE_URL)
+}
+
+/// Variant of `list_icgem_models` that targets a configurable base URL (for tests).
+pub fn list_icgem_models_with_url(
+    body: &ICGEMBody,
+    base_url: &str,
+) -> Result<Vec<IndexEntry>, BraheError> {
+    let path = index_path_for(body)?;
+    let existing = read_index_file(&path)?;
+    let now = now_unix_seconds();
+
+    let needs_refresh = match &existing {
+        None => true,
+        Some(f) => now.saturating_sub(f.fetched_at) > DEFAULT_INDEX_TTL_SECONDS,
+    };
+
+    // The celestial cache file (`index_celestial.json`) holds entries for ALL
+    // non-Earth bodies. Always filter on read so a caller asking for Mars
+    // doesn't get Moon/Venus/Ceres entries back. Earth's cache only contains
+    // Earth entries, so the filter is a no-op there.
+    let filter_for_body = |all: Vec<IndexEntry>| -> Vec<IndexEntry> {
+        all.into_iter().filter(|e| &e.body == body).collect()
+    };
+
+    if !needs_refresh {
+        return Ok(filter_for_body(existing.unwrap().entries));
+    }
+
+    match fetch_index_with_url(body, base_url) {
+        Ok(fresh) => {
+            write_index_file(&path, &fresh)?;
+            Ok(filter_for_body(fresh.entries))
+        }
+        Err(fetch_err) => {
+            if let Some(stale) = existing {
+                eprintln!(
+                    "Warning: ICGEM index refresh failed ({}); using stale cache from {}",
+                    fetch_err, path.display()
+                );
+                Ok(filter_for_body(stale.entries))
+            } else {
+                Err(fetch_err)
+            }
+        }
+    }
+}
+
+/// Force-refresh the index for a single body, regardless of TTL.
+pub fn refresh_icgem_index(body: ICGEMBody) -> Result<(), BraheError> {
+    refresh_icgem_index_with_url(&body, ICGEM_BASE_URL)
+}
+
+pub(crate) fn refresh_icgem_index_with_url(
+    body: &ICGEMBody,
+    base_url: &str,
+) -> Result<(), BraheError> {
+    let fresh = fetch_index_with_url(body, base_url)?;
+    let path = index_path_for(body)?;
+    write_index_file(&path, &fresh)
+}
+
+/// Force-refresh both Earth and celestial index files.
+pub fn refresh_all_icgem_indexes() -> Result<(), BraheError> {
+    refresh_icgem_index(ICGEMBody::Earth)?;
+    // Any non-Earth body triggers the celestial fetch — pick Moon arbitrarily.
+    refresh_icgem_index(ICGEMBody::Moon)
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_index_entry_round_trip_json() {
+        let entry = IndexEntry {
+            body: ICGEMBody::Earth,
+            name: "EGM2008".into(),
+            year: Some(2008),
+            degree: 2190,
+            download_path: "/getmodel/gfc/abc/EGM2008.gfc".into(),
+        };
+        let s = serde_json::to_string(&entry).unwrap();
+        let back: IndexEntry = serde_json::from_str(&s).unwrap();
+        assert_eq!(entry, back);
+    }
+
+    #[test]
+    fn test_index_file_round_trip_json() {
+        let file = IndexFile {
+            fetched_at: 1_700_000_000,
+            entries: vec![IndexEntry {
+                body: ICGEMBody::Moon,
+                name: "GRGM1200B".into(),
+                year: Some(2016),
+                degree: 1200,
+                download_path: "/getmodel/gfc/xyz/GRGM1200B.gfc".into(),
+            }],
+        };
+        let s = serde_json::to_string(&file).unwrap();
+        let back: IndexFile = serde_json::from_str(&s).unwrap();
+        assert_eq!(back.entries.len(), 1);
+        assert_eq!(back.fetched_at, 1_700_000_000);
+    }
+
+    #[test]
+    fn test_index_path_dispatches_by_body() {
+        let earth = index_path_for(&ICGEMBody::Earth).unwrap();
+        assert!(earth.to_string_lossy().ends_with("index_earth.json"));
+        let moon = index_path_for(&ICGEMBody::Moon).unwrap();
+        assert!(moon.to_string_lossy().ends_with("index_celestial.json"));
+        let pluto = index_path_for(&ICGEMBody::Other("pluto".into())).unwrap();
+        assert!(pluto.to_string_lossy().ends_with("index_celestial.json"));
+    }
+
+    #[test]
+    fn test_read_index_file_missing_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nope.json");
+        assert!(read_index_file(&path).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_write_then_read_index_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("x.json");
+        let file = IndexFile {
+            fetched_at: 42,
+            entries: vec![],
+        };
+        write_index_file(&path, &file).unwrap();
+        let back = read_index_file(&path).unwrap().unwrap();
+        assert_eq!(back.fetched_at, 42);
+    }
+
+    #[test]
+    fn test_fetch_index_http_404() {
+        use httpmock::prelude::*;
+        let server = MockServer::start();
+        let _m = server.mock(|when, then| {
+            when.method(GET).path("/tom_longtime");
+            then.status(404);
+        });
+        let result = fetch_index_with_url(&ICGEMBody::Earth, &server.base_url());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_fetch_index_success_serves_fixture() {
+        use httpmock::prelude::*;
+        let fixture =
+            std::fs::read_to_string("test_assets/icgem/tom_longtime_sample.html").unwrap();
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(GET).path_includes("/tom_longtime");
+            then.status(200).body(&fixture);
+        });
+        let result = fetch_index_with_url(&ICGEMBody::Earth, &server.base_url());
+        let file = result.unwrap();
+        assert!(!file.entries.is_empty());
+        mock.assert_calls(1);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_list_models_uses_fresh_cache() {
+        let dir = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("BRAHE_CACHE", dir.path()); }
+
+        let path = index_path_for(&ICGEMBody::Earth).unwrap();
+        let file = IndexFile {
+            fetched_at: now_unix_seconds(),
+            entries: vec![IndexEntry {
+                body: ICGEMBody::Earth,
+                name: "JGM3".into(),
+                year: Some(1996),
+                degree: 70,
+                download_path: "/getmodel/gfc/abc/JGM3.gfc".into(),
+            }],
+        };
+        write_index_file(&path, &file).unwrap();
+
+        // No HTTP mock — if the implementation tries to fetch, the test fails.
+        let entries = list_icgem_models_with_url(&ICGEMBody::Earth, "http://127.0.0.1:1").unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "JGM3");
+
+        unsafe { std::env::remove_var("BRAHE_CACHE"); }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_list_models_refreshes_stale_cache() {
+        use httpmock::prelude::*;
+        let dir = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("BRAHE_CACHE", dir.path()); }
+
+        let path = index_path_for(&ICGEMBody::Earth).unwrap();
+        let stale = IndexFile {
+            fetched_at: 0,
+            entries: vec![],
+        };
+        write_index_file(&path, &stale).unwrap();
+
+        let fixture =
+            std::fs::read_to_string("test_assets/icgem/tom_longtime_sample.html").unwrap();
+        let server = MockServer::start();
+        let _m = server.mock(|when, then| {
+            when.method(GET).path_includes("/tom_longtime");
+            then.status(200).body(&fixture);
+        });
+
+        let entries = list_icgem_models_with_url(&ICGEMBody::Earth, &server.base_url()).unwrap();
+        assert!(!entries.is_empty());
+
+        unsafe { std::env::remove_var("BRAHE_CACHE"); }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_list_models_stale_fallback_on_network_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("BRAHE_CACHE", dir.path()); }
+
+        let path = index_path_for(&ICGEMBody::Earth).unwrap();
+        let stale = IndexFile {
+            fetched_at: 0,
+            entries: vec![IndexEntry {
+                body: ICGEMBody::Earth,
+                name: "STALE".into(),
+                year: None,
+                degree: 10,
+                download_path: "/getmodel/gfc/x/STALE.gfc".into(),
+            }],
+        };
+        write_index_file(&path, &stale).unwrap();
+
+        // Point at an unreachable URL so refresh fails; stale cache should be returned.
+        let entries = list_icgem_models_with_url(&ICGEMBody::Earth, "http://127.0.0.1:1").unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "STALE");
+
+        unsafe { std::env::remove_var("BRAHE_CACHE"); }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_list_models_filters_celestial_by_body() {
+        // The celestial cache file holds entries for ALL non-Earth bodies.
+        // list_icgem_models(Mars) must return only Mars entries — not Moon,
+        // Venus, or Ceres ones that share the same file.
+        let dir = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("BRAHE_CACHE", dir.path()); }
+
+        let path = index_path_for(&ICGEMBody::Moon).unwrap(); // celestial index file
+        let file = IndexFile {
+            fetched_at: now_unix_seconds(),
+            entries: vec![
+                IndexEntry {
+                    body: ICGEMBody::Moon,
+                    name: "GRGM1200B".into(),
+                    year: Some(2016),
+                    degree: 1200,
+                    download_path: "/getmodel/gfc/m/GRGM1200B.gfc".into(),
+                },
+                IndexEntry {
+                    body: ICGEMBody::Mars,
+                    name: "MRO120F".into(),
+                    year: Some(2016),
+                    degree: 120,
+                    download_path: "/getmodel/gfc/r/MRO120F.gfc".into(),
+                },
+                IndexEntry {
+                    body: ICGEMBody::Venus,
+                    name: "MGNP180U".into(),
+                    year: Some(1999),
+                    degree: 180,
+                    download_path: "/getmodel/gfc/v/MGNP180U.gfc".into(),
+                },
+            ],
+        };
+        write_index_file(&path, &file).unwrap();
+
+        let moon_entries =
+            list_icgem_models_with_url(&ICGEMBody::Moon, "http://127.0.0.1:1").unwrap();
+        assert_eq!(moon_entries.len(), 1);
+        assert_eq!(moon_entries[0].body, ICGEMBody::Moon);
+        assert_eq!(moon_entries[0].name, "GRGM1200B");
+
+        let mars_entries =
+            list_icgem_models_with_url(&ICGEMBody::Mars, "http://127.0.0.1:1").unwrap();
+        assert_eq!(mars_entries.len(), 1);
+        assert_eq!(mars_entries[0].body, ICGEMBody::Mars);
+        assert_eq!(mars_entries[0].name, "MRO120F");
+
+        let venus_entries =
+            list_icgem_models_with_url(&ICGEMBody::Venus, "http://127.0.0.1:1").unwrap();
+        assert_eq!(venus_entries.len(), 1);
+        assert_eq!(venus_entries[0].body, ICGEMBody::Venus);
+
+        // A body not present in the file should give an empty list, not error.
+        let ceres_entries =
+            list_icgem_models_with_url(&ICGEMBody::Ceres, "http://127.0.0.1:1").unwrap();
+        assert!(ceres_entries.is_empty());
+
+        unsafe { std::env::remove_var("BRAHE_CACHE"); }
+    }
+}

--- a/src/datasets/icgem/mod.rs
+++ b/src/datasets/icgem/mod.rs
@@ -1,0 +1,17 @@
+/*!
+ * ICGEM data source: spherical harmonic gravity models from
+ * the International Centre for Global Earth Models (icgem.gfz.de).
+ *
+ * Supports Earth and celestial bodies (Moon, Mars, Venus, Ceres, plus
+ * arbitrary bodies via `ICGEMBody::Other`). Models are listed via cached
+ * index files and downloaded on demand into `$BRAHE_CACHE/icgem/`.
+ */
+
+pub mod body;
+pub mod download;
+pub mod index;
+pub mod parser;
+
+pub use body::ICGEMBody;
+pub use download::download_icgem_model;
+pub use index::{IndexEntry, list_icgem_models, refresh_all_icgem_indexes, refresh_icgem_index};

--- a/src/datasets/icgem/parser.rs
+++ b/src/datasets/icgem/parser.rs
@@ -1,0 +1,329 @@
+//! HTML scraping for ICGEM listing pages.
+
+use crate::datasets::icgem::body::ICGEMBody;
+use crate::datasets::icgem::index::IndexEntry;
+use crate::utils::BraheError;
+use scraper::{Html, Selector};
+
+/// Collect the text content of an element, inserting a space at every `<br>`
+/// boundary so that values separated only by `<br>` (with no surrounding
+/// whitespace) become distinct whitespace-delimited tokens.
+///
+/// `scraper`'s `.text()` iterator yields only text nodes; `<br>` elements
+/// produce no text, so adjacent values like `11000<br>5500<br>760` would be
+/// concatenated into `"110005500760"` by a plain `.collect::<String>()`.
+///
+/// Implementation: split `inner_html()` on `<br>` tags (any case/variant),
+/// strip remaining tags from each chunk, then join with a space.
+fn text_with_br_spaces(el: &scraper::ElementRef<'_>) -> String {
+    let inner = el.inner_html();
+    split_on_br(&inner)
+        .into_iter()
+        .map(strip_html_tags)
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Split a raw HTML string on `<br>`, `<br/>`, or `<br ...>` tags (any case).
+fn split_on_br(html: &str) -> Vec<&str> {
+    let mut parts = Vec::new();
+    let mut start = 0;
+    let bytes = html.as_bytes();
+    let len = bytes.len();
+    let mut i = 0;
+    while i < len {
+        if bytes[i] == b'<' {
+            // Peek at the tag name, skipping an optional leading '/'.
+            let after_open = i + 1;
+            let tag_start = if after_open < len && bytes[after_open] == b'/' {
+                after_open + 1
+            } else {
+                after_open
+            };
+            if tag_start + 2 <= len {
+                let tag_lo = html[tag_start..tag_start + 2].to_ascii_lowercase();
+                if tag_lo == "br" {
+                    // Find the closing '>'.
+                    if let Some(close_offset) = html[i..].find('>') {
+                        parts.push(&html[start..i]);
+                        i += close_offset + 1; // advance past '>'
+                        start = i;
+                        continue;
+                    }
+                }
+            }
+        }
+        i += 1;
+    }
+    parts.push(&html[start..]);
+    parts
+}
+
+/// Strip all `<...>` HTML tags from a string slice, returning plain text.
+fn strip_html_tags(s: &str) -> String {
+    let mut out = String::new();
+    let mut in_tag = false;
+    for ch in s.chars() {
+        match ch {
+            '<' => in_tag = true,
+            '>' => in_tag = false,
+            _ if !in_tag => out.push(ch),
+            _ => {}
+        }
+    }
+    out
+}
+
+/// Parse the Earth catalog HTML (`tom_longtime`) into index entries.
+///
+/// All entries are tagged with `ICGEMBody::Earth`.
+pub fn parse_earth_catalog(html: &str) -> Result<Vec<IndexEntry>, BraheError> {
+    parse_catalog(html, |_object_text| ICGEMBody::Earth)
+}
+
+/// Parse the celestial catalog HTML (`tom_celestial`) into index entries.
+///
+/// The body for each row is read from the "Object" column.
+pub fn parse_celestial_catalog(html: &str) -> Result<Vec<IndexEntry>, BraheError> {
+    parse_catalog(html, |object_text| {
+        if object_text.is_empty() {
+            ICGEMBody::Other("unknown".to_string())
+        } else {
+            ICGEMBody::from_name(object_text)
+        }
+    })
+}
+
+/// Parse any ICGEM listing-page HTML into `IndexEntry` values.
+///
+/// `classify_body` is called with the trimmed text of the "Object" column
+/// (cell index 1) to determine the `ICGEMBody` for a row.
+///
+/// # Table layout (tom_longtime / tom_celestial)
+///
+/// Column indices (0-based `<td>` children of a data `<tr>`):
+/// - 0  : Row number
+/// - 1  : Object (body name; empty for Earth models)
+/// - 2  : Model name (`fw-bold`, may contain an `<a>`)
+/// - 3  : Year
+/// - 4  : Degree (one or more values separated by `<br>`; first is primary)
+/// - 5  : Data type codes
+/// - 6  : References
+/// - 7  : Download links (one or more `<a href="/getmodel/gfc/…">`)
+/// - 8+ : Calculate / 3D / DOI (ignored)
+///
+/// One `IndexEntry` is emitted **per `getmodel/gfc/` link** found in cell 7.
+/// Rows that have no such link (header rows, etc.) are skipped.
+///
+/// **Degree resolution:**
+/// 1. Primary: cell[4] degree paired with download link by index. Multi-variant
+///    rows list degrees separated by `<br>` (collapsed to whitespace by `.text()`);
+///    the i-th degree corresponds to the i-th gfc link.
+/// 2. Fallback: trailing `_NUMBER` suffix of the `.gfc` filename — used only
+///    when cell[4] has fewer degree values than gfc links.
+///
+/// **Model name resolution:**
+/// Model name comes from cell[2] (`.fw-bold`), which holds the canonical model
+/// name as displayed by ICGEM (sometimes wrapped in an `<a>` tag; `.text()`
+/// collects descendant text correctly). For multi-variant rows all emitted
+/// entries share this name and differ only by `degree`.
+fn parse_catalog<F>(html: &str, classify_body: F) -> Result<Vec<IndexEntry>, BraheError>
+where
+    F: Fn(&str) -> ICGEMBody,
+{
+    let doc = Html::parse_document(html);
+
+    let row_sel = Selector::parse("tr").unwrap();
+    let cell_sel = Selector::parse("td").unwrap();
+    let link_sel = Selector::parse("a[href*='/getmodel/gfc/']").unwrap();
+
+    let mut entries = Vec::new();
+
+    for tr in doc.select(&row_sel) {
+        // Collect all <td> children.
+        let cells: Vec<_> = tr.select(&cell_sel).collect();
+        // Must have at least 8 columns to contain a Download cell.
+        if cells.len() < 8 {
+            continue;
+        }
+
+        // Cell 7: Download — look for all gfc links.
+        let download_cell = &cells[7];
+        let gfc_links: Vec<_> = download_cell.select(&link_sel).collect();
+        if gfc_links.is_empty() {
+            continue;
+        }
+
+        // Cell 1: Object (body).
+        let object_text = cells[1].text().collect::<String>();
+        let object_text = object_text.trim();
+        let body = classify_body(object_text);
+
+        // Cell 2: Model name (.fw-bold cell; may contain an <a> wrapper).
+        let name = cells[2].text().collect::<String>().trim().to_string();
+        if name.is_empty() {
+            continue;
+        }
+
+        // Cell 3: Year — first 4-digit integer in [1900, 2100].
+        let year_text = cells[3].text().collect::<String>();
+        let year = year_text
+            .split_whitespace()
+            .find_map(|tok| {
+                tok.parse::<u16>()
+                    .ok()
+                    .filter(|&y| (1900..=2100).contains(&y))
+            });
+
+        // Cell 4: All degrees in document order. Multi-variant rows list degrees
+        // with `<br>` separators that `.text()` collapses to nothing — we use
+        // `text_with_br_spaces` to insert a space at each `<br>` boundary so
+        // that values like `11000<br>5500<br>760` become distinct tokens.
+        let degree_text = text_with_br_spaces(&cells[4]);
+        let cell_degrees: Vec<u32> = degree_text
+            .split_whitespace()
+            .filter_map(|tok| tok.parse::<u32>().ok())
+            .filter(|&n| n >= 2)
+            .collect();
+
+        // Emit one IndexEntry per gfc link, paired positionally with cell_degrees.
+        for (i, link) in gfc_links.iter().enumerate() {
+            let href = match link.value().attr("href") {
+                Some(h) => h.to_string(),
+                None => continue,
+            };
+
+            // Primary degree source: the i-th value from the Degree cell.
+            // Fallback: trailing `_NUMBER` in the filename (defensive — only used
+            // if cell_degrees has fewer values than gfc_links).
+            let degree = cell_degrees.get(i).copied().or_else(|| {
+                let filename = href
+                    .rsplit('/')
+                    .next()
+                    .unwrap_or("")
+                    .trim_end_matches(".gfc");
+                filename.rfind('_').and_then(|pos| {
+                    filename[pos + 1..].parse::<u32>().ok().filter(|&n| n >= 2)
+                })
+            });
+
+            let degree = match degree {
+                Some(d) => d,
+                None => continue,
+            };
+
+            entries.push(IndexEntry {
+                body: body.clone(),
+                name: name.clone(),
+                year,
+                degree,
+                download_path: href,
+            });
+        }
+    }
+
+    if entries.is_empty() {
+        return Err(BraheError::Error(
+            "ICGEM catalog parse returned no entries — page format may have changed".to_string(),
+        ));
+    }
+
+    Ok(entries)
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    const EARTH_FIXTURE: &str =
+        include_str!("../../../test_assets/icgem/tom_longtime_sample.html");
+
+    #[test]
+    fn test_parse_earth_catalog_has_entries() {
+        let entries = parse_earth_catalog(EARTH_FIXTURE).unwrap();
+        assert!(
+            !entries.is_empty(),
+            "expected at least 1 Earth model entry, got {}",
+            entries.len()
+        );
+        for e in &entries {
+            assert_eq!(e.body, ICGEMBody::Earth);
+            assert!(!e.name.is_empty());
+            assert!(e.download_path.contains("/getmodel/gfc/"));
+            assert!(e.degree >= 2);
+        }
+    }
+
+    #[test]
+    fn test_parse_earth_catalog_empty_html_errors() {
+        let result = parse_earth_catalog("<html><body></body></html>");
+        assert!(result.is_err());
+    }
+
+    const CELESTIAL_FIXTURE: &str =
+        include_str!("../../../test_assets/icgem/tom_celestial_sample.html");
+
+    #[test]
+    fn test_parse_earth_catalog_multi_variant_degrees_from_cell() {
+        // WHU-CASM-UGM2025_2159 is in the fixture and has 4 download variants.
+        // The Degree column lists 2190, 11000, 5500, 760 (in that order); the
+        // filenames are _2159.gfc, _11000.gfc, _5399.gfc, _719.gfc. The parser
+        // MUST use the Degree column, not the filename suffix.
+        let entries = parse_earth_catalog(EARTH_FIXTURE).unwrap();
+        let whu: Vec<&IndexEntry> = entries
+            .iter()
+            .filter(|e| e.name == "WHU-CASM-UGM2025_2159")
+            .collect();
+        assert_eq!(whu.len(), 4, "expected 4 download variants for WHU-CASM-UGM2025_2159");
+
+        let mut degrees: Vec<u32> = whu.iter().map(|e| e.degree).collect();
+        degrees.sort();
+        assert_eq!(
+            degrees,
+            vec![760, 2190, 5500, 11000],
+            "degrees must come from the Degree column, not the filename suffix"
+        );
+    }
+
+    #[test]
+    fn test_parse_earth_catalog_single_variant_uses_cell_name() {
+        // EGM2008 is a single-variant row. Name comes from cell[2], degree from cell[4].
+        let entries = parse_earth_catalog(EARTH_FIXTURE).unwrap();
+        let egm = entries.iter().find(|e| e.name == "EGM2008");
+        assert!(egm.is_some(), "EGM2008 entry missing");
+        assert_eq!(egm.unwrap().degree, 2190);
+    }
+
+    #[test]
+    fn test_parse_earth_catalog_keeps_year_range_degrees() {
+        // EIGEN-6C2 and EIGEN-6C3stat have degree 1949, which falls within the
+        // year range 1900-2100. The parser must not exclude it.
+        let entries = parse_earth_catalog(EARTH_FIXTURE).unwrap();
+        let degrees_1949: Vec<&IndexEntry> = entries
+            .iter()
+            .filter(|e| e.degree == 1949)
+            .collect();
+        assert!(
+            !degrees_1949.is_empty(),
+            "expected at least one entry with degree 1949 (e.g. EIGEN-6C2 or EIGEN-6C3stat)"
+        );
+    }
+
+    #[test]
+    fn test_parse_celestial_catalog_assigns_bodies() {
+        let entries = parse_celestial_catalog(CELESTIAL_FIXTURE).unwrap();
+        assert!(!entries.is_empty());
+
+        // We expect Moon and Mars to appear among the rows; the fixture must include them.
+        let bodies: std::collections::HashSet<_> = entries.iter().map(|e| e.body.clone()).collect();
+        assert!(
+            bodies.contains(&ICGEMBody::Moon) || bodies.contains(&ICGEMBody::Mars),
+            "expected at least one Moon or Mars entry; got bodies: {:?}",
+            bodies
+        );
+
+        // No row should be tagged as Earth on the celestial page.
+        assert!(!bodies.contains(&ICGEMBody::Earth));
+    }
+}

--- a/src/datasets/mod.rs
+++ b/src/datasets/mod.rs
@@ -8,6 +8,7 @@
 
 pub mod gcat;
 pub mod groundstations;
+pub mod icgem;
 pub mod loaders;
 pub mod naif;
 pub mod parsers;

--- a/src/orbit_dynamics/gravity.rs
+++ b/src/orbit_dynamics/gravity.rs
@@ -394,6 +394,18 @@ pub enum GravityModelType {
     ///
     /// Allows using custom gravity models. File must be in standard GFC format.
     FromFile(String),
+    /// Load a gravity model from ICGEM by body + model name.
+    ///
+    /// `name` is either an exact ICGEM model name (auto-resolves to the largest
+    /// available degree variant) or a `name-DEGREE` suffix to pick a specific
+    /// variant. The model is downloaded on first use and cached under
+    /// `$BRAHE_CACHE/icgem/models/<body>/<name>-<degree>.gfc`.
+    ICGEMModel {
+        /// Celestial body whose gravity model to load.
+        body: crate::datasets::icgem::ICGEMBody,
+        /// ICGEM model name (e.g. `"JGM3"`) or `"name-DEGREE"` for a specific variant.
+        name: String,
+    },
 }
 
 impl GravityModelType {
@@ -807,6 +819,14 @@ impl GravityModel {
                 Self::from_bufreader(reader)
             }
             GravityModelType::FromFile(path) => Self::from_file(Path::new(path)),
+            GravityModelType::ICGEMModel { body, name } => {
+                let path = crate::datasets::icgem::download_icgem_model(
+                    body.clone(),
+                    name,
+                    None,
+                )?;
+                Self::from_file(&path)
+            }
         }
     }
 
@@ -1972,5 +1992,48 @@ mod tests {
         let result = GravityModelType::from_file("data/gravity_models");
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("not a file"));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_gravity_model_type_icgem_variant_loads_jgm3() {
+        use crate::datasets::icgem::ICGEMBody;
+
+        let dir = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("BRAHE_CACHE", dir.path()); }
+
+        // Seed the icgem cache with a manually-placed gfc file so no network
+        // fetch is required.
+        let cache_dir = std::path::PathBuf::from(
+            crate::utils::cache::get_icgem_cache_dir().unwrap(),
+        );
+        let model_dir = cache_dir.join("models").join("earth");
+        std::fs::create_dir_all(&model_dir).unwrap();
+        let gfc = std::fs::read("data/gravity_models/JGM3.gfc").unwrap();
+        std::fs::write(model_dir.join("JGM3-70-x.gfc"), &gfc).unwrap();
+
+        // Seed a fresh index so list/refresh doesn't fetch.
+        let idx = crate::datasets::icgem::index::IndexFile {
+            fetched_at: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH).unwrap().as_secs(),
+            entries: vec![crate::datasets::icgem::IndexEntry {
+                body: ICGEMBody::Earth,
+                name: "JGM3".into(),
+                year: Some(1996),
+                degree: 70,
+                download_path: "/getmodel/gfc/x/JGM3.gfc".into(),
+            }],
+        };
+        let idx_path = crate::datasets::icgem::index::index_path_for(&ICGEMBody::Earth).unwrap();
+        crate::datasets::icgem::index::write_index_file(&idx_path, &idx).unwrap();
+
+        let mt = GravityModelType::ICGEMModel {
+            body: ICGEMBody::Earth,
+            name: "JGM3".into(),
+        };
+        let model = GravityModel::from_model_type(&mt).unwrap();
+        assert_eq!(model.n_max, 70);
+
+        unsafe { std::env::remove_var("BRAHE_CACHE"); }
     }
 }

--- a/src/orbit_dynamics/gravity.rs
+++ b/src/orbit_dynamics/gravity.rs
@@ -2036,4 +2036,113 @@ mod tests {
 
         unsafe { std::env::remove_var("BRAHE_CACHE"); }
     }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_numerical_propagator_with_icgem_jgm3_model() {
+        // End-to-end: a DNumericalOrbitPropagator built from a ForceModelConfig
+        // whose gravity source is `GravityModelType::ICGEMModel { Earth, "JGM3" }`
+        // must initialize cleanly and advance the state.
+        use crate::datasets::icgem::ICGEMBody;
+        use crate::propagators::{
+            DNumericalOrbitPropagator, ForceModelConfig, GravityConfiguration,
+            GravityModelSource, NumericalPropagationConfig,
+        };
+
+        let eop = FileEOPProvider::from_default_standard(true, EOPExtrapolation::Hold).unwrap();
+        set_global_eop_provider(eop);
+
+        let dir = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("BRAHE_CACHE", dir.path()); }
+
+        // Seed the ICGEM cache with JGM3 so no network fetch is required.
+        let cache_dir = std::path::PathBuf::from(
+            crate::utils::cache::get_icgem_cache_dir().unwrap(),
+        );
+        let model_dir = cache_dir.join("models").join("earth");
+        std::fs::create_dir_all(&model_dir).unwrap();
+        let gfc = std::fs::read("data/gravity_models/JGM3.gfc").unwrap();
+        std::fs::write(model_dir.join("JGM3-70-x.gfc"), &gfc).unwrap();
+
+        let idx = crate::datasets::icgem::index::IndexFile {
+            fetched_at: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH).unwrap().as_secs(),
+            entries: vec![crate::datasets::icgem::IndexEntry {
+                body: ICGEMBody::Earth,
+                name: "JGM3".into(),
+                year: Some(1996),
+                degree: 70,
+                download_path: "/getmodel/gfc/x/JGM3.gfc".into(),
+            }],
+        };
+        let idx_path = crate::datasets::icgem::index::index_path_for(&ICGEMBody::Earth).unwrap();
+        crate::datasets::icgem::index::write_index_file(&idx_path, &idx).unwrap();
+
+        // Drop the process-wide gravity cache so the propagator forces a fresh
+        // load of the ICGEM model under BRAHE_CACHE rather than reusing a model
+        // a prior test loaded under a different cache root.
+        clear_gravity_model_cache();
+
+        let epoch = Epoch::from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+        let oe = SVector6::new(R_EARTH + 500e3, 0.01, 97.8, 15.0, 30.0, 45.0);
+        let state = state_koe_to_eci(oe, AngleFormat::Degrees);
+        let dstate = DVector::from_column_slice(state.as_slice());
+
+        let icgem_model = GravityModelType::ICGEMModel {
+            body: ICGEMBody::Earth,
+            name: "JGM3".into(),
+        };
+        let force_model = ForceModelConfig {
+            gravity: GravityConfiguration::SphericalHarmonic {
+                source: GravityModelSource::ModelType(icgem_model),
+                degree: 20,
+                order: 20,
+            },
+            drag: None,
+            srp: None,
+            third_body: None,
+            relativity: false,
+            mass: None,
+            frame_transform: FrameTransformationModel::FullEarthRotation,
+        };
+
+        // Construction must succeed: the propagator has to be able to resolve
+        // the ICGEMModel variant through download_icgem_model → from_gfc_file.
+        let mut prop = DNumericalOrbitPropagator::new(
+            epoch,
+            dstate.clone(),
+            NumericalPropagationConfig::default(),
+            force_model,
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("propagator construction with ICGEMModel must succeed");
+
+        // Step once to confirm the propagator actually runs and the gravity
+        // model is wired in (a wiring failure typically shows up here as a
+        // panic or NaN state).
+        let target = epoch + 60.0;
+        prop.propagate_to(target);
+        let final_state = prop.current_state();
+
+        assert_eq!(final_state.len(), 6);
+        for i in 0..6 {
+            assert!(
+                final_state[i].is_finite(),
+                "state element {} is non-finite after 60 s ICGEM-JGM3 propagation",
+                i
+            );
+        }
+        // Position should have moved by at least ~100 km in 60 s at LEO orbital
+        // speed (~7.6 km/s).
+        let dx = final_state[0] - dstate[0];
+        let dy = final_state[1] - dstate[1];
+        let dz = final_state[2] - dstate[2];
+        let drift = (dx * dx + dy * dy + dz * dz).sqrt();
+        assert!(drift > 100e3, "state barely moved: drift = {} m", drift);
+
+        unsafe { std::env::remove_var("BRAHE_CACHE"); }
+    }
 }

--- a/src/utils/cache.rs
+++ b/src/utils/cache.rs
@@ -160,6 +160,25 @@ pub fn get_naif_cache_dir() -> Result<String, BraheError> {
     get_brahe_cache_dir_with_subdir(Some("naif"))
 }
 
+/// Get the ICGEM cache directory path.
+///
+/// Returns `~/.cache/brahe/icgem` (or `$BRAHE_CACHE/icgem` if environment variable is set).
+/// The directory is created if it doesn't exist.
+///
+/// # Returns
+///
+/// * `Result<String, BraheError>` - The full path to the ICGEM cache directory as a String
+///
+/// # Examples
+/// ```
+/// use brahe::utils::cache::get_icgem_cache_dir;
+/// let icgem_cache_dir = get_icgem_cache_dir().unwrap();
+/// println!("ICGEM cache directory: {}", icgem_cache_dir);
+/// ```
+pub fn get_icgem_cache_dir() -> Result<String, BraheError> {
+    get_brahe_cache_dir_with_subdir(Some("icgem"))
+}
+
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
@@ -354,6 +373,25 @@ mod tests {
             }
         }
         let _ = std::fs::remove_dir_all(&test_dir);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_get_icgem_cache_dir() {
+        let original_brahe_cache = env::var("BRAHE_CACHE").ok();
+        unsafe { env::remove_var("BRAHE_CACHE"); }
+
+        let icgem_cache_dir = get_icgem_cache_dir().unwrap();
+        assert!(!icgem_cache_dir.is_empty());
+        assert!(std::path::Path::new(&icgem_cache_dir).exists());
+        assert!(icgem_cache_dir.contains("brahe"));
+        assert!(icgem_cache_dir.contains("icgem"));
+
+        unsafe {
+            if let Some(original) = original_brahe_cache {
+                env::set_var("BRAHE_CACHE", original);
+            }
+        }
     }
 
     #[test]

--- a/test_assets/icgem/tom_celestial_sample.html
+++ b/test_assets/icgem/tom_celestial_sample.html
@@ -1,0 +1,1224 @@
+<!DOCTYPE html>
+<html>
+    <head>
+    <link rel="stylesheet" type="text/css" href="/libs/sortable-theme-bootstrap.css">
+            <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
+        <meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline' https://icgem.gfz.de blob: data: ws: https://webstats.gfz.de;
+                                                            script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: https://webstats.gfz.de;
+                                                            img-src * data:;">
+        <meta content="Franz Barthelmes, Elmas Sinem Ince, Sven Rei&szlig;land" name="Author">
+        <meta name="keywords"
+            content="CHAMP, GOCE, GPS levelling, GPS levelling, GRACE, calculation, comparison,
+                     computation, geoid, geopotential, gravity, gravity anomaly, gravity field,
+                     gravity model, grid, iag, map, spherical harmonic coefficients,
+                     spherical harmonics, validation, visualisation">
+        <meta name="description" content="ICGEM: International Centre for Global Earth Models">
+        <title>ICGEM International Center for Global Gravity Field Models</title>
+        <link rel="stylesheet" type="text/css" href="/libs/bootstrap_5.3.3.min.css">
+        <link rel="stylesheet" type="text/css" href="/colors.css">
+        <link rel="stylesheet" type="text/css" href="/icgem_bs.css">
+        <script src="/libs/jquery-3.7.0.min.js"></script>
+        <script src="/libs/underscore-umd-min.js"></script>
+        <script src="/common.js"></script>
+        <script>
+            const newurl = "https://icgem.gfz.de" + window.location.pathname + window.location.hash;
+            if (window.location.hostname.endsWith(".gfz-potsdam.de")) {
+                window.location.replace(newurl);
+            }
+        </script>
+            <script src="/libs/editorjs/header.js"></script>
+    <script src="/libs/editorjs/image.js"></script>
+    <script src="/libs/editorjs/inlineimage.js"></script>
+    <script src="/libs/editorjs/delimiter.js"></script>
+    <script src="/libs/editorjs/list.js"></script>
+    <script src="/libs/editorjs/quote.js"></script>
+    <script src="/libs/editorjs/code.js"></script>
+    <script src="/libs/editorjs/table.js"></script>
+    <script src="/libs/editorjs/marker.js"></script>
+    <script src="/libs/editorjs/underline.js"></script>
+    <script src="/libs/editorjs/inline-code.js"></script>
+    <script src="/libs/editorjs/attaches.js"></script>
+    <script src="/libs/editorjs/alignment.js"></script>
+    <script src="/libs/editorjs/raw.js"></script>
+    <link rel="stylesheet" type="text/css" href="/libs/editorjs/Hyperlink.css">
+    <script src="/libs/editorjs/SelectionUtils.js"></script>
+    <script src="/libs/editorjs/Hyperlink.js"></script>
+    <link rel="stylesheet" type="text/css" href="/libs/editorjs/color-picker.css">
+    <script src="/libs/editorjs/color-picker.js"></script>
+    <script src="/libs/editorjs/genericinline.js"></script>
+    <script src="/libs/editorjs.umd.min.js"></script>
+
+
+    </head>
+    <body>
+        
+        <div class="w-100 h-100 d-flex">
+            <div id="sidebar" class="d-flex flex-column">
+                <img id="logo" class="logo" src="/imgs/icgem.png" alt="Logo">
+                <div id="menu">
+
+
+
+
+        <a href="/home">ICGEM Home</a>
+
+
+<h4>Gravity Field Models</h4>
+        <a class="sub " href="/tom_longtime">Static Models</a>
+
+        <a class="sub " href="/sl/temporal">Temporal Models</a>
+
+        <a class="sub " href="/sl/simulated">Simulated Models</a>
+
+        <a class="sub " href="/tom_reltopo">Topographic Models</a>
+
+
+<h4>Calculation Service</h4>
+        <a class="sub " href="/calcgrid">Regular grids</a>
+
+        <a class="sub " href="/calcpoints">User-defined points</a>
+
+        <a class="sub " href="/g3">G3-Browser</a>
+
+
+<h4>3D Visualisation</h4>
+        <a class="sub " href="/vis3d/longtime">Static Models</a>
+
+        <a class="sub " href="/vis3d/series">Temporal Models</a>
+
+        <a class="sub " href="/vis3d/trend">Trend &amp; Amplitude</a>
+
+        <a class="sub " href="/vis3d/tutorial">Spherical Harmonics</a>
+
+
+<h4>Evaluation</h4>
+        <a class="sub " href="/evalchart">Spectral domain</a>
+
+        <a class="sub " href="/tom_gpslev">GNSS Leveling</a>
+
+
+        <a href="/dochome">Documentation</a>
+
+        <a class="sub " href="/faq">FAQ</a>
+
+        <a class="sub " href="/theory">Theory</a>
+
+        <a class="sub " href="/refs">References</a>
+
+        <a class="sub " href="/changes">Latest Changes</a>
+
+        <a class="sub " href="/contact">Contact</a>
+
+
+<h4>Other Celestial Bodies<br>
+    (Moon,Venus, Mars)</h4>
+        <a class="sub self " href="/tom_celestial">Table of Models</a>
+
+        <a class="sub " href="/vis3d/celestial">3D Visualization</a>
+
+        <a class="sub " href="/calcgrid?modeltype=celestial">Calculation Service</a>
+
+<hr noshade color="black" width="100%" size="3" align="center">
+        <a class="sub " href="/imprint">Imprint</a>
+
+        <a class="sub " href="/dataprotection">Data Protection</a>
+
+                <a class="sub " href="/login?redirecturl=/tom_celestial">Admin-Login</a>
+
+                </div>
+            </div>
+            <div id="content">
+                <div id="header" class="row">
+                    <img src="/imgs/iaglogo-short-web.png" alt="iaglogo">
+                    <img src="/imgs/logo_gfz.svg" alt="gfzlogo">
+                </div>
+<h1 class="display-4 text-center textshadow mb-4">Gravity Field Models of other Celestial Bodies
+</h1>
+<div>
+        <p><b>
+        We kindly ask the authors of the models to check the links to the original websites of the models from time to time.
+        <br>
+        Please let us know if something has changed.
+    </b></p>
+    <p>
+        The table can be interactively re-sorted by clicking on the column header fields (Nr, Model, Year, Degree, Data, Reference). 
+    </p>
+    <p>
+        In the data column, the datasets used in the development of the models are summarized, where
+        <b>A</b> is for altimetry,
+        <b>S</b> is for satellite (e.g., GRACE, GOCE, LAGEOS),
+        <b>G</b> for ground data (e.g., terrestrial, shipborne and airborne measurements) and
+        <b>T</b> is for topography.
+    </p>
+
+    <p>
+        It is not planned to offer the complete service of ICGEM also for non-Earth gravity field models. Nevertheless, we think it could be useful
+        to compile also some gravity field models of other celestial bodies for downloading and for use in our visualisation and calculation service.
+    </p>
+</div>
+<div class="d-flex flex-wrap">
+    <table data-sortable class="table table-striped table-sm sortable-bootstrap w-100">
+    <thead>
+        <tr>
+            <th style="min-width: 4rem;">#</th>
+            <th style="min-width:12rem;">Object</th>
+            <th style="min-width:12rem;">Model</th>
+            <th style="min-width: 5rem;">Year</th>
+            <th style="min-width: 6rem;">Degree</th>
+            <th style="min-width: 6rem;">Data</th>
+            <th style="min-width:12rem;">References</th>
+            <th style="min-width: 8rem;" data-sortable="false">Download</th>
+            <th style="min-width: 8rem;" data-sortable="false">Calculate</th>
+            <th style="min-width: 6rem;" data-sortable="false">3D</th>
+            <th style="min-width: 5rem;" data-sortable="false">DOI</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+    <td></td>
+    <td class="fw-bold">Moon (of the Earth)</td>
+    <td class="fw-bold">        <a href="https://doi.org/10.1029/2020EA001454" target="_blank">AIUB-GRL350A</a>
+</td>
+    <td>2021</td>
+    <td>        350
+</td>
+    <td>            GRAIL</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_0431c2d23ee2ad20c91329da05af67a0711e055ecb5a7f846710413f4c5d9710').toggle(); "><b>Bertone et al. (2021)</b></div>
+        <div id="ref_0431c2d23ee2ad20c91329da05af67a0711e055ecb5a7f846710413f4c5d9710" class="mt-1" style="display:none">Bertone, S., Arnold, D., Girardin, V., Lasser, M., Meyer, U., Jäggi, A.,
+2021: <br> 
+<b>Assessing Reduced‐Dynamic Parametrizations for GRAIL Orbit Determination and the
+Recovery of Independent Lunar Gravity Field Solutions. </b><br> 
+Earth and Space Science.
+doi: <a href="https://doi.org/10.1029/2020EA001454" target="_blank">10.1029/2020EA001454</a>.<br>
+<br>
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/0431c2d23ee2ad20c91329da05af67a0711e055ecb5a7f846710413f4c5d9710/AIUB-GRL350A.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/0431c2d23ee2ad20c91329da05af67a0711e055ecb5a7f846710413f4c5d9710/AIUB-GRL350A.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=celestial&object=Moon (of the Earth)&modelid=0431c2d23ee2ad20c91329da05af67a0711e055ecb5a7f846710413f4c5d9710" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/celestial?modelid=0431c2d23ee2ad20c91329da05af67a0711e055ecb5a7f846710413f4c5d9710" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td></td>
+    <td class="fw-bold">Moon (of the Earth)</td>
+    <td class="fw-bold">        <a href="https://doi.org/10.1029/2020EA001454" target="_blank">AIUB-GRL350B</a>
+</td>
+    <td>2021</td>
+    <td>        350
+</td>
+    <td>            GRAIL</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_f17df1b5fe44a1bf945027d159772bf1d0831ff0edf7533ceffcb3ec2836c7e0').toggle(); "><b>Bertone et al. (2021)</b></div>
+        <div id="ref_f17df1b5fe44a1bf945027d159772bf1d0831ff0edf7533ceffcb3ec2836c7e0" class="mt-1" style="display:none">Bertone, S., Arnold, D., Girardin, V., Lasser, M., Meyer, U., Jäggi, A.,
+2021: <br> 
+<b>Assessing Reduced‐Dynamic Parametrizations for GRAIL Orbit Determination and the
+Recovery of Independent Lunar Gravity Field Solutions. </b><br> 
+Earth and Space Science.
+doi: <a href="https://doi.org/10.1029/2020EA001454" target="_blank">10.1029/2020EA001454</a>.<br>
+<br></div>
+    </td>
+    <td>        <a href="/getmodel/gfc/f17df1b5fe44a1bf945027d159772bf1d0831ff0edf7533ceffcb3ec2836c7e0/AIUB-GRL350B.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/f17df1b5fe44a1bf945027d159772bf1d0831ff0edf7533ceffcb3ec2836c7e0/AIUB-GRL350B.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=celestial&object=Moon (of the Earth)&modelid=f17df1b5fe44a1bf945027d159772bf1d0831ff0edf7533ceffcb3ec2836c7e0" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/celestial?modelid=f17df1b5fe44a1bf945027d159772bf1d0831ff0edf7533ceffcb3ec2836c7e0" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td></td>
+    <td class="fw-bold">Moon (of the Earth) - density</td>
+    <td class="fw-bold">        <a href="https://doi.org/10.1016/j.pss.2020.105032" target="_blank">densityMOON</a>
+</td>
+    <td>2020</td>
+    <td>        89
+</td>
+    <td></td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_995a87a2689dec499879a212cc3c9394a6137d17744e6ee94127d750ec550761').toggle(); "><b>Sprlak et al. (2020)</b></div>
+        <div id="ref_995a87a2689dec499879a212cc3c9394a6137d17744e6ee94127d750ec550761" class="mt-1" style="display:none">Sprlak M, Han S-C, Featherstone W. (2020): <br>
+<b>Crustal Density and Global
+Gravitational Field Estimation of the Moon from GRAIL and LOLA Satellite Data,</b> Planetary and Space Science, 192, 105032.
+doi: <a href="https://doi.org/10.1016/j.pss.2020.105032" target="_blank">https://doi.org/10.1016/j.pss.2020.105032</a>
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/995a87a2689dec499879a212cc3c9394a6137d17744e6ee94127d750ec550761/densityMOON.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/995a87a2689dec499879a212cc3c9394a6137d17744e6ee94127d750ec550761/densityMOON.zip" target="_blank">zip</a>
+</td>
+    <td></td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td></td>
+    <td class="fw-bold">Moon (of the Earth)</td>
+    <td class="fw-bold">        <a href="https://link.springer.com/article/10.1007/s00190-018-1177-4" target="_blank">STU_MoonTopo720</a>
+</td>
+    <td>2019</td>
+    <td>        2160
+</td>
+    <td>            Topography</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_fb7f42825475bbd192d5be2febb6c9222a9c6c30145ca77bfb152361d187d981').toggle(); "><b>Bucha et al. (2019)</b></div>
+        <div id="ref_fb7f42825475bbd192d5be2febb6c9222a9c6c30145ca77bfb152361d187d981" class="mt-1" style="display:none">Bucha, B., Hirt, C., Kuhn, M., (2019):<br>
+Divergence-free spherical harmonic gravity field modelling based on the Runge-Krarup theorem: a case study for the Moon. Journal of Geodesy 93, 489-513, https://doi.org/10.1007/s00190-018-1177-4.
+</b><br>
+<br>
+Hirt, C., Kuhn, M., (2017):<br>
+Convergence and divergence in spherical harmonic series of the gravitational field generated by high-resolution planetary topography - a case study for the Moon.  Journal of Geophysical Research: Planets 122, 17271746, https://doi.org/10.1002/2017JE005298.
+</b><br>
+<br>
+Wieczorek, M. A., (2015): <br> 
+Gravity and topography of the terrestrial planets. In: Schubert, G. (ed.) Treatise on geophysics, 2nd edn. Elsevier, New York, pp 153193.
+https://doi.org/10.1016/B978-0-444-53802-4.00169-X.
+</b><br>
+<br>
+Moritz, H., (1980): Advanced Physical Geodesy, Herbert Wichmann Verlag, Karlsruhe, Germany, 500 pp
+</b><br>
+<br>
+Web: http://edisk.cvt.stuba.sk/~xbuchab/
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/fb7f42825475bbd192d5be2febb6c9222a9c6c30145ca77bfb152361d187d981/STU_MoonTopo720.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/fb7f42825475bbd192d5be2febb6c9222a9c6c30145ca77bfb152361d187d981/STU_MoonTopo720.zip" target="_blank">zip</a>
+</td>
+    <td></td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td></td>
+    <td class="fw-bold">Moon (of the Earth)</td>
+    <td class="fw-bold">        <a href="https://link.springer.com/article/10.1007/s00190-018-1177-4" target="_blank">STU_MoonTopo720_plusNormalField</a>
+</td>
+    <td>2019</td>
+    <td>        2160
+</td>
+    <td>            Topography</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_cd6c8d8855f497e8b5ab1cb9ec91412f60175a51c0bc6b16acaa31503df98a8e').toggle(); "><b>Bucha et al. (2019)</b></div>
+        <div id="ref_cd6c8d8855f497e8b5ab1cb9ec91412f60175a51c0bc6b16acaa31503df98a8e" class="mt-1" style="display:none">Bucha, B., Hirt, C., Kuhn, M., (2019):<br>
+Divergence-free spherical harmonic gravity field modelling based on the Runge-Krarup theorem: a case study for the Moon. Journal of Geodesy 93, 489-513, https://doi.org/10.1007/s00190-018-1177-4.
+</b><br>
+<br>
+Hirt, C., Kuhn, M., (2017):<br>
+Convergence and divergence in spherical harmonic series of the gravitational field generated by high-resolution planetary topography - a case study for the Moon.  Journal of Geophysical Research: Planets 122, 17271746, https://doi.org/10.1002/2017JE005298.
+</b><br>
+<br>
+Wieczorek, M. A., (2015): <br> 
+Gravity and topography of the terrestrial planets. In: Schubert, G. (ed.) Treatise on geophysics, 2nd edn. Elsevier, New York, pp 153193.
+https://doi.org/10.1016/B978-0-444-53802-4.00169-X.
+</b><br>
+<br>
+Moritz, H., (1980): Advanced Physical Geodesy, Herbert Wichmann Verlag, Karlsruhe, Germany, 500 pp
+</b><br>
+<br>
+Web: http://edisk.cvt.stuba.sk/~xbuchab/
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/cd6c8d8855f497e8b5ab1cb9ec91412f60175a51c0bc6b16acaa31503df98a8e/STU_MoonTopo720_plusNormalField.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/cd6c8d8855f497e8b5ab1cb9ec91412f60175a51c0bc6b16acaa31503df98a8e/STU_MoonTopo720_plusNormalField.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=celestial&object=Moon (of the Earth)&modelid=cd6c8d8855f497e8b5ab1cb9ec91412f60175a51c0bc6b16acaa31503df98a8e" target="_blank">Calculate</a>
+</td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td></td>
+    <td class="fw-bold">Ceres</td>
+    <td class="fw-bold">        <a href="https://doi.org/10.1016/j.icarus.2019.113412" target="_blank">sphericalRFM_CERES_2519.gfc</a>
+</td>
+    <td>2019</td>
+    <td>        2519
+</td>
+    <td>            Topography</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_7ff3989b256e3b3a8c7cb2cf3f2308ca4f63aab10893f97fd146f24f7afbd260').toggle(); "><b>Sprlak et al. (2020)</b></div>
+        <div id="ref_7ff3989b256e3b3a8c7cb2cf3f2308ca4f63aab10893f97fd146f24f7afbd260" class="mt-1" style="display:none">Sprlak, M., Han, S-C, Featherstone, W. (2020): <br>
+Spheroidal Forward Modelling of the Gravitational Fields of 1 Ceres and the Moon. Icarus 335, doi: https://doi.org/10.1016/j.icarus.2019.113412.
+</b><br>
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/7ff3989b256e3b3a8c7cb2cf3f2308ca4f63aab10893f97fd146f24f7afbd260/sphericalRFM_CERES_2519.gfc.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/7ff3989b256e3b3a8c7cb2cf3f2308ca4f63aab10893f97fd146f24f7afbd260/sphericalRFM_CERES_2519.gfc.zip" target="_blank">zip</a>
+</td>
+    <td></td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td></td>
+    <td class="fw-bold">Moon (of the Earth)</td>
+    <td class="fw-bold">        <a href="https://doi.org/10.1016/j.icarus.2019.113412" target="_blank">sphericalRFM_MOON_2519.gfc</a>
+</td>
+    <td>2019</td>
+    <td>        2519
+</td>
+    <td>            Topography</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_668f45cea126901fdd534c5d5e38f170de1a4aa71b39086f816ce4571776094e').toggle(); "><b>Sprlak et al. (2020)</b></div>
+        <div id="ref_668f45cea126901fdd534c5d5e38f170de1a4aa71b39086f816ce4571776094e" class="mt-1" style="display:none">Sprlak, M., Han, S-C, Featherstone, W. (2020): <br>
+Spheroidal Forward Modelling of the Gravitational Fields of 1 Ceres and the Moon. Icarus 335, doi: https://doi.org/10.1016/j.icarus.2019.113412.
+</b><br>
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/668f45cea126901fdd534c5d5e38f170de1a4aa71b39086f816ce4571776094e/sphericalRFM_MOON_2519.gfc.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/668f45cea126901fdd534c5d5e38f170de1a4aa71b39086f816ce4571776094e/sphericalRFM_MOON_2519.gfc.zip" target="_blank">zip</a>
+</td>
+    <td></td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td></td>
+    <td class="fw-bold">Moon (of the Earth)</td>
+    <td class="fw-bold">        <a href="https://doi.org/10.1016/j.icarus.2019.113412" target="_blank">sphericalRFM_MOON_2519_plusNormalField.gfc</a>
+</td>
+    <td>2019</td>
+    <td>        2519
+</td>
+    <td>            Topography</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_55a22c3a79557b51fdae8200698aaa0dc32e4781ee414da714b492c7f7a1e479').toggle(); "><b>Sprlak et al. (2020)</b></div>
+        <div id="ref_55a22c3a79557b51fdae8200698aaa0dc32e4781ee414da714b492c7f7a1e479" class="mt-1" style="display:none">Sprlak, M., Han, S-C, Featherstone, W. (2020): <br>
+Spheroidal Forward Modelling of the Gravitational Fields of 1 Ceres and the Moon. Icarus 335, doi: https://doi.org/10.1016/j.icarus.2019.113412.
+</b><br></div>
+    </td>
+    <td>        <a href="/getmodel/gfc/55a22c3a79557b51fdae8200698aaa0dc32e4781ee414da714b492c7f7a1e479/sphericalRFM_MOON_2519_plusNormalField.gfc.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/55a22c3a79557b51fdae8200698aaa0dc32e4781ee414da714b492c7f7a1e479/sphericalRFM_MOON_2519_plusNormalField.gfc.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=celestial&object=Moon (of the Earth)&modelid=55a22c3a79557b51fdae8200698aaa0dc32e4781ee414da714b492c7f7a1e479" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/celestial?modelid=55a22c3a79557b51fdae8200698aaa0dc32e4781ee414da714b492c7f7a1e479" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td></td>
+    <td class="fw-bold">Moon (of the Earth)</td>
+    <td class="fw-bold">        <a href="http://geodesy.iwf.oeaw.ac.at/p_grazil.html" target="_blank">GrazLGM420b</a>
+</td>
+    <td>2018</td>
+    <td>        420
+</td>
+    <td></td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_f2147532a5ea47807531309d343b7d338419770764cd34d89b33fb9e550069f0').toggle(); "><b>Wirnsberger et al. (2018)</b></div>
+        <div id="ref_f2147532a5ea47807531309d343b7d338419770764cd34d89b33fb9e550069f0" class="mt-1" style="display:none">Wirnsberger H., Krauss S., and Mayer-Gürr, T., 2018<br>
+<b>First independent Graz Lunar Gravity Field Model derived from GRAIL.</b><br>
+submitted to Icarus 2018_244.<br>
+<br></div>
+    </td>
+    <td>        <a href="/getmodel/gfc/f2147532a5ea47807531309d343b7d338419770764cd34d89b33fb9e550069f0/GrazLGM420b.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/f2147532a5ea47807531309d343b7d338419770764cd34d89b33fb9e550069f0/GrazLGM420b.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=celestial&object=Moon (of the Earth)&modelid=f2147532a5ea47807531309d343b7d338419770764cd34d89b33fb9e550069f0" target="_blank">Calculate</a>
+</td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td></td>
+    <td class="fw-bold">Moon (of the Earth)</td>
+    <td class="fw-bold">        <a href="http://geodesy.iwf.oeaw.ac.at/p_grazil.html" target="_blank">GrazLGM420b+</a>
+</td>
+    <td>2018</td>
+    <td>        420
+</td>
+    <td></td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_43d37bf3cd989ce670cd2375b725a69c974bed4a3d356faa88ffd47a8998902b').toggle(); "><b>Wirnsberger et al. (2018)</b></div>
+        <div id="ref_43d37bf3cd989ce670cd2375b725a69c974bed4a3d356faa88ffd47a8998902b" class="mt-1" style="display:none">Wirnsberger H., Krauss S., and Mayer-Gürr, T., 2018<br>
+<b>First independent Graz Lunar Gravity Field Model derived from GRAIL.</b><br>
+submitted to Icarus 2018_244.<br>
+<br></div>
+    </td>
+    <td>        <a href="/getmodel/gfc/43d37bf3cd989ce670cd2375b725a69c974bed4a3d356faa88ffd47a8998902b/GrazLGM420b+.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/43d37bf3cd989ce670cd2375b725a69c974bed4a3d356faa88ffd47a8998902b/GrazLGM420b+.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=celestial&object=Moon (of the Earth)&modelid=43d37bf3cd989ce670cd2375b725a69c974bed4a3d356faa88ffd47a8998902b" target="_blank">Calculate</a>
+</td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td></td>
+    <td class="fw-bold">Moon (of the Earth)</td>
+    <td class="fw-bold">        <a href="https://link.springer.com/article/10.1007/s00190-017-1098-7" target="_blank">RFM_Moon_2520</a>
+</td>
+    <td>2018</td>
+    <td>        2520
+</td>
+    <td></td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_8558f4a78ad41980f218bc84f2f70679bbac8382266a9812e6cb62f7efdaadb0').toggle(); "><b>Sprlak et al. (2018)</b></div>
+        <div id="ref_8558f4a78ad41980f218bc84f2f70679bbac8382266a9812e6cb62f7efdaadb0" class="mt-1" style="display:none">Sprlak, M., Han, S-C., Featherstone, W.E. (2018) (2018):<br> 
+<br>Forward modelling of global gravity fields with 3D density structures and an application to the high-resolution (~2 km) gravity fields of the Moon.</b><br>
+Journal of Geodesy, doi: 10.1007/s00190-017-1098-7.</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/8558f4a78ad41980f218bc84f2f70679bbac8382266a9812e6cb62f7efdaadb0/RFM_Moon_2520.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/8558f4a78ad41980f218bc84f2f70679bbac8382266a9812e6cb62f7efdaadb0/RFM_Moon_2520.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=celestial&object=Moon (of the Earth)&modelid=8558f4a78ad41980f218bc84f2f70679bbac8382266a9812e6cb62f7efdaadb0" target="_blank">Calculate</a>
+</td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td></td>
+    <td class="fw-bold">Moon (of the Earth)</td>
+    <td class="fw-bold">        <a href="http://geodesy.iwf.oeaw.ac.at/p_grazil.html" target="_blank">GrazLGM420a</a>
+</td>
+    <td>2017</td>
+    <td>        420
+</td>
+    <td></td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_c7e8b2a6d413b7c59803929d5a8f57ae523f1924da8704a9677b6aeab0a38f01').toggle(); "><b>Wirnsberger et al. (2017)</b></div>
+        <div id="ref_c7e8b2a6d413b7c59803929d5a8f57ae523f1924da8704a9677b6aeab0a38f01" class="mt-1" style="display:none">Wirnsberger H., Klinger B., Krauss S., and Mayer-Gürr, T., 2017<br>
+<b>First independent lunar gravity field solution in the framework of project GRAZIL.</b><br>
+European Geoscience Union 2017, Vienna.<br>
+<br>
+Krauss, S., Klinger, B., Baur, O., Mayer-Guerr, T. 2015.<br>
+<b>Development of the lunar gravity field model GrazLGM300a.</b><br>
+Oesterr. Zeitschr. Verm. Geoinf., ISSN 1605-1653, 103, 156-161, 2015.</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/c7e8b2a6d413b7c59803929d5a8f57ae523f1924da8704a9677b6aeab0a38f01/GrazLGM420a.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/c7e8b2a6d413b7c59803929d5a8f57ae523f1924da8704a9677b6aeab0a38f01/GrazLGM420a.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=celestial&object=Moon (of the Earth)&modelid=c7e8b2a6d413b7c59803929d5a8f57ae523f1924da8704a9677b6aeab0a38f01" target="_blank">Calculate</a>
+</td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td></td>
+    <td class="fw-bold">Moon (of the Earth)</td>
+    <td class="fw-bold">        <a href="http://ddfe.curtin.edu.au/models/" target="_blank">dV_MoonTopo_2160</a>
+</td>
+    <td>2017</td>
+    <td>        2160
+</td>
+    <td></td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_e9e44b5057424f91baf0bfa1bdfe2b1a888a9a7ec368b03ed95be75f531a978f').toggle(); "><b>Hirt and Kuhn (2017)</b></div>
+        <div id="ref_e9e44b5057424f91baf0bfa1bdfe2b1a888a9a7ec368b03ed95be75f531a978f" class="mt-1" style="display:none">Hirt, C. and M. Kuhn, 2017:<br>
+<b>Convergence and divergence in spherical harmonic series of the gravitational field generated by high-resolution planetary topography  a case study for the Moon.</b><br>
+Journal of Geophysical Research (JGR) - Planets, 122, doi:10.1002/2017JE005298.</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/e9e44b5057424f91baf0bfa1bdfe2b1a888a9a7ec368b03ed95be75f531a978f/dV_MoonTopo_2160.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/e9e44b5057424f91baf0bfa1bdfe2b1a888a9a7ec368b03ed95be75f531a978f/dV_MoonTopo_2160.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=celestial&object=Moon (of the Earth)&modelid=e9e44b5057424f91baf0bfa1bdfe2b1a888a9a7ec368b03ed95be75f531a978f" target="_blank">Calculate</a>
+</td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td></td>
+    <td class="fw-bold">Moon (of the Earth)</td>
+    <td class="fw-bold">        <a href="http://geodesy.iwf.oeaw.ac.at/p_grazil.html" target="_blank">GrazLGM300c</a>
+</td>
+    <td>2016</td>
+    <td>        300
+</td>
+    <td></td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_40b2e51005b1ed43865a8e7d0a4af06db0d30930c882acf7af702cf75f80f1b8').toggle(); "><b>Krauss et al. (2016)</b></div>
+        <div id="ref_40b2e51005b1ed43865a8e7d0a4af06db0d30930c882acf7af702cf75f80f1b8" class="mt-1" style="display:none">Krauss, S., Wirnsberger, H., Klinger, B., Mayer-Guerr, T., Baur, O.;<br>
+<b>Latest developments in lunar gravity field recovery within the project GRAZIL</b><br>
+European Geoscience Union 2016, Vienna, 2016
+<br><br>
+Related References:<br>
+Krauss, S., Klinger, B., Baur, O., Mayer-Guerr, T.;<br>
+<b>Development of the lunar gravity field model GrazLGM300a</b><br>
+Oesterr. Zeitschr. Verm. Geoinf., ISSN 1605-1653, 103, 156-161, 2015</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/40b2e51005b1ed43865a8e7d0a4af06db0d30930c882acf7af702cf75f80f1b8/GrazLGM300c.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/40b2e51005b1ed43865a8e7d0a4af06db0d30930c882acf7af702cf75f80f1b8/GrazLGM300c.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=celestial&object=Moon (of the Earth)&modelid=40b2e51005b1ed43865a8e7d0a4af06db0d30930c882acf7af702cf75f80f1b8" target="_blank">Calculate</a>
+</td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td></td>
+    <td class="fw-bold">Moon (of the Earth)</td>
+    <td class="fw-bold">        <a href="http://dx.doi.org/10.1016/j.icarus.2015.08.015" target="_blank">AIUB-GRL200A</a>
+</td>
+    <td>2015</td>
+    <td>        200
+</td>
+    <td></td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_de07bfc4a3b18d157eb02b16352fbac8aff156a8d43366cc73d9cf77a5201ace').toggle(); "><b>Arnold et al. (2015)</b></div>
+        <div id="ref_de07bfc4a3b18d157eb02b16352fbac8aff156a8d43366cc73d9cf77a5201ace" class="mt-1" style="display:none">Arnold D., Bertone S., Jäggi A., Beutler G., Mervart L.;<br>
+<b>GRAIL gravity field determination using the Celestial Mechanics Approach</b><br>
+http://dx.doi.org/10.1016/j.icarus.2015.08.015, Icarus, 2015</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/de07bfc4a3b18d157eb02b16352fbac8aff156a8d43366cc73d9cf77a5201ace/AIUB-GRL200A.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/de07bfc4a3b18d157eb02b16352fbac8aff156a8d43366cc73d9cf77a5201ace/AIUB-GRL200A.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=celestial&object=Moon (of the Earth)&modelid=de07bfc4a3b18d157eb02b16352fbac8aff156a8d43366cc73d9cf77a5201ace" target="_blank">Calculate</a>
+</td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td></td>
+    <td class="fw-bold">Moon (of the Earth)</td>
+    <td class="fw-bold">        <a href="http://dx.doi.org/10.1016/j.icarus.2015.08.015" target="_blank">AIUB-GRL200B</a>
+</td>
+    <td>2015</td>
+    <td>        200
+</td>
+    <td></td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_61cedca83a193d510db62498924eec06cfdb6a043a836195a467afa441c9658b').toggle(); "><b>Arnold et al. (2015)</b></div>
+        <div id="ref_61cedca83a193d510db62498924eec06cfdb6a043a836195a467afa441c9658b" class="mt-1" style="display:none">Arnold D., Bertone S., Jäggi A., Beutler G., Mervart L.;<br>
+<b>GRAIL gravity field determination using the Celestial Mechanics Approach;</b><br>
+http://dx.doi.org/10.1016/j.icarus.2015.08.015, Icarus, 2015</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/61cedca83a193d510db62498924eec06cfdb6a043a836195a467afa441c9658b/AIUB-GRL200B.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/61cedca83a193d510db62498924eec06cfdb6a043a836195a467afa441c9658b/AIUB-GRL200B.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=celestial&object=Moon (of the Earth)&modelid=61cedca83a193d510db62498924eec06cfdb6a043a836195a467afa441c9658b" target="_blank">Calculate</a>
+</td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td></td>
+    <td class="fw-bold">Moon (of the Earth)</td>
+    <td class="fw-bold">        <a href="http://geo.pds.nasa.gov/" target="_blank">GL0660B</a>
+</td>
+    <td>2013</td>
+    <td>        660
+</td>
+    <td></td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_b4f8182e0e0a2112fc3720a2fb5d10f885e4aed39652b8ba8e9d3c2a8645c29c').toggle(); "><b></b></div>
+        <div id="ref_b4f8182e0e0a2112fc3720a2fb5d10f885e4aed39652b8ba8e9d3c2a8645c29c" class="mt-1" style="display:none"></div>
+    </td>
+    <td>        <a href="/getmodel/gfc/b4f8182e0e0a2112fc3720a2fb5d10f885e4aed39652b8ba8e9d3c2a8645c29c/GL0660B.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/b4f8182e0e0a2112fc3720a2fb5d10f885e4aed39652b8ba8e9d3c2a8645c29c/GL0660B.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=celestial&object=Moon (of the Earth)&modelid=b4f8182e0e0a2112fc3720a2fb5d10f885e4aed39652b8ba8e9d3c2a8645c29c" target="_blank">Calculate</a>
+</td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td></td>
+    <td class="fw-bold">Moon (of the Earth)</td>
+    <td class="fw-bold">        <a href="http://geo.pds.nasa.gov/" target="_blank">GRGM660PRIM</a>
+</td>
+    <td>2013</td>
+    <td>        660
+</td>
+    <td></td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_50844d1a07b40af4d19592e360f93304a9b63362af1643f4fe135b4a7f517c40').toggle(); "><b></b></div>
+        <div id="ref_50844d1a07b40af4d19592e360f93304a9b63362af1643f4fe135b4a7f517c40" class="mt-1" style="display:none"></div>
+    </td>
+    <td>        <a href="/getmodel/gfc/50844d1a07b40af4d19592e360f93304a9b63362af1643f4fe135b4a7f517c40/GRGM660PRIM.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/50844d1a07b40af4d19592e360f93304a9b63362af1643f4fe135b4a7f517c40/GRGM660PRIM.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=celestial&object=Moon (of the Earth)&modelid=50844d1a07b40af4d19592e360f93304a9b63362af1643f4fe135b4a7f517c40" target="_blank">Calculate</a>
+</td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td></td>
+    <td class="fw-bold">Mars</td>
+    <td class="fw-bold">        <a href="http://pds-geosciences.wustl.edu/" target="_blank">ggm1025a</a>
+</td>
+    <td>2002</td>
+    <td>        80
+</td>
+    <td></td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_9c774f955897e8b9c79832cf21a1eb8c14a1a348aa131e4044f640b7482aff7b').toggle(); "><b>Lemoine et al. 2001</b></div>
+        <div id="ref_9c774f955897e8b9c79832cf21a1eb8c14a1a348aa131e4044f640b7482aff7b" class="mt-1" style="display:none">F.G. Lemoine, G.A. Neumann, D.S. Chinn, D.E. Smith, M.T. Zuber, D.D. Rowlands, D.P. Rubincam,  and D.E. Pavlis;<br>
+<b>Solution for Mars Geophysical Parameters from Mars Global Surveyor Tracking Data</b><br>
+American Geophysical Union Fall Meeting 2001 (EOS, Trans. AGU 82(47), Fall Meeting Supplement, Abstract P42A-0545, F721, 2001)
+<br><br>
+Lemoine et al.;<br>
+<b>An Improved Solution of the Gravity Field of Mars (GMM-2B) from Mars Global Surveyor;</b><br>
+J. Geophys Res., 106(E10), 23359-23376, Oct 25, 2001</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/9c774f955897e8b9c79832cf21a1eb8c14a1a348aa131e4044f640b7482aff7b/ggm1025a.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/9c774f955897e8b9c79832cf21a1eb8c14a1a348aa131e4044f640b7482aff7b/ggm1025a.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=celestial&object=Mars&modelid=9c774f955897e8b9c79832cf21a1eb8c14a1a348aa131e4044f640b7482aff7b" target="_blank">Calculate</a>
+</td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td></td>
+    <td class="fw-bold">Mars</td>
+    <td class="fw-bold">        <a href="http://pds-geosciences.wustl.edu/" target="_blank">jgm85f01</a>
+</td>
+    <td>2002</td>
+    <td>        85
+</td>
+    <td></td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_80de1efc0b1c7322207164b8749b85839384d4994e1a0cc2822617eccd7f2162').toggle(); "><b></b></div>
+        <div id="ref_80de1efc0b1c7322207164b8749b85839384d4994e1a0cc2822617eccd7f2162" class="mt-1" style="display:none"></div>
+    </td>
+    <td>        <a href="/getmodel/gfc/80de1efc0b1c7322207164b8749b85839384d4994e1a0cc2822617eccd7f2162/jgm85f01.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/80de1efc0b1c7322207164b8749b85839384d4994e1a0cc2822617eccd7f2162/jgm85f01.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=celestial&object=Mars&modelid=80de1efc0b1c7322207164b8749b85839384d4994e1a0cc2822617eccd7f2162" target="_blank">Calculate</a>
+</td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td></td>
+    <td class="fw-bold">Moon (of the Earth)</td>
+    <td class="fw-bold">        <a href="http://pds-geosciences.wustl.edu/missions/lunarp/shadr.html" target="_blank">JGL150Q1</a>
+</td>
+    <td>2000</td>
+    <td>        150
+</td>
+    <td></td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_c1f2f546dbed7afb651d86b8daa8bc54f0bd56cb0fb4ccda6472e843d30dcae5').toggle(); "><b></b></div>
+        <div id="ref_c1f2f546dbed7afb651d86b8daa8bc54f0bd56cb0fb4ccda6472e843d30dcae5" class="mt-1" style="display:none"></div>
+    </td>
+    <td>        <a href="/getmodel/gfc/c1f2f546dbed7afb651d86b8daa8bc54f0bd56cb0fb4ccda6472e843d30dcae5/JGL150Q1.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/c1f2f546dbed7afb651d86b8daa8bc54f0bd56cb0fb4ccda6472e843d30dcae5/JGL150Q1.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=celestial&object=Moon (of the Earth)&modelid=c1f2f546dbed7afb651d86b8daa8bc54f0bd56cb0fb4ccda6472e843d30dcae5" target="_blank">Calculate</a>
+</td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td></td>
+    <td class="fw-bold">Moon (of the Earth)</td>
+    <td class="fw-bold">        <a href="http://pds-geosciences.wustl.edu/missions/lunarp/shadr.html" target="_blank">JGL165P1</a>
+</td>
+    <td>2000</td>
+    <td>        165
+</td>
+    <td></td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_7445953c07d1041fc6f14cda870e6525d4e839d65f39cb0b0b01d0f00afc7274').toggle(); "><b></b></div>
+        <div id="ref_7445953c07d1041fc6f14cda870e6525d4e839d65f39cb0b0b01d0f00afc7274" class="mt-1" style="display:none"></div>
+    </td>
+    <td>        <a href="/getmodel/gfc/7445953c07d1041fc6f14cda870e6525d4e839d65f39cb0b0b01d0f00afc7274/JGL165P1.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/7445953c07d1041fc6f14cda870e6525d4e839d65f39cb0b0b01d0f00afc7274/JGL165P1.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=celestial&object=Moon (of the Earth)&modelid=7445953c07d1041fc6f14cda870e6525d4e839d65f39cb0b0b01d0f00afc7274" target="_blank">Calculate</a>
+</td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td></td>
+    <td class="fw-bold">Mars</td>
+    <td class="fw-bold">        <a href="http://pds-geosciences.wustl.edu/" target="_blank">ggm2bc80</a>
+</td>
+    <td>2000</td>
+    <td>        80
+</td>
+    <td></td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_9dceb9535c3aee1b189e84025852ca7c34c118982fc42e8a5c05416238657009').toggle(); "><b></b></div>
+        <div id="ref_9dceb9535c3aee1b189e84025852ca7c34c118982fc42e8a5c05416238657009" class="mt-1" style="display:none"></div>
+    </td>
+    <td>        <a href="/getmodel/gfc/9dceb9535c3aee1b189e84025852ca7c34c118982fc42e8a5c05416238657009/ggm2bc80.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/9dceb9535c3aee1b189e84025852ca7c34c118982fc42e8a5c05416238657009/ggm2bc80.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=celestial&object=Mars&modelid=9dceb9535c3aee1b189e84025852ca7c34c118982fc42e8a5c05416238657009" target="_blank">Calculate</a>
+</td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td></td>
+    <td class="fw-bold">Moon (of the Earth)</td>
+    <td class="fw-bold">        <a href="http://pds-geosciences.wustl.edu/missions/lunarp/shadr.html" target="_blank">JGL100J1</a>
+</td>
+    <td>1999</td>
+    <td>        100
+</td>
+    <td></td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_ba5b9bd1d76674272da040b367bf1662edf21ae88f2e112dfed89dffc1fcd5bc').toggle(); "><b></b></div>
+        <div id="ref_ba5b9bd1d76674272da040b367bf1662edf21ae88f2e112dfed89dffc1fcd5bc" class="mt-1" style="display:none"></div>
+    </td>
+    <td>        <a href="/getmodel/gfc/ba5b9bd1d76674272da040b367bf1662edf21ae88f2e112dfed89dffc1fcd5bc/JGL100J1.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/ba5b9bd1d76674272da040b367bf1662edf21ae88f2e112dfed89dffc1fcd5bc/JGL100J1.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=celestial&object=Moon (of the Earth)&modelid=ba5b9bd1d76674272da040b367bf1662edf21ae88f2e112dfed89dffc1fcd5bc" target="_blank">Calculate</a>
+</td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td></td>
+    <td class="fw-bold">Moon (of the Earth)</td>
+    <td class="fw-bold">        <a href="http://pds-geosciences.wustl.edu/missions/lunarp/shadr.html" target="_blank">JGL100K1</a>
+</td>
+    <td>1999</td>
+    <td>        100
+</td>
+    <td></td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_11a499697b582606af4c4855735ad73fa0eaeb32f8c43502022f304640a721f3').toggle(); "><b></b></div>
+        <div id="ref_11a499697b582606af4c4855735ad73fa0eaeb32f8c43502022f304640a721f3" class="mt-1" style="display:none"></div>
+    </td>
+    <td>        <a href="/getmodel/gfc/11a499697b582606af4c4855735ad73fa0eaeb32f8c43502022f304640a721f3/JGL100K1.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/11a499697b582606af4c4855735ad73fa0eaeb32f8c43502022f304640a721f3/JGL100K1.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=celestial&object=Moon (of the Earth)&modelid=11a499697b582606af4c4855735ad73fa0eaeb32f8c43502022f304640a721f3" target="_blank">Calculate</a>
+</td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td></td>
+    <td class="fw-bold">Moon (of the Earth)</td>
+    <td class="fw-bold">        <a href="http://pds-geosciences.wustl.edu/missions/lunarp/shadr.html" target="_blank">JGL075D1</a>
+</td>
+    <td>1998</td>
+    <td>        75
+</td>
+    <td></td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_5c19143d5796435028119c63902945a0e9804b1e872247062e65199af525b236').toggle(); "><b></b></div>
+        <div id="ref_5c19143d5796435028119c63902945a0e9804b1e872247062e65199af525b236" class="mt-1" style="display:none"></div>
+    </td>
+    <td>        <a href="/getmodel/gfc/5c19143d5796435028119c63902945a0e9804b1e872247062e65199af525b236/JGL075D1.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/5c19143d5796435028119c63902945a0e9804b1e872247062e65199af525b236/JGL075D1.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=celestial&object=Moon (of the Earth)&modelid=5c19143d5796435028119c63902945a0e9804b1e872247062e65199af525b236" target="_blank">Calculate</a>
+</td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td></td>
+    <td class="fw-bold">Moon (of the Earth)</td>
+    <td class="fw-bold">        <a href="http://pds-geosciences.wustl.edu/missions/lunarp/shadr.html" target="_blank">JGL075G1</a>
+</td>
+    <td>1998</td>
+    <td>        75
+</td>
+    <td></td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_3857a98334afe28ca71c8ad2b5fc99c47409e4c8fb637f8457305fb3b2f7acac').toggle(); "><b></b></div>
+        <div id="ref_3857a98334afe28ca71c8ad2b5fc99c47409e4c8fb637f8457305fb3b2f7acac" class="mt-1" style="display:none">
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/3857a98334afe28ca71c8ad2b5fc99c47409e4c8fb637f8457305fb3b2f7acac/JGL075G1.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/3857a98334afe28ca71c8ad2b5fc99c47409e4c8fb637f8457305fb3b2f7acac/JGL075G1.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=celestial&object=Moon (of the Earth)&modelid=3857a98334afe28ca71c8ad2b5fc99c47409e4c8fb637f8457305fb3b2f7acac" target="_blank">Calculate</a>
+</td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td></td>
+    <td class="fw-bold">Mars</td>
+    <td class="fw-bold">        <a href="http://pds-geosciences.wustl.edu/" target="_blank">ggm50a01</a>
+</td>
+    <td>1998</td>
+    <td>        50
+</td>
+    <td></td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_cf57d34afcdef00871888c0627c2d8130c4db6bd6cf66938bc315ef9b473a740').toggle(); "><b></b></div>
+        <div id="ref_cf57d34afcdef00871888c0627c2d8130c4db6bd6cf66938bc315ef9b473a740" class="mt-1" style="display:none"></div>
+    </td>
+    <td>        <a href="/getmodel/gfc/cf57d34afcdef00871888c0627c2d8130c4db6bd6cf66938bc315ef9b473a740/ggm50a01.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/cf57d34afcdef00871888c0627c2d8130c4db6bd6cf66938bc315ef9b473a740/ggm50a01.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=celestial&object=Mars&modelid=cf57d34afcdef00871888c0627c2d8130c4db6bd6cf66938bc315ef9b473a740" target="_blank">Calculate</a>
+</td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td></td>
+    <td class="fw-bold">Mars</td>
+    <td class="fw-bold">        <a href="http://pds-geosciences.wustl.edu/" target="_blank">ggm50a02</a>
+</td>
+    <td>1998</td>
+    <td>        50
+</td>
+    <td></td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_3b129db5fc25874d2d5b9d27cc541e19e723e5e5c30d9ee779acf47c30c50bd7').toggle(); "><b></b></div>
+        <div id="ref_3b129db5fc25874d2d5b9d27cc541e19e723e5e5c30d9ee779acf47c30c50bd7" class="mt-1" style="display:none"></div>
+    </td>
+    <td>        <a href="/getmodel/gfc/3b129db5fc25874d2d5b9d27cc541e19e723e5e5c30d9ee779acf47c30c50bd7/ggm50a02.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/3b129db5fc25874d2d5b9d27cc541e19e723e5e5c30d9ee779acf47c30c50bd7/ggm50a02.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=celestial&object=Mars&modelid=3b129db5fc25874d2d5b9d27cc541e19e723e5e5c30d9ee779acf47c30c50bd7" target="_blank">Calculate</a>
+</td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td></td>
+    <td class="fw-bold">Mars</td>
+    <td class="fw-bold">        <a href="http://pds-geosciences.wustl.edu/" target="_blank">jgm50c01</a>
+</td>
+    <td>1998</td>
+    <td>        50
+</td>
+    <td></td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_3e03743db46f22e9d103b52cce8b081e46bf502d22e67ff7984437918bdaa058').toggle(); "><b></b></div>
+        <div id="ref_3e03743db46f22e9d103b52cce8b081e46bf502d22e67ff7984437918bdaa058" class="mt-1" style="display:none"></div>
+    </td>
+    <td>        <a href="/getmodel/gfc/3e03743db46f22e9d103b52cce8b081e46bf502d22e67ff7984437918bdaa058/jgm50c01.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/3e03743db46f22e9d103b52cce8b081e46bf502d22e67ff7984437918bdaa058/jgm50c01.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=celestial&object=Mars&modelid=3e03743db46f22e9d103b52cce8b081e46bf502d22e67ff7984437918bdaa058" target="_blank">Calculate</a>
+</td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td></td>
+    <td class="fw-bold">Venus</td>
+    <td class="fw-bold">        <a href="http://pds-geosciences.wustl.edu/missions/magellan/shadr_topo_grav/index.htm" target="_blank">shgj180ua01</a>
+</td>
+    <td>1997</td>
+    <td>        180
+</td>
+    <td></td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_9283b24c0d7b64a37ae8d45669ffb16a63496fd090dd678ddaba64ac4c99178a').toggle(); "><b></b></div>
+        <div id="ref_9283b24c0d7b64a37ae8d45669ffb16a63496fd090dd678ddaba64ac4c99178a" class="mt-1" style="display:none"></div>
+    </td>
+    <td>        <a href="/getmodel/gfc/9283b24c0d7b64a37ae8d45669ffb16a63496fd090dd678ddaba64ac4c99178a/shgj180ua01.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/9283b24c0d7b64a37ae8d45669ffb16a63496fd090dd678ddaba64ac4c99178a/shgj180ua01.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=celestial&object=Venus&modelid=9283b24c0d7b64a37ae8d45669ffb16a63496fd090dd678ddaba64ac4c99178a" target="_blank">Calculate</a>
+</td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td></td>
+    <td class="fw-bold">Venus</td>
+    <td class="fw-bold">        <a href="http://pds-geosciences.wustl.edu/missions/magellan/shadr_topo_grav/index.htm" target="_blank">shgj120pa01</a>
+</td>
+    <td>1996</td>
+    <td>        120
+</td>
+    <td></td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_a84a4306816873c005d835b8b5c5048e0659828220f1ba12b250a9ffa51a7977').toggle(); "><b></b></div>
+        <div id="ref_a84a4306816873c005d835b8b5c5048e0659828220f1ba12b250a9ffa51a7977" class="mt-1" style="display:none"></div>
+    </td>
+    <td>        <a href="/getmodel/gfc/a84a4306816873c005d835b8b5c5048e0659828220f1ba12b250a9ffa51a7977/shgj120pa01.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/a84a4306816873c005d835b8b5c5048e0659828220f1ba12b250a9ffa51a7977/shgj120pa01.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=celestial&object=Venus&modelid=a84a4306816873c005d835b8b5c5048e0659828220f1ba12b250a9ffa51a7977" target="_blank">Calculate</a>
+</td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td></td>
+    <td class="fw-bold">Moon (of the Earth)</td>
+    <td class="fw-bold">        <a href="http://pds-geosciences.wustl.edu/missions/lunarp/shadr.html" target="_blank">GLGM-2</a>
+</td>
+    <td>1995</td>
+    <td>        70
+</td>
+    <td></td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_b72d74cd994ff41a4970b5080df661ba544da6d2a913520127f943ff0f3d610a').toggle(); "><b>Lemoine et al. (1995)</b></div>
+        <div id="ref_b72d74cd994ff41a4970b5080df661ba544da6d2a913520127f943ff0f3d610a" class="mt-1" style="display:none">F. G. Lemoine, D. E. Smith, M.T. Zuber, G. A. Neumann, D. D. Rowlands;<br>
+<b>GLGM-2, A 70th Degree and Order Lunar Gravity Model from Clementine and Historical Data</b><br>
+J. Geophys. Res, November 1995
+<br><br>
+<b>Related References</b><br>
+F. G. Lemoine, D. E. Smith, M. T. Zuber, and G. A. Neumann;<br>
+<b>High Degree and Order Spherical Harmonic MOdels for the Moon from Clementine and Historic S-Band Doppler Data</b><br>
+1995 XXI General Assembly, IUGG, Boulder, Colorado, July 12, 1995
+<br><br>
+M E Davies, V K Abalakin, A. Brahic, M. Bursa, B H Chovitz, J H Lieske, P K Seidelmann, A T Sinclair, Y S Tjuflin;
+<b>Report of the IAU/IAG/COSPAR Working Group on Cartographic Coordinates and Rotational Elements of the Planets and Satellites 1991</b><br>
+Cel. Mechanics and Dynamical Astronomy, 53, 377-397, 1992</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/b72d74cd994ff41a4970b5080df661ba544da6d2a913520127f943ff0f3d610a/GLGM-2.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/b72d74cd994ff41a4970b5080df661ba544da6d2a913520127f943ff0f3d610a/GLGM-2.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=celestial&object=Moon (of the Earth)&modelid=b72d74cd994ff41a4970b5080df661ba544da6d2a913520127f943ff0f3d610a" target="_blank">Calculate</a>
+</td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td></td>
+    <td class="fw-bold">Moon (of the Earth)</td>
+    <td class="fw-bold">        <a href="http://pds-geosciences.wustl.edu/missions/lunarp/shadr.html" target="_blank">GLGM-1</a>
+</td>
+    <td>1994</td>
+    <td>        70
+</td>
+    <td></td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_c3358942ca593e05b37cea8cb180bef0d0a98c40d55509c41038932a57c3685b').toggle(); "><b>Lemoine et al. (1994)</b></div>
+        <div id="ref_c3358942ca593e05b37cea8cb180bef0d0a98c40d55509c41038932a57c3685b" class="mt-1" style="display:none">F. G. Lemoine, D. E. Smith, M. T. Zuber;<br>
+<b>Goddard Lunar Gravity Model-1 (GLGM-1): A 70th degree and order gravity model for the Moon;</b><br>
+P11A-9, EOS, Transactions of the American Geophysical Union Volume 75, No. 44, 1994
+<br><br>
+<b>Related References:</b><br>
+M E Davies, V K Abalakin, A. Brahic, M. Bursa, B H Chovitz, J H Lieske, P K Seidelmann, A T Sinclair, Y S Tjuflin;
+<b>Report of the IAU/IAG/COSPAR Working Group on Cartographic Coordinates and Rotational Elements of the Planets and Satellites 1991</b><br>
+Cel. Mechanics and Dynamical Astronomy, 53, 377-397, 1992</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/c3358942ca593e05b37cea8cb180bef0d0a98c40d55509c41038932a57c3685b/GLGM-1.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/c3358942ca593e05b37cea8cb180bef0d0a98c40d55509c41038932a57c3685b/GLGM-1.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=celestial&object=Moon (of the Earth)&modelid=c3358942ca593e05b37cea8cb180bef0d0a98c40d55509c41038932a57c3685b" target="_blank">Calculate</a>
+</td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+    </tbody>
+</table>
+
+</div>
+<script src="/libs/sortable.min.js"></script>
+<script>
+    $('table').each(function() {
+        let empty_cols = [];
+        let cols = $(this).find("thead tr th").length;
+        let col;
+        for (col=0; col < cols; col++) {
+            let empty = true;
+            let line;
+            for (line of $(this).find("tbody tr")) {
+                if ($($(line).children()[col]).html().trim() != "") {
+                    empty = false;
+                    continue;
+                }
+            }
+            if (empty) {
+                empty_cols.push(col);
+            }
+        }
+        for (col of empty_cols.reverse()) {
+            console.log("Column " + col + " empty.")
+            $(this).find("tbody tr").each(function() {
+                $(this).children("td:eq(" + col + ")").remove();
+            });
+            $(this).find("thead tr").each(function() {
+                $(this).children("th:eq(" + col + ")").remove();
+            });
+        }
+    });
+</script>
+
+            </div>
+        </div>
+        <div id="footer_outer">
+            <div id="footer_inner">
+                <i>icgem (at) gfz.de</i>
+            </div>
+        </div>
+<div id='popup'>
+    <a class="x" href="javascript:hidePopup();" title="Hide this message and set a cookie">X</a>
+    <h4><b><a target="_blank" href="https://www.listserv.dfn.de/sympa/subscribe/icgemusers">Subscribe</a> to the<br>ICGEM-users mailinglist.</b></h4>
+</div>
+<!--<div id='popup'>
+    <a class="x" href="javascript:hidePopup();" title="Hide this message and set a cookie">X</a>
+    <h4>We appreciate your feedback. Please use our <a target="_blank" href="/survey">user survey</a> to send us your opinion.</h4>
+</div>-->
+<script type="text/javascript">
+    var hidemax = 7*24*60*60;
+    function hidePopup() {
+        document.getElementById('popup').style.display="none";
+        if ( getCookie("cookieconsent_status") == "accept" ) {
+            var htime = Math.min(parseInt(getCookie("popuphide")) * 2, hidemax) || 60*60;
+            console.log(htime);
+            setCookie("popuphide", htime, 30);
+            setCookie("popupnext", new Date() / 1000 + htime, 30);
+        }
+    }
+    if ( getCookie("cookieconsent_status") == "accept" ) {
+        if ( parseInt(getCookie("popupnext")) > (new Date() / 1000) ) {
+            document.getElementById('popup').style.display="none";
+            if ( parseInt(getCookie("popuphide")) >= hidemax ) {
+                setCookie("popupnext", new Date() / 1000 + hidemax, 30);
+            }
+        }
+    } else {
+        delCookie("popuphide");
+        delCookie("popupnext");
+        if (Math.random() > 0.05) { // hide popup most of the time
+            document.getElementById('popup').style.display="none";
+        }
+    }
+</script><div id="cookiebanner" class="modal show fade" data-bs-backdrop="static" style="display:block;">
+    <div class="position-fixed top-0 left-0 w-100 h-100" style="background-color:rgba(0,0,0,.5)"></div>
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Privacy Settings</h5>
+                <button type="button" class="btn-close" aria-label="Close" onclick="$('#cookiebanner').hide();"></button>
+            </div>
+            <div class="modal-body">
+                <p>
+                We use cookies that are necessary for the basic functionality of our website so that it can be continuously optimized for you and its user-friendliness
+                improved. We also use the Matomo web analysis tool, which tracks data anonymously. This enables us to statistically evaluate the use of our website.
+                Your consent to the use of Matomo can be revoked at any time via the <a href="/dataprotection">privacy policy</a>.
+                </p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" onclick="setCookie('cookieconsent_status', 'deny'); $('#cookiebanner').hide();">Refuse</button>
+                <button type="button" class="btn btn-primary" onclick="setCookie('cookieconsent_status', 'accept'); $('#cookiebanner').hide();">Accept</button>
+            </div>
+        </div>
+    </div>
+</div>
+<script>
+    if ( getCookie("cookieconsent_status") != "" ) {
+        $('#cookiebanner').hide()
+    }
+    var _paq = window._paq = window._paq || [];
+    _paq.push(['requireCookieConsent']);
+    if ( getCookie("cookieconsent_status") == "accept" ) {
+        _paq.push(['setCookieConsentGiven']);
+    }
+    // tracker methods like "setCustomDimension" should be called before "trackPageView"
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+        var u="https://webstats.gfz.de/";
+        _paq.push(['setTrackerUrl', u+'matomo.php']);
+        _paq.push(['setSiteId', '45']);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+    })();
+</script>    </body>
+</html>

--- a/test_assets/icgem/tom_longtime_sample.html
+++ b/test_assets/icgem/tom_longtime_sample.html
@@ -1,0 +1,7668 @@
+<!DOCTYPE html>
+<html>
+    <head>
+    <link rel="stylesheet" type="text/css" href="/libs/sortable-theme-bootstrap.css">
+            <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
+        <meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline' https://icgem.gfz.de blob: data: ws: https://webstats.gfz.de;
+                                                            script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: https://webstats.gfz.de;
+                                                            img-src * data:;">
+        <meta content="Franz Barthelmes, Elmas Sinem Ince, Sven Rei&szlig;land" name="Author">
+        <meta name="keywords"
+            content="CHAMP, GOCE, GPS levelling, GPS levelling, GRACE, calculation, comparison,
+                     computation, geoid, geopotential, gravity, gravity anomaly, gravity field,
+                     gravity model, grid, iag, map, spherical harmonic coefficients,
+                     spherical harmonics, validation, visualisation">
+        <meta name="description" content="ICGEM: International Centre for Global Earth Models">
+        <title>ICGEM International Center for Global Gravity Field Models</title>
+        <link rel="stylesheet" type="text/css" href="/libs/bootstrap_5.3.3.min.css">
+        <link rel="stylesheet" type="text/css" href="/colors.css">
+        <link rel="stylesheet" type="text/css" href="/icgem_bs.css">
+        <script src="/libs/jquery-3.7.0.min.js"></script>
+        <script src="/libs/underscore-umd-min.js"></script>
+        <script src="/common.js"></script>
+        <script>
+            const newurl = "https://icgem.gfz.de" + window.location.pathname + window.location.hash;
+            if (window.location.hostname.endsWith(".gfz-potsdam.de")) {
+                window.location.replace(newurl);
+            }
+        </script>
+            <script src="/libs/editorjs/header.js"></script>
+    <script src="/libs/editorjs/image.js"></script>
+    <script src="/libs/editorjs/inlineimage.js"></script>
+    <script src="/libs/editorjs/delimiter.js"></script>
+    <script src="/libs/editorjs/list.js"></script>
+    <script src="/libs/editorjs/quote.js"></script>
+    <script src="/libs/editorjs/code.js"></script>
+    <script src="/libs/editorjs/table.js"></script>
+    <script src="/libs/editorjs/marker.js"></script>
+    <script src="/libs/editorjs/underline.js"></script>
+    <script src="/libs/editorjs/inline-code.js"></script>
+    <script src="/libs/editorjs/attaches.js"></script>
+    <script src="/libs/editorjs/alignment.js"></script>
+    <script src="/libs/editorjs/raw.js"></script>
+    <link rel="stylesheet" type="text/css" href="/libs/editorjs/Hyperlink.css">
+    <script src="/libs/editorjs/SelectionUtils.js"></script>
+    <script src="/libs/editorjs/Hyperlink.js"></script>
+    <link rel="stylesheet" type="text/css" href="/libs/editorjs/color-picker.css">
+    <script src="/libs/editorjs/color-picker.js"></script>
+    <script src="/libs/editorjs/genericinline.js"></script>
+    <script src="/libs/editorjs.umd.min.js"></script>
+
+
+    </head>
+    <body>
+        
+        <div class="w-100 h-100 d-flex">
+            <div id="sidebar" class="d-flex flex-column">
+                <img id="logo" class="logo" src="/imgs/icgem.png" alt="Logo">
+                <div id="menu">
+
+
+
+
+        <a href="/home">ICGEM Home</a>
+
+
+<h4>Gravity Field Models</h4>
+        <a class="sub self " href="/tom_longtime">Static Models</a>
+
+        <a class="sub " href="/sl/temporal">Temporal Models</a>
+
+        <a class="sub " href="/sl/simulated">Simulated Models</a>
+
+        <a class="sub " href="/tom_reltopo">Topographic Models</a>
+
+
+<h4>Calculation Service</h4>
+        <a class="sub " href="/calcgrid">Regular grids</a>
+
+        <a class="sub " href="/calcpoints">User-defined points</a>
+
+        <a class="sub " href="/g3">G3-Browser</a>
+
+
+<h4>3D Visualisation</h4>
+        <a class="sub " href="/vis3d/longtime">Static Models</a>
+
+        <a class="sub " href="/vis3d/series">Temporal Models</a>
+
+        <a class="sub " href="/vis3d/trend">Trend &amp; Amplitude</a>
+
+        <a class="sub " href="/vis3d/tutorial">Spherical Harmonics</a>
+
+
+<h4>Evaluation</h4>
+        <a class="sub " href="/evalchart">Spectral domain</a>
+
+        <a class="sub " href="/tom_gpslev">GNSS Leveling</a>
+
+
+        <a href="/dochome">Documentation</a>
+
+        <a class="sub " href="/faq">FAQ</a>
+
+        <a class="sub " href="/theory">Theory</a>
+
+        <a class="sub " href="/refs">References</a>
+
+        <a class="sub " href="/changes">Latest Changes</a>
+
+        <a class="sub " href="/contact">Contact</a>
+
+
+<h4>Other Celestial Bodies<br>
+    (Moon,Venus, Mars)</h4>
+        <a class="sub " href="/tom_celestial">Table of Models</a>
+
+        <a class="sub " href="/vis3d/celestial">3D Visualization</a>
+
+        <a class="sub " href="/calcgrid?modeltype=celestial">Calculation Service</a>
+
+<hr noshade color="black" width="100%" size="3" align="center">
+        <a class="sub " href="/imprint">Imprint</a>
+
+        <a class="sub " href="/dataprotection">Data Protection</a>
+
+                <a class="sub " href="/login?redirecturl=/tom_longtime">Admin-Login</a>
+
+                </div>
+            </div>
+            <div id="content">
+                <div id="header" class="row">
+                    <img src="/imgs/iaglogo-short-web.png" alt="iaglogo">
+                    <img src="/imgs/logo_gfz.svg" alt="gfzlogo">
+                </div>
+<h1 class="display-4 text-center textshadow mb-4">Global Gravity Field Models</h1>
+<div>
+        <p><b>
+        We kindly ask the authors of the models to check the links to the original websites of the models from time to time.
+        <br>
+        Please let us know if something has changed.
+    </b></p>
+    <p>
+        The table can be interactively re-sorted by clicking on the column header fields (Nr, Model, Year, Degree, Data, Reference). 
+    </p>
+    <p>
+        In the data column, the datasets used in the development of the models are summarized, where
+        <b>A</b> is for altimetry,
+        <b>S</b> is for satellite (e.g., GRACE, GOCE, LAGEOS),
+        <b>G</b> for ground data (e.g., terrestrial, shipborne and airborne measurements) and
+        <b>T</b> is for topography.
+    </p>
+
+    <p>
+        The links <a href="/calcgrid"><b>calculate</b></a> and <a href="/vis3d/longtime"><b>show</b></a> in the last columns of the table directly invoke the 
+        <i>Calculation Service</i> and <i>Visualization page</i> for the selected model.
+        <br>
+        For models with a registered <b>doi</b> ("digital object identifier") the last column contains the symbol
+        <a href="http://dx.doi.org/" target="_blank"><b>&#10004;</b></a>, which directly opens the page on "http://dx.doi.org/".
+        <br> 
+        If you click on the reference, the complete list of references can be seen.
+    </p>
+</div>
+<div class="d-flex flex-wrap">
+    <table data-sortable class="table table-striped table-sm sortable-bootstrap w-100">
+    <thead>
+        <tr>
+            <th style="min-width: 4rem;">#</th>
+            <th style="min-width:12rem;">Object</th>
+            <th style="min-width:12rem;">Model</th>
+            <th style="min-width: 5rem;">Year</th>
+            <th style="min-width: 6rem;">Degree</th>
+            <th style="min-width: 6rem;">Data</th>
+            <th style="min-width:12rem;">References</th>
+            <th style="min-width: 8rem;" data-sortable="false">Download</th>
+            <th style="min-width: 8rem;" data-sortable="false">Calculate</th>
+            <th style="min-width: 6rem;" data-sortable="false">3D</th>
+            <th style="min-width: 5rem;" data-sortable="false">DOI</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+    <td>182</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        WHU-CASM-UGM2025_2159
+</td>
+    <td>2026</td>
+    <td>        <b>2190</b><br>
+        11000<br>5500<br>760
+</td>
+    <td>            A,             G,             S,             T</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_82962bb8156bfbf074b8f97bf558ac0e0ee5e481c864a29441fb0f68ddb26be2').toggle(); "><b>Liu et al., 2026</b></div>
+        <div id="ref_82962bb8156bfbf074b8f97bf558ac0e0ee5e481c864a29441fb0f68ddb26be2" class="mt-1" style="display:none"><p>Liu, Cong; Wang, Zhengtao; Jiang, Tao (2026):<br>
+<b>WHU-CASM-UGM2025 The combined global gravity field model up to degree and order 11000.</b><br>
+GFZ Data Services. https://doi.org/10.5880/icgem.2026.002</p>
+
+<p>Hirt, C., Yang, M., Kuhn, M., Bucha, B., Kurzmann, A., & Pail, R. (2019).<br>
+<b>SRTM2gravity: An Ultrahigh Resolution Global Model of Gravimetric Terrain Corrections.</b><br>
+Geophysical Research Letters, 46(9), 4618-4627. https://doi.org/10.1029/2019gl082521.</p>
+
+<p>Liu, C., Wang, Z., Li, F., Gao, Y., & Xiao, Y. (2025).<br>
+<b>Efficient Solutions for Forward Modeling of the Earth's Topographic Potential in Spheroidal Harmonics.</b><br>
+Surveys in Geophysics, 46(1), 169-196. https://doi.org/10.1007/s10712-024-09871-7.</p>
+
+<p>Zingerle, P., Pail, R., Gruber, T., & Oikonomidou, X. (2020).<br>
+<b>The combined global gravity field model XGM2019e.</b><br>
+Journal of Geodesy, 94(7). https://doi.org/10.1007/s00190-020-01398-0.</p>
+
+<p>Sandwell, D. T., Müller, R. D., Smith, W. H. F., Garcia, E., & Francis, R. (2014).<br>
+<b>New global marine gravity model from CryoSat-2 and Jason-1 reveals buried tectonic structure.</b><br>
+Science, 346(6205), 65-67. https://doi.org/10.1126/science.1258213.</p>
+
+<p>Andersen, O.B., Knudsen, P. (2019).<br>
+<b>The DTU17 Global Marine Gravity Field: First Validation Results.</b><br>
+In: Mertikas, S., Pail, R. (eds) Fiducial Reference Measurements for Altimetry. International Association of Geodesy Symposia, vol 150. Springer, Cham. https://doi.org/10.1007/1345_2019_65.</p>
+
+<p>Kvas, A., Brockmann, J. M., Krauss, S., Schubert, T., Gruber, T., Meyer, U., Mayer-Gürr, T., Schuh, W.-D., Jäggi, A., & Pail, R. (2021).<br>
+<b>GOCO06s – a satellite-only global gravity field model.</b><br>
+Earth System Science Data, 13(1), 99-118. https://doi.org/10.5194/essd-13-99-2021.</p>
+
+<p>Liu, C., Wang, Z., Gao, Y., & Xiao, Y. (2026).<br>
+<b>Iterative Downward Continuation and Modeling of the Earth’s Global Gravity Field in Ellipsoidal Harmonics.</b><br>
+Surveys in Geophysics. https://doi.org/10.1007/s10712-026-09931-0</p>
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/82962bb8156bfbf074b8f97bf558ac0e0ee5e481c864a29441fb0f68ddb26be2/WHU-CASM-UGM2025_2159.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/82962bb8156bfbf074b8f97bf558ac0e0ee5e481c864a29441fb0f68ddb26be2/WHU-CASM-UGM2025_2159.zip" target="_blank">zip</a>
+            <br>
+                <a href="/getmodel/gfc/3408a369cbe17b0ff2fad5027bab244ade6ccde25b191fe76af4314fd47059d7/WHU-CASM-UGM2025_11000.gfc" target="_blank">gfc</a>
+                    <a href="/getmodel/zip/3408a369cbe17b0ff2fad5027bab244ade6ccde25b191fe76af4314fd47059d7/WHU-CASM-UGM2025_11000.zip" target="_blank">zip</a>
+            <br>
+                <a href="/getmodel/gfc/ef9714bd94ef0b78b77089a35845e95e7c30bdfa6151f92704a9e9ebdeb283fe/WHU-CASM-UGM2025_5399.gfc" target="_blank">gfc</a>
+                    <a href="/getmodel/zip/ef9714bd94ef0b78b77089a35845e95e7c30bdfa6151f92704a9e9ebdeb283fe/WHU-CASM-UGM2025_5399.zip" target="_blank">zip</a>
+            <br>
+                <a href="/getmodel/gfc/e09128f94c1fa308a19bf009638f76c0ae335641140c7d90bac1868e393210b7/WHU-CASM-UGM2025_719.gfc" target="_blank">gfc</a>
+                    <a href="/getmodel/zip/e09128f94c1fa308a19bf009638f76c0ae335641140c7d90bac1868e393210b7/WHU-CASM-UGM2025_719.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=82962bb8156bfbf074b8f97bf558ac0e0ee5e481c864a29441fb0f68ddb26be2" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=82962bb8156bfbf074b8f97bf558ac0e0ee5e481c864a29441fb0f68ddb26be2" target="_blank">Show</a>
+    </td>
+    <td>
+            <a href="https://doi.org/10.5880/icgem.2026.002" target="_blank">✔</a>
+    </td>
+</tr>
+
+        <tr>
+    <td>181</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        GOCO2025s
+</td>
+    <td>2025</td>
+    <td>        300
+</td>
+    <td>            S</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_b9bd89dd63d94f2191246753b8cc9616593804c098ad363782a9d189586a77f2').toggle(); "><b>Oehlinger, Felix et al 2025</b></div>
+        <div id="ref_b9bd89dd63d94f2191246753b8cc9616593804c098ad363782a9d189586a77f2" class="mt-1" style="display:none">Oehlinger, Felix; Mayer-Guerr, Torsten; Krauss, Sandro; Dumitraschkewitz, Patrick; Suesser-Rechberger, Barbara; Strasser, Andreas; Tieber-Hubmann, Cornelia; Brockmann, Jan Martin 2025:<br>
+<b>The satellite-only gravity field model GOCO2025s.</b><br>
+Data set. Graz University of Technology. <a href="https://doi.org/10.3217/f48p8-8h651" target="_blank">10.3217/f48p8-8h651</a></div>
+    </td>
+    <td>        <a href="/getmodel/gfc/b9bd89dd63d94f2191246753b8cc9616593804c098ad363782a9d189586a77f2/GOCO2025s.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/b9bd89dd63d94f2191246753b8cc9616593804c098ad363782a9d189586a77f2/GOCO2025s.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=b9bd89dd63d94f2191246753b8cc9616593804c098ad363782a9d189586a77f2" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=b9bd89dd63d94f2191246753b8cc9616593804c098ad363782a9d189586a77f2" target="_blank">Show</a>
+    </td>
+    <td>
+            <a href="https://doi.org/10.3217/f48p8-8h651" target="_blank">✔</a>
+    </td>
+</tr>
+
+        <tr>
+    <td>180</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        WHU-SWPU-GOGR2022S
+</td>
+    <td>2023</td>
+    <td>        300
+</td>
+    <td>            S (Goce),             S (Grace)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_5ecd256bfe5f630deaf9b387a9e739a31dc4aafc008bbfee8c3e970c64e7983c').toggle(); "><b>Zhao, Yongqi et al 2023</b></div>
+        <div id="ref_5ecd256bfe5f630deaf9b387a9e739a31dc4aafc008bbfee8c3e970c64e7983c" class="mt-1" style="display:none">Zhao, Yongqi; Li, Jiancheng; Xu, Xinyu; Su, Yong 2023: <br>
+<b>WHU-SWPU-GOGR2022S: A combined gravity model of GOCE and GRACE.</b><br>
+GFZ Data Services. <a href="https://doi.org/10.5880/icgem.2023.003">10.5880/icgem.2023.003</a></div>
+    </td>
+    <td>        <a href="/getmodel/gfc/5ecd256bfe5f630deaf9b387a9e739a31dc4aafc008bbfee8c3e970c64e7983c/WHU-SWPU-GOGR2022S.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/5ecd256bfe5f630deaf9b387a9e739a31dc4aafc008bbfee8c3e970c64e7983c/WHU-SWPU-GOGR2022S.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=5ecd256bfe5f630deaf9b387a9e739a31dc4aafc008bbfee8c3e970c64e7983c" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=5ecd256bfe5f630deaf9b387a9e739a31dc4aafc008bbfee8c3e970c64e7983c" target="_blank">Show</a>
+    </td>
+    <td>
+            <a href="https://doi.org/10.5880/icgem.2023.003" target="_blank">✔</a>
+    </td>
+</tr>
+
+        <tr>
+    <td>179</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        GOSG02S
+</td>
+    <td>2023</td>
+    <td>        300
+</td>
+    <td>            S (Goce)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_254a68a7c4d8970476cf85da3feab411a0d4e635bd0af41265adc4fca7fd37a1').toggle(); "><b>Xu, Xinyu et al 2023</b></div>
+        <div id="ref_254a68a7c4d8970476cf85da3feab411a0d4e635bd0af41265adc4fca7fd37a1" class="mt-1" style="display:none">Xu, Xinyu; Li, Jiancheng; Zhao, Yongqi; Wei, Hui (2023): <br>
+<b>A GOCE only gravity model GOSG02S based on the SGG and SST observations.</b><br>
+GFZ Data Services. <a href="https://doi.org/10.5880/icgem.2023.002">10.5880/icgem.2023.002</a>
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/254a68a7c4d8970476cf85da3feab411a0d4e635bd0af41265adc4fca7fd37a1/GOSG02S.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/254a68a7c4d8970476cf85da3feab411a0d4e635bd0af41265adc4fca7fd37a1/GOSG02S.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=254a68a7c4d8970476cf85da3feab411a0d4e635bd0af41265adc4fca7fd37a1" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=254a68a7c4d8970476cf85da3feab411a0d4e635bd0af41265adc4fca7fd37a1" target="_blank">Show</a>
+    </td>
+    <td>
+            <a href="https://doi.org/10.5880/icgem.2023.002" target="_blank">✔</a>
+    </td>
+</tr>
+
+        <tr>
+    <td>178</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        Tongji-GMMG2021S
+</td>
+    <td>2022</td>
+    <td>        300
+</td>
+    <td>            S (Goce),             S (Grace)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_f81966ed1ca42cd6c0d5c7b5733fab62f6c5136cace452f1f009474b3bd2c0a3').toggle(); "><b>Chen, J. et al, 2022</b></div>
+        <div id="ref_f81966ed1ca42cd6c0d5c7b5733fab62f6c5136cace452f1f009474b3bd2c0a3" class="mt-1" style="display:none">Chen J, Zhang X, Chen Q, Shen Y, Nie Y. 2022: <br>
+<b>Static Gravity Field Recovery and Accuracy Analysis Based on Reprocessed GOCE Level 1b Gravity Gradient Observations</b><br>
+EGU General Assembly 2022, Vienna, Austria, 23–27 May 2022, EGU22-6771, <a href="https://doi.org/10.5194/egusphere-egu22-6771">10.5194/egusphere-egu22-6771</a>.<br>
+<br>
+
+Chen Q, Shen Y, Francis O, Chen W, Zhang X, Hsu H. 2018: <br>
+<b>Tongji‐grace02s and Tongji‐grace02k: High‐Precision Static GRACE‐only Global Earth's Gravity Field Models Derived by Refined Data Processing Strategies.</b><br>
+Journal of Geophysical Research: Solid Earth, 123(7), 6111-6137, <a href="http://doi.org/10.1029/2018JB015641">10.1029/2018JB015641</a>.</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/f81966ed1ca42cd6c0d5c7b5733fab62f6c5136cace452f1f009474b3bd2c0a3/Tongji-GMMG2021S.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/f81966ed1ca42cd6c0d5c7b5733fab62f6c5136cace452f1f009474b3bd2c0a3/Tongji-GMMG2021S.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=f81966ed1ca42cd6c0d5c7b5733fab62f6c5136cace452f1f009474b3bd2c0a3" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=f81966ed1ca42cd6c0d5c7b5733fab62f6c5136cace452f1f009474b3bd2c0a3" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>177</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="https://www.sciencedirect.com/science/article/pii/S2095809919305661" target="_blank">SGG-UGM-2</a>
+</td>
+    <td>2020</td>
+    <td>        2190
+</td>
+    <td>            A,             EGM2008,             S(Goce),             S(Grace)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_3b3a7e227093cbad89bbe33f515c3f2d762b24392b64cabffd890cc016293526').toggle(); "><b> Liang, W. et al, 2020</b></div>
+        <div id="ref_3b3a7e227093cbad89bbe33f515c3f2d762b24392b64cabffd890cc016293526" class="mt-1" style="display:none">Liang W.; Li J.; Xu, X; Zhang, S.; Zhao, Y. 2020: <br>
+<b>A High-Resolution Earth’s Gravity Field Model SGG-UGM-2
+from GOCE, GRACE, Satellite Altimetry, and EGM2008.</b><br>
+Engineering, 860-878. doi: <a href="http://doi.org/10.1016/j.eng.2020.05.008" target="_blank">10.1016/j.eng.2020.05.008</a>.<br>
+<br>
+
+
+
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/3b3a7e227093cbad89bbe33f515c3f2d762b24392b64cabffd890cc016293526/SGG-UGM-2.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/3b3a7e227093cbad89bbe33f515c3f2d762b24392b64cabffd890cc016293526/SGG-UGM-2.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=3b3a7e227093cbad89bbe33f515c3f2d762b24392b64cabffd890cc016293526" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=3b3a7e227093cbad89bbe33f515c3f2d762b24392b64cabffd890cc016293526" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>176</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="https://doi.org/10.1007/s00190-020-01398-0" target="_blank">XGM2019e_2159</a>
+</td>
+    <td>2019</td>
+    <td>        <b>2190</b><br>
+        5540<br>760
+</td>
+    <td>            A,             G,             S(GOCO06s),             T</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_eeb03971cf6e533e6eeb6b010336463286dcda0846684248d5530acf8e800055').toggle(); "><b>Zingerle, P. et al, 2019</b></div>
+        <div id="ref_eeb03971cf6e533e6eeb6b010336463286dcda0846684248d5530acf8e800055" class="mt-1" style="display:none"><b>Advice for users:</b><br>
+<p>To comply with the ICGEM standard, the model coefficients are provided in the spherical harmonic domain. To simplify the utilization of the model, coefficients are precalculated in three different spectral resolution scales (in the spheroidal harmonic domain, then converted back to spherical harmonics, thus, avoiding truncation errors near the spheroidal surface):</p>
+<br>
+<a href="/getmodel/gfc/8e01a2aba4f291ac0638b79a390155713b70fdc9b266981023c756839c11c9b8/XGM2019e.gfc">
+<b>XGM2019e</b></a> (spheroidal harmonic d/o 5399, spherical harmonic d/o 5540)<br>
+
+<a href="/getmodel/gfc/eeb03971cf6e533e6eeb6b010336463286dcda0846684248d5530acf8e800055/XGM2019e_2159.gfc">
+<b>XGM2019e_2159</b></a> (spheroidal harmonic d/o 2159, spherical harmonic d/o 2190)<br>
+
+<a href="/getmodel/gfc/38f8a3efe050bab49acaa41f9624e564d5288260188b6511a063597efaa4dc99/XGM2019.gfc">
+<b>XGM2019</b></a> (spheroidal harmonic d/o 719, spherical harmonic d/o 760)<br>
+<br>
+
+Kvas, A.; T. Mayer-Gürr; S. Krauss; J. M. Brockmann; T. Schubert; W.-D. Schuh; R. Pail; T. Gruber; A. Jäggi; U. Meyer, 2019:<br>
+<b>The satellite-only gravity field model GOCO06s.</b><br>
+GFZ Data Services.   doi: <a href="http://doi.org/10.5880/ICGEM.2019.002" target="_blank">10.5880/ICGEM.2019.002</a>.<br>
+<br>
+
+
+Pail, R.; T. Fecher; D. Barnes; J. Factor; S. Holmes; T. Gruber; P. Zingerle, 2017:<br>
+<b>The experimental gravity field model XGM2016.</b><br>
+GFZ Data Services. doi:<a href="http://doi.org/10.5880/icgem.2017.003" target="blank">10.5880/icgem.2017.003</a>.<br>
+<br>
+
+Hirt, C.; M. Rexer, 2015:<br>
+<b>Earth2014: 1 arc-min shape, topography, bedrock and ice-sheet models–available as gridded data and degree-10,800 spherical harmonics.</b><br>
+International Journal of Applied Earth Observation and Geoinformation 39: 103-112.<br>
+<br>
+
+Andersen, O.; P. Knudsen; L. Stenseng, 2015:<br>
+<b>The DTU13 MSS (Mean Sea Surface) and MDT (Mean Dynamic Topography) from 20 Years of Satellite Altimetry.</b><br>
+IGFS 2014, 111–121. doi:<a href="http://doi.org/10.1007/1345_2015_182" target="blank">10.1007/1345_2015_182</a>.<br>
+<br>
+
+Pavlis, N. K.; S. A. Holmes; S. C. Kenyon; J. K. Factor, 2012:<br>
+<b>The development and evaluation of the Earth Gravitational Model 2008 (EGM2008).</b><br>
+Journal of geophysical research: solid earth, 117(B4).<br>
+<br>
+
+Förste, C.; S. L. Bruinsma; O. Abrikosov; J.-M. Lemoine; J. C. Marty; F. Flechtner; G. Balmino; F. Barthelmes; R. Biancale, 2014:<br>
+<b>EIGEN-6C4 The latest combined global gravity field model including GOCE data up to degree and order 2190 of GFZ Potsdam and GRGS Toulouse.</b><br>
+GFZ Data Services. doi:<a href="http://doi.org/10.5880/icgem.2015.1" target="blank">10.5880/icgem.2015.1</a>.<br>
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/eeb03971cf6e533e6eeb6b010336463286dcda0846684248d5530acf8e800055/XGM2019e_2159.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/eeb03971cf6e533e6eeb6b010336463286dcda0846684248d5530acf8e800055/XGM2019e_2159.zip" target="_blank">zip</a>
+            <br>
+                <a href="/getmodel/gfc/8e01a2aba4f291ac0638b79a390155713b70fdc9b266981023c756839c11c9b8/XGM2019e.gfc" target="_blank">gfc</a>
+                    <a href="/getmodel/zip/8e01a2aba4f291ac0638b79a390155713b70fdc9b266981023c756839c11c9b8/XGM2019e.zip" target="_blank">zip</a>
+            <br>
+                <a href="/getmodel/gfc/38f8a3efe050bab49acaa41f9624e564d5288260188b6511a063597efaa4dc99/XGM2019.gfc" target="_blank">gfc</a>
+                    <a href="/getmodel/zip/38f8a3efe050bab49acaa41f9624e564d5288260188b6511a063597efaa4dc99/XGM2019.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=eeb03971cf6e533e6eeb6b010336463286dcda0846684248d5530acf8e800055" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=eeb03971cf6e533e6eeb6b010336463286dcda0846684248d5530acf8e800055" target="_blank">Show</a>
+    </td>
+    <td>
+            <a href="http://doi.org/10.5880/ICGEM.2019.007" target="_blank">✔</a>
+    </td>
+</tr>
+
+        <tr>
+    <td>175</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="https://earth.esa.int/web/guest/missions/esa-operational-eo-missions/goce" target="_blank">GO_CONS_GCF_2_TIM_R6e</a>
+</td>
+    <td>2019</td>
+    <td>        300
+</td>
+    <td>            G (Polar),             S(Goce)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_2b82cfe40a06ab1d7cf36cbdb954f5ca0753fb711f20c9c63b3eb70de0f8fac8').toggle(); "><b>        Zingerle, P. et al,
+    2019</b></div>
+        <div id="ref_2b82cfe40a06ab1d7cf36cbdb954f5ca0753fb711f20c9c63b3eb70de0f8fac8" class="mt-1" style="display:none">        Zingerle, P., Brockmann, J.M., Pail, R.; Gruber, T., Willberg, M. (2019): <br>
+    <b>The polar extended gravity field model TIM_R6</b>
+    <br>
+doi: <a href="http://doi.org/10.5880/ICGEM.2019.005" target="blank">10.5880/ICGEM.2019.005</a>
+    2019
+
+<br><br>
+        <b>Related References:</b><br>
+        Brockmann, J. M., T. Schubert, T. Mayer-Gürr, Schuh, W.-D. Schuh. (2019);<br>
+    <b>The Earth's gravity field as seen by the GOCE satellite - an improved sixth release derived with the time-wise approach</b>
+    <br>
+doi: <a href="http://doi.org/10.5880/ICGEM.2019.003" target="_blank">10.5880/ICGEM.2019.003</a>
+    2019
+
+<br><br>
+        Forsberg, R., A. V. Olesen, F. Ferraccioli, T. Jordan, H. Corr, K. Matsuoka. (2017).;<br>
+    <b>PolarGap 2015/16 - Filling the GOCE polar gap in Antarctica and ASIRAS flight around South Pole.</b>
+<br>
+ Final Report of ESA Contract Nr. 4000115220/15/NL/gp. NERC-British Antarctic Survey.</b>
+
+
+<br><br>
+
+        Scheinert, M., F. Ferraccioli, J. Schwabe, R. Bell, M. Studinger, D. Damaske, W. Jokat, N. Aleshkova, T. Jordan, G. Leitchenkov, D. D. Blankenship, T. M. Damiani, D. Young,J. R. Cochran, T. D. Richter. (2016); <br>
+    <b>New Antarctic gravity anomaly grid for enhanced geodetic and geophysical studies in Antarctica</b>
+    <br>
+ Geophysical Research Letters,
+            Vol 43,
+            No. 2,
+            p. 600-610,
+        doi: <a href="http://doi.org/10.1002/2015GL067439" target="_blank">10.1002/2015GL067439</a>,
+    2014
+
+<br><br>
+        Forsberg, R., H. Skourup, O. B. Andersen, P. Knudsen, S. W. Laxon, A. Ridout, J. Johannesen, F. Siegismund, H. Drange, C. C. Tscherning,  D. Arabelos, A Braun, and V. Renganathan. (2007).;<br>
+    <b>Combination of spaceborne, airborne and in-situ gravity measurements in support of Arctic sea ice thickness mapping.</b> 
+    <br>
+Danish National Space Center Technical Report 7: 137.</b>
+    <br>
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/2b82cfe40a06ab1d7cf36cbdb954f5ca0753fb711f20c9c63b3eb70de0f8fac8/GO_CONS_GCF_2_TIM_R6e.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/2b82cfe40a06ab1d7cf36cbdb954f5ca0753fb711f20c9c63b3eb70de0f8fac8/GO_CONS_GCF_2_TIM_R6e.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=2b82cfe40a06ab1d7cf36cbdb954f5ca0753fb711f20c9c63b3eb70de0f8fac8" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=2b82cfe40a06ab1d7cf36cbdb954f5ca0753fb711f20c9c63b3eb70de0f8fac8" target="_blank">Show</a>
+    </td>
+    <td>
+            <a href="http://doi.org/10.5880/ICGEM.2019.005" target="_blank">✔</a>
+    </td>
+</tr>
+
+        <tr>
+    <td>174</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="http://ifg.tugraz.at/ITSG-Grace2018" target="_blank">ITSG-Grace2018s</a>
+</td>
+    <td>2019</td>
+    <td>        200
+</td>
+    <td>            S(Grace)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_cdcab005ac449315efdb79244dbd7a7f2426dff747305644f6d9e509843f3968').toggle(); "><b>Mayer-Gürr, T. et al, 
+2018</b></div>
+        <div id="ref_cdcab005ac449315efdb79244dbd7a7f2426dff747305644f6d9e509843f3968" class="mt-1" style="display:none">       Mayer-Gürr, T., Behzadpur, S.; Ellmer, M.; Kvas, A.; Klinger, B.; Strasser, S.; Zehentner, N.;<br>
+    <b>ITSG-Grace2018 - Monthly, Daily and Static Gravity Field Solutions from GRACE. 
+    </b><br>
+GFZ Data Services. 
+
+doi: <a href="http://doi.org/10.5880/ICGEM.2018.003" target="_blank">10.5880/ICGEM.2018.003</a>
+
+
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/cdcab005ac449315efdb79244dbd7a7f2426dff747305644f6d9e509843f3968/ITSG-Grace2018s.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/cdcab005ac449315efdb79244dbd7a7f2426dff747305644f6d9e509843f3968/ITSG-Grace2018s.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=cdcab005ac449315efdb79244dbd7a7f2426dff747305644f6d9e509843f3968" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=cdcab005ac449315efdb79244dbd7a7f2426dff747305644f6d9e509843f3968" target="_blank">Show</a>
+    </td>
+    <td>
+            <a href="http://doi.org/10.5880/icgem.2018.003" target="_blank">✔</a>
+    </td>
+</tr>
+
+        <tr>
+    <td>173</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href=" https://grace.obs-mip.fr/variable-models-grace-lageos/mean-fields/release-04/" target="_blank">EIGEN-GRGS.RL04.MEAN-FIELD</a>
+</td>
+    <td>2019</td>
+    <td>        300
+</td>
+    <td>            S</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_96e984f23a31505411d943341767e9ff082ad2c77fbbdcba1be2e393cf35110a').toggle(); "><b>Lemoine, J.M. et al, 2019</b></div>
+        <div id="ref_96e984f23a31505411d943341767e9ff082ad2c77fbbdcba1be2e393cf35110a" class="mt-1" style="display:none">Lemoine, J.M., Bourgogne, S., Biancale, R. (†), Reinquin F., and Bruinsma, S.;<br>
+   <b>EIGEN-GRGS.RL04.MEAN-FIELD – Mean Earth gravity field model with a time-variable part from 
+      CNES/GRGS RL04;</b><br>
+   <br>
+   <a href="https://ids-doris.org/images/documents/report/ids_workshop_2018/IDS18_s3_LemoineJM_NewtimeVariableGravityFieldModelForPOD.pdf" target="_blank">The new time-variable gravity field model for POD of altimetric satellites based on GRACE+SLR RL04 from CNES/GRGS</a>
+ 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/96e984f23a31505411d943341767e9ff082ad2c77fbbdcba1be2e393cf35110a/EIGEN-GRGS.RL04.MEAN-FIELD.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/96e984f23a31505411d943341767e9ff082ad2c77fbbdcba1be2e393cf35110a/EIGEN-GRGS.RL04.MEAN-FIELD.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=96e984f23a31505411d943341767e9ff082ad2c77fbbdcba1be2e393cf35110a" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=96e984f23a31505411d943341767e9ff082ad2c77fbbdcba1be2e393cf35110a" target="_blank">Show</a>
+    </td>
+    <td>
+            <a href="https://doi.org/10.5880/ICGEM.2019.010" target="_blank">✔</a>
+    </td>
+</tr>
+
+        <tr>
+    <td>172</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="http://www.goco.eu/" target="_blank">GOCO06s</a>
+</td>
+    <td>2019</td>
+    <td>        300
+</td>
+    <td>            S</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_32ec2884630a02670476f752d2a2bf1c395d8c8d6d768090ed95b4f04b0d5863').toggle(); "><b>Kvas, A. et al, 2021</b></div>
+        <div id="ref_32ec2884630a02670476f752d2a2bf1c395d8c8d6d768090ed95b4f04b0d5863" class="mt-1" style="display:none">Kvas, Andreas; Brockmann, Jan Martin; Krauss, Sandro; Schubert, Till; Gruber, Thomas, Meyer, Ulrich; Mayer-Gürr, Torsten; Schuh, Wolf-Dieter; Jäggi, Adrian; Pail, Roland. (2021): <br> 
+<b>GOCO06s - a satellite-only global gravity field model, </b> Earth System Science Data, 13(1), 99–118. 
+<a href="https://doi.org/10.5194/essd-13-99-2021" target="_blank">https://doi.org/10.5194/essd-13-99-2021</a>
+
+
+<br><br>
+Kvas, Andreas; Mayer-Gürr, Torsten; Krauss, Sandro; Brockmann, Jan Martin;
+Schubert, Till; Schuh, Wolf-Dieter; Pail, Roland; Gruber, Thomas;
+Jäggi, Adrian; Meyer, Ulrich (2019):<br>
+<b>The satellite-only gravity field model GOCO06s.</b> GFZ Data Services.
+<a href="http://doi.org/10.5880/ICGEM.2019.002" target="_blank">http://doi.org/10.5880/ICGEM.2019.002</a>
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/32ec2884630a02670476f752d2a2bf1c395d8c8d6d768090ed95b4f04b0d5863/GOCO06s.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/32ec2884630a02670476f752d2a2bf1c395d8c8d6d768090ed95b4f04b0d5863/GOCO06s.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=32ec2884630a02670476f752d2a2bf1c395d8c8d6d768090ed95b4f04b0d5863" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=32ec2884630a02670476f752d2a2bf1c395d8c8d6d768090ed95b4f04b0d5863" target="_blank">Show</a>
+    </td>
+    <td>
+            <a href="http://doi.org/10.5880/ICGEM.2019.002" target="_blank">✔</a>
+    </td>
+</tr>
+
+        <tr>
+    <td>171</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="https://earth.esa.int/eogateway/missions/goce" target="_blank">GO_CONS_GCF_2_TIM_R6</a>
+</td>
+    <td>2019</td>
+    <td>        300
+</td>
+    <td>            S(Goce)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_48b3a4a83f17db2621744774a594ce60f2f8583847e2330a1e08f036483a24de').toggle(); "><b>        Brockmann, J. M. et al,
+    2021</b></div>
+        <div id="ref_48b3a4a83f17db2621744774a594ce60f2f8583847e2330a1e08f036483a24de" class="mt-1" style="display:none">    Brockmann, J. M., Schubert, T., Schuh WD<br>
+    <b>An Improved Model of the Earth’s Static Gravity Field Solely Derived from Reprocessed GOCE Data</b>
+    <br>
+                Surveys in Geophysics,
+        doi: <a href="https://doi.org/10.1007/s10712-020-09626-0" target="_blank">10.1007/s10712-020-09626-0</a>,
+    2021    
+
+        <br><br>
+  Brockmann, J. M.<br>
+    <b>On High Performance Computing in Geodesy -- Applications in Global Gravity Field
+Determination;</b>
+    <br>
+        Phd thesis,
+            Institute of Geodesy and Geoinformation, University of Bonn.
+            No. 22,
+         <a href="http://nbn-resolving.de/urn:nbn:de:hbz:5n-38608" target="_blank">http://nbn-resolving.de/urn:nbn:de:hbz:5n-38608</a>,
+    2014
+
+
+        <br><br>
+        Brockmann, J. M., Zehentner, N., Hock, E., Pail, R., Loth, I., Mayer-Gurr, T., Schuh, W. D.;<br>
+    <b>EGM_TIM_RL05: An independent geoid with centimeter accuracy purely based on the GOCE mission;</b>
+    <br>
+        Geophysical Research Letters,
+            Vol 41,
+            No. 22,
+            p. 8089-8099,
+        doi: <a href="http://doi.org/10.1002/2014gl061904" target="_blank">10.1002/2014gl061904</a>,
+    2014
+
+
+        <br><br>
+        Pail, Roland, Bruinsma, Sean, Migliaccio, Federica, Förste, Christoph, Goiginger, Helmut, Schuh, Wolf-Dieter, Höck, Eduard, Reguzzoni, Mirko, Brockmann, Jan Martin, Abrikosov, Oleg, Veicherts, Martin, Fecher, Thomas, Mayrhofer, Reinhard, Krasbutter, Ina, Sansò, Fernando, Tscherning, Carl Christian;<br>
+    <b>First GOCE gravity field models derived by three different approaches;</b>
+    <br>
+        Journal of Geodesy,
+            Vol 85,
+            No. 11,
+            p. 819-843,
+        doi: <a href="http://doi.org/10.1007/s00190-011-0467-x" target="_blank">10.1007/s00190-011-0467-x</a>,
+    2011
+
+
+        <br><br>
+        Mayer-Gürr, T., Ilk, K. H., Eicker, A., Feuchtinger, M.;<br>
+    <b>ITG-CHAMP01: a CHAMP gravity field model from short kinematic arcs over a one-year observation period;</b>
+    <br>
+        Journal of Geodesy,
+            Vol 78,
+            No. 7-8,
+            p. 462-480,
+        doi: <a href="http://doi.org/10.1007/s00190-004-0413-2" target="_blank">10.1007/s00190-004-0413-2</a>,
+    2005
+
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/48b3a4a83f17db2621744774a594ce60f2f8583847e2330a1e08f036483a24de/GO_CONS_GCF_2_TIM_R6.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/48b3a4a83f17db2621744774a594ce60f2f8583847e2330a1e08f036483a24de/GO_CONS_GCF_2_TIM_R6.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=48b3a4a83f17db2621744774a594ce60f2f8583847e2330a1e08f036483a24de" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=48b3a4a83f17db2621744774a594ce60f2f8583847e2330a1e08f036483a24de" target="_blank">Show</a>
+    </td>
+    <td>
+            <a href="http://doi.org/10.5880/ICGEM.2019.003" target="_blank">✔</a>
+    </td>
+</tr>
+
+        <tr>
+    <td>170</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="https://earth.esa.int/eogateway/missions/goce" target="_blank">GO_CONS_GCF_2_DIR_R6</a>
+</td>
+    <td>2019</td>
+    <td>        300
+</td>
+    <td>            S</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_acffd529e1949c6055ab5a503bda803906ed8e85ae6750dc71dd881b37a34757').toggle(); "><b>Bruinsma, S. L. et al, 2014</b></div>
+        <div id="ref_acffd529e1949c6055ab5a503bda803906ed8e85ae6750dc71dd881b37a34757" class="mt-1" style="display:none">        Bruinsma, S., Förste, C., Abrikosov, O., Lemoine, J., Marty, J., Mulet, S.,
+Rio, M. and Bonvalot, S.;<br>
+    <b>ESA's satellite-only gravity field model via the
+direct approach based on all GOCE data;</b>
+    <br>
+        Geophysical Research Letters,
+            Vol 41,
+            No. 21,
+            p. 7508-7514,
+        doi: <a href="http://doi.org/10.1002/2014GL062045" target="_blank">10.1002/2014GL062045</a>,
+    2014
+
+        <br><br>
+        <b>Related References:</b><br>
+        Bruinsma S.L., Marty J.C., Balmino G., Biancale R., Foerste C.,
+Abrikosov O. and Neumayer H.;<br>
+    <b>GOCE GOCE Gravity Field Recovery by Means
+of the Direct Numerical Method; presented at the ESA Living Planet
+Symposium</b>
+    <br>
+        27th June - 2nd July 2010, Bergen, Norway,
+            Vol SP 686,
+        Bergen, Norway,
+    2010
+
+        <br><br>
+        Dahle, C., Flechtner, F., Murböck, M., Michalak, G., Neumayer, K., Abrykosov, O.,
+Reinhold, A., König, R.,<br>
+    <b>GRACE 327-743 (Gravity Recovery and Climate Experiment:
+GFZ Level-2 Processing Standards Document for Level-2 Product Release 06
+(Rev. 1.0, October 26, 2018), (Scientific Technical Report STR - Data ; 18),
+GFZ German Research Centre for Geosciences: Potsdam, 20 p.</b>
+    <br>
+        doi: <a href="http://doi.org/10.2312/GFZ.b103-18048" target="_blank">10.2312/GFZ.b103-18048</a>,
+        Potsdam,
+    2018
+
+        <br><br>
+        Metzler, B., Pail, R.;<br>
+    <b>GOCE Data Processing: The Spherical Cap Regularization Approach;</b>
+    <br>
+        Studia Geophysica et Geodaetica,
+            Vol 49,
+            No. 4,
+            p. 441-462,
+        doi: <a href="http://doi.org/10.1007/s11200-005-0021-5" target="_blank">10.1007/s11200-005-0021-5</a>,
+    2005
+
+        <br><br>
+        Pail, Roland, Bruinsma, Sean, Migliaccio, Federica, Förste, Christoph, Goiginger, Helmut, Schuh, Wolf-Dieter, Höck, Eduard, Reguzzoni, Mirko, Brockmann, Jan Martin, Abrikosov, Oleg, Veicherts, Martin, Fecher, Thomas, Mayrhofer, Reinhard, Krasbutter, Ina, Sansò, Fernando, Tscherning, Carl Christian;<br>
+    <b>First GOCE gravity field models derived by three different approaches;</b>
+    <br>
+        Journal of Geodesy,
+            Vol 85,
+            No. 11,
+            p. 819-843,
+        doi: <a href="http://doi.org/10.1007/s00190-011-0467-x" target="_blank">10.1007/s00190-011-0467-x</a>,
+    2011
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/acffd529e1949c6055ab5a503bda803906ed8e85ae6750dc71dd881b37a34757/GO_CONS_GCF_2_DIR_R6.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/acffd529e1949c6055ab5a503bda803906ed8e85ae6750dc71dd881b37a34757/GO_CONS_GCF_2_DIR_R6.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=acffd529e1949c6055ab5a503bda803906ed8e85ae6750dc71dd881b37a34757" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=acffd529e1949c6055ab5a503bda803906ed8e85ae6750dc71dd881b37a34757" target="_blank">Show</a>
+    </td>
+    <td>
+            <a href="http://doi.org/10.5880/ICGEM.2019.004" target="_blank">✔</a>
+    </td>
+</tr>
+
+        <tr>
+    <td>169</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        IGGT_R1C
+</td>
+    <td>2018</td>
+    <td>        240
+</td>
+    <td>            G,             S(Goce),             S(Grace)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_9d971f8d1969d8d1d4e2b485a63e875f6b68c65ecbbed9ccfd65980af51eb2c9').toggle(); "><b>Lu, B. et al., 2019</b></div>
+        <div id="ref_9d971f8d1969d8d1d4e2b485a63e875f6b68c65ecbbed9ccfd65980af51eb2c9" class="mt-1" style="display:none">Lu, B., Luo, Z., Zhong, B., Zhou, H., Flechtner, F., Förste, C., Barthelmes, F., Zhou, R. (2018):<br> 
+<b>The gravity field model IGGT_R1 based on the second invariant of the GOCE gravitational gradient tensor. Journal of Geodesy, 2018, 92(5): 561-572.</b><br>
+<br>
+Lu, B., Förste, C., Barthelmes F., Petrovic, S., Flechtner, F., Luo, Z., Zhong B., Zhou H., Wang X.L., Wu T.T. (2018):<br>
+<b>Using real polar terrestrial gravimetry data to overcome the polar gap problem of GOCE[J]. Submitted.</b><br>
+
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/9d971f8d1969d8d1d4e2b485a63e875f6b68c65ecbbed9ccfd65980af51eb2c9/IGGT_R1C.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/9d971f8d1969d8d1d4e2b485a63e875f6b68c65ecbbed9ccfd65980af51eb2c9/IGGT_R1C.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=9d971f8d1969d8d1d4e2b485a63e875f6b68c65ecbbed9ccfd65980af51eb2c9" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=9d971f8d1969d8d1d4e2b485a63e875f6b68c65ecbbed9ccfd65980af51eb2c9" target="_blank">Show</a>
+    </td>
+    <td>
+            <a href="http://doi.org/10.5880/icgem.2019.001" target="_blank">✔</a>
+    </td>
+</tr>
+
+        <tr>
+    <td>168</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="https://doi.org/10.1029/2018JB015641" target="_blank">Tongji-Grace02k</a>
+</td>
+    <td>2018</td>
+    <td>        180
+</td>
+    <td>            S(Grace)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_3b2b6e97907904c636a42d187a65bce18e3c4f4b4f384861ad4021eefa350fa5').toggle(); "><b>Chen, Q. et al, 2018</b></div>
+        <div id="ref_3b2b6e97907904c636a42d187a65bce18e3c4f4b4f384861ad4021eefa350fa5" class="mt-1" style="display:none">Chen, Q., Shen, Y., Francis , O., Chen, W., Zhang, X., Hsu, H., 2018:<br> 
+<b>Tongji-Grace02s and Tongji-Grace02k: high-precision static GRACE-only global Earth's gravity field models derived by refined data processing strategies.</b><br>
+Journal of Geophysical Research: Solid Earth,<br> doi: <a href="https://doi.org/10.1029/2018JB015641" target="_blank">10.1029/2018JB015641</a>,
+2018
+<br>
+
+<br><br>
+Chen, Q., Shen, Y., Chen, W., Zhang, X., Hsu, H., 2016:<br>
+<b>An improved GRACE monthly gravity field solution by modelling the non-conservative acceleration and attitude observation errors</b><br>
+Journal of Geodesy, 90(6), 503-523. 
+doi: <a href="http://doi.org/10.1007/s00190-016-0889-6" target="_blank">10.1007/s00190-016-0889-6</a><br>
+<br>
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/3b2b6e97907904c636a42d187a65bce18e3c4f4b4f384861ad4021eefa350fa5/Tongji-Grace02k.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/3b2b6e97907904c636a42d187a65bce18e3c4f4b4f384861ad4021eefa350fa5/Tongji-Grace02k.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=3b2b6e97907904c636a42d187a65bce18e3c4f4b4f384861ad4021eefa350fa5" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=3b2b6e97907904c636a42d187a65bce18e3c4f4b4f384861ad4021eefa350fa5" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>167</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="DOI:10.11947/j.AGCS.2018.20170269" target="_blank">SGG-UGM-1</a>
+</td>
+    <td>2018</td>
+    <td>        2159
+</td>
+    <td>            EGM2008,             S(Goce)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_88855f2a04db5362a70f327fa1a071aed9bbe276bbe0ca969ec37f2aa534b54e').toggle(); "><b>Liang, W. et al., 2018 & Xu, X. et al. (2017)</b></div>
+        <div id="ref_88855f2a04db5362a70f327fa1a071aed9bbe276bbe0ca969ec37f2aa534b54e" class="mt-1" style="display:none">Liang W., Xu X., Li J., Zhu G., 2018: <br>
+<b>The determination of an ultra high gravity field model SGG-UGM-1 by combining EGM2008 gravity anomaly and GOCE observation data</b><br>
+Acta Geodaeticaet Cartographica Sinica, 47(4): 425-434. DOI:10.11947/j.AGCS.2018.20170269.<br>
+<br>
+Xu X., Zhao Y., Reubelt T., Robert T., 2017: <br> 
+<b>A GOCE only gravity model GOSG01S and the validation of GOCE related satellite gravity models</b><br> 
+Geodesy and Geodynamics. 2017, 8(4): 260-272. http://dx.doi.org/10.1016/j.geog.2017.03.013.<br></div>
+    </td>
+    <td>        <a href="/getmodel/gfc/88855f2a04db5362a70f327fa1a071aed9bbe276bbe0ca969ec37f2aa534b54e/SGG-UGM-1.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/88855f2a04db5362a70f327fa1a071aed9bbe276bbe0ca969ec37f2aa534b54e/SGG-UGM-1.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=88855f2a04db5362a70f327fa1a071aed9bbe276bbe0ca969ec37f2aa534b54e" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=88855f2a04db5362a70f327fa1a071aed9bbe276bbe0ca969ec37f2aa534b54e" target="_blank">Show</a>
+    </td>
+    <td>
+            <a href="http://doi.org/10.5880/icgem.2018.001" target="_blank">✔</a>
+    </td>
+</tr>
+
+        <tr>
+    <td>166</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="https://doi.org/10.1016/j.geog.2017.03.013" target="_blank">GOSG01S</a>
+</td>
+    <td>2018</td>
+    <td>        220
+</td>
+    <td>            S(Goce)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_9b0b4c2b7cdc04fe0f3c54b56fa195a3022c20dcff5bbd2ad6a0afe7d98d461b').toggle(); "><b>Xu, X. et al., 2018</b></div>
+        <div id="ref_9b0b4c2b7cdc04fe0f3c54b56fa195a3022c20dcff5bbd2ad6a0afe7d98d461b" class="mt-1" style="display:none">Xu X., Zhao Y., Reubelt T., Robert T. 2017<br>
+<b>A GOCE only gravity model GOSG01S and the validation of GOCE related satellite gravity models</b><br>
+Geodesy and Geodynamics, 8(4): 260-272, http://dx.doi.org/10.1016/j.geog.2017.03.013
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/9b0b4c2b7cdc04fe0f3c54b56fa195a3022c20dcff5bbd2ad6a0afe7d98d461b/GOSG01S.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/9b0b4c2b7cdc04fe0f3c54b56fa195a3022c20dcff5bbd2ad6a0afe7d98d461b/GOSG01S.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=9b0b4c2b7cdc04fe0f3c54b56fa195a3022c20dcff5bbd2ad6a0afe7d98d461b" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=9b0b4c2b7cdc04fe0f3c54b56fa195a3022c20dcff5bbd2ad6a0afe7d98d461b" target="_blank">Show</a>
+    </td>
+    <td>
+            <a href="http://doi.org/10.5880/icgem.2018.002" target="_blank">✔</a>
+    </td>
+</tr>
+
+        <tr>
+    <td>165</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="https://doi.org/10.1007/s00190-017-1089-8" target="_blank">IGGT_R1</a>
+</td>
+    <td>2017</td>
+    <td>        240
+</td>
+    <td>            S(Goce)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_c5edb180901554de3c9f280f3c2994acea39453aa6016d5a2dabbbfdd14c05fe').toggle(); "><b>Lu, B. et al, 2017</b></div>
+        <div id="ref_c5edb180901554de3c9f280f3c2994acea39453aa6016d5a2dabbbfdd14c05fe" class="mt-1" style="display:none">Lu B., Luo Z., Zhong B., Zhou H., Flechtner F., Foerste C., Barthelmes F., Zhou R., 2017<br> 
+<b>The gravity field model IGGT_R1 based on the second invariant of the GOCE gravitational gradient tensor</b><br>
+Journal of Geodesy,  https://doi.org/10.1007/s00190-017-1089-8.
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/c5edb180901554de3c9f280f3c2994acea39453aa6016d5a2dabbbfdd14c05fe/IGGT_R1.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/c5edb180901554de3c9f280f3c2994acea39453aa6016d5a2dabbbfdd14c05fe/IGGT_R1.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=c5edb180901554de3c9f280f3c2994acea39453aa6016d5a2dabbbfdd14c05fe" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=c5edb180901554de3c9f280f3c2994acea39453aa6016d5a2dabbbfdd14c05fe" target="_blank">Show</a>
+    </td>
+    <td>
+            <a href="http://doi.org/10.5880/icgem.2017.007" target="_blank">✔</a>
+    </td>
+</tr>
+
+        <tr>
+    <td>164</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="https://www.ife.uni-hannover.de" target="_blank">IfE_GOCE05s</a>
+</td>
+    <td>2017</td>
+    <td>        250
+</td>
+    <td>            S</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_e1d168f5c30855944dd9afeaad975c129de17cca7d2d6939dc0116af15282598').toggle(); "><b>Wu, H. et al, 2017</b></div>
+        <div id="ref_e1d168f5c30855944dd9afeaad975c129de17cca7d2d6939dc0116af15282598" class="mt-1" style="display:none">Wu, H., Müller, J., and Brieden, P. (2016)<br>
+<b>The IfE global gravity field model from GOCE-only observations:</b><br>
+Presented at the International Symposium on Gravity, Geoid and Height Systems, 19-23 September 2016, Thessaloníki, Greece
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/e1d168f5c30855944dd9afeaad975c129de17cca7d2d6939dc0116af15282598/IfE_GOCE05s.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/e1d168f5c30855944dd9afeaad975c129de17cca7d2d6939dc0116af15282598/IfE_GOCE05s.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=e1d168f5c30855944dd9afeaad975c129de17cca7d2d6939dc0116af15282598" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=e1d168f5c30855944dd9afeaad975c129de17cca7d2d6939dc0116af15282598" target="_blank">Show</a>
+    </td>
+    <td>
+            <a href="http://doi.org/10.5880/icgem.2017.006" target="_blank">✔</a>
+    </td>
+</tr>
+
+        <tr>
+    <td>163</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="https://earth.esa.int/eogateway/missions/goce" target="_blank">GO_CONS_GCF_2_SPW_R5</a>
+</td>
+    <td>2017</td>
+    <td>        330
+</td>
+    <td>            S(Goce)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_3e12c154b0e94e44637d8192aa9b5f2eec6c175f07b9c2b6ff3e7565e7d8a7eb').toggle(); "><b>Gatti, A. et al, 2016</b></div>
+        <div id="ref_3e12c154b0e94e44637d8192aa9b5f2eec6c175f07b9c2b6ff3e7565e7d8a7eb" class="mt-1" style="display:none">A. Gatti, M. Reguzzoni, F. Migliaccio, F. Sansò. 2016<br>
+<b>Computation and assessment of the fifth release of the GOCE-only space-wise solution:</b><br>
+Presented at the 1st Joint Commission 2 and IGFS Meeting, 19-23 September 2016, Thessaloníki, Greece
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/3e12c154b0e94e44637d8192aa9b5f2eec6c175f07b9c2b6ff3e7565e7d8a7eb/GO_CONS_GCF_2_SPW_R5.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/3e12c154b0e94e44637d8192aa9b5f2eec6c175f07b9c2b6ff3e7565e7d8a7eb/GO_CONS_GCF_2_SPW_R5.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=3e12c154b0e94e44637d8192aa9b5f2eec6c175f07b9c2b6ff3e7565e7d8a7eb" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=3e12c154b0e94e44637d8192aa9b5f2eec6c175f07b9c2b6ff3e7565e7d8a7eb" target="_blank">Show</a>
+    </td>
+    <td>
+            <a href="http://doi.org/10.5880/icgem.2017.005" target="_blank">✔</a>
+    </td>
+</tr>
+
+        <tr>
+    <td>162</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="/getmodel/doc/d70c77c81d1b47dd8e672ce1868178258d95d14e72f75fd74b6a30b49473b1f7" target="_blank">GAO2012</a>
+</td>
+    <td>2012</td>
+    <td>        360
+</td>
+    <td>            A,             G,             S(Goce),             S(Grace)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_d70c77c81d1b47dd8e672ce1868178258d95d14e72f75fd74b6a30b49473b1f7').toggle(); "><b>Demianov, G. et al, 2012</b></div>
+        <div id="ref_d70c77c81d1b47dd8e672ce1868178258d95d14e72f75fd74b6a30b49473b1f7" class="mt-1" style="display:none">Demianov Gleb, Sermyagin Roman, Tsybankov Ivan, 2012:<br>
+<b>Global Gravity Field Model GAO2012 [Data set]</b><br>
+DOI: 10.5281/zenodo.814573</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/d70c77c81d1b47dd8e672ce1868178258d95d14e72f75fd74b6a30b49473b1f7/GAO2012.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/d70c77c81d1b47dd8e672ce1868178258d95d14e72f75fd74b6a30b49473b1f7/GAO2012.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=d70c77c81d1b47dd8e672ce1868178258d95d14e72f75fd74b6a30b49473b1f7" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=d70c77c81d1b47dd8e672ce1868178258d95d14e72f75fd74b6a30b49473b1f7" target="_blank">Show</a>
+    </td>
+    <td>
+            <a href="https://doi.org/10.5281/zenodo.814573" target="_blank">✔</a>
+    </td>
+</tr>
+
+        <tr>
+    <td>161</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="https://doi.org/10.1007/s00190-017-1070-6" target="_blank">XGM2016</a>
+</td>
+    <td>2017</td>
+    <td>        719
+</td>
+    <td>            A,             G,             S(GOCO05s)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_9d5b5c3439c3cddd3e419f6fd416c289be2751df92f84509f66687638dadc4d6').toggle(); "><b>Pail, R. et al, 2017</b></div>
+        <div id="ref_9d5b5c3439c3cddd3e419f6fd416c289be2751df92f84509f66687638dadc4d6" class="mt-1" style="display:none">Mayer-Guerr T. et al, 2015:<br>
+<b>The combined satellite gravity field model GOCO05s</b><br>
+Presentation at EGU 2015, Geophysical Research Abstracts Vol. 17, EGU2015-12364, Vienna.<br>
+<br>
+Pail R. et al, 2016:<br>
+<b>The experimental gravity field model XGM2016</b><br>
+Presentation at International Symposium on Gravity, Geoid and Height System 2016, Thessaloniki.<br>
+<br>
+Fecher T. et al, 2017:<br>
+<b>GOCO05c: A New Combined Gravity Field Model Based on Full Normal Equations and Regionally Varying Weighting</b><br>
+Surveys in Geophysics, Vol. 38, Nr. 3, pp 571-590, Springer, DOI: 10.1007/s10712-016-9406-y.<br>
+<br>
+Pail R. et al, 2017:<br>
+<b>Short note: the experimental geopotential model XGM2016</b><br>
+Journal of Geodesy, doi: 10.1007/s00190-017-1070-6.<br>
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/9d5b5c3439c3cddd3e419f6fd416c289be2751df92f84509f66687638dadc4d6/XGM2016.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/9d5b5c3439c3cddd3e419f6fd416c289be2751df92f84509f66687638dadc4d6/XGM2016.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=9d5b5c3439c3cddd3e419f6fd416c289be2751df92f84509f66687638dadc4d6" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=9d5b5c3439c3cddd3e419f6fd416c289be2751df92f84509f66687638dadc4d6" target="_blank">Show</a>
+    </td>
+    <td>
+            <a href="http://doi.org/10.5880/icgem.2017.003" target="_blank">✔</a>
+    </td>
+</tr>
+
+        <tr>
+    <td>160</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        Tongji-Grace02s
+</td>
+    <td>2017</td>
+    <td>        180
+</td>
+    <td>            S(Grace)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_98ad3c073aef674db5fe5e3780041c7b0c3268c588457e5ce268526060034be2').toggle(); "><b>Chen, Q. et al, 2016</b></div>
+        <div id="ref_98ad3c073aef674db5fe5e3780041c7b0c3268c588457e5ce268526060034be2" class="mt-1" style="display:none">Chen, Q., Shen, Y., Chen, W., Zhang, X., Hsu, H., 2016:<br>
+<b>An improved GRACE monthly gravity field solution by modelling the non-conservative acceleration and attitude observation errors</b><br>
+Journal of Geodesy, 90(6), 503-523. http://doi.org/10.1007/s00190-016-0889-6<br>
+<br>
+Chen, Q., Shen, Y., Zhang, X., Hsu, H., Chen, W., Ju, X., Lou, L., 2015:<br>
+<b>Monthly gravity field models derived from GRACE Level 1B data using a modified short-arc approach</b><br>
+Journal of Geophysical Research: Solid Earth, 120(3), 1804-1819. http://doi.org/10.1002/2014jb011470</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/98ad3c073aef674db5fe5e3780041c7b0c3268c588457e5ce268526060034be2/Tongji-Grace02s.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/98ad3c073aef674db5fe5e3780041c7b0c3268c588457e5ce268526060034be2/Tongji-Grace02s.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=98ad3c073aef674db5fe5e3780041c7b0c3268c588457e5ce268526060034be2" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=98ad3c073aef674db5fe5e3780041c7b0c3268c588457e5ce268526060034be2" target="_blank">Show</a>
+    </td>
+    <td>
+            <a href="http://doi.org/10.5880/icgem.2017.002" target="_blank">✔</a>
+    </td>
+</tr>
+
+        <tr>
+    <td>159</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        NULP-02s
+</td>
+    <td>2017</td>
+    <td>        250
+</td>
+    <td>            S(Goce)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_5bbb1f419b4faecff7952385e7b5842f7511d00501c027cc0dcd99e97cf64e99').toggle(); "><b>A.N. Marchenko et al, 2016</b></div>
+        <div id="ref_5bbb1f419b4faecff7952385e7b5842f7511d00501c027cc0dcd99e97cf64e99" class="mt-1" style="display:none">A.N. Marchenko (1), D.A. Marchenko (2), A.N. Lopushansky (1) Gravity Field Models
+Derived from the Second Degree Radial Derivatives of the GOCE Mission: A Case Study.
+Annals of Geophysics, Vol. 59, No 6, 2016, s0649 - s0659, DOI:10.4401/ag-7049
+
+(1) National university "Lviv polytechnic", Institute of Geodesy, Lviv, Ukraine
+(2) Carpathian Branch of the Subbotin institute of geophysics, Lviv, Ukraine
+
+
+
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/5bbb1f419b4faecff7952385e7b5842f7511d00501c027cc0dcd99e97cf64e99/NULP-02s.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/5bbb1f419b4faecff7952385e7b5842f7511d00501c027cc0dcd99e97cf64e99/NULP-02s.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=5bbb1f419b4faecff7952385e7b5842f7511d00501c027cc0dcd99e97cf64e99" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=5bbb1f419b4faecff7952385e7b5842f7511d00501c027cc0dcd99e97cf64e99" target="_blank">Show</a>
+    </td>
+    <td>
+            <a href="http://doi.org/10.5880/icgem.2017.001" target="_blank">✔</a>
+    </td>
+</tr>
+
+        <tr>
+    <td>158</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        HUST-Grace2016s
+</td>
+    <td>2016</td>
+    <td>        160
+</td>
+    <td>            S(Grace)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_f9e5a5aca9d8550ceb94ff27aba8e1571fd7eaf703b5b351641e9fa20d8cd67c').toggle(); "><b>Zhou, H. et al, 2016</b></div>
+        <div id="ref_f9e5a5aca9d8550ceb94ff27aba8e1571fd7eaf703b5b351641e9fa20d8cd67c" class="mt-1" style="display:none">Zhou, H.; Luo, Z; Zhou, Z.; Li, Q.; Zhong, B.; Hsu, H. (2016):<br>
+<b>A new time series of GRACE monthly gravity field models:</b><br>
+HUST-Grace2016. GFZ Data Services. http://doi.org/10.5880/ICGEM.2016.0</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/f9e5a5aca9d8550ceb94ff27aba8e1571fd7eaf703b5b351641e9fa20d8cd67c/HUST-Grace2016s.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/f9e5a5aca9d8550ceb94ff27aba8e1571fd7eaf703b5b351641e9fa20d8cd67c/HUST-Grace2016s.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=f9e5a5aca9d8550ceb94ff27aba8e1571fd7eaf703b5b351641e9fa20d8cd67c" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=f9e5a5aca9d8550ceb94ff27aba8e1571fd7eaf703b5b351641e9fa20d8cd67c" target="_blank">Show</a>
+    </td>
+    <td>
+            <a href="http://doi.org/10.5880/icgem.2016.010" target="_blank">✔</a>
+    </td>
+</tr>
+
+        <tr>
+    <td>157</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="http://www.geo.itu.edu.tr/gravity/ITU_GRACE16.html" target="_blank">ITU_GRACE16</a>
+</td>
+    <td>2016</td>
+    <td>        180
+</td>
+    <td>            S(Grace)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_0cbbaba92c08482d2d221c5d375264f4c6233e8f695cbcfb86ecfc5e19345a42').toggle(); "><b>        Akyilmaz, O. et al,
+    2016
+</b></div>
+        <div id="ref_0cbbaba92c08482d2d221c5d375264f4c6233e8f695cbcfb86ecfc5e19345a42" class="mt-1" style="display:none">
+        Akyilmaz, O., Ustun, A., Aydin, C., Arslan, N., Doganalp, S., Guney, C., Mercan, H., Uygur, S.O., Uz, M., Yagci, O.;<br>
+    <b>High Resolution Gravity Field Determination and Monitoring of Regional Mass Variations using Low-Earth Orbit Satellites;</b>
+    <br>
+        Quelle nicht nachvollziehbar, zu aktuelle? Wo erschienen?,
+    2016
+
+        <br><br>
+        <b>Related References:</b><br>
+        Dahle, C., Flechtner, F., Gruber, C., König, D., König, R., Michalak, G., Neumayer, K.-H., Deutsches GeoForschungsZentrum GFZ;<br>
+    <b>GFZ GRACE Level-2 Processing Standards Document for Level-2 Product Release 0005: revised edition;</b>
+    <br>
+        doi: <a href="http://doi.org/10.2312/GFZ.b103-1202-25" target="_blank">10.2312/GFZ.b103-1202-25</a>,
+        Potsdam,
+    2013
+
+        <br><br>
+        Guo, J. Y., Shang, K., Jekeli, C., Shum, C. K.;<br>
+    <b>On the energy integral formulation of gravitational potential differences from satellite-to-satellite tracking;</b>
+    <br>
+        Celestial Mechanics and Dynamical Astronomy,
+            Vol 121,
+            No. 4,
+            p. 415-429,
+        doi: <a href="http://doi.org/10.1007/s10569-015-9610-y" target="_blank">10.1007/s10569-015-9610-y</a>,
+    2015
+
+        <br><br>
+        Shang, Kun, Guo, Junyi, Shum, C. K., Dai, Chunli, Luo, Jia;<br>
+    <b>GRACE time-variable gravity field recovery using an improved energy balance approach;</b>
+    <br>
+        Geophysical Journal International,
+            Vol 203,
+            No. 3,
+            p. 1773-1786,
+        doi: <a href="http://doi.org/10.1093/gji/ggv392" target="_blank">10.1093/gji/ggv392</a>,
+    2015
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/0cbbaba92c08482d2d221c5d375264f4c6233e8f695cbcfb86ecfc5e19345a42/ITU_GRACE16.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/0cbbaba92c08482d2d221c5d375264f4c6233e8f695cbcfb86ecfc5e19345a42/ITU_GRACE16.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=0cbbaba92c08482d2d221c5d375264f4c6233e8f695cbcfb86ecfc5e19345a42" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=0cbbaba92c08482d2d221c5d375264f4c6233e8f695cbcfb86ecfc5e19345a42" target="_blank">Show</a>
+    </td>
+    <td>
+            <a href="http://doi.org/10.5880/icgem.2016.006" target="_blank">✔</a>
+    </td>
+</tr>
+
+        <tr>
+    <td>156</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="http://www.geo.itu.edu.tr/gravity/ITU_GGC16.html" target="_blank">ITU_GGC16</a>
+</td>
+    <td>2016</td>
+    <td>        280
+</td>
+    <td>            S(Goce),             S(Grace)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_ce010e734a1d706501699bf4862e2c264587e417b975a49c43937b7f83a92617').toggle(); "><b>        Akyilmaz, O. et al,
+    2016
+</b></div>
+        <div id="ref_ce010e734a1d706501699bf4862e2c264587e417b975a49c43937b7f83a92617" class="mt-1" style="display:none">
+        Akyilmaz, O., Ustun, A., Aydin, C., Arslan, N., Doganalp, S., Guney, C., Mercan, H., Uygur, S.O., Uz, M., Yagci, O.;<br>
+    <b>High Resolution Gravity Field Determination and Monitoring of Regional Mass Variations using Low-Earth Orbit Satellites;</b>
+    <br>
+        Quelle nicht nachvollziehbar, zu aktuelle? Wo erschienen?,
+    2016
+
+        <br><br>
+        <b>Related References:</b><br>
+        Dahle, C., Flechtner, F., Gruber, C., König, D., König, R., Michalak, G., Neumayer, K.-H., Deutsches GeoForschungsZentrum GFZ;<br>
+    <b>GFZ GRACE Level-2 Processing Standards Document for Level-2 Product Release 0005: revised edition;</b>
+    <br>
+        doi: <a href="http://doi.org/10.2312/GFZ.b103-1202-25" target="_blank">10.2312/GFZ.b103-1202-25</a>,
+        Potsdam,
+    2013
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/ce010e734a1d706501699bf4862e2c264587e417b975a49c43937b7f83a92617/ITU_GGC16.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/ce010e734a1d706501699bf4862e2c264587e417b975a49c43937b7f83a92617/ITU_GGC16.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=ce010e734a1d706501699bf4862e2c264587e417b975a49c43937b7f83a92617" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=ce010e734a1d706501699bf4862e2c264587e417b975a49c43937b7f83a92617" target="_blank">Show</a>
+    </td>
+    <td>
+            <a href="http://doi.org/10.5880/icgem.2016.005" target="_blank">✔</a>
+    </td>
+</tr>
+
+        <tr>
+    <td>155</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="/getmodel/doc/4cc119d62d3f83adce857914bcabdfa7ca2f91677ed2905934cf52698584b4c9" target="_blank">EIGEN-6S4 (v2)</a>
+</td>
+    <td>2016</td>
+    <td>        300
+</td>
+    <td>            S(Goce),             S(Grace),             S(Lageos)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_4cc119d62d3f83adce857914bcabdfa7ca2f91677ed2905934cf52698584b4c9').toggle(); "><b>        Förste, C. et al. 
+    2016
+</b></div>
+        <div id="ref_4cc119d62d3f83adce857914bcabdfa7ca2f91677ed2905934cf52698584b4c9" class="mt-1" style="display:none">        Förste, Christoph; Bruinsma, Sean; Abrikosov, Oleh; Rudenko, Sergiy; Lemoine, Jean-Michel; Marty, Jean-Charles; Neumayer, Karl Hans; Biancale, Richard (2016): ;<br>
+    <b>EIGEN-6S4:  EIGEN-6S4 A time-variable satellite-only gravity field model to d/o 300 based on LAGEOS, GRACE and GOCE data from the collaboration of GFZ Potsdam and GRGS Toulouse. V. 2.0.;</b>
+    <br>
+        doi: <a href="http://doi.org/10.5880/icgem.2016.008" target="_blank">10.5880/icgem.2016.008</a>,
+        http://doi.org/10.5880/icgem.2016.008,
+    2016
+
+        <br><br>
+        <b>Related References:</b><br>
+        Bruinsma, Sean, Lemoine, Jean-Michel, Biancale, Richard, Valès, Nicole;<br>
+    <b>CNES/GRGS 10-day gravity field models (release 2) and their evaluation;</b>
+    <br>
+        Advances in Space Research,
+            Vol 45,
+            No. 4,
+            p. 587-601,
+        doi: <a href="http://doi.org/10.1016/j.asr.2009.10.012" target="_blank">10.1016/j.asr.2009.10.012</a>,
+    2010
+
+        <br><br>
+        Bruinsma, Sean L., Förste, Christoph, Abrikosov, Oleg, Lemoine, Jean-Michel, Marty, Jean-Charles, Mulet, Sandrine, Rio, Marie-Helene, Bonvalot, Sylvain;<br>
+    <b>ESA's satellite-only gravity field model via the direct approach based on all GOCE data;</b>
+    <br>
+        Geophysical Research Letters,
+            Vol 41,
+            No. 21,
+            p. 7508-7514,
+        doi: <a href="http://doi.org/10.1002/2014gl062045" target="_blank">10.1002/2014gl062045</a>,
+    2014
+
+        <br><br>
+        Metzler, B., Pail, R.;<br>
+    <b>GOCE Data Processing: The Spherical Cap Regularization Approach;</b>
+    <br>
+        Studia Geophysica et Geodaetica,
+            Vol 49,
+            No. 4,
+            p. 441-462,
+        doi: <a href="http://doi.org/10.1007/s11200-005-0021-5" target="_blank">10.1007/s11200-005-0021-5</a>,
+    2005
+
+        <br><br>
+        Pail, Roland, Bruinsma, Sean, Migliaccio, Federica, Förste, Christoph, Goiginger, Helmut, Schuh, Wolf-Dieter, Höck, Eduard, Reguzzoni, Mirko, Brockmann, Jan Martin, Abrikosov, Oleg, Veicherts, Martin, Fecher, Thomas, Mayrhofer, Reinhard, Krasbutter, Ina, Sansò, Fernando, Tscherning, Carl Christian;<br>
+    <b>First GOCE gravity field models derived by three different approaches;</b>
+    <br>
+        Journal of Geodesy,
+            Vol 85,
+            No. 11,
+            p. 819-843,
+        doi: <a href="http://doi.org/10.1007/s00190-011-0467-x" target="_blank">10.1007/s00190-011-0467-x</a>,
+    2011
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/4cc119d62d3f83adce857914bcabdfa7ca2f91677ed2905934cf52698584b4c9/EIGEN-6S4 (v2).gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/4cc119d62d3f83adce857914bcabdfa7ca2f91677ed2905934cf52698584b4c9/EIGEN-6S4 (v2).zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=4cc119d62d3f83adce857914bcabdfa7ca2f91677ed2905934cf52698584b4c9" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=4cc119d62d3f83adce857914bcabdfa7ca2f91677ed2905934cf52698584b4c9" target="_blank">Show</a>
+    </td>
+    <td>
+            <a href="http://doi.org/10.5880/icgem.2016.008" target="_blank">✔</a>
+    </td>
+</tr>
+
+        <tr>
+    <td>154</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="/getmodel/doc/17de3c1a5391d7d0397425eb7cfc8367ccbf77e33b8709600550ff8ea7ae9ceb" target="_blank">GOCO05c</a>
+</td>
+    <td>2016</td>
+    <td>        720
+</td>
+    <td>            (see model),             A,             G,             S</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_17de3c1a5391d7d0397425eb7cfc8367ccbf77e33b8709600550ff8ea7ae9ceb').toggle(); "><b>        Fecher, T. et al,
+    2016
+</b></div>
+        <div id="ref_17de3c1a5391d7d0397425eb7cfc8367ccbf77e33b8709600550ff8ea7ae9ceb" class="mt-1" style="display:none">        Fecher, T., Pail, R., Gruber, T., GOCO Project Team,;<br>
+    <b>The combined gravity field model GOCO05c;</b>
+    <br>
+        Vienna,
+    2016
+
+        <br><br>
+        <b>Related References:</b><br>
+        Fecher, Thomas, Pail, Roland, Gruber, Thomas;<br>
+    <b>Global gravity field modeling based on GOCE and complementary gravity data;</b>
+    <br>
+        International Journal of Applied Earth Observation and Geoinformation,
+            Vol 35,
+            p. 120-127,
+        doi: <a href="http://doi.org/10.1016/j.jag.2013.10.005" target="_blank">10.1016/j.jag.2013.10.005</a>,
+    2015
+
+        <br><br>
+        Mayer-Gürr, T., Pail, R., Gruber, T., Fecher, T., Rexer, M., Schuh, W.-D., Kusche, J., Brockmann, J.-M., Rieser, D., Zehentner, N., Kvas, A., Klinger, B., Baur, O., Höck, E., Krauss, S., Jäggi, A.;<br>
+    <b>The combined satellite gravity field model GOCO05s;</b>
+    <br>
+        Vienna, Austria,
+    2015
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/17de3c1a5391d7d0397425eb7cfc8367ccbf77e33b8709600550ff8ea7ae9ceb/GOCO05c.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/17de3c1a5391d7d0397425eb7cfc8367ccbf77e33b8709600550ff8ea7ae9ceb/GOCO05c.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=17de3c1a5391d7d0397425eb7cfc8367ccbf77e33b8709600550ff8ea7ae9ceb" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=17de3c1a5391d7d0397425eb7cfc8367ccbf77e33b8709600550ff8ea7ae9ceb" target="_blank">Show</a>
+    </td>
+    <td>
+            <a href="http://doi.org/10.5880/icgem.2016.003" target="_blank">✔</a>
+    </td>
+</tr>
+
+        <tr>
+    <td>153</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="https://repositories.lib.utexas.edu/handle/2152/74341" target="_blank">GGM05C</a>
+</td>
+    <td>2015</td>
+    <td>        360
+</td>
+    <td>            A,             G,             S(Goce),             S(Grace)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_778a683780a5b0ad3163f4772b97b9075a0a13c389d2bd8ea3f891b64cfa383d').toggle(); "><b>        Ries, J. et al,
+    2016
+</b></div>
+        <div id="ref_778a683780a5b0ad3163f4772b97b9075a0a13c389d2bd8ea3f891b64cfa383d" class="mt-1" style="display:none">        Ries, J., Bettadpur, S., Eanes, R., Kang, Z., Ko, U., McCullough, C., Nagel, P., Pie, N., Poole, S., Richter, T., Save, H., Tapley, B.;<br>
+    <b>The Combined Gravity Model GGM05C;</b>
+    <br>
+        GFZ Data Services,
+        doi: <a href="http://doi.org/10.5880/ICGEM.2016.002" target="_blank">10.5880/ICGEM.2016.002</a>,
+        Potsdam,
+    2016
+
+<br><br>
+        Ries, J., Bettadpur, S., Eanes, R., Kang, Z., Ko, U., McCullough, C., Nagel, P., Pie, N., Poole, S., Richter, T., Save, H., Tapley, B.;<br>
+    <b>Development and Evaluation of the Global Gravity Model GGM05;</b>
+    <br>
+        CSR-16-02, Center for Space Research, The University of Texas at Austin,
+        doi: <a href="http://dx.doi.org/10.26153/tsw/1461" target="_blank">http://dx.doi.org/10.26153/tsw/1461</a>,
+    2016
+
+
+
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/778a683780a5b0ad3163f4772b97b9075a0a13c389d2bd8ea3f891b64cfa383d/GGM05C.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/778a683780a5b0ad3163f4772b97b9075a0a13c389d2bd8ea3f891b64cfa383d/GGM05C.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=778a683780a5b0ad3163f4772b97b9075a0a13c389d2bd8ea3f891b64cfa383d" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=778a683780a5b0ad3163f4772b97b9075a0a13c389d2bd8ea3f891b64cfa383d" target="_blank">Show</a>
+    </td>
+    <td>
+            <a href="http://doi.org/10.5880/icgem.2016.002" target="_blank">✔</a>
+    </td>
+</tr>
+
+        <tr>
+    <td>152</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        GECO
+</td>
+    <td>2015</td>
+    <td>        2190
+</td>
+    <td>            EGM2008,             S(Goce)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_62543e631aed9909373442747e4dcb2cbd716937c948434e78ea4ab81572c4f9').toggle(); "><b>        Gilardoni, M. et al,
+    2016
+</b></div>
+        <div id="ref_62543e631aed9909373442747e4dcb2cbd716937c948434e78ea4ab81572c4f9" class="mt-1" style="display:none">
+        Gilardoni, M., Reguzzoni, M., Sampietro, D.;<br>
+    <b>GECO: a global gravity model by locally combining GOCE data and EGM2008;</b>
+    <br>
+        Studia Geophysica et Geodaetica,
+            Vol 60,
+            p. 228-247,
+        doi: <a href="http://doi.org/10.1007/s11200-015-1114-4" target="_blank">10.1007/s11200-015-1114-4</a>,
+    2016
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/62543e631aed9909373442747e4dcb2cbd716937c948434e78ea4ab81572c4f9/GECO.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/62543e631aed9909373442747e4dcb2cbd716937c948434e78ea4ab81572c4f9/GECO.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=62543e631aed9909373442747e4dcb2cbd716937c948434e78ea4ab81572c4f9" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=62543e631aed9909373442747e4dcb2cbd716937c948434e78ea4ab81572c4f9" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>151</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="/getmodel/doc/8f5c8ba977572bc2d3d64714cac20a188e33f27fb992534c12eff41e8a3c27a8" target="_blank">GGM05G</a>
+</td>
+    <td>2015</td>
+    <td>        240
+</td>
+    <td>            S(Goce),             S(Grace)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_8f5c8ba977572bc2d3d64714cac20a188e33f27fb992534c12eff41e8a3c27a8').toggle(); "><b>        Bettadpur, S. et al,
+    2015
+</b></div>
+        <div id="ref_8f5c8ba977572bc2d3d64714cac20a188e33f27fb992534c12eff41e8a3c27a8" class="mt-1" style="display:none">
+        Bettadpur, S., Ries, J., Eanes, R., Nagel, P., Pie, N., Poole, S., Richter, T., Save, H.;<br>
+    <b>Evaluation of the GGM05 Mean Earth Gravity models;</b>
+    <br>
+        Geophysical Research Abstracts, Vol. 17, EGU2015-4153, 2015,
+        Vienna, Austria,
+    2015
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/8f5c8ba977572bc2d3d64714cac20a188e33f27fb992534c12eff41e8a3c27a8/GGM05G.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/8f5c8ba977572bc2d3d64714cac20a188e33f27fb992534c12eff41e8a3c27a8/GGM05G.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=8f5c8ba977572bc2d3d64714cac20a188e33f27fb992534c12eff41e8a3c27a8" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=8f5c8ba977572bc2d3d64714cac20a188e33f27fb992534c12eff41e8a3c27a8" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>150</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="http://www.goco.eu/" target="_blank">GOCO05s</a>
+</td>
+    <td>2015</td>
+    <td>        280
+</td>
+    <td>            (see model),             S</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_f77139b673203554b2445a94818a4d35ca6e2b5fca1042177434b7e0b72cf4d1').toggle(); "><b>        Mayer-Gürr, T. et al,
+    2015
+</b></div>
+        <div id="ref_f77139b673203554b2445a94818a4d35ca6e2b5fca1042177434b7e0b72cf4d1" class="mt-1" style="display:none">
+        Mayer-Gürr, T., Pail, R., Gruber, T., Fecher, T., Rexer, M., Schuh, W.-D., Kusche, J., Brockmann, J.-M., Rieser, D., Zehentner, N., Kvas, A., Klinger, B., Baur, O., Höck, E., Krauss, S., Jäggi, A.;<br>
+    <b>The combined satellite gravity field model GOCO05s;</b>
+    <br>
+        Vienna, Austria,
+    2015
+
+        <br><br>
+        <b>Related References:</b><br>
+        Pail, R., Goiginger, H., Schuh, W. D., Höck, E., Brockmann, J. M., Fecher, T., Gruber, T., Mayer-Gürr, T., Kusche, J., Jäggi, A., Rieser, D.;<br>
+    <b>Combined satellite gravity field model GOCO01S derived from GOCE and GRACE;</b>
+    <br>
+        Geophysical Research Letters,
+            Vol 37,
+            No. 20,
+            p. n/a-n/a,
+        doi: <a href="http://doi.org/10.1029/2010gl044906" target="_blank">10.1029/2010gl044906</a>,
+    2010
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/f77139b673203554b2445a94818a4d35ca6e2b5fca1042177434b7e0b72cf4d1/GOCO05s.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/f77139b673203554b2445a94818a4d35ca6e2b5fca1042177434b7e0b72cf4d1/GOCO05s.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=f77139b673203554b2445a94818a4d35ca6e2b5fca1042177434b7e0b72cf4d1" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=f77139b673203554b2445a94818a4d35ca6e2b5fca1042177434b7e0b72cf4d1" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>149</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="https://earth.esa.int/eogateway/missions/goce" target="_blank">GO_CONS_GCF_2_SPW_R4</a>
+</td>
+    <td>2014</td>
+    <td>        280
+</td>
+    <td>            S(Goce)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_e06e3bcb9cb2b3cfe94c97b09f16ab7fb45955fd1187acd1b220d27faec9eaa9').toggle(); "><b>        Gatti, A. et al,
+    2014
+</b></div>
+        <div id="ref_e06e3bcb9cb2b3cfe94c97b09f16ab7fb45955fd1187acd1b220d27faec9eaa9" class="mt-1" style="display:none">        Gatti, A., Reguzzoni, M., Migliaccio, F., Sanso, F.;<br>
+    <b>Space-wise grids of gravity gradients from GOCE data at nominal satellite altitude;</b>
+    <br>
+        Paris,
+    2014
+
+        <br><br>
+        <b>Related References:</b><br>
+        Reguzzoni, Mirko, Tselfes, Nikolaos;<br>
+    <b>Optimal multi-step collocation: application to the space-wise approach for GOCE data analysis;</b>
+    <br>
+        Journal of Geodesy,
+            Vol 83,
+            No. 1,
+            p. 13-29,
+        doi: <a href="http://doi.org/10.1007/s00190-008-0225-x" target="_blank">10.1007/s00190-008-0225-x</a>,
+    2008
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/e06e3bcb9cb2b3cfe94c97b09f16ab7fb45955fd1187acd1b220d27faec9eaa9/GO_CONS_GCF_2_SPW_R4.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/e06e3bcb9cb2b3cfe94c97b09f16ab7fb45955fd1187acd1b220d27faec9eaa9/GO_CONS_GCF_2_SPW_R4.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=e06e3bcb9cb2b3cfe94c97b09f16ab7fb45955fd1187acd1b220d27faec9eaa9" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=e06e3bcb9cb2b3cfe94c97b09f16ab7fb45955fd1187acd1b220d27faec9eaa9" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>148</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="/getmodel/doc/7fd8fe44aa1518cd79ca84300aef4b41ddb2364aef9e82b7cdaabdb60a9053f1" target="_blank">EIGEN-6C4</a>
+</td>
+    <td>2014</td>
+    <td>        2190
+</td>
+    <td>            A,             G,             S(Goce),             S(Grace),             S(Lageos)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_7fd8fe44aa1518cd79ca84300aef4b41ddb2364aef9e82b7cdaabdb60a9053f1').toggle(); "><b>        Förste, Christoph et al,
+    2014
+</b></div>
+        <div id="ref_7fd8fe44aa1518cd79ca84300aef4b41ddb2364aef9e82b7cdaabdb60a9053f1" class="mt-1" style="display:none">        Förste, Christoph, Bruinsma, Sean L., Abrikosov, Oleg, Lemoine, Jean-Michel, Marty, Jean Charles, Flechtner, Frank, Balmino, G., Barthelmes, F., Biancale, R.;<br>
+    <b>EIGEN-6C4 The latest combined global gravity field model including GOCE data up to degree and order 2190 of GFZ Potsdam and GRGS Toulouse;</b>
+    <br>
+        GFZ Data Services,
+        doi: <a href="http://doi.org/10.5880/ICGEM.2015.1" target="_blank">10.5880/ICGEM.2015.1</a>,
+    2014
+
+        <br><br>
+        <b>Related References:</b><br>
+        Andersen, Ole B., Knudsen, Per;<br>
+    <b>DNSC08 mean sea surface and mean dynamic topography models;</b>
+    <br>
+        Journal of Geophysical Research,
+            Vol 114,
+            No. C11,
+        doi: <a href="http://doi.org/10.1029/2008jc005179" target="_blank">10.1029/2008jc005179</a>,
+    2009
+
+        <br><br>
+        Bruinsma, Sean, Lemoine, Jean-Michel, Biancale, Richard, Valès, Nicole;<br>
+    <b>CNES/GRGS 10-day gravity field models (release 2) and their evaluation;</b>
+    <br>
+        Advances in Space Research,
+            Vol 45,
+            No. 4,
+            p. 587-601,
+        doi: <a href="http://doi.org/10.1016/j.asr.2009.10.012" target="_blank">10.1016/j.asr.2009.10.012</a>,
+    2010
+
+        <br><br>
+        Bruinsma, Sean L., Förste, Christoph, Abrikosov, Oleg, Lemoine, Jean-Michel, Marty, Jean-Charles, Mulet, Sandrine, Rio, Marie-Helene, Bonvalot, Sylvain;<br>
+    <b>ESA's satellite-only gravity field model via the direct approach based on all GOCE data;</b>
+    <br>
+        Geophysical Research Letters,
+            Vol 41,
+            No. 21,
+            p. 7508-7514,
+        doi: <a href="http://doi.org/10.1002/2014gl062045" target="_blank">10.1002/2014gl062045</a>,
+    2014
+
+        <br><br>
+        Metzler, B., Pail, R.;<br>
+    <b>GOCE Data Processing: The Spherical Cap Regularization Approach;</b>
+    <br>
+        Studia Geophysica et Geodaetica,
+            Vol 49,
+            No. 4,
+            p. 441-462,
+        doi: <a href="http://doi.org/10.1007/s11200-005-0021-5" target="_blank">10.1007/s11200-005-0021-5</a>,
+    2005
+
+        <br><br>
+        Pail, Roland, Bruinsma, Sean, Migliaccio, Federica, Förste, Christoph, Goiginger, Helmut, Schuh, Wolf-Dieter, Höck, Eduard, Reguzzoni, Mirko, Brockmann, Jan Martin, Abrikosov, Oleg, Veicherts, Martin, Fecher, Thomas, Mayrhofer, Reinhard, Krasbutter, Ina, Sansò, Fernando, Tscherning, Carl Christian;<br>
+    <b>First GOCE gravity field models derived by three different approaches;</b>
+    <br>
+        Journal of Geodesy,
+            Vol 85,
+            No. 11,
+            p. 819-843,
+        doi: <a href="http://doi.org/10.1007/s00190-011-0467-x" target="_blank">10.1007/s00190-011-0467-x</a>,
+    2011
+
+        <br><br>
+        Shako, R., Förste , C., Abrikosov, O., Bruinsma, S., Marty, J., Lemoine, J., Flechtner, F., Neumayer, H., Dahle, C.;<br>
+    <b>EIGEN-6C: A High-Resolution Global Gravity Combination Model Including GOCE Data;</b>
+    <br>
+        Springer,
+            p. 155-161,
+        doi: <a href="http://doi.org/10.1007/978-3-642-32135-1_20" target="_blank">10.1007/978-3-642-32135-1_20</a>,
+        Berlin-Heidelberg,
+    2014
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/7fd8fe44aa1518cd79ca84300aef4b41ddb2364aef9e82b7cdaabdb60a9053f1/EIGEN-6C4.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/7fd8fe44aa1518cd79ca84300aef4b41ddb2364aef9e82b7cdaabdb60a9053f1/EIGEN-6C4.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=7fd8fe44aa1518cd79ca84300aef4b41ddb2364aef9e82b7cdaabdb60a9053f1" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=7fd8fe44aa1518cd79ca84300aef4b41ddb2364aef9e82b7cdaabdb60a9053f1" target="_blank">Show</a>
+    </td>
+    <td>
+            <a href="http://doi.org/10.5880/icgem.2015.1" target="_blank">✔</a>
+    </td>
+</tr>
+
+        <tr>
+    <td>147</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="http://itsg.tugraz.at/research/ITSG-Grace2014" target="_blank">ITSG-Grace2014s</a>
+</td>
+    <td>2014</td>
+    <td>        200
+</td>
+    <td>        S(Grace)
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_ffdae83eb9473af3972e1833da6c1fa5bbadc7e77e9d39da07de7814f436b729').toggle(); "><b>        Mayer-Gürr, T. et al,
+    2014
+</b></div>
+        <div id="ref_ffdae83eb9473af3972e1833da6c1fa5bbadc7e77e9d39da07de7814f436b729" class="mt-1" style="display:none">
+        Mayer-Gürr, T., Zehentner, N., Klinger, B., Kvas, A.;<br>
+    <b>ITSG-Grace2014: a new GRACE gravity field release computed in Graz;</b>
+    <br>
+        Potsdam,
+    2014
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/ffdae83eb9473af3972e1833da6c1fa5bbadc7e77e9d39da07de7814f436b729/ITSG-Grace2014s.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/ffdae83eb9473af3972e1833da6c1fa5bbadc7e77e9d39da07de7814f436b729/ITSG-Grace2014s.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=ffdae83eb9473af3972e1833da6c1fa5bbadc7e77e9d39da07de7814f436b729" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=ffdae83eb9473af3972e1833da6c1fa5bbadc7e77e9d39da07de7814f436b729" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>146</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="http://itsg.tugraz.at/research/ITSG-Grace2014" target="_blank">ITSG-Grace2014k</a>
+</td>
+    <td>2014</td>
+    <td>        200
+</td>
+    <td>        S(Grace)
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_7dabc3fcb066077024aa92984c141e96956d5c7168a580d36bc0e1f532e378a7').toggle(); "><b>        Mayer-Gürr, T. et al,
+    2014
+</b></div>
+        <div id="ref_7dabc3fcb066077024aa92984c141e96956d5c7168a580d36bc0e1f532e378a7" class="mt-1" style="display:none">
+        Mayer-Gürr, T., Zehentner, N., Klinger, B., Kvas, A.;<br>
+    <b>ITSG-Grace2014: a new GRACE gravity field release computed in Graz;</b>
+    <br>
+        Potsdam,
+    2014
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/7dabc3fcb066077024aa92984c141e96956d5c7168a580d36bc0e1f532e378a7/ITSG-Grace2014k.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/7dabc3fcb066077024aa92984c141e96956d5c7168a580d36bc0e1f532e378a7/ITSG-Grace2014k.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=7dabc3fcb066077024aa92984c141e96956d5c7168a580d36bc0e1f532e378a7" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=7dabc3fcb066077024aa92984c141e96956d5c7168a580d36bc0e1f532e378a7" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>145</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="https://earth.esa.int/eogateway/missions/goce" target="_blank">GO_CONS_GCF_2_TIM_R5</a>
+</td>
+    <td>2014</td>
+    <td>        280
+</td>
+    <td>            S(Goce)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_692919a51bf5c27824b2964055227fa70e8a779b21e4477dc766285acee90ad8').toggle(); "><b>        Brockmann, J. M. et al,
+    2014
+</b></div>
+        <div id="ref_692919a51bf5c27824b2964055227fa70e8a779b21e4477dc766285acee90ad8" class="mt-1" style="display:none">        Brockmann, J. M., Zehentner, N., Hock, E., Pail, R., Loth, I., Mayer-Gurr, T., Schuh, W. D.;<br>
+    <b>EGM_TIM_RL05: An independent geoid with centimeter accuracy purely based on the GOCE mission;</b>
+    <br>
+        Geophysical Research Letters,
+            Vol 41,
+            No. 22,
+            p. 8089-8099,
+        doi: <a href="http://doi.org/10.1002/2014gl061904" target="_blank">10.1002/2014gl061904</a>,
+    2014
+
+        <br><br>
+        <b>Related References:</b><br>
+        Mayer-Gürr, T., Ilk, K. H., Eicker, A., Feuchtinger, M.;<br>
+    <b>ITG-CHAMP01: a CHAMP gravity field model from short kinematic arcs over a one-year observation period;</b>
+    <br>
+        Journal of Geodesy,
+            Vol 78,
+            No. 7-8,
+            p. 462-480,
+        doi: <a href="http://doi.org/10.1007/s00190-004-0413-2" target="_blank">10.1007/s00190-004-0413-2</a>,
+    2005
+
+        <br><br>
+        Pail, R., Goiginger, H., Mayrhofer, R., Schuh, W., Brockmann, J.M., Krasbutter, I., Hoeck, E., Fecher, T.;<br>
+    <b>GOCE gravity field model derived from orbit and gradiometry data applying the time-wise method;</b>
+    <br>
+        ESA Publications Division, Norwijk, The Nethelands,
+        Bergen, Norway,
+    2010
+
+        <br><br>
+        Pail, Roland, Bruinsma, Sean, Migliaccio, Federica, Förste, Christoph, Goiginger, Helmut, Schuh, Wolf-Dieter, Höck, Eduard, Reguzzoni, Mirko, Brockmann, Jan Martin, Abrikosov, Oleg, Veicherts, Martin, Fecher, Thomas, Mayrhofer, Reinhard, Krasbutter, Ina, Sansò, Fernando, Tscherning, Carl Christian;<br>
+    <b>First GOCE gravity field models derived by three different approaches;</b>
+    <br>
+        Journal of Geodesy,
+            Vol 85,
+            No. 11,
+            p. 819-843,
+        doi: <a href="http://doi.org/10.1007/s00190-011-0467-x" target="_blank">10.1007/s00190-011-0467-x</a>,
+    2011
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/692919a51bf5c27824b2964055227fa70e8a779b21e4477dc766285acee90ad8/GO_CONS_GCF_2_TIM_R5.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/692919a51bf5c27824b2964055227fa70e8a779b21e4477dc766285acee90ad8/GO_CONS_GCF_2_TIM_R5.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=692919a51bf5c27824b2964055227fa70e8a779b21e4477dc766285acee90ad8" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=692919a51bf5c27824b2964055227fa70e8a779b21e4477dc766285acee90ad8" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>144</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="https://earth.esa.int/eogateway/missions/goce" target="_blank">GO_CONS_GCF_2_DIR_R5</a>
+</td>
+    <td>2014</td>
+    <td>        300
+</td>
+    <td>            S(Goce),             S(Grace),             S(Lageos)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_b3bf408e4542018a3fc0cad63c3728fe92dfe7cde5d1081c2f8915df91dbd66f').toggle(); "><b>        Bruinsma, S. L. et al,
+    2013
+</b></div>
+        <div id="ref_b3bf408e4542018a3fc0cad63c3728fe92dfe7cde5d1081c2f8915df91dbd66f" class="mt-1" style="display:none">        Bruinsma, S. L., Forste, C., Abrikosov, O., Marty, J. C., Rio, M. H., Mulet, S., Bonvalot, S.;<br>
+    <b>The new ESA satellite-only gravity field model via the direct approach;</b>
+    <br>
+        Geophysical Research Letters,
+            Vol 40,
+            No. 14,
+            p. 3607-3612,
+        doi: <a href="http://doi.org/10.1002/grl.50716" target="_blank">10.1002/grl.50716</a>,
+    2013
+
+        <br><br>
+        <b>Related References:</b><br>
+        Bruinsma, S.L., Marty, J.C., Balmino, G., Biancale, R., Foerste, C., Abrikosov, O., Neumayer, H.;<br>
+    <b>GOCE Gravity Field Recovery by Means of the Direct Numerical Method;</b>
+    <br>
+        ESA Publications Division, Norwijk, The Nethelands,
+            Vol SP 686,
+        Bergen, Norway,
+    2010
+
+        <br><br>
+        Dahle, C., Flechtner, F., Gruber, C., König, D., König, R., Michalak, G., Neumayer, K.-H., Deutsches GeoForschungsZentrum GFZ;<br>
+    <b>GFZ GRACE Level-2 Processing Standards Document for Level-2 Product Release 0005: revised edition;</b>
+    <br>
+        doi: <a href="http://doi.org/10.2312/GFZ.b103-1202-25" target="_blank">10.2312/GFZ.b103-1202-25</a>,
+        Potsdam,
+    2013
+
+        <br><br>
+        Metzler, B., Pail, R.;<br>
+    <b>GOCE Data Processing: The Spherical Cap Regularization Approach;</b>
+    <br>
+        Studia Geophysica et Geodaetica,
+            Vol 49,
+            No. 4,
+            p. 441-462,
+        doi: <a href="http://doi.org/10.1007/s11200-005-0021-5" target="_blank">10.1007/s11200-005-0021-5</a>,
+    2005
+
+        <br><br>
+        Pail, Roland, Bruinsma, Sean, Migliaccio, Federica, Förste, Christoph, Goiginger, Helmut, Schuh, Wolf-Dieter, Höck, Eduard, Reguzzoni, Mirko, Brockmann, Jan Martin, Abrikosov, Oleg, Veicherts, Martin, Fecher, Thomas, Mayrhofer, Reinhard, Krasbutter, Ina, Sansò, Fernando, Tscherning, Carl Christian;<br>
+    <b>First GOCE gravity field models derived by three different approaches;</b>
+    <br>
+        Journal of Geodesy,
+            Vol 85,
+            No. 11,
+            p. 819-843,
+        doi: <a href="http://doi.org/10.1007/s00190-011-0467-x" target="_blank">10.1007/s00190-011-0467-x</a>,
+    2011
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/b3bf408e4542018a3fc0cad63c3728fe92dfe7cde5d1081c2f8915df91dbd66f/GO_CONS_GCF_2_DIR_R5.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/b3bf408e4542018a3fc0cad63c3728fe92dfe7cde5d1081c2f8915df91dbd66f/GO_CONS_GCF_2_DIR_R5.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=b3bf408e4542018a3fc0cad63c3728fe92dfe7cde5d1081c2f8915df91dbd66f" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=b3bf408e4542018a3fc0cad63c3728fe92dfe7cde5d1081c2f8915df91dbd66f" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>143</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="http://www.iapg.bgu.tum.de/Mitarbeiter/Weiyong_Yi/" target="_blank">JYY_GOCE04S</a>
+</td>
+    <td>2014</td>
+    <td>        230
+</td>
+    <td>        S(Goce)
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_abe3f85e5670f6e572798d105e0ea468d5eac7d9189aab5f77c0a318b2b8cc37').toggle(); "><b>        Yi, Weiyong et al,
+    2013
+</b></div>
+        <div id="ref_abe3f85e5670f6e572798d105e0ea468d5eac7d9189aab5f77c0a318b2b8cc37" class="mt-1" style="display:none">
+        Yi, Weiyong, Rummel, Reiner, Gruber, Thomas;<br>
+    <b>Gravity field contribution analysis of GOCE gravitational gradient components;</b>
+    <br>
+        Studia Geophysica et Geodaetica,
+            Vol 57,
+            No. 2,
+            p. 174-202,
+        doi: <a href="http://doi.org/10.1007/s11200-011-1178-8" target="_blank">10.1007/s11200-011-1178-8</a>,
+    2013
+
+        <br><br>
+        <b>Related References:</b><br>
+        Yi, Weiyong;<br>
+    <b>An alternative computation of a gravity field model from GOCE;</b>
+    <br>
+        Advances in Space Research,
+            Vol 50,
+            No. 3,
+            p. 371-384,
+        doi: <a href="http://doi.org/10.1016/j.asr.2012.04.018" target="_blank">10.1016/j.asr.2012.04.018</a>,
+    2012
+
+        <br><br>
+        Yi, Weiyong, Rummel, Reiner;<br>
+    <b>A comparison of GOCE gravitational models with EGM2008;</b>
+    <br>
+        Journal of Geodynamics,
+            Vol 73,
+            p. 14-22,
+        doi: <a href="http://doi.org/10.1016/j.jog.2013.10.004" target="_blank">10.1016/j.jog.2013.10.004</a>,
+    2014
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/abe3f85e5670f6e572798d105e0ea468d5eac7d9189aab5f77c0a318b2b8cc37/JYY_GOCE04S.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/abe3f85e5670f6e572798d105e0ea468d5eac7d9189aab5f77c0a318b2b8cc37/JYY_GOCE04S.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=abe3f85e5670f6e572798d105e0ea468d5eac7d9189aab5f77c0a318b2b8cc37" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=abe3f85e5670f6e572798d105e0ea468d5eac7d9189aab5f77c0a318b2b8cc37" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>142</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="http://www.iapg.bgu.tum.de/Mitarbeiter/Weiyong_Yi/" target="_blank">GOGRA04S</a>
+</td>
+    <td>2014</td>
+    <td>        230
+</td>
+    <td>            S(Goce),             S(Grace)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_5fd699d34827e057f871b50e568fbe59d110a0fa8dea4a41575d2264e3293355').toggle(); "><b>        Yi, Weiyong et al,
+    2013
+</b></div>
+        <div id="ref_5fd699d34827e057f871b50e568fbe59d110a0fa8dea4a41575d2264e3293355" class="mt-1" style="display:none">
+        Yi, Weiyong, Rummel, Reiner, Gruber, Thomas;<br>
+    <b>Gravity field contribution analysis of GOCE gravitational gradient components;</b>
+    <br>
+        Studia Geophysica et Geodaetica,
+            Vol 57,
+            No. 2,
+            p. 174-202,
+        doi: <a href="http://doi.org/10.1007/s11200-011-1178-8" target="_blank">10.1007/s11200-011-1178-8</a>,
+    2013
+
+        <br><br>
+        <b>Related References:</b><br>
+        Yi, Weiyong;<br>
+    <b>An alternative computation of a gravity field model from GOCE;</b>
+    <br>
+        Advances in Space Research,
+            Vol 50,
+            No. 3,
+            p. 371-384,
+        doi: <a href="http://doi.org/10.1016/j.asr.2012.04.018" target="_blank">10.1016/j.asr.2012.04.018</a>,
+    2012
+
+        <br><br>
+        Yi, Weiyong, Rummel, Reiner;<br>
+    <b>A comparison of GOCE gravitational models with EGM2008;</b>
+    <br>
+        Journal of Geodynamics,
+            Vol 73,
+            p. 14-22,
+        doi: <a href="http://doi.org/10.1016/j.jog.2013.10.004" target="_blank">10.1016/j.jog.2013.10.004</a>,
+    2014
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/5fd699d34827e057f871b50e568fbe59d110a0fa8dea4a41575d2264e3293355/GOGRA04S.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/5fd699d34827e057f871b50e568fbe59d110a0fa8dea4a41575d2264e3293355/GOGRA04S.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=5fd699d34827e057f871b50e568fbe59d110a0fa8dea4a41575d2264e3293355" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=5fd699d34827e057f871b50e568fbe59d110a0fa8dea4a41575d2264e3293355" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>141</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="/getmodel/doc/964132f7ca728149373a427965eddeb2553056e2daa281d9b86eb7a1b2203df8" target="_blank">EIGEN-6S2</a>
+</td>
+    <td>2014</td>
+    <td>        260
+</td>
+    <td>            S(Goce),             S(Grace),             S(Lageos)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_964132f7ca728149373a427965eddeb2553056e2daa281d9b86eb7a1b2203df8').toggle(); "><b>        Rudenko, Sergei et al,
+    2014
+</b></div>
+        <div id="ref_964132f7ca728149373a427965eddeb2553056e2daa281d9b86eb7a1b2203df8" class="mt-1" style="display:none">
+        Rudenko, Sergei, Dettmering, Denise, Esselborn, Saskia, Schöne, Tilo, Förste, Christoph, Lemoine, Jean-Michel, Ablain, Michaël, Alexandre, David, Neumayer, Karl-Hans;<br>
+    <b>Influence of time variable geopotential models on precise orbits of altimetry satellites, global and regional mean sea level trends;</b>
+    <br>
+        Advances in Space Research,
+            Vol 54,
+            No. 1,
+            p. 92-118,
+        doi: <a href="http://doi.org/10.1016/j.asr.2014.03.010" target="_blank">10.1016/j.asr.2014.03.010</a>,
+    2014
+
+        <br><br>
+        <b>Related References:</b><br>
+        Bruinsma, S. L., Forste, C., Abrikosov, O., Marty, J. C., Rio, M. H., Mulet, S., Bonvalot, S.;<br>
+    <b>The new ESA satellite-only gravity field model via the direct approach;</b>
+    <br>
+        Geophysical Research Letters,
+            Vol 40,
+            No. 14,
+            p. 3607-3612,
+        doi: <a href="http://doi.org/10.1002/grl.50716" target="_blank">10.1002/grl.50716</a>,
+    2013
+
+        <br><br>
+        Bruinsma, Sean, Lemoine, Jean-Michel, Biancale, Richard, Valès, Nicole;<br>
+    <b>CNES/GRGS 10-day gravity field models (release 2) and their evaluation;</b>
+    <br>
+        Advances in Space Research,
+            Vol 45,
+            No. 4,
+            p. 587-601,
+        doi: <a href="http://doi.org/10.1016/j.asr.2009.10.012" target="_blank">10.1016/j.asr.2009.10.012</a>,
+    2010
+
+        <br><br>
+        Dahle, C., Flechtner, F., Gruber, C., König, D., König, R., Michalak, G., Neumayer, K.-H., Deutsches GeoForschungsZentrum GFZ;<br>
+    <b>GFZ GRACE Level-2 Processing Standards Document for Level-2 Product Release 0005: revised edition;</b>
+    <br>
+        doi: <a href="http://doi.org/10.2312/GFZ.b103-1202-25" target="_blank">10.2312/GFZ.b103-1202-25</a>,
+        Potsdam,
+    2013
+
+        <br><br>
+        Metzler, B., Pail, R.;<br>
+    <b>GOCE Data Processing: The Spherical Cap Regularization Approach;</b>
+    <br>
+        Studia Geophysica et Geodaetica,
+            Vol 49,
+            No. 4,
+            p. 441-462,
+        doi: <a href="http://doi.org/10.1007/s11200-005-0021-5" target="_blank">10.1007/s11200-005-0021-5</a>,
+    2005
+
+        <br><br>
+        Pail, Roland, Bruinsma, Sean, Migliaccio, Federica, Förste, Christoph, Goiginger, Helmut, Schuh, Wolf-Dieter, Höck, Eduard, Reguzzoni, Mirko, Brockmann, Jan Martin, Abrikosov, Oleg, Veicherts, Martin, Fecher, Thomas, Mayrhofer, Reinhard, Krasbutter, Ina, Sansò, Fernando, Tscherning, Carl Christian;<br>
+    <b>First GOCE gravity field models derived by three different approaches;</b>
+    <br>
+        Journal of Geodesy,
+            Vol 85,
+            No. 11,
+            p. 819-843,
+        doi: <a href="http://doi.org/10.1007/s00190-011-0467-x" target="_blank">10.1007/s00190-011-0467-x</a>,
+    2011
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/964132f7ca728149373a427965eddeb2553056e2daa281d9b86eb7a1b2203df8/EIGEN-6S2.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/964132f7ca728149373a427965eddeb2553056e2daa281d9b86eb7a1b2203df8/EIGEN-6S2.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=964132f7ca728149373a427965eddeb2553056e2daa281d9b86eb7a1b2203df8" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=964132f7ca728149373a427965eddeb2553056e2daa281d9b86eb7a1b2203df8" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>140</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="/getmodel/doc/06a6faa24892df587d29c8a345e09e7031428cf97d4fcc9435b31ae8e4ccc021" target="_blank">GGM05S</a>
+</td>
+    <td>2014</td>
+    <td>        180
+</td>
+    <td>        S(Grace)
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_06a6faa24892df587d29c8a345e09e7031428cf97d4fcc9435b31ae8e4ccc021').toggle(); "><b>        Tapley, B.D. et al,
+    2013
+</b></div>
+        <div id="ref_06a6faa24892df587d29c8a345e09e7031428cf97d4fcc9435b31ae8e4ccc021" class="mt-1" style="display:none">
+        Tapley, B.D., Flechtner, F., Bettadpur, S., Watkins, M.M.;<br>
+    <b>The status and future prospect for GRACE after the first decade;</b>
+    <br>
+        Eos Trans.,
+            Vol Fall Meet. Suppl., Abstract G22A-01,
+    2013
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/06a6faa24892df587d29c8a345e09e7031428cf97d4fcc9435b31ae8e4ccc021/GGM05S.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/06a6faa24892df587d29c8a345e09e7031428cf97d4fcc9435b31ae8e4ccc021/GGM05S.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=06a6faa24892df587d29c8a345e09e7031428cf97d4fcc9435b31ae8e4ccc021" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=06a6faa24892df587d29c8a345e09e7031428cf97d4fcc9435b31ae8e4ccc021" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>139</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="/getmodel/doc/7de5f4776818768629ccc05741eab71caea0753f591b5fa16769d49a58c8d9ea" target="_blank">EIGEN-6C3stat</a>
+</td>
+    <td>2014</td>
+    <td>        1949
+</td>
+    <td>            A,             G,             S(Goce),             S(Grace),             S(Lageos)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_7de5f4776818768629ccc05741eab71caea0753f591b5fa16769d49a58c8d9ea').toggle(); "><b>        Förste, C. et al,
+    2012
+</b></div>
+        <div id="ref_7de5f4776818768629ccc05741eab71caea0753f591b5fa16769d49a58c8d9ea" class="mt-1" style="display:none">
+        Förste, C., Bruinsma, S.L., Flechtner, F., Marty, J.C., Lemoine, J.M., Dahle, C., Abrikosov, O., Neumayer, K.H., Biancale, R., Barthelmes, F., Balmino, G.;<br>
+    <b>A preliminary update of the Direct approach GOCE Processing and a new release of EIGEN-6C;</b>
+    <br>
+        San Francisco, USA,
+    2012
+
+        <br><br>
+        <b>Related References:</b><br>
+        Andersen, Ole B., Knudsen, Per;<br>
+    <b>DNSC08 mean sea surface and mean dynamic topography models;</b>
+    <br>
+        Journal of Geophysical Research,
+            Vol 114,
+            No. C11,
+        doi: <a href="http://doi.org/10.1029/2008jc005179" target="_blank">10.1029/2008jc005179</a>,
+    2009
+
+        <br><br>
+        Bruinsma, S. L., Forste, C., Abrikosov, O., Marty, J. C., Rio, M. H., Mulet, S., Bonvalot, S.;<br>
+    <b>The new ESA satellite-only gravity field model via the direct approach;</b>
+    <br>
+        Geophysical Research Letters,
+            Vol 40,
+            No. 14,
+            p. 3607-3612,
+        doi: <a href="http://doi.org/10.1002/grl.50716" target="_blank">10.1002/grl.50716</a>,
+    2013
+
+        <br><br>
+        Bruinsma, Sean, Lemoine, Jean-Michel, Biancale, Richard, Valès, Nicole;<br>
+    <b>CNES/GRGS 10-day gravity field models (release 2) and their evaluation;</b>
+    <br>
+        Advances in Space Research,
+            Vol 45,
+            No. 4,
+            p. 587-601,
+        doi: <a href="http://doi.org/10.1016/j.asr.2009.10.012" target="_blank">10.1016/j.asr.2009.10.012</a>,
+    2010
+
+        <br><br>
+        Dahle, C., Flechtner, F., Gruber, C., König, D., König, R., Michalak, G., Neumayer, K.-H., Deutsches GeoForschungsZentrum GFZ;<br>
+    <b>GFZ GRACE Level-2 Processing Standards Document for Level-2 Product Release 0005: revised edition;</b>
+    <br>
+        doi: <a href="http://doi.org/10.2312/GFZ.b103-1202-25" target="_blank">10.2312/GFZ.b103-1202-25</a>,
+        Potsdam,
+    2013
+
+        <br><br>
+        Metzler, B., Pail, R.;<br>
+    <b>GOCE Data Processing: The Spherical Cap Regularization Approach;</b>
+    <br>
+        Studia Geophysica et Geodaetica,
+            Vol 49,
+            No. 4,
+            p. 441-462,
+        doi: <a href="http://doi.org/10.1007/s11200-005-0021-5" target="_blank">10.1007/s11200-005-0021-5</a>,
+    2005
+
+        <br><br>
+        Pail, Roland, Bruinsma, Sean, Migliaccio, Federica, Förste, Christoph, Goiginger, Helmut, Schuh, Wolf-Dieter, Höck, Eduard, Reguzzoni, Mirko, Brockmann, Jan Martin, Abrikosov, Oleg, Veicherts, Martin, Fecher, Thomas, Mayrhofer, Reinhard, Krasbutter, Ina, Sansò, Fernando, Tscherning, Carl Christian;<br>
+    <b>First GOCE gravity field models derived by three different approaches;</b>
+    <br>
+        Journal of Geodesy,
+            Vol 85,
+            No. 11,
+            p. 819-843,
+        doi: <a href="http://doi.org/10.1007/s00190-011-0467-x" target="_blank">10.1007/s00190-011-0467-x</a>,
+    2011
+
+        <br><br>
+        Shako, R., Förste , C., Abrikosov, O., Bruinsma, S., Marty, J., Lemoine, J., Flechtner, F., Neumayer, H., Dahle, C.;<br>
+    <b>EIGEN-6C: A High-Resolution Global Gravity Combination Model Including GOCE Data;</b>
+    <br>
+        Springer,
+            p. 155-161,
+        doi: <a href="http://doi.org/10.1007/978-3-642-32135-1_20" target="_blank">10.1007/978-3-642-32135-1_20</a>,
+        Berlin-Heidelberg,
+    2014
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/7de5f4776818768629ccc05741eab71caea0753f591b5fa16769d49a58c8d9ea/EIGEN-6C3stat.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/7de5f4776818768629ccc05741eab71caea0753f591b5fa16769d49a58c8d9ea/EIGEN-6C3stat.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=7de5f4776818768629ccc05741eab71caea0753f591b5fa16769d49a58c8d9ea" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=7de5f4776818768629ccc05741eab71caea0753f591b5fa16769d49a58c8d9ea" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>138</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="/getmodel/doc/38ab6257492131cf0b97001b2a13845a0000a4971b9a0bc4da1fa76bdc6e9d7d" target="_blank">Tongji-GRACE01</a>
+</td>
+    <td>2013</td>
+    <td>        160
+</td>
+    <td>        S(Grace)
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_38ab6257492131cf0b97001b2a13845a0000a4971b9a0bc4da1fa76bdc6e9d7d').toggle(); "><b>        Shen, Y. et al,
+    2013
+</b></div>
+        <div id="ref_38ab6257492131cf0b97001b2a13845a0000a4971b9a0bc4da1fa76bdc6e9d7d" class="mt-1" style="display:none">
+        Shen, Y., Chen, Q., Hsu, H., Zhang, X., Lou, L.;<br>
+    <b>A modified short arc approach for recovering gravity field model;</b>
+    <br>
+        Austin, TX,
+    2013
+
+        <br><br>
+        <b>Related References:</b><br>
+        Chen, Qiujie, Shen, Yunzhong, Zhang, Xingfu, Chen, Wu, Hsu, Houze;<br>
+    <b>Tongji-GRACE01: A GRACE-only static gravity field model recovered from GRACE Level-1B data using modified short arc approach;</b>
+    <br>
+        Advances in Space Research,
+            Vol 56,
+            No. 5,
+            p. 941-951,
+        doi: <a href="http://doi.org/10.1016/j.asr.2015.05.034" target="_blank">10.1016/j.asr.2015.05.034</a>,
+    2015
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/38ab6257492131cf0b97001b2a13845a0000a4971b9a0bc4da1fa76bdc6e9d7d/Tongji-GRACE01.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/38ab6257492131cf0b97001b2a13845a0000a4971b9a0bc4da1fa76bdc6e9d7d/Tongji-GRACE01.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=38ab6257492131cf0b97001b2a13845a0000a4971b9a0bc4da1fa76bdc6e9d7d" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=38ab6257492131cf0b97001b2a13845a0000a4971b9a0bc4da1fa76bdc6e9d7d" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>137</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="http://www.iapg.bgu.tum.de/Mitarbeiter/Weiyong_Yi/" target="_blank">JYY_GOCE02S</a>
+</td>
+    <td>2013</td>
+    <td>        230
+</td>
+    <td>            S(Goce)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_a9d64c2f9a31b5bbdec2bb0ad47f853e1af01202daa82c2c09bf9f2e68204102').toggle(); "><b>        Yi, Weiyong et al,
+    2013
+</b></div>
+        <div id="ref_a9d64c2f9a31b5bbdec2bb0ad47f853e1af01202daa82c2c09bf9f2e68204102" class="mt-1" style="display:none">
+        Yi, Weiyong, Rummel, Reiner, Gruber, Thomas;<br>
+    <b>Gravity field contribution analysis of GOCE gravitational gradient components;</b>
+    <br>
+        Studia Geophysica et Geodaetica,
+            Vol 57,
+            No. 2,
+            p. 174-202,
+        doi: <a href="http://doi.org/10.1007/s11200-011-1178-8" target="_blank">10.1007/s11200-011-1178-8</a>,
+    2013
+
+        <br><br>
+        <b>Related References:</b><br>
+        Yi, Weiyong;<br>
+    <b>An alternative computation of a gravity field model from GOCE;</b>
+    <br>
+        Advances in Space Research,
+            Vol 50,
+            No. 3,
+            p. 371-384,
+        doi: <a href="http://doi.org/10.1016/j.asr.2012.04.018" target="_blank">10.1016/j.asr.2012.04.018</a>,
+    2012
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/a9d64c2f9a31b5bbdec2bb0ad47f853e1af01202daa82c2c09bf9f2e68204102/JYY_GOCE02S.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/a9d64c2f9a31b5bbdec2bb0ad47f853e1af01202daa82c2c09bf9f2e68204102/JYY_GOCE02S.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=a9d64c2f9a31b5bbdec2bb0ad47f853e1af01202daa82c2c09bf9f2e68204102" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=a9d64c2f9a31b5bbdec2bb0ad47f853e1af01202daa82c2c09bf9f2e68204102" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>136</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="http://www.iapg.bv.tum.de/iapg.html" target="_blank">GOGRA02S</a>
+</td>
+    <td>2013</td>
+    <td>        230
+</td>
+    <td>            S(Goce),             S(Grace)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_c5a936e7bb1d510536a42f2388656d03251cb52e771a2a03a5ff3aea74eb8764').toggle(); "><b>        Yi, Weiyong et al,
+    2013
+</b></div>
+        <div id="ref_c5a936e7bb1d510536a42f2388656d03251cb52e771a2a03a5ff3aea74eb8764" class="mt-1" style="display:none">
+        Yi, Weiyong, Rummel, Reiner, Gruber, Thomas;<br>
+    <b>Gravity field contribution analysis of GOCE gravitational gradient components;</b>
+    <br>
+        Studia Geophysica et Geodaetica,
+            Vol 57,
+            No. 2,
+            p. 174-202,
+        doi: <a href="http://doi.org/10.1007/s11200-011-1178-8" target="_blank">10.1007/s11200-011-1178-8</a>,
+    2013
+
+        <br><br>
+        <b>Related References:</b><br>
+        Yi, Weiyong;<br>
+    <b>An alternative computation of a gravity field model from GOCE;</b>
+    <br>
+        Advances in Space Research,
+            Vol 50,
+            No. 3,
+            p. 371-384,
+        doi: <a href="http://doi.org/10.1016/j.asr.2012.04.018" target="_blank">10.1016/j.asr.2012.04.018</a>,
+    2012
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/c5a936e7bb1d510536a42f2388656d03251cb52e771a2a03a5ff3aea74eb8764/GOGRA02S.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/c5a936e7bb1d510536a42f2388656d03251cb52e771a2a03a5ff3aea74eb8764/GOGRA02S.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=c5a936e7bb1d510536a42f2388656d03251cb52e771a2a03a5ff3aea74eb8764" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=c5a936e7bb1d510536a42f2388656d03251cb52e771a2a03a5ff3aea74eb8764" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>135</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        ULux_CHAMP2013s
+</td>
+    <td>2013</td>
+    <td>        120
+</td>
+    <td>        S(Champ)
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_57f505ff0ccd2abe271627238f005390607a38b0dfd4cc9f73f08675b57f2d9e').toggle(); "><b>        Weigelt, M. et al,
+    2013
+</b></div>
+        <div id="ref_57f505ff0ccd2abe271627238f005390607a38b0dfd4cc9f73f08675b57f2d9e" class="mt-1" style="display:none">
+        Weigelt, M., van Dam, T., Jäggi, A., Prange, L., Tourian, M. J., Keller, W., Sneeuw, N.;<br>
+    <b>Time-variable gravity signal in Greenland revealed by high-low satellite-to-satellite tracking;</b>
+    <br>
+        Journal of Geophysical Research,
+            Vol 118,
+            No. 7,
+            p. 3848-3859,
+        doi: <a href="http://doi.org/10.1002/jgrb.50283" target="_blank">10.1002/jgrb.50283</a>,
+    2013
+
+        <br><br>
+        <b>Related References:</b><br>
+        Prange, L.;<br>
+    <b>Global Gravity Field Determination Using the GPS Measurements Made Onboard the Low Earth Orbiting Satellite CHAMP;</b>
+    <br>
+        PhD Thesis, Geodätisch-geophysikalische Arbeiten in der Schweiz, vol. 81. http://www.sgc.ethz.ch/sgc-volumes/sgk-81.pdf, 2011,
+        Geodätisch-geophysikalische Arbeiten in der Schweiz, Vol. 81, Schweizerische Geodätische Kommission,
+    2010
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/57f505ff0ccd2abe271627238f005390607a38b0dfd4cc9f73f08675b57f2d9e/ULux_CHAMP2013s.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/57f505ff0ccd2abe271627238f005390607a38b0dfd4cc9f73f08675b57f2d9e/ULux_CHAMP2013s.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=57f505ff0ccd2abe271627238f005390607a38b0dfd4cc9f73f08675b57f2d9e" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=57f505ff0ccd2abe271627238f005390607a38b0dfd4cc9f73f08675b57f2d9e" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>134</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="http://www.igg.uni-bonn.de/apmg/index.php?id=itg-goce02" target="_blank">ITG-Goce02</a>
+</td>
+    <td>2013</td>
+    <td>        240
+</td>
+    <td>        S(Goce)
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_0b2481ada9095a39fb5849f0c031b18603d6cb824b95b5908f17932187d161bb').toggle(); "><b>        Schall, Judith et al,
+    2014
+</b></div>
+        <div id="ref_0b2481ada9095a39fb5849f0c031b18603d6cb824b95b5908f17932187d161bb" class="mt-1" style="display:none">
+        Schall, Judith, Eicker, Annette, Kusche, Jürgen;<br>
+    <b>The ITG-Goce02 gravity field model from GOCE orbit and gradiometer data based on the short arc approach;</b>
+    <br>
+        Journal of Geodesy,
+            Vol 88,
+            No. 4,
+            p. 403-409,
+        doi: <a href="http://doi.org/10.1007/s00190-014-0691-2" target="_blank">10.1007/s00190-014-0691-2</a>,
+    2014
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/0b2481ada9095a39fb5849f0c031b18603d6cb824b95b5908f17932187d161bb/ITG-Goce02.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/0b2481ada9095a39fb5849f0c031b18603d6cb824b95b5908f17932187d161bb/ITG-Goce02.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=0b2481ada9095a39fb5849f0c031b18603d6cb824b95b5908f17932187d161bb" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=0b2481ada9095a39fb5849f0c031b18603d6cb824b95b5908f17932187d161bb" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>133</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="https://earth.esa.int/eogateway/missions/goce" target="_blank">GO_CONS_GCF_2_TIM_R4</a>
+</td>
+    <td>2013</td>
+    <td>        250
+</td>
+    <td>        S(Goce)
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_d402a877b3659c2b6fb8a8359ed110e7f3a0bfa1723affd3c6945ef7ddbcf7bb').toggle(); "><b>        Pail, Roland et al,
+    2011
+</b></div>
+        <div id="ref_d402a877b3659c2b6fb8a8359ed110e7f3a0bfa1723affd3c6945ef7ddbcf7bb" class="mt-1" style="display:none">
+        Pail, Roland, Bruinsma, Sean, Migliaccio, Federica, Förste, Christoph, Goiginger, Helmut, Schuh, Wolf-Dieter, Höck, Eduard, Reguzzoni, Mirko, Brockmann, Jan Martin, Abrikosov, Oleg, Veicherts, Martin, Fecher, Thomas, Mayrhofer, Reinhard, Krasbutter, Ina, Sansò, Fernando, Tscherning, Carl Christian;<br>
+    <b>First GOCE gravity field models derived by three different approaches;</b>
+    <br>
+        Journal of Geodesy,
+            Vol 85,
+            No. 11,
+            p. 819-843,
+        doi: <a href="http://doi.org/10.1007/s00190-011-0467-x" target="_blank">10.1007/s00190-011-0467-x</a>,
+    2011
+
+        <br><br>
+        <b>Related References:</b><br>
+        Mayer-Gürr, T., Ilk, K. H., Eicker, A., Feuchtinger, M.;<br>
+    <b>ITG-CHAMP01: a CHAMP gravity field model from short kinematic arcs over a one-year observation period;</b>
+    <br>
+        Journal of Geodesy,
+            Vol 78,
+            No. 7-8,
+            p. 462-480,
+        doi: <a href="http://doi.org/10.1007/s00190-004-0413-2" target="_blank">10.1007/s00190-004-0413-2</a>,
+    2005
+
+        <br><br>
+        Pail, R., Goiginger, H., Mayrhofer, R., Schuh, W., Brockmann, J.M., Krasbutter, I., Hoeck, E., Fecher, T.;<br>
+    <b>GOCE gravity field model derived from orbit and gradiometry data applying the time-wise method;</b>
+    <br>
+        ESA Publications Division, Norwijk, The Nethelands,
+        Bergen, Norway,
+    2010
+
+        <br><br>
+        Pail, Roland, Bruinsma, Sean, Migliaccio, Federica, Förste, Christoph, Goiginger, Helmut, Schuh, Wolf-Dieter, Höck, Eduard, Reguzzoni, Mirko, Brockmann, Jan Martin, Abrikosov, Oleg, Veicherts, Martin, Fecher, Thomas, Mayrhofer, Reinhard, Krasbutter, Ina, Sansò, Fernando, Tscherning, Carl Christian;<br>
+    <b>First GOCE gravity field models derived by three different approaches;</b>
+    <br>
+        Journal of Geodesy,
+            Vol 85,
+            No. 11,
+            p. 819-843,
+        doi: <a href="http://doi.org/10.1007/s00190-011-0467-x" target="_blank">10.1007/s00190-011-0467-x</a>,
+    2011
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/d402a877b3659c2b6fb8a8359ed110e7f3a0bfa1723affd3c6945ef7ddbcf7bb/GO_CONS_GCF_2_TIM_R4.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/d402a877b3659c2b6fb8a8359ed110e7f3a0bfa1723affd3c6945ef7ddbcf7bb/GO_CONS_GCF_2_TIM_R4.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=d402a877b3659c2b6fb8a8359ed110e7f3a0bfa1723affd3c6945ef7ddbcf7bb" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=d402a877b3659c2b6fb8a8359ed110e7f3a0bfa1723affd3c6945ef7ddbcf7bb" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>132</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="https://earth.esa.int/eogateway/missions/goce" target="_blank">GO_CONS_GCF_2_DIR_R4</a>
+</td>
+    <td>2013</td>
+    <td>        260
+</td>
+    <td>            S(Goce),             S(Grace),             S(Lageos)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_b7d7c74ab683c99db7f554cf119cb784831c4cadc1c80270c260e54b47c3b8da').toggle(); "><b>        Bruinsma, S. L. et al,
+    2013
+</b></div>
+        <div id="ref_b7d7c74ab683c99db7f554cf119cb784831c4cadc1c80270c260e54b47c3b8da" class="mt-1" style="display:none">
+        Bruinsma, S. L., Forste, C., Abrikosov, O., Marty, J. C., Rio, M. H., Mulet, S., Bonvalot, S.;<br>
+    <b>The new ESA satellite-only gravity field model via the direct approach;</b>
+    <br>
+        Geophysical Research Letters,
+            Vol 40,
+            No. 14,
+            p. 3607-3612,
+        doi: <a href="http://doi.org/10.1002/grl.50716" target="_blank">10.1002/grl.50716</a>,
+    2013
+
+        <br><br>
+        <b>Related References:</b><br>
+        Bruinsma, S.L., Marty, J.C., Balmino, G., Biancale, R., Foerste, C., Abrikosov, O., Neumayer, H.;<br>
+    <b>GOCE Gravity Field Recovery by Means of the Direct Numerical Method;</b>
+    <br>
+        ESA Publications Division, Norwijk, The Nethelands,
+            Vol SP 686,
+        Bergen, Norway,
+    2010
+
+        <br><br>
+        Bruinsma, Sean, Lemoine, Jean-Michel, Biancale, Richard, Valès, Nicole;<br>
+    <b>CNES/GRGS 10-day gravity field models (release 2) and their evaluation;</b>
+    <br>
+        Advances in Space Research,
+            Vol 45,
+            No. 4,
+            p. 587-601,
+        doi: <a href="http://doi.org/10.1016/j.asr.2009.10.012" target="_blank">10.1016/j.asr.2009.10.012</a>,
+    2010
+
+        <br><br>
+        Dahle, C., Flechtner, F., Gruber, C., König, D., König, R., Michalak, G., Neumayer, K.-H., Deutsches GeoForschungsZentrum GFZ;<br>
+    <b>GFZ GRACE Level-2 Processing Standards Document for Level-2 Product Release 0005: revised edition;</b>
+    <br>
+        doi: <a href="http://doi.org/10.2312/GFZ.b103-1202-25" target="_blank">10.2312/GFZ.b103-1202-25</a>,
+        Potsdam,
+    2013
+
+        <br><br>
+        Metzler, B., Pail, R.;<br>
+    <b>GOCE Data Processing: The Spherical Cap Regularization Approach;</b>
+    <br>
+        Studia Geophysica et Geodaetica,
+            Vol 49,
+            No. 4,
+            p. 441-462,
+        doi: <a href="http://doi.org/10.1007/s11200-005-0021-5" target="_blank">10.1007/s11200-005-0021-5</a>,
+    2005
+
+        <br><br>
+        Pail, Roland, Bruinsma, Sean, Migliaccio, Federica, Förste, Christoph, Goiginger, Helmut, Schuh, Wolf-Dieter, Höck, Eduard, Reguzzoni, Mirko, Brockmann, Jan Martin, Abrikosov, Oleg, Veicherts, Martin, Fecher, Thomas, Mayrhofer, Reinhard, Krasbutter, Ina, Sansò, Fernando, Tscherning, Carl Christian;<br>
+    <b>First GOCE gravity field models derived by three different approaches;</b>
+    <br>
+        Journal of Geodesy,
+            Vol 85,
+            No. 11,
+            p. 819-843,
+        doi: <a href="http://doi.org/10.1007/s00190-011-0467-x" target="_blank">10.1007/s00190-011-0467-x</a>,
+    2011
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/b7d7c74ab683c99db7f554cf119cb784831c4cadc1c80270c260e54b47c3b8da/GO_CONS_GCF_2_DIR_R4.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/b7d7c74ab683c99db7f554cf119cb784831c4cadc1c80270c260e54b47c3b8da/GO_CONS_GCF_2_DIR_R4.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=b7d7c74ab683c99db7f554cf119cb784831c4cadc1c80270c260e54b47c3b8da" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=b7d7c74ab683c99db7f554cf119cb784831c4cadc1c80270c260e54b47c3b8da" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>131</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="/getmodel/doc/dbc1ec5b24ad63b1cabc83497cd2e38c486aed3ee8b08a866f057cd2baa58fcc" target="_blank">EIGEN-6C2</a>
+</td>
+    <td>2012</td>
+    <td>        1949
+</td>
+    <td>            A,             G,             S(Goce),             S(Grace),             S(Lageos)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_dbc1ec5b24ad63b1cabc83497cd2e38c486aed3ee8b08a866f057cd2baa58fcc').toggle(); "><b>        Förste, C. et al,
+    2012
+</b></div>
+        <div id="ref_dbc1ec5b24ad63b1cabc83497cd2e38c486aed3ee8b08a866f057cd2baa58fcc" class="mt-1" style="display:none">
+        Förste, C., Bruinsma, S.L., Flechtner, F., Marty, J.C., Lemoine, J.M., Dahle, C., Abrikosov, O., Neumayer, K.H., Biancale, R., Barthelmes, F., Balmino, G.;<br>
+    <b>A preliminary update of the Direct approach GOCE Processing and a new release of EIGEN-6C;</b>
+    <br>
+        San Francisco, USA,
+    2012
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/dbc1ec5b24ad63b1cabc83497cd2e38c486aed3ee8b08a866f057cd2baa58fcc/EIGEN-6C2.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/dbc1ec5b24ad63b1cabc83497cd2e38c486aed3ee8b08a866f057cd2baa58fcc/EIGEN-6C2.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=dbc1ec5b24ad63b1cabc83497cd2e38c486aed3ee8b08a866f057cd2baa58fcc" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=dbc1ec5b24ad63b1cabc83497cd2e38c486aed3ee8b08a866f057cd2baa58fcc" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>130</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="http://www.citg.tudelft.nl/dgm-1s" target="_blank">DGM-1S</a>
+</td>
+    <td>2012</td>
+    <td>        250
+</td>
+    <td>            S(Goce),             S(Grace)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_27ede3663d822037901974f094f28523f3cc622a1c8d440b8f4188711673fefa').toggle(); "><b>        Farahani, H. Hashemi et al,
+    2013
+</b></div>
+        <div id="ref_27ede3663d822037901974f094f28523f3cc622a1c8d440b8f4188711673fefa" class="mt-1" style="display:none">
+        Farahani, H. Hashemi, Ditmar, P., Klees, R., Liu, X., Zhao, Q., Guo, J.;<br>
+    <b>The static gravity field model DGM-1S from GRACE and GOCE data: computation, validation and an analysis of GOCE mission’s added value;</b>
+    <br>
+        Journal of Geodesy,
+            Vol 87,
+            No. 9,
+            p. 843-867,
+        doi: <a href="http://doi.org/10.1007/s00190-013-0650-3" target="_blank">10.1007/s00190-013-0650-3</a>,
+    2013
+
+        <br><br>
+        <b>Related References:</b><br>
+        Hashemi Farahani, H., Ditmar, P., Klees, R., Teixeira da Encarnacao, J., Liu, X., Zhao, Q., Guo, J.;<br>
+    <b>Validation of static gravity field models using GRACE K-band ranging and GOCE gradiometry data;</b>
+    <br>
+        Geophysical Journal International,
+            Vol 194,
+            No. 2,
+            p. 751-771,
+        doi: <a href="http://doi.org/10.1093/gji/ggt149" target="_blank">10.1093/gji/ggt149</a>,
+    2013
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/27ede3663d822037901974f094f28523f3cc622a1c8d440b8f4188711673fefa/DGM-1S.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/27ede3663d822037901974f094f28523f3cc622a1c8d440b8f4188711673fefa/DGM-1S.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=27ede3663d822037901974f094f28523f3cc622a1c8d440b8f4188711673fefa" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=27ede3663d822037901974f094f28523f3cc622a1c8d440b8f4188711673fefa" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>129</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="http://www.goco.eu/" target="_blank">GOCO03s</a>
+</td>
+    <td>2012</td>
+    <td>        250
+</td>
+    <td>            S(Goce),             S(Grace)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_bc90304a935b78227298a116cf55c977460d4d3d4d1dafb4994f2aea4705041f').toggle(); "><b>        Mayer-Gürr, T. et al,
+    2012
+</b></div>
+        <div id="ref_bc90304a935b78227298a116cf55c977460d4d3d4d1dafb4994f2aea4705041f" class="mt-1" style="display:none">
+        Mayer-Gürr, T., Rieser, D., Höck, E., Brockmann, J.M., Schuh, W.-D., Krasbutter, I., Kusche, J., Maier, A., Krauss, S., Hausleitner, W., Baur, O., Jäggi, A., Meyer, U., Prange, L., Pail, R., Fecher, T., Gruber, T.;<br>
+    <b>The new combined satellite only model GOCO03s;</b>
+    <br>
+        Venice,
+    2012
+
+        <br><br>
+        <b>Related References:</b><br>
+        Pail, R., Goiginger, H., Schuh, W. D., Höck, E., Brockmann, J. M., Fecher, T., Gruber, T., Mayer-Gürr, T., Kusche, J., Jäggi, A., Rieser, D.;<br>
+    <b>Combined satellite gravity field model GOCO01S derived from GOCE and GRACE;</b>
+    <br>
+        Geophysical Research Letters,
+            Vol 37,
+            No. 20,
+            p. n/a-n/a,
+        doi: <a href="http://doi.org/10.1029/2010gl044906" target="_blank">10.1029/2010gl044906</a>,
+    2010
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/bc90304a935b78227298a116cf55c977460d4d3d4d1dafb4994f2aea4705041f/GOCO03s.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/bc90304a935b78227298a116cf55c977460d4d3d4d1dafb4994f2aea4705041f/GOCO03s.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=bc90304a935b78227298a116cf55c977460d4d3d4d1dafb4994f2aea4705041f" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=bc90304a935b78227298a116cf55c977460d4d3d4d1dafb4994f2aea4705041f" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>128</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="https://earth.esa.int/eogateway/missions/goce" target="_blank">GO_CONS_GCF_2_DIR_R3</a>
+</td>
+    <td>2011</td>
+    <td>        240
+</td>
+    <td>            S(Goce),             S(Grace),             S(Lageos)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_a3d297b0c541a877c4a53a0031cf5767a59bdf8b752f4b432cfaa7d0c63e8db4').toggle(); "><b>        Bruinsma, S.L. et al,
+    2010
+</b></div>
+        <div id="ref_a3d297b0c541a877c4a53a0031cf5767a59bdf8b752f4b432cfaa7d0c63e8db4" class="mt-1" style="display:none">
+        Bruinsma, S.L., Marty, J.C., Balmino, G., Biancale, R., Foerste, C., Abrikosov, O., Neumayer, H.;<br>
+    <b>GOCE Gravity Field Recovery by Means of the Direct Numerical Method;</b>
+    <br>
+        ESA Publications Division, Norwijk, The Nethelands,
+            Vol SP 686,
+        Bergen, Norway,
+    2010
+
+        <br><br>
+        <b>Related References:</b><br>
+        Bruinsma, Sean, Lemoine, Jean-Michel, Biancale, Richard, Valès, Nicole;<br>
+    <b>CNES/GRGS 10-day gravity field models (release 2) and their evaluation;</b>
+    <br>
+        Advances in Space Research,
+            Vol 45,
+            No. 4,
+            p. 587-601,
+        doi: <a href="http://doi.org/10.1016/j.asr.2009.10.012" target="_blank">10.1016/j.asr.2009.10.012</a>,
+    2010
+
+        <br><br>
+        Metzler, B., Pail, R.;<br>
+    <b>GOCE Data Processing: The Spherical Cap Regularization Approach;</b>
+    <br>
+        Studia Geophysica et Geodaetica,
+            Vol 49,
+            No. 4,
+            p. 441-462,
+        doi: <a href="http://doi.org/10.1007/s11200-005-0021-5" target="_blank">10.1007/s11200-005-0021-5</a>,
+    2005
+
+        <br><br>
+        Pail, Roland, Bruinsma, Sean, Migliaccio, Federica, Förste, Christoph, Goiginger, Helmut, Schuh, Wolf-Dieter, Höck, Eduard, Reguzzoni, Mirko, Brockmann, Jan Martin, Abrikosov, Oleg, Veicherts, Martin, Fecher, Thomas, Mayrhofer, Reinhard, Krasbutter, Ina, Sansò, Fernando, Tscherning, Carl Christian;<br>
+    <b>First GOCE gravity field models derived by three different approaches;</b>
+    <br>
+        Journal of Geodesy,
+            Vol 85,
+            No. 11,
+            p. 819-843,
+        doi: <a href="http://doi.org/10.1007/s00190-011-0467-x" target="_blank">10.1007/s00190-011-0467-x</a>,
+    2011
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/a3d297b0c541a877c4a53a0031cf5767a59bdf8b752f4b432cfaa7d0c63e8db4/GO_CONS_GCF_2_DIR_R3.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/a3d297b0c541a877c4a53a0031cf5767a59bdf8b752f4b432cfaa7d0c63e8db4/GO_CONS_GCF_2_DIR_R3.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=a3d297b0c541a877c4a53a0031cf5767a59bdf8b752f4b432cfaa7d0c63e8db4" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=a3d297b0c541a877c4a53a0031cf5767a59bdf8b752f4b432cfaa7d0c63e8db4" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>127</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="https://earth.esa.int/eogateway/missions/goce" target="_blank">GO_CONS_GCF_2_TIM_R3</a>
+</td>
+    <td>2011</td>
+    <td>        250
+</td>
+    <td>        S(Goce)
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_fdba04544ad9d12658e000f643bdf287997782fdc3daaf4195e4c5e70d3dba4a').toggle(); "><b>        Pail, R. et al,
+    2010
+</b></div>
+        <div id="ref_fdba04544ad9d12658e000f643bdf287997782fdc3daaf4195e4c5e70d3dba4a" class="mt-1" style="display:none">
+        Pail, R., Goiginger, H., Mayrhofer, R., Schuh, W., Brockmann, J.M., Krasbutter, I., Hoeck, E., Fecher, T.;<br>
+    <b>GOCE gravity field model derived from orbit and gradiometry data applying the time-wise method;</b>
+    <br>
+        ESA Publications Division, Norwijk, The Nethelands,
+        Bergen, Norway,
+    2010
+
+        <br><br>
+        <b>Related References:</b><br>
+        Pail, Roland, Bruinsma, Sean, Migliaccio, Federica, Förste, Christoph, Goiginger, Helmut, Schuh, Wolf-Dieter, Höck, Eduard, Reguzzoni, Mirko, Brockmann, Jan Martin, Abrikosov, Oleg, Veicherts, Martin, Fecher, Thomas, Mayrhofer, Reinhard, Krasbutter, Ina, Sansò, Fernando, Tscherning, Carl Christian;<br>
+    <b>First GOCE gravity field models derived by three different approaches;</b>
+    <br>
+        Journal of Geodesy,
+            Vol 85,
+            No. 11,
+            p. 819-843,
+        doi: <a href="http://doi.org/10.1007/s00190-011-0467-x" target="_blank">10.1007/s00190-011-0467-x</a>,
+    2011
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/fdba04544ad9d12658e000f643bdf287997782fdc3daaf4195e4c5e70d3dba4a/GO_CONS_GCF_2_TIM_R3.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/fdba04544ad9d12658e000f643bdf287997782fdc3daaf4195e4c5e70d3dba4a/GO_CONS_GCF_2_TIM_R3.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=fdba04544ad9d12658e000f643bdf287997782fdc3daaf4195e4c5e70d3dba4a" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=fdba04544ad9d12658e000f643bdf287997782fdc3daaf4195e4c5e70d3dba4a" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>126</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="/getmodel/doc/8c90e8bd08ca3d65b871238fb16c60182643df62ded5bd7621d69d85532e1fa2" target="_blank">GIF48</a>
+</td>
+    <td>2011</td>
+    <td>        360
+</td>
+    <td>            A,             G,             S(Grace)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_8c90e8bd08ca3d65b871238fb16c60182643df62ded5bd7621d69d85532e1fa2').toggle(); "><b>        Ries, J.C. et al,
+    2011
+</b></div>
+        <div id="ref_8c90e8bd08ca3d65b871238fb16c60182643df62ded5bd7621d69d85532e1fa2" class="mt-1" style="display:none">
+        Ries, J.C., Bettadpur, S., Poole, S., Richter, T.;<br>
+    <b>Mean Background Gravity Fields for GRACE Processing;</b>
+    <br>
+        Austin, TX,
+    2011
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/8c90e8bd08ca3d65b871238fb16c60182643df62ded5bd7621d69d85532e1fa2/GIF48.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/8c90e8bd08ca3d65b871238fb16c60182643df62ded5bd7621d69d85532e1fa2/GIF48.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=8c90e8bd08ca3d65b871238fb16c60182643df62ded5bd7621d69d85532e1fa2" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=8c90e8bd08ca3d65b871238fb16c60182643df62ded5bd7621d69d85532e1fa2" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>125</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="/getmodel/doc/0776caed6c65af24051697a65147b59e436cb464cb0930c1863fee6ecfbc31b0" target="_blank">EIGEN-6C</a>
+</td>
+    <td>2011</td>
+    <td>        1420
+</td>
+    <td>            A,             G,             S(Goce),             S(Grace),             S(Lageos)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_0776caed6c65af24051697a65147b59e436cb464cb0930c1863fee6ecfbc31b0').toggle(); "><b>        Förste, C. et al,
+    2011
+</b></div>
+        <div id="ref_0776caed6c65af24051697a65147b59e436cb464cb0930c1863fee6ecfbc31b0" class="mt-1" style="display:none">
+        Förste, C., Bruinsma, S.L., Shako, R., Marty, J.C., Flechtner, F., Abrikosov, O., Dahle, C., Lemoine, J.M., Neumayer, K.H., Biancale, R., Barthelmes, F., König, R., Balmino, G.;<br>
+    <b>EIGEN-6 - A new combined global gravity field model including GOCE data from the collaboration of GFZ-Potsdam and GRGS-Toulouse;</b>
+    <br>
+        Geophysical Research Abstracts, Vol. 13, EGU2011-3242-2, EGU General Assembly, 2011,
+    2011
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/0776caed6c65af24051697a65147b59e436cb464cb0930c1863fee6ecfbc31b0/EIGEN-6C.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/0776caed6c65af24051697a65147b59e436cb464cb0930c1863fee6ecfbc31b0/EIGEN-6C.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=0776caed6c65af24051697a65147b59e436cb464cb0930c1863fee6ecfbc31b0" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=0776caed6c65af24051697a65147b59e436cb464cb0930c1863fee6ecfbc31b0" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>124</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="/getmodel/doc/12a07b4177cb72a2a84598d66248f2645638c012e6e10cfb77f9a144dfcb17ec" target="_blank">EIGEN-6S</a>
+</td>
+    <td>2011</td>
+    <td>        240
+</td>
+    <td>            S(Goce),             S(Grace),             S(Lageos)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_12a07b4177cb72a2a84598d66248f2645638c012e6e10cfb77f9a144dfcb17ec').toggle(); "><b>        Förste, C. et al,
+    2011
+</b></div>
+        <div id="ref_12a07b4177cb72a2a84598d66248f2645638c012e6e10cfb77f9a144dfcb17ec" class="mt-1" style="display:none">
+        Förste, C., Bruinsma, S.L., Shako, R., Marty, J.C., Flechtner, F., Abrikosov, O., Dahle, C., Lemoine, J.M., Neumayer, K.H., Biancale, R., Barthelmes, F., König, R., Balmino, G.;<br>
+    <b>EIGEN-6 - A new combined global gravity field model including GOCE data from the collaboration of GFZ-Potsdam and GRGS-Toulouse;</b>
+    <br>
+        Geophysical Research Abstracts, Vol. 13, EGU2011-3242-2, EGU General Assembly, 2011,
+    2011
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/12a07b4177cb72a2a84598d66248f2645638c012e6e10cfb77f9a144dfcb17ec/EIGEN-6S.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/12a07b4177cb72a2a84598d66248f2645638c012e6e10cfb77f9a144dfcb17ec/EIGEN-6S.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=12a07b4177cb72a2a84598d66248f2645638c012e6e10cfb77f9a144dfcb17ec" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=12a07b4177cb72a2a84598d66248f2645638c012e6e10cfb77f9a144dfcb17ec" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>123</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="http://www.goco.eu/" target="_blank">GOCO02s</a>
+</td>
+    <td>2011</td>
+    <td>        250
+</td>
+    <td>            S(Goce),             S(Grace)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_00b3c41ff1666a7944945ee0069b4a49ab2ad2b9c9483e5397fe191d286a0681').toggle(); "><b>        Goiginger, H. et al,
+    2011
+</b></div>
+        <div id="ref_00b3c41ff1666a7944945ee0069b4a49ab2ad2b9c9483e5397fe191d286a0681" class="mt-1" style="display:none">
+        Goiginger, H., Höck, E., Rieser, D., Mayer-Gürr, T., Maier, A., Krauss, S., Pail, R., Fecher, T., Gruber, T., Brockmann, J.M., Krasbutter, I., Schuh, W.D., Jäggi, A., Prange, L., Hausleitner, W., Baur, O., Kusche, J.;<br>
+    <b>The combined satellite-only global gravity field model GOCO02S;</b>
+    <br>
+        Vienna, Austria,
+    2011
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/00b3c41ff1666a7944945ee0069b4a49ab2ad2b9c9483e5397fe191d286a0681/GOCO02s.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/00b3c41ff1666a7944945ee0069b4a49ab2ad2b9c9483e5397fe191d286a0681/GOCO02s.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=00b3c41ff1666a7944945ee0069b4a49ab2ad2b9c9483e5397fe191d286a0681" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=00b3c41ff1666a7944945ee0069b4a49ab2ad2b9c9483e5397fe191d286a0681" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>122</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="http://www.aiub.unibe.ch/" target="_blank">AIUB-GRACE03S</a>
+</td>
+    <td>2011</td>
+    <td>        160
+</td>
+    <td>        S(Grace)
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_adcddf84c12be7804b762e2883d61a680c2c755e6dc8a8c971cce68ba6e490bd').toggle(); "><b>        Jäggi, A. et al,
+    
+</b></div>
+        <div id="ref_adcddf84c12be7804b762e2883d61a680c2c755e6dc8a8c971cce68ba6e490bd" class="mt-1" style="display:none">
+        Jäggi, A., Meyer, U., Beutler, G., Prange, L., Dach, R., Mervart, L.;<br>
+    <b>AIUB-GRACE03S: A static gravity field model computed with simultaneously solved-for time variations from 6 years of GRACE data using the Celestial Mechanics Approach;</b>
+    <br>
+        Paper in preparation, 2011,
+    
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/adcddf84c12be7804b762e2883d61a680c2c755e6dc8a8c971cce68ba6e490bd/AIUB-GRACE03S.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/adcddf84c12be7804b762e2883d61a680c2c755e6dc8a8c971cce68ba6e490bd/AIUB-GRACE03S.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=adcddf84c12be7804b762e2883d61a680c2c755e6dc8a8c971cce68ba6e490bd" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=adcddf84c12be7804b762e2883d61a680c2c755e6dc8a8c971cce68ba6e490bd" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>121</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="https://earth.esa.int/eogateway/missions/goce" target="_blank">GO_CONS_GCF_2_DIR_R2</a>
+</td>
+    <td>2011</td>
+    <td>        240
+</td>
+    <td>        S(Goce)
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_d8044bd8ae5984858c06cd6dba8bbdb9ea275079bfa9caf686e995066dd7c84f').toggle(); "><b>        Bruinsma, S.L. et al,
+    2010
+</b></div>
+        <div id="ref_d8044bd8ae5984858c06cd6dba8bbdb9ea275079bfa9caf686e995066dd7c84f" class="mt-1" style="display:none">
+        Bruinsma, S.L., Marty, J.C., Balmino, G., Biancale, R., Foerste, C., Abrikosov, O., Neumayer, H.;<br>
+    <b>GOCE Gravity Field Recovery by Means of the Direct Numerical Method;</b>
+    <br>
+        ESA Publications Division, Norwijk, The Nethelands,
+            Vol SP 686,
+        Bergen, Norway,
+    2010
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/d8044bd8ae5984858c06cd6dba8bbdb9ea275079bfa9caf686e995066dd7c84f/GO_CONS_GCF_2_DIR_R2.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/d8044bd8ae5984858c06cd6dba8bbdb9ea275079bfa9caf686e995066dd7c84f/GO_CONS_GCF_2_DIR_R2.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=d8044bd8ae5984858c06cd6dba8bbdb9ea275079bfa9caf686e995066dd7c84f" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=d8044bd8ae5984858c06cd6dba8bbdb9ea275079bfa9caf686e995066dd7c84f" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>120</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="https://earth.esa.int/eogateway/missions/goce" target="_blank">GO_CONS_GCF_2_TIM_R2</a>
+</td>
+    <td>2011</td>
+    <td>        250
+</td>
+    <td>        S(Goce)
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_50ab0404b8c85abbef1671a327400f7fc818f72dd8fcf1042c50e024264c0050').toggle(); "><b>        Pail, Roland et al,
+    2011
+</b></div>
+        <div id="ref_50ab0404b8c85abbef1671a327400f7fc818f72dd8fcf1042c50e024264c0050" class="mt-1" style="display:none">
+        Pail, Roland, Bruinsma, Sean, Migliaccio, Federica, Förste, Christoph, Goiginger, Helmut, Schuh, Wolf-Dieter, Höck, Eduard, Reguzzoni, Mirko, Brockmann, Jan Martin, Abrikosov, Oleg, Veicherts, Martin, Fecher, Thomas, Mayrhofer, Reinhard, Krasbutter, Ina, Sansò, Fernando, Tscherning, Carl Christian;<br>
+    <b>First GOCE gravity field models derived by three different approaches;</b>
+    <br>
+        Journal of Geodesy,
+            Vol 85,
+            No. 11,
+            p. 819-843,
+        doi: <a href="http://doi.org/10.1007/s00190-011-0467-x" target="_blank">10.1007/s00190-011-0467-x</a>,
+    2011
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/50ab0404b8c85abbef1671a327400f7fc818f72dd8fcf1042c50e024264c0050/GO_CONS_GCF_2_TIM_R2.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/50ab0404b8c85abbef1671a327400f7fc818f72dd8fcf1042c50e024264c0050/GO_CONS_GCF_2_TIM_R2.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=50ab0404b8c85abbef1671a327400f7fc818f72dd8fcf1042c50e024264c0050" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=50ab0404b8c85abbef1671a327400f7fc818f72dd8fcf1042c50e024264c0050" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>119</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="https://earth.esa.int/eogateway/missions/goce" target="_blank">GO_CONS_GCF_2_SPW_R2</a>
+</td>
+    <td>2011</td>
+    <td>        240
+</td>
+    <td>        S(Goce)
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_1afe108ccedcda1d2b7c34ff0ef40060ae89cfa8afdea04f05dc5d19f4b72482').toggle(); "><b>        Migliaccio, F. et al,
+    2011
+</b></div>
+        <div id="ref_1afe108ccedcda1d2b7c34ff0ef40060ae89cfa8afdea04f05dc5d19f4b72482" class="mt-1" style="display:none">
+        Migliaccio, F., Reguzzoni, M., Gatti, A., Sanso, F., Herceg, M.;<br>
+    <b>A GOCE-only global gravity field model by the space-wise approach;</b>
+    <br>
+        European Space Agency, ESA,
+        Munich,
+    2011
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/1afe108ccedcda1d2b7c34ff0ef40060ae89cfa8afdea04f05dc5d19f4b72482/GO_CONS_GCF_2_SPW_R2.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/1afe108ccedcda1d2b7c34ff0ef40060ae89cfa8afdea04f05dc5d19f4b72482/GO_CONS_GCF_2_SPW_R2.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=1afe108ccedcda1d2b7c34ff0ef40060ae89cfa8afdea04f05dc5d19f4b72482" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=1afe108ccedcda1d2b7c34ff0ef40060ae89cfa8afdea04f05dc5d19f4b72482" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>118</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="https://earth.esa.int/eogateway/missions/goce" target="_blank">GO_CONS_GCF_2_DIR_R1</a>
+</td>
+    <td>2010</td>
+    <td>        240
+</td>
+    <td>        S(Goce)
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_2c47a816b731d2dfff1083eab016f655199f3eeac9d3f51a7a230ad1a10ae6b0').toggle(); "><b>        Bruinsma, S.L. et al,
+    2010
+</b></div>
+        <div id="ref_2c47a816b731d2dfff1083eab016f655199f3eeac9d3f51a7a230ad1a10ae6b0" class="mt-1" style="display:none">
+        Bruinsma, S.L., Marty, J.C., Balmino, G., Biancale, R., Foerste, C., Abrikosov, O., Neumayer, H.;<br>
+    <b>GOCE Gravity Field Recovery by Means of the Direct Numerical Method;</b>
+    <br>
+        ESA Publications Division, Norwijk, The Nethelands,
+            Vol SP 686,
+        Bergen, Norway,
+    2010
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/2c47a816b731d2dfff1083eab016f655199f3eeac9d3f51a7a230ad1a10ae6b0/GO_CONS_GCF_2_DIR_R1.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/2c47a816b731d2dfff1083eab016f655199f3eeac9d3f51a7a230ad1a10ae6b0/GO_CONS_GCF_2_DIR_R1.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=2c47a816b731d2dfff1083eab016f655199f3eeac9d3f51a7a230ad1a10ae6b0" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=2c47a816b731d2dfff1083eab016f655199f3eeac9d3f51a7a230ad1a10ae6b0" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>117</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="https://earth.esa.int/eogateway/missions/goce" target="_blank">GO_CONS_GCF_2_TIM_R1</a>
+</td>
+    <td>2010</td>
+    <td>        224
+</td>
+    <td>        S(Goce)
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_d64925acadc1fc512db61d5b3c773cfe5da67a725c7afa036c67e4b00a94a5d8').toggle(); "><b>        Pail, R. et al,
+    2010
+</b></div>
+        <div id="ref_d64925acadc1fc512db61d5b3c773cfe5da67a725c7afa036c67e4b00a94a5d8" class="mt-1" style="display:none">
+        Pail, R., Goiginger, H., Mayrhofer, R., Schuh, W., Brockmann, J.M., Krasbutter, I., Hoeck, E., Fecher, T.;<br>
+    <b>GOCE gravity field model derived from orbit and gradiometry data applying the time-wise method;</b>
+    <br>
+        ESA Publications Division, Norwijk, The Nethelands,
+        Bergen, Norway,
+    2010
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/d64925acadc1fc512db61d5b3c773cfe5da67a725c7afa036c67e4b00a94a5d8/GO_CONS_GCF_2_TIM_R1.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/d64925acadc1fc512db61d5b3c773cfe5da67a725c7afa036c67e4b00a94a5d8/GO_CONS_GCF_2_TIM_R1.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=d64925acadc1fc512db61d5b3c773cfe5da67a725c7afa036c67e4b00a94a5d8" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=d64925acadc1fc512db61d5b3c773cfe5da67a725c7afa036c67e4b00a94a5d8" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>116</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="https://earth.esa.int/eogateway/missions/goce" target="_blank">GO_CONS_GCF_2_SPW_R1</a>
+</td>
+    <td>2010</td>
+    <td>        210
+</td>
+    <td>        S(Goce)
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_e61fde28495a26c4e9543d202aef591168a604f9d6f5c2acc9fbebd28e069d91').toggle(); "><b>        Migliaccio, F. et al,
+    2010
+</b></div>
+        <div id="ref_e61fde28495a26c4e9543d202aef591168a604f9d6f5c2acc9fbebd28e069d91" class="mt-1" style="display:none">
+        Migliaccio, F., Reguzzoni, M., Sanso, F., Tscherning, C.C., Veicherts, M.;<br>
+    <b>GOCE data analysis: the space-wise approach and the first space-wise gravity field model;</b>
+    <br>
+        ESA Publications Division, Norwijk, The Nethelands,
+        Bergen, Norway,
+    2010
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/e61fde28495a26c4e9543d202aef591168a604f9d6f5c2acc9fbebd28e069d91/GO_CONS_GCF_2_SPW_R1.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/e61fde28495a26c4e9543d202aef591168a604f9d6f5c2acc9fbebd28e069d91/GO_CONS_GCF_2_SPW_R1.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=e61fde28495a26c4e9543d202aef591168a604f9d6f5c2acc9fbebd28e069d91" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=e61fde28495a26c4e9543d202aef591168a604f9d6f5c2acc9fbebd28e069d91" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>115</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="http://www.goco.eu/" target="_blank">GOCO01S</a>
+</td>
+    <td>2010</td>
+    <td>        224
+</td>
+    <td>            S(Champ),             S(Grace)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_7a3dbee2101de5cbf878512c9306bfc0d50fd79373c842edc0c9908cd2989dfb').toggle(); "><b>        Pail, R. et al,
+    2010
+</b></div>
+        <div id="ref_7a3dbee2101de5cbf878512c9306bfc0d50fd79373c842edc0c9908cd2989dfb" class="mt-1" style="display:none">
+        Pail, R., Goiginger, H., Schuh, W. D., Höck, E., Brockmann, J. M., Fecher, T., Gruber, T., Mayer-Gürr, T., Kusche, J., Jäggi, A., Rieser, D.;<br>
+    <b>Combined satellite gravity field model GOCO01S derived from GOCE and GRACE;</b>
+    <br>
+        Geophysical Research Letters,
+            Vol 37,
+            No. 20,
+            p. n/a-n/a,
+        doi: <a href="http://doi.org/10.1029/2010gl044906" target="_blank">10.1029/2010gl044906</a>,
+    2010
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/7a3dbee2101de5cbf878512c9306bfc0d50fd79373c842edc0c9908cd2989dfb/GOCO01S.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/7a3dbee2101de5cbf878512c9306bfc0d50fd79373c842edc0c9908cd2989dfb/GOCO01S.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=7a3dbee2101de5cbf878512c9306bfc0d50fd79373c842edc0c9908cd2989dfb" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=7a3dbee2101de5cbf878512c9306bfc0d50fd79373c842edc0c9908cd2989dfb" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>114</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        EIGEN-51C
+</td>
+    <td>2010</td>
+    <td>        359
+</td>
+    <td>            A,             G,             S(Champ),             S(Grace)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_9c8df7d2e12c0f86087465ab64239b6e8859f20c7480ed158bea1ba03a629c9b').toggle(); "><b>        Bruinsma, S.L. et al,
+    2010
+</b></div>
+        <div id="ref_9c8df7d2e12c0f86087465ab64239b6e8859f20c7480ed158bea1ba03a629c9b" class="mt-1" style="display:none">
+        Bruinsma, S.L., Marty, J.C., Balmino, G., Biancale, R., Foerste, C., Abrikosov, O., Neumayer, H.;<br>
+    <b>GOCE Gravity Field Recovery by Means of the Direct Numerical Method;</b>
+    <br>
+        ESA Publications Division, Norwijk, The Nethelands,
+            Vol SP 686,
+        Bergen, Norway,
+    2010
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/9c8df7d2e12c0f86087465ab64239b6e8859f20c7480ed158bea1ba03a629c9b/EIGEN-51C.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/9c8df7d2e12c0f86087465ab64239b6e8859f20c7480ed158bea1ba03a629c9b/EIGEN-51C.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=9c8df7d2e12c0f86087465ab64239b6e8859f20c7480ed158bea1ba03a629c9b" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=9c8df7d2e12c0f86087465ab64239b6e8859f20c7480ed158bea1ba03a629c9b" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>113</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="http://www.aiub.unibe.ch/content/research/satellite_geodesy/gnss___research/global_gravity_field_determination_champ/index_eng.html" target="_blank">AIUB-CHAMP03S</a>
+</td>
+    <td>2010</td>
+    <td>        100
+</td>
+    <td>        S(Champ)
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_b25ea1f192702c2c2d6a9955913c9401633db4be951ff674f1dfbeb143225ede').toggle(); "><b>        Prange, L.,
+    2010
+</b></div>
+        <div id="ref_b25ea1f192702c2c2d6a9955913c9401633db4be951ff674f1dfbeb143225ede" class="mt-1" style="display:none">
+        Prange, L.;<br>
+    <b>Global Gravity Field Determination Using the GPS Measurements Made Onboard the Low Earth Orbiting Satellite CHAMP;</b>
+    <br>
+        PhD Thesis, Geodätisch-geophysikalische Arbeiten in der Schweiz, vol. 81. http://www.sgc.ethz.ch/sgc-volumes/sgk-81.pdf, 2011,
+        Geodätisch-geophysikalische Arbeiten in der Schweiz, Vol. 81, Schweizerische Geodätische Kommission,
+    2010
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/b25ea1f192702c2c2d6a9955913c9401633db4be951ff674f1dfbeb143225ede/AIUB-CHAMP03S.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/b25ea1f192702c2c2d6a9955913c9401633db4be951ff674f1dfbeb143225ede/AIUB-CHAMP03S.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=b25ea1f192702c2c2d6a9955913c9401633db4be951ff674f1dfbeb143225ede" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=b25ea1f192702c2c2d6a9955913c9401633db4be951ff674f1dfbeb143225ede" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>112</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        EIGEN-CHAMP05S
+</td>
+    <td>2010</td>
+    <td>        150
+</td>
+    <td>        S(Champ)
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_57185999c8ae4c3852032808a0e2c7cb0244bcd4a66559166c019b8deb4981fb').toggle(); "><b>        Flechtner, Frank et al,
+    2010
+</b></div>
+        <div id="ref_57185999c8ae4c3852032808a0e2c7cb0244bcd4a66559166c019b8deb4981fb" class="mt-1" style="display:none">
+        Flechtner, Frank, Dahle, Christoph, Neumayer, Karl Hans, König, Rolf, Förste, Christoph, Flechtner, F.M., Gruber, Th., Güntner, A., Mandea, M., Rothacher, M., Schöne, T., Wickert, J.;<br>
+    <b>The Release 04 CHAMP and GRACE EIGEN Gravity Field Models;</b>
+    <br>
+        Springer,
+            p. 41-58,
+        doi: <a href="http://doi.org/10.1007/978-3-642-10228-8_4" target="_blank">10.1007/978-3-642-10228-8_4</a>,
+        Berlin/Heidelberg,
+    2010
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/57185999c8ae4c3852032808a0e2c7cb0244bcd4a66559166c019b8deb4981fb/EIGEN-CHAMP05S.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/57185999c8ae4c3852032808a0e2c7cb0244bcd4a66559166c019b8deb4981fb/EIGEN-CHAMP05S.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=57185999c8ae4c3852032808a0e2c7cb0244bcd4a66559166c019b8deb4981fb" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=57185999c8ae4c3852032808a0e2c7cb0244bcd4a66559166c019b8deb4981fb" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>111</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="http://www.igg.uni-bonn.de/apmg/index.php?id=itg-grace2010" target="_blank">ITG-Grace2010s</a>
+</td>
+    <td>2010</td>
+    <td>        180
+</td>
+    <td>        S(Grace)
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_e1137252ffe386e01eb3e77005ec5f170d518c67797b8ec0945f849a1660e9c0').toggle(); "><b>        Mayer-Gürr, T. et al,
+    2010
+</b></div>
+        <div id="ref_e1137252ffe386e01eb3e77005ec5f170d518c67797b8ec0945f849a1660e9c0" class="mt-1" style="display:none">
+        Mayer-Gürr, T., Kurtenbach, E., Eicker, A.;<br>
+    <b>ITG-Grace2010 Gravity Field Model;</b>
+    <br>
+        http://www.igg.uni-bonn.de/apmg/index.php?id=itg-grace2010, 2010,
+    2010
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/e1137252ffe386e01eb3e77005ec5f170d518c67797b8ec0945f849a1660e9c0/ITG-Grace2010s.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/e1137252ffe386e01eb3e77005ec5f170d518c67797b8ec0945f849a1660e9c0/ITG-Grace2010s.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=e1137252ffe386e01eb3e77005ec5f170d518c67797b8ec0945f849a1660e9c0" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=e1137252ffe386e01eb3e77005ec5f170d518c67797b8ec0945f849a1660e9c0" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>110</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="http://www.aiub.unibe.ch/" target="_blank">AIUB-GRACE02S</a>
+</td>
+    <td>2009</td>
+    <td>        150
+</td>
+    <td>        S(Grace)
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_c2ea66021b1a0329609d01abb3bd13f94748b634a95182e7b3b970e09261dcaa').toggle(); "><b>        Jäggi, A. et al,
+    2012
+</b></div>
+        <div id="ref_c2ea66021b1a0329609d01abb3bd13f94748b634a95182e7b3b970e09261dcaa" class="mt-1" style="display:none">
+        Jäggi, A., Beutler, G., Meyer, U., Prange, L., Dach, R., Mervart, L.;<br>
+    <b>AIUB-GRACE02S: Status of GRACE Gravity Field Recovery Using the Celestial Mechanics Approach;</b>
+    <br>
+        presented at the IAG Scientific Assembly 2009, August 31 - September 4 2009, Buenos Aires, Argentina,
+        doi: <a href="http://doi.org/10.1007/978-3-642-20338-1_20" target="_blank">10.1007/978-3-642-20338-1_20</a>,
+    2012
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/c2ea66021b1a0329609d01abb3bd13f94748b634a95182e7b3b970e09261dcaa/AIUB-GRACE02S.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/c2ea66021b1a0329609d01abb3bd13f94748b634a95182e7b3b970e09261dcaa/AIUB-GRACE02S.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=c2ea66021b1a0329609d01abb3bd13f94748b634a95182e7b3b970e09261dcaa" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=c2ea66021b1a0329609d01abb3bd13f94748b634a95182e7b3b970e09261dcaa" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>109</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="http://www.csr.utexas.edu/grace/gravity/" target="_blank">GGM03C</a>
+</td>
+    <td>2009</td>
+    <td>        360
+</td>
+    <td>            A,             G,             S(Grace)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_78f8d1cf5f78d8a7161762fba0d996940b3ae6741676904cc2fa986cf8f45522').toggle(); "><b>        Tapley, B.D. et al,
+    2007
+</b></div>
+        <div id="ref_78f8d1cf5f78d8a7161762fba0d996940b3ae6741676904cc2fa986cf8f45522" class="mt-1" style="display:none">
+        Tapley, B.D., Ries, J., Bettadpur, S., Chambers, D., Cheng, M., Condi, F., Poole, S.;<br>
+    <b>The GGM03 Mean Earth Gravity Model from GRACE;</b>
+    <br>
+        Eos Trans,
+            Vol AGU 88(52), Fall Meet. Suppl., Abstract G42A-03,
+    2007
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/78f8d1cf5f78d8a7161762fba0d996940b3ae6741676904cc2fa986cf8f45522/GGM03C.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/78f8d1cf5f78d8a7161762fba0d996940b3ae6741676904cc2fa986cf8f45522/GGM03C.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=78f8d1cf5f78d8a7161762fba0d996940b3ae6741676904cc2fa986cf8f45522" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=78f8d1cf5f78d8a7161762fba0d996940b3ae6741676904cc2fa986cf8f45522" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>108</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="http://www.csr.utexas.edu/grace/gravity/" target="_blank">GGM03S</a>
+</td>
+    <td>2008</td>
+    <td>        180
+</td>
+    <td>            S(Grace)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_cd87c2eab7ae4904fd9a6c53f317af811bc27da4dba103a09d89f7dce77ee238').toggle(); "><b>Tapley, B.D. et al, 2007</b></div>
+        <div id="ref_cd87c2eab7ae4904fd9a6c53f317af811bc27da4dba103a09d89f7dce77ee238" class="mt-1" style="display:none">        Tapley, B.D., Ries, J., Bettadpur, S., Chambers, D., Cheng, M., Condi, F., Poole, S.;<br>
+    <b>The GGM03 Mean Earth Gravity Model from GRACE;</b>
+    <br>
+        Eos Trans,
+            Vol AGU 88(52), Fall Meet. Suppl., Abstract G42A-03,
+    2007</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/cd87c2eab7ae4904fd9a6c53f317af811bc27da4dba103a09d89f7dce77ee238/GGM03S.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/cd87c2eab7ae4904fd9a6c53f317af811bc27da4dba103a09d89f7dce77ee238/GGM03S.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=cd87c2eab7ae4904fd9a6c53f317af811bc27da4dba103a09d89f7dce77ee238" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=cd87c2eab7ae4904fd9a6c53f317af811bc27da4dba103a09d89f7dce77ee238" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>107</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="http://www.aiub.unibe.ch/" target="_blank">AIUB-GRACE01S</a>
+</td>
+    <td>2008</td>
+    <td>        120
+</td>
+    <td>        S(Grace)
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_5ae34f45861448ca9bda9784103836d643961702bdbc6dcaad1217d9a328a7eb').toggle(); "><b>        Jäggi, A. et al,
+    2010
+</b></div>
+        <div id="ref_5ae34f45861448ca9bda9784103836d643961702bdbc6dcaad1217d9a328a7eb" class="mt-1" style="display:none">
+        Jäggi, A., Beutler, G., Mervart, L.;<br>
+    <b>GRACE Gravity Field Determination Using the Celestial Mechanics Approach – First Results;</b>
+    <br>
+        Gravity, Geoid and Earth Observation,
+            Vol 135,
+            p. 177-184,
+        doi: <a href="http://doi.org/10.1007/978-3-642-10634-7_24" target="_blank">10.1007/978-3-642-10634-7_24</a>,
+    2010
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/5ae34f45861448ca9bda9784103836d643961702bdbc6dcaad1217d9a328a7eb/AIUB-GRACE01S.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/5ae34f45861448ca9bda9784103836d643961702bdbc6dcaad1217d9a328a7eb/AIUB-GRACE01S.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=5ae34f45861448ca9bda9784103836d643961702bdbc6dcaad1217d9a328a7eb" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=5ae34f45861448ca9bda9784103836d643961702bdbc6dcaad1217d9a328a7eb" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>106</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="/getmodel/doc/cb435fdc583f41a17acb58152b371788a577290f81af86ebded1696c56aea124" target="_blank">EIGEN-5S</a>
+</td>
+    <td>2008</td>
+    <td>        150
+</td>
+    <td>            S(Grace),             S(Lageos)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_cb435fdc583f41a17acb58152b371788a577290f81af86ebded1696c56aea124').toggle(); "><b>        Förste, C. et al,
+    2008
+</b></div>
+        <div id="ref_cb435fdc583f41a17acb58152b371788a577290f81af86ebded1696c56aea124" class="mt-1" style="display:none">        Förste, C., Flechtner, F., Schmidt, R., Stubenvoll, R., Rothacher, M., Kusche, J., Neumayer, K.H., Biancale, R., Lemoine, J.M., Barthelmes, F., Bruinsma, S.L., König, R., Meyer, U.;<br>
+    <b>EIGEN-GL05C - A new global combined high-resolution GRACE-based gravity field model of the GFZ-GRGS cooperation;</b>
+    <br>
+        Geophysical Research Abstracts, Vol. 10, EGU2008-A-03426, SRef-ID: 1607-7962/gra/EGU2008-A-03426, 2008,
+        Vienna, Austria,
+    2008
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/cb435fdc583f41a17acb58152b371788a577290f81af86ebded1696c56aea124/EIGEN-5S.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/cb435fdc583f41a17acb58152b371788a577290f81af86ebded1696c56aea124/EIGEN-5S.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=cb435fdc583f41a17acb58152b371788a577290f81af86ebded1696c56aea124" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=cb435fdc583f41a17acb58152b371788a577290f81af86ebded1696c56aea124" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>105</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="/getmodel/doc/fc51e0803271a9355bd55be4eea2790049c50a2e0a96a2077503da1df7db3bd0" target="_blank">EIGEN-5C</a>
+</td>
+    <td>2008</td>
+    <td>        360
+</td>
+    <td>            A,             G,             S(Grace),             S(Lageos)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_fc51e0803271a9355bd55be4eea2790049c50a2e0a96a2077503da1df7db3bd0').toggle(); "><b>        Förste, C. et al,
+    2008
+</b></div>
+        <div id="ref_fc51e0803271a9355bd55be4eea2790049c50a2e0a96a2077503da1df7db3bd0" class="mt-1" style="display:none">        Förste, C., Flechtner, F., Schmidt, R., Stubenvoll, R., Rothacher, M., Kusche, J., Neumayer, K.H., Biancale, R., Lemoine, J.M., Barthelmes, F., Bruinsma, S.L., König, R., Meyer, U.;<br>
+    <b>EIGEN-GL05C - A new global combined high-resolution GRACE-based gravity field model of the GFZ-GRGS cooperation;</b>
+    <br>
+        Geophysical Research Abstracts, Vol. 10, EGU2008-A-03426, SRef-ID: 1607-7962/gra/EGU2008-A-03426, 2008,
+        Vienna, Austria,
+    2008
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/fc51e0803271a9355bd55be4eea2790049c50a2e0a96a2077503da1df7db3bd0/EIGEN-5C.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/fc51e0803271a9355bd55be4eea2790049c50a2e0a96a2077503da1df7db3bd0/EIGEN-5C.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=fc51e0803271a9355bd55be4eea2790049c50a2e0a96a2077503da1df7db3bd0" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=fc51e0803271a9355bd55be4eea2790049c50a2e0a96a2077503da1df7db3bd0" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>104</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="https://doi.org/10.1029/2011JB008916" target="_blank">EGM2008</a>
+</td>
+    <td>2008</td>
+    <td>        2190
+</td>
+    <td>            A,             G,             S(Grace)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_c50128797a9cb62e936337c890e4425f03f0461d7329b09a8cc8561504465340').toggle(); "><b>        Pavlis, N.K. et al,
+    2012
+</b></div>
+        <div id="ref_c50128797a9cb62e936337c890e4425f03f0461d7329b09a8cc8561504465340" class="mt-1" style="display:none">Pavlis, N.K, Holmes, S.A, Kenyon, S.C, Factor, J.K.:, <br>
+<b>The development and evaluation of the Earth Gravitational Model 2008 (EGM2008);</b>, Journal of Geophysical Research: Solid Earth (1978-2012) Volume 117, B04406, 2012.       
+<a href="https://doi.org/10.1029/2011JB008916 " target="_blank">https://doi.org/10.1029/2011JB008916 </a>,
+2012
+
+        <br><br>
+ Pavlis, N.K., Holmes, S.A., Kenyon, S.C., Factor, J.K.;<br>
+    <b>An Earth Gravitational Model to Degree 2160: EGM2008;</b>
+    <br>
+        Vienna, Austria,
+    2008
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/c50128797a9cb62e936337c890e4425f03f0461d7329b09a8cc8561504465340/EGM2008.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/c50128797a9cb62e936337c890e4425f03f0461d7329b09a8cc8561504465340/EGM2008.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=c50128797a9cb62e936337c890e4425f03f0461d7329b09a8cc8561504465340" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=c50128797a9cb62e936337c890e4425f03f0461d7329b09a8cc8561504465340" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>103</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="http://www.igg.uni-bonn.de/apmg/index.php?id=gravitationsfeldmodelle" target="_blank">ITG-Grace03</a>
+</td>
+    <td>2007</td>
+    <td>        180
+</td>
+    <td>        S(Grace)
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_aa45aad8427a87efdb462fe0b5910b44920ad705962de0fa58376e914ad21f28').toggle(); "><b>        Mayer-Gürr, T. et al,
+    2007
+</b></div>
+        <div id="ref_aa45aad8427a87efdb462fe0b5910b44920ad705962de0fa58376e914ad21f28" class="mt-1" style="display:none">
+        Mayer-Gürr, T., Eicker, A., Ilk, K.H.;<br>
+    <b>ITG-Grace03 Gravity Field Model;</b>
+    <br>
+        http://www.igg.uni-bonn.de/apmg/index.php?id=itg-grace03,
+    2007
+
+        <br><br>
+        <b>Related References:</b><br>
+        Mayer-Gürr, T.;<br>
+    <b>Gravitationsfeldbestimmung aus der Analyse kurzer Bahnbögen am Beispiel der Satellitenmissionen CHAMP und GRACE;</b>
+    <br>
+        Universität Bonn,
+            Vol Dr. Ing.,
+    2006
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/aa45aad8427a87efdb462fe0b5910b44920ad705962de0fa58376e914ad21f28/ITG-Grace03.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/aa45aad8427a87efdb462fe0b5910b44920ad705962de0fa58376e914ad21f28/ITG-Grace03.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=aa45aad8427a87efdb462fe0b5910b44920ad705962de0fa58376e914ad21f28" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=aa45aad8427a87efdb462fe0b5910b44920ad705962de0fa58376e914ad21f28" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>102</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="http://www.aiub.unibe.ch/content/research/satellite_geodesy/gnss___research/global_gravity_field_determination_champ/index_eng.html" target="_blank">AIUB-CHAMP01S</a>
+</td>
+    <td>2007</td>
+    <td>        70
+</td>
+    <td>        S(Champ)
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_1d3d282b3afc8422a3e10eda2261754b447f429797cb025512210f6e0b5995c2').toggle(); "><b>        Prange, L. et al,
+    2009
+</b></div>
+        <div id="ref_1d3d282b3afc8422a3e10eda2261754b447f429797cb025512210f6e0b5995c2" class="mt-1" style="display:none">
+        Prange, L., Jäggi, A., Beutler, G., Dach, R., Mervart, L., M. Sideris;<br>
+    <b>Gravity Field Determination at the AIUB – The Celestial Mechanics Approach;</b>
+    <br>
+        Springer,
+            Vol 133,
+            p. 353-362,
+        doi: <a href="http://doi.org/10.1007/978-3-540-85426-5_42" target="_blank">10.1007/978-3-540-85426-5_42</a>,
+        Perugia,
+    2009
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/1d3d282b3afc8422a3e10eda2261754b447f429797cb025512210f6e0b5995c2/AIUB-CHAMP01S.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/1d3d282b3afc8422a3e10eda2261754b447f429797cb025512210f6e0b5995c2/AIUB-CHAMP01S.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=1d3d282b3afc8422a3e10eda2261754b447f429797cb025512210f6e0b5995c2" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=1d3d282b3afc8422a3e10eda2261754b447f429797cb025512210f6e0b5995c2" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>101</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="http://www.igg.uni-bonn.de/apmg/index.php?id=gravitationsfeldmodelle" target="_blank">ITG-Grace02s</a>
+</td>
+    <td>2006</td>
+    <td>        170
+</td>
+    <td>        S(Grace)
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_c83bea8a3a7308e9a37751399572747f4f952f3824a5dfbef93eb00d4d9294e2').toggle(); "><b>        Mayer-Gürr, T. et al,
+    2006
+</b></div>
+        <div id="ref_c83bea8a3a7308e9a37751399572747f4f952f3824a5dfbef93eb00d4d9294e2" class="mt-1" style="display:none">
+        Mayer-Gürr, T., Eicker, A., Ilk, K.H.;<br>
+    <b>ITG-GRACE02s: a GRACE gravity field derived from short arcs of the satellite’s orbit;</b>
+    <br>
+        Proceedings of the First Symposium of International Gravity Field Service, Istanbul, 2006Presentation:http://ifen.bauv.unibw-muenchen.de/gw06/down/mayer-guerr_muenchen_2006.pdfProceedings:http://www.hgk.msb.gov.tr/images/dergi/df57dbded091b01.pdf,
+        Istanbul,
+    2006
+
+        <br><br>
+        <b>Related References:</b><br>
+        Mayer-Gürr, T.;<br>
+    <b>Gravitationsfeldbestimmung aus der Analyse kurzer Bahnbögen am Beispiel der Satellitenmissionen CHAMP und GRACE;</b>
+    <br>
+        Universität Bonn,
+            Vol Dr. Ing.,
+    2006
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/c83bea8a3a7308e9a37751399572747f4f952f3824a5dfbef93eb00d4d9294e2/ITG-Grace02s.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/c83bea8a3a7308e9a37751399572747f4f952f3824a5dfbef93eb00d4d9294e2/ITG-Grace02s.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=c83bea8a3a7308e9a37751399572747f4f952f3824a5dfbef93eb00d4d9294e2" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=c83bea8a3a7308e9a37751399572747f4f952f3824a5dfbef93eb00d4d9294e2" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>100</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="https://gfzpublic.gfz.de/rest/items/item_236437_5/component/file_236436/content" target="_blank">EIGEN-GL04S1</a>
+</td>
+    <td>2006</td>
+    <td>        150
+</td>
+    <td>            S(Grace),             S(Lageos)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_6cea9609189e66c728d0a04b906225bde206b445cf183f0bbe0ca2e06ad2e7de').toggle(); "><b>Förste, C. et al, 2008
+</b></div>
+        <div id="ref_6cea9609189e66c728d0a04b906225bde206b445cf183f0bbe0ca2e06ad2e7de" class="mt-1" style="display:none">Förste, C., Schmidt, R., Stubenvoll, R., Flechtner, F., Meyer, U., König, R., Neumayer, H., Biancale, R., Lemoine, J.-M., Bruinsma, S., Loyer, S., Barthelmes, F., Esselborn, S. 2008:<br>
+<b>The GeoForschungsZentrum Potsdam / Groupe de Recherche de Géodésie Spatiale satellite-only and combined gravity field models: EIGEN-GL04S1 and EIGEN-GL04C</b><br>
+Journal of Geodesy, 82, 6, 331-346. <a href="https://doi.org/10.1007/s00190-007-0183-8" target="_blank">https://doi.org/10.1007/s00190-007-0183-8</a></div>
+    </td>
+    <td>        <a href="/getmodel/gfc/6cea9609189e66c728d0a04b906225bde206b445cf183f0bbe0ca2e06ad2e7de/EIGEN-GL04S1.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/6cea9609189e66c728d0a04b906225bde206b445cf183f0bbe0ca2e06ad2e7de/EIGEN-GL04S1.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=6cea9609189e66c728d0a04b906225bde206b445cf183f0bbe0ca2e06ad2e7de" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=6cea9609189e66c728d0a04b906225bde206b445cf183f0bbe0ca2e06ad2e7de" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>99</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="https://gfzpublic.gfz.de/rest/items/item_236437_5/component/file_236436/content" target="_blank">EIGEN-GL04C</a>
+</td>
+    <td>2006</td>
+    <td>        360
+</td>
+    <td>            A,             G,             S(Grace),             S(Lageos)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_34e80bcb3c40498b7bd3735e3511d70ce82106acb84d41f03ee3677da4f59af0').toggle(); "><b>Förste, C. et al, 2008
+</b></div>
+        <div id="ref_34e80bcb3c40498b7bd3735e3511d70ce82106acb84d41f03ee3677da4f59af0" class="mt-1" style="display:none">Förste, C., Schmidt, R., Stubenvoll, R., Flechtner, F., Meyer, U., König, R., Neumayer, H., Biancale, R., Lemoine, J.-M., Bruinsma, S., Loyer, S., Barthelmes, F., Esselborn, S. 2008:<br>
+<b>The GeoForschungsZentrum Potsdam / Groupe de Recherche de Géodésie Spatiale satellite-only and combined gravity field models: EIGEN-GL04S1 and EIGEN-GL04C</b><br>
+Journal of Geodesy, 82, 6, 331-346. <a href="https://doi.org/10.1007/s00190-007-0183-8" target="_blank">https://doi.org/10.1007/s00190-007-0183-8</a></div>
+    </td>
+    <td>        <a href="/getmodel/gfc/34e80bcb3c40498b7bd3735e3511d70ce82106acb84d41f03ee3677da4f59af0/EIGEN-GL04C.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/34e80bcb3c40498b7bd3735e3511d70ce82106acb84d41f03ee3677da4f59af0/EIGEN-GL04C.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=34e80bcb3c40498b7bd3735e3511d70ce82106acb84d41f03ee3677da4f59af0" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=34e80bcb3c40498b7bd3735e3511d70ce82106acb84d41f03ee3677da4f59af0" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>98</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="/getmodel/doc/4005ed898a508916c78bdedaef6571427e1c13860594097e5f42ef5c2da2a55e" target="_blank">EIGEN-CG03C</a>
+</td>
+    <td>2005</td>
+    <td>        360
+</td>
+    <td>            A,             G,             S(Champ),             S(Grace)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_4005ed898a508916c78bdedaef6571427e1c13860594097e5f42ef5c2da2a55e').toggle(); "><b>        Förste, C. et al,
+    2005
+</b></div>
+        <div id="ref_4005ed898a508916c78bdedaef6571427e1c13860594097e5f42ef5c2da2a55e" class="mt-1" style="display:none">        Förste, C., Flechtner, F., Schmidt, R., Meyer, U., Stubenvoll, R., Barthelmes, F., König, R., Neumayer, K.H., Rothacher, M., Reigber, C., Biancale, R., Bruinsma, S.L., Lemoine, J.M., Raimondo, J.C.;<br>
+    <b>A New High Resolution Global Gravity Field Model Derived From Combination of GRACE and CHAMP Mission and Altimetry/Gravimetry Surface Gravity Data;</b>
+    <br>
+        Poster presented at EGU General Assembly 2005, Vienna, Austria, 24-29 April 2005,
+        Vienna, Austria,
+    2005
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/4005ed898a508916c78bdedaef6571427e1c13860594097e5f42ef5c2da2a55e/EIGEN-CG03C.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/4005ed898a508916c78bdedaef6571427e1c13860594097e5f42ef5c2da2a55e/EIGEN-CG03C.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=4005ed898a508916c78bdedaef6571427e1c13860594097e5f42ef5c2da2a55e" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=4005ed898a508916c78bdedaef6571427e1c13860594097e5f42ef5c2da2a55e" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>97</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="http://www.csr.utexas.edu/grace/gravity/" target="_blank">GGM02C</a>
+</td>
+    <td>2004</td>
+    <td>        200
+</td>
+    <td>            A,             G,             S(Grace)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_7656b79145d344c300815c46e82b1c47c49c8afc5393e178d2d8dec8c325be04').toggle(); "><b>        Tapley, B. et al,
+    2005
+</b></div>
+        <div id="ref_7656b79145d344c300815c46e82b1c47c49c8afc5393e178d2d8dec8c325be04" class="mt-1" style="display:none">
+        Tapley, B., Ries, J., Bettadpur, S., Chambers, D., Cheng, M., Condi, F., Gunter, B., Kang, Z., Nagel, P., Pastor, R., Pekker, T., Poole, S., Wang, F.;<br>
+    <b>GGM02 – An improved Earth gravity field model from GRACE;</b>
+    <br>
+        Journal of Geodesy,
+            Vol 79,
+            No. 8,
+            p. 467-478,
+        doi: <a href="http://doi.org/10.1007/s00190-005-0480-z" target="_blank">10.1007/s00190-005-0480-z</a>,
+    2005
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/7656b79145d344c300815c46e82b1c47c49c8afc5393e178d2d8dec8c325be04/GGM02C.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/7656b79145d344c300815c46e82b1c47c49c8afc5393e178d2d8dec8c325be04/GGM02C.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=7656b79145d344c300815c46e82b1c47c49c8afc5393e178d2d8dec8c325be04" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=7656b79145d344c300815c46e82b1c47c49c8afc5393e178d2d8dec8c325be04" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>96</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="http://www.csr.utexas.edu/grace/gravity/" target="_blank">GGM02S</a>
+</td>
+    <td>2004</td>
+    <td>        160
+</td>
+    <td>        S(Grace)
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_36ae01cbc2a7338d2884d11b897e1bec8003a1968254da2a1430f1ab1560daee').toggle(); "><b>        Tapley, B. et al,
+    2005
+</b></div>
+        <div id="ref_36ae01cbc2a7338d2884d11b897e1bec8003a1968254da2a1430f1ab1560daee" class="mt-1" style="display:none">
+        Tapley, B., Ries, J., Bettadpur, S., Chambers, D., Cheng, M., Condi, F., Gunter, B., Kang, Z., Nagel, P., Pastor, R., Pekker, T., Poole, S., Wang, F.;<br>
+    <b>GGM02 – An improved Earth gravity field model from GRACE;</b>
+    <br>
+        Journal of Geodesy,
+            Vol 79,
+            No. 8,
+            p. 467-478,
+        doi: <a href="http://doi.org/10.1007/s00190-005-0480-z" target="_blank">10.1007/s00190-005-0480-z</a>,
+    2005
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/36ae01cbc2a7338d2884d11b897e1bec8003a1968254da2a1430f1ab1560daee/GGM02S.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/36ae01cbc2a7338d2884d11b897e1bec8003a1968254da2a1430f1ab1560daee/GGM02S.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=36ae01cbc2a7338d2884d11b897e1bec8003a1968254da2a1430f1ab1560daee" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=36ae01cbc2a7338d2884d11b897e1bec8003a1968254da2a1430f1ab1560daee" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>95</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="http://op.gfz-potsdam.de/grace/results/" target="_blank">EIGEN-CG01C</a>
+</td>
+    <td>2004</td>
+    <td>        360
+</td>
+    <td>            A,             G,             S(Champ),             S(Grace)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_1bf59ea6b930bcdb5cce02986b1fdc175fb746b1dec2a56a815d1f7d6edb3876').toggle(); "><b>        Reigber, C. et al,
+    2006
+</b></div>
+        <div id="ref_1bf59ea6b930bcdb5cce02986b1fdc175fb746b1dec2a56a815d1f7d6edb3876" class="mt-1" style="display:none">
+        Reigber, C., Schwintzer, P., Stubenvoll, R., Schmidt, R., Flechtner, F., Meyer, U., König, R., Neumayer, K.H., Förste, C., Barthelmes, F., Zhu, S.Y., Balmino, G., Biancale, R., Lemoine, J.M., Meixner, H., Raimondo, J.C., GeoForschungsZentrum Potsdam (GFZ);<br>
+    <b>A High Resolution Global Gravity Field Model Combining CHAMP and GRACE Satellite Mission and Surface Data: EIGEN-CG01C;</b>
+    <br>
+        doi: <a href="http://doi.org/10.2312/GFZ.b103-06075" target="_blank">10.2312/GFZ.b103-06075</a>,
+        Potsdam,
+    2006
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/1bf59ea6b930bcdb5cce02986b1fdc175fb746b1dec2a56a815d1f7d6edb3876/EIGEN-CG01C.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/1bf59ea6b930bcdb5cce02986b1fdc175fb746b1dec2a56a815d1f7d6edb3876/EIGEN-CG01C.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=1bf59ea6b930bcdb5cce02986b1fdc175fb746b1dec2a56a815d1f7d6edb3876" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=1bf59ea6b930bcdb5cce02986b1fdc175fb746b1dec2a56a815d1f7d6edb3876" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>94</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="http://www.gfz-potsdam.de/champ/results/index_RESULTS.html" target="_blank">EIGEN-CHAMP03S</a>
+</td>
+    <td>2004</td>
+    <td>        140
+</td>
+    <td>        S(Champ)
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_1b7deafee195bae7ba1273199823b9f1ae2f0d6d506b7858b5f72a9f93e5dc24').toggle(); "><b>        Reigber, C. et al,
+    2004
+</b></div>
+        <div id="ref_1b7deafee195bae7ba1273199823b9f1ae2f0d6d506b7858b5f72a9f93e5dc24" class="mt-1" style="display:none">
+        Reigber, C., Jochmann, H., Wünsch, J., Petrovic, S., Schwintzer, P., Barthelmes, F., Neumayer, K.H., König, R., Förste, C., Balmino, G., Biancale, R., Lemoine, J.M., Loyer, S., Perosanz, F., Reigber, C., Lühr, H., Schwintzer, P., Wickert, J.;<br>
+    <b>Earth Gravity Field and Seasonal Variability from CHAMP;</b>
+    <br>
+        Springer,
+            p. 25-30,
+        doi: <a href="http://doi.org/10.1007/3-540-26800-6_4" target="_blank">10.1007/3-540-26800-6_4</a>,
+        Berlin,
+    2004
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/1b7deafee195bae7ba1273199823b9f1ae2f0d6d506b7858b5f72a9f93e5dc24/EIGEN-CHAMP03S.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/1b7deafee195bae7ba1273199823b9f1ae2f0d6d506b7858b5f72a9f93e5dc24/EIGEN-CHAMP03S.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=1b7deafee195bae7ba1273199823b9f1ae2f0d6d506b7858b5f72a9f93e5dc24" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=1b7deafee195bae7ba1273199823b9f1ae2f0d6d506b7858b5f72a9f93e5dc24" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>93</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="http://op.gfz-potsdam.de/grace/results/" target="_blank">EIGEN-GRACE02S</a>
+</td>
+    <td>2004</td>
+    <td>        150
+</td>
+    <td>        S(Grace)
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_0f050448f497886f4aee9f3c1cb337ab31a174ce2d00e1fee299255db83ef49f').toggle(); "><b>        Reigber, Christoph et al,
+    2005
+</b></div>
+        <div id="ref_0f050448f497886f4aee9f3c1cb337ab31a174ce2d00e1fee299255db83ef49f" class="mt-1" style="display:none">
+        Reigber, Christoph, Schmidt, Roland, Flechtner, Frank, König, Rolf, Meyer, Ulrich, Neumayer, Karl-Hans, Schwintzer, Peter, Zhu, Sheng Yuan;<br>
+    <b>An Earth gravity field model complete to degree and order 150 from GRACE: EIGEN-GRACE02S;</b>
+    <br>
+        Journal of Geodynamics,
+            Vol 39,
+            No. 1,
+            p. 1-10,
+        doi: <a href="http://doi.org/10.1016/j.jog.2004.07.001" target="_blank">10.1016/j.jog.2004.07.001</a>,
+    2005
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/0f050448f497886f4aee9f3c1cb337ab31a174ce2d00e1fee299255db83ef49f/EIGEN-GRACE02S.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/0f050448f497886f4aee9f3c1cb337ab31a174ce2d00e1fee299255db83ef49f/EIGEN-GRACE02S.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=0f050448f497886f4aee9f3c1cb337ab31a174ce2d00e1fee299255db83ef49f" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=0f050448f497886f4aee9f3c1cb337ab31a174ce2d00e1fee299255db83ef49f" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>92</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        TUM-2S
+</td>
+    <td>2004</td>
+    <td>        60
+</td>
+    <td>        S(Champ)
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_7821fcb32fc5ad5202352789d8c92562ffad95c9bd9c13429ca29c66ecba5238').toggle(); "><b>        Wermuth, M. et al,
+    2004
+</b></div>
+        <div id="ref_7821fcb32fc5ad5202352789d8c92562ffad95c9bd9c13429ca29c66ecba5238" class="mt-1" style="display:none">
+        Wermuth, M., Svehla, D., Földvary, L., Gerlach, C., Gruber, T., Frommknecht, B., Peters, T., Rothacher, M., Rummel, R., Steigenberger, P.;<br>
+    <b>A gravity field model from two years of CHAMP kinematic orbits using the energy balance approach;</b>
+    <br>
+        Nice/France,
+    2004
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/7821fcb32fc5ad5202352789d8c92562ffad95c9bd9c13429ca29c66ecba5238/TUM-2S.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/7821fcb32fc5ad5202352789d8c92562ffad95c9bd9c13429ca29c66ecba5238/TUM-2S.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=7821fcb32fc5ad5202352789d8c92562ffad95c9bd9c13429ca29c66ecba5238" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=7821fcb32fc5ad5202352789d8c92562ffad95c9bd9c13429ca29c66ecba5238" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>91</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        DEOS_CHAMP-01C
+</td>
+    <td>2004</td>
+    <td>        70
+</td>
+    <td>        S(Champ)
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_3c9e9a6052f3b8e0377691ed3c94217b1a9199ae80f1047d22d74b8cdf8f1531').toggle(); "><b>        Ditmar, P. et al,
+    2005
+</b></div>
+        <div id="ref_3c9e9a6052f3b8e0377691ed3c94217b1a9199ae80f1047d22d74b8cdf8f1531" class="mt-1" style="display:none">
+        Ditmar, P., Kuznetsov, V., van der Sluijs, A. A. van Eck, Schrama, E., Klees, R.;<br>
+    <b>‘DEOS_CHAMP-01C_70’: a model of the Earth’s gravity field computed from accelerations of the CHAMP satellite;</b>
+    <br>
+        Journal of Geodesy,
+            Vol 79,
+            No. 10-11,
+            p. 586-601,
+        doi: <a href="http://doi.org/10.1007/s00190-005-0008-6" target="_blank">10.1007/s00190-005-0008-6</a>,
+    2005
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/3c9e9a6052f3b8e0377691ed3c94217b1a9199ae80f1047d22d74b8cdf8f1531/DEOS_CHAMP-01C.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/3c9e9a6052f3b8e0377691ed3c94217b1a9199ae80f1047d22d74b8cdf8f1531/DEOS_CHAMP-01C.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=3c9e9a6052f3b8e0377691ed3c94217b1a9199ae80f1047d22d74b8cdf8f1531" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=3c9e9a6052f3b8e0377691ed3c94217b1a9199ae80f1047d22d74b8cdf8f1531" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>90</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="http://www.igg.uni-bonn.de/apmg/index.php?id=gravitationsfeldmodelle" target="_blank">ITG_Champ01K</a>
+</td>
+    <td>2003</td>
+    <td>        70
+</td>
+    <td>        S(Champ)
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_77fbe879a8910171df42ffeff96cd1b4b6a46bf942850355840faebda7d99391').toggle(); "><b>        Ilk, K.H. et al,
+    2005
+</b></div>
+        <div id="ref_77fbe879a8910171df42ffeff96cd1b4b6a46bf942850355840faebda7d99391" class="mt-1" style="display:none">
+        Ilk, K.H., Mayer-Gürr, T., Feuchtinger, M., Reigber, C., Lühr, H., Schwintzer, P., Wickert, J.;<br>
+    <b>Gravity Field Recovery by Analysis of Short Arcs of CHAMP;</b>
+    <br>
+        Springer Berlin-Heidelberg,
+            p. 127-132,
+        doi: <a href="http://doi.org/10.1007/3-540-26800-6_20" target="_blank">10.1007/3-540-26800-6_20</a>,
+    2005
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/77fbe879a8910171df42ffeff96cd1b4b6a46bf942850355840faebda7d99391/ITG_Champ01K.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/77fbe879a8910171df42ffeff96cd1b4b6a46bf942850355840faebda7d99391/ITG_Champ01K.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=77fbe879a8910171df42ffeff96cd1b4b6a46bf942850355840faebda7d99391" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=77fbe879a8910171df42ffeff96cd1b4b6a46bf942850355840faebda7d99391" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>89</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="http://www.igg.uni-bonn.de/apmg/index.php?id=gravitationsfeldmodelle" target="_blank">ITG_Champ01S</a>
+</td>
+    <td>2003</td>
+    <td>        70
+</td>
+    <td>        S(Champ)
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_cf7734d6928dea5d744d6c7e2981ab792a45fa1b82a740faad2ae526299c60f3').toggle(); "><b>        Ilk, K.H. et al,
+    2005
+</b></div>
+        <div id="ref_cf7734d6928dea5d744d6c7e2981ab792a45fa1b82a740faad2ae526299c60f3" class="mt-1" style="display:none">
+        Ilk, K.H., Mayer-Gürr, T., Feuchtinger, M., Reigber, C., Lühr, H., Schwintzer, P., Wickert, J.;<br>
+    <b>Gravity Field Recovery by Analysis of Short Arcs of CHAMP;</b>
+    <br>
+        Springer Berlin-Heidelberg,
+            p. 127-132,
+        doi: <a href="http://doi.org/10.1007/3-540-26800-6_20" target="_blank">10.1007/3-540-26800-6_20</a>,
+    2005
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/cf7734d6928dea5d744d6c7e2981ab792a45fa1b82a740faad2ae526299c60f3/ITG_Champ01S.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/cf7734d6928dea5d744d6c7e2981ab792a45fa1b82a740faad2ae526299c60f3/ITG_Champ01S.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=cf7734d6928dea5d744d6c7e2981ab792a45fa1b82a740faad2ae526299c60f3" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=cf7734d6928dea5d744d6c7e2981ab792a45fa1b82a740faad2ae526299c60f3" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>88</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="http://www.igg.uni-bonn.de/apmg/index.php?id=gravitationsfeldmodelle" target="_blank">ITG_Champ01E</a>
+</td>
+    <td>2003</td>
+    <td>        75
+</td>
+    <td>        S(Champ)
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_9809c3c914c40cee609641e24f11318110852a7f2f33fe2881526cfd3ddce406').toggle(); "><b>        Ilk, K.H. et al,
+    2005
+</b></div>
+        <div id="ref_9809c3c914c40cee609641e24f11318110852a7f2f33fe2881526cfd3ddce406" class="mt-1" style="display:none">
+        Ilk, K.H., Mayer-Gürr, T., Feuchtinger, M., Reigber, C., Lühr, H., Schwintzer, P., Wickert, J.;<br>
+    <b>Gravity Field Recovery by Analysis of Short Arcs of CHAMP;</b>
+    <br>
+        Springer Berlin-Heidelberg,
+            p. 127-132,
+        doi: <a href="http://doi.org/10.1007/3-540-26800-6_20" target="_blank">10.1007/3-540-26800-6_20</a>,
+    2005
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/9809c3c914c40cee609641e24f11318110852a7f2f33fe2881526cfd3ddce406/ITG_Champ01E.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/9809c3c914c40cee609641e24f11318110852a7f2f33fe2881526cfd3ddce406/ITG_Champ01E.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=9809c3c914c40cee609641e24f11318110852a7f2f33fe2881526cfd3ddce406" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=9809c3c914c40cee609641e24f11318110852a7f2f33fe2881526cfd3ddce406" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>87</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        TUM-2Sp
+</td>
+    <td>2003</td>
+    <td>        60
+</td>
+    <td>        S(Champ)
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_8fceacf15f4ea0d86d774749d150a50c3ce3827d6c7e594a4803cbab2b65f895').toggle(); "><b>        Földváry, Lóránt et al,
+    2005
+</b></div>
+        <div id="ref_8fceacf15f4ea0d86d774749d150a50c3ce3827d6c7e594a4803cbab2b65f895" class="mt-1" style="display:none">
+        Földváry, Lóránt, Švehla, Dražen, Gerlach, Christian, Wermuth, Martin, Gruber, Thomas, Rummel, Reiner, Rothacher, Markus, Frommknecht, Björn, Peters, Thomas, Steigenberger, Peter, Reigber, C., Lühr, H., Schwintzer, P., Wickert, J.;<br>
+    <b>Gravity Model TUM-2Sp Based on the Energy Balance Approach and Kinematic CHAMP Orbits;</b>
+    <br>
+        Springer Berlin-Heidelberg,
+            p. 13-18,
+        doi: <a href="http://doi.org/10.1007/3-540-26800-6_2" target="_blank">10.1007/3-540-26800-6_2</a>,
+    2005
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/8fceacf15f4ea0d86d774749d150a50c3ce3827d6c7e594a4803cbab2b65f895/TUM-2Sp.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/8fceacf15f4ea0d86d774749d150a50c3ce3827d6c7e594a4803cbab2b65f895/TUM-2Sp.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=8fceacf15f4ea0d86d774749d150a50c3ce3827d6c7e594a4803cbab2b65f895" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=8fceacf15f4ea0d86d774749d150a50c3ce3827d6c7e594a4803cbab2b65f895" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>86</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        TUM-1S
+</td>
+    <td>2003</td>
+    <td>        60
+</td>
+    <td>        S(Champ)
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_c1623d1a059f19782d10135c6ffb6426a38a37570559b2ccd3bb75677805d3d8').toggle(); "><b>        Gerlach, Ch et al,
+    2003
+</b></div>
+        <div id="ref_c1623d1a059f19782d10135c6ffb6426a38a37570559b2ccd3bb75677805d3d8" class="mt-1" style="display:none">
+        Gerlach, Ch, Földvary, L., Švehla, D., Gruber, Th, Wermuth, M., Sneeuw, N., Frommknecht, B., Oberndorfer, H., Peters, Th, Rothacher, M., Rummel, R., Steigenberger, P.;<br>
+    <b>A CHAMP-only gravity field model from kinematic orbits using the energy integral;</b>
+    <br>
+        Geophysical Research Letters,
+            Vol 30,
+            No. 20,
+        doi: <a href="http://doi.org/10.1029/2003gl018025" target="_blank">10.1029/2003gl018025</a>,
+    2003
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/c1623d1a059f19782d10135c6ffb6426a38a37570559b2ccd3bb75677805d3d8/TUM-1S.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/c1623d1a059f19782d10135c6ffb6426a38a37570559b2ccd3bb75677805d3d8/TUM-1S.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=c1623d1a059f19782d10135c6ffb6426a38a37570559b2ccd3bb75677805d3d8" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=c1623d1a059f19782d10135c6ffb6426a38a37570559b2ccd3bb75677805d3d8" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>85</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="http://www.csr.utexas.edu/grace/gravity/" target="_blank">GGM01C</a>
+</td>
+    <td>2003</td>
+    <td>        200
+</td>
+    <td>            S(Grace),             TEG4</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_847bf1ca0a9f53ec3bd6e05c0a720bd447c32e158e0a8175aea6e2ca6bbf6277').toggle(); "><b>        Tapley, B. D. et al,
+    2004
+</b></div>
+        <div id="ref_847bf1ca0a9f53ec3bd6e05c0a720bd447c32e158e0a8175aea6e2ca6bbf6277" class="mt-1" style="display:none">
+        Tapley, B. D., Bettadpur, S., Watkins, M., Reigber, C.;<br>
+    <b>The gravity recovery and climate experiment: Mission overview and early results;</b>
+    <br>
+        Geophysical Research Letters,
+            Vol 31,
+            No. 9,
+            p. n/a-n/a,
+        doi: <a href="http://doi.org/10.1029/2004gl019920" target="_blank">10.1029/2004gl019920</a>,
+    2004
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/847bf1ca0a9f53ec3bd6e05c0a720bd447c32e158e0a8175aea6e2ca6bbf6277/GGM01C.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/847bf1ca0a9f53ec3bd6e05c0a720bd447c32e158e0a8175aea6e2ca6bbf6277/GGM01C.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=847bf1ca0a9f53ec3bd6e05c0a720bd447c32e158e0a8175aea6e2ca6bbf6277" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=847bf1ca0a9f53ec3bd6e05c0a720bd447c32e158e0a8175aea6e2ca6bbf6277" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>84</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="http://www.csr.utexas.edu/grace/gravity/" target="_blank">GGM01S</a>
+</td>
+    <td>2003</td>
+    <td>        120
+</td>
+    <td>        S(Grace)
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_6766f3700482c1c1ff200dbbe135e2ff29a763fe74b87b59177267a6615a1371').toggle(); "><b>        Tapley, B. D. et al,
+    2003
+</b></div>
+        <div id="ref_6766f3700482c1c1ff200dbbe135e2ff29a763fe74b87b59177267a6615a1371" class="mt-1" style="display:none">
+        Tapley, B. D., Chambers, D. P., Bettadpur, S., Ries, J. C.;<br>
+    <b>Large scale ocean circulation from the GRACE GGM01 Geoid;</b>
+    <br>
+        Geophysical Research Letters,
+            Vol 30,
+            No. 22,
+        doi: <a href="http://doi.org/10.1029/2003gl018622" target="_blank">10.1029/2003gl018622</a>,
+    2003
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/6766f3700482c1c1ff200dbbe135e2ff29a763fe74b87b59177267a6615a1371/GGM01S.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/6766f3700482c1c1ff200dbbe135e2ff29a763fe74b87b59177267a6615a1371/GGM01S.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=6766f3700482c1c1ff200dbbe135e2ff29a763fe74b87b59177267a6615a1371" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=6766f3700482c1c1ff200dbbe135e2ff29a763fe74b87b59177267a6615a1371" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>83</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        EIGEN-GRACE01S
+</td>
+    <td>2003</td>
+    <td>        140
+</td>
+    <td>            S(Grace)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_a4eedec090a3eb6067a0f0f22f4f73f776249470bb64ea68f1bae809e39cd2b8').toggle(); "><b>        Reigber, C. et al,
+    2003
+</b></div>
+        <div id="ref_a4eedec090a3eb6067a0f0f22f4f73f776249470bb64ea68f1bae809e39cd2b8" class="mt-1" style="display:none">        Reigber, C., Schmidt, R., Flechtner, F., König, R., Meyer, U., Neumayer, K.H., Schwintzer, P., Zhu, S.Y.;<br>
+    <b>First EIGEN Gravity Field Model based on GRACE Mission Data Only;</b>
+    <br>
+        (in preparation for GRL) 2003c,
+    2003
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/a4eedec090a3eb6067a0f0f22f4f73f776249470bb64ea68f1bae809e39cd2b8/EIGEN-GRACE01S.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/a4eedec090a3eb6067a0f0f22f4f73f776249470bb64ea68f1bae809e39cd2b8/EIGEN-GRACE01S.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=a4eedec090a3eb6067a0f0f22f4f73f776249470bb64ea68f1bae809e39cd2b8" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=a4eedec090a3eb6067a0f0f22f4f73f776249470bb64ea68f1bae809e39cd2b8" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>82</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        EIGEN-CHAMP03Sp
+</td>
+    <td>2003</td>
+    <td>        140
+</td>
+    <td>            S(Champ)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_0c5fe7c7ef3b0d47fab6348f8be22f7c8c5807c5f1cb28b04fb656bcabc93eb1').toggle(); "><b>        Reigber, C. et al,
+    2004
+</b></div>
+        <div id="ref_0c5fe7c7ef3b0d47fab6348f8be22f7c8c5807c5f1cb28b04fb656bcabc93eb1" class="mt-1" style="display:none">        Reigber, C., Jochmann, H., Wünsch, J., Petrovic, S., Schwintzer, P., Barthelmes, F., Neumayer, K.H., König, R., Förste, C., Balmino, G., Biancale, R., Lemoine, J.M., Loyer, S., Perosanz, F., Reigber, C., Lühr, H., Schwintzer, P., Wickert, J.;<br>
+    <b>Earth Gravity Field and Seasonal Variability from CHAMP;</b>
+    <br>
+        Springer,
+            p. 25-30,
+        doi: <a href="http://doi.org/10.1007/3-540-26800-6_4" target="_blank">10.1007/3-540-26800-6_4</a>,
+        Berlin,
+    2004
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/0c5fe7c7ef3b0d47fab6348f8be22f7c8c5807c5f1cb28b04fb656bcabc93eb1/EIGEN-CHAMP03Sp.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/0c5fe7c7ef3b0d47fab6348f8be22f7c8c5807c5f1cb28b04fb656bcabc93eb1/EIGEN-CHAMP03Sp.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=0c5fe7c7ef3b0d47fab6348f8be22f7c8c5807c5f1cb28b04fb656bcabc93eb1" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=0c5fe7c7ef3b0d47fab6348f8be22f7c8c5807c5f1cb28b04fb656bcabc93eb1" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>81</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        EIGEN-2
+</td>
+    <td>2003</td>
+    <td>        140
+</td>
+    <td>            S(Champ)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_4dbcdba7387ea4621f5306a55e91f82e346242791f23a4912b18fc40effdca4e').toggle(); "><b>        Reigber, C. et al,
+    2003
+</b></div>
+        <div id="ref_4dbcdba7387ea4621f5306a55e91f82e346242791f23a4912b18fc40effdca4e" class="mt-1" style="display:none">        Reigber, C., Schwintzer, P., Neumayer, K. H., Barthelmes, F., König, R., Förste, C., Balmino, G., Biancale, R., Lemoine, J. M., Loyer, S., Bruinsma, S., Perosanz, F., Fayard, T.;<br>
+    <b>The CHAMP-only earth gravity field model EIGEN-2;</b>
+    <br>
+        Advances in Space Research,
+            Vol 31,
+            No. 8,
+            p. 1883-1888,
+        doi: <a href="http://doi.org/10.1016/s0273-1177(03)00162-5" target="_blank">10.1016/s0273-1177(03)00162-5</a>,
+    2003
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/4dbcdba7387ea4621f5306a55e91f82e346242791f23a4912b18fc40effdca4e/EIGEN-2.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/4dbcdba7387ea4621f5306a55e91f82e346242791f23a4912b18fc40effdca4e/EIGEN-2.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=4dbcdba7387ea4621f5306a55e91f82e346242791f23a4912b18fc40effdca4e" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=4dbcdba7387ea4621f5306a55e91f82e346242791f23a4912b18fc40effdca4e" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>80</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        EIGEN-1
+</td>
+    <td>2002</td>
+    <td>        119
+</td>
+    <td>            S(Champ)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_a7c3a5964fc24e0ba21759774c4e51fb08d4ac16aae89d6b7c66384dcb1f15da').toggle(); "><b>        Reigber, C. et al,
+    2003
+</b></div>
+        <div id="ref_a7c3a5964fc24e0ba21759774c4e51fb08d4ac16aae89d6b7c66384dcb1f15da" class="mt-1" style="display:none">        Reigber, C., Balmino, G., Schwintzer, P., Biancale, R., Bode, A., Lemoine, J. M., Konig, R., Loyer, S., Neumayer, H., Marty, J. C., Barthelmes, F., Perosanz, F., Zhu, S. Y.;<br>
+    <b>Global gravity field recovery using solely GPS tracking and accelerometer data from CHAMP;</b>
+    <br>
+        Space Science Reviews,
+            Vol 108,
+            No. 1-2,
+            p. 55-66,
+        doi: <a href="http://doi.org/Doi 10.1023/A:1026217713133" target="_blank">Doi 10.1023/A:1026217713133</a>,
+    2003
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/a7c3a5964fc24e0ba21759774c4e51fb08d4ac16aae89d6b7c66384dcb1f15da/EIGEN-1.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/a7c3a5964fc24e0ba21759774c4e51fb08d4ac16aae89d6b7c66384dcb1f15da/EIGEN-1.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=a7c3a5964fc24e0ba21759774c4e51fb08d4ac16aae89d6b7c66384dcb1f15da" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=a7c3a5964fc24e0ba21759774c4e51fb08d4ac16aae89d6b7c66384dcb1f15da" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>79</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        EIGEN-1s
+</td>
+    <td>2002</td>
+    <td>        119
+</td>
+    <td>            GRIM5,             S</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_ea767cd71d4326f6c8bb8bdc2db58fa7f0a9bbd5853a4a360c0a649979c23027').toggle(); "><b>        Reigber, Christoph et al,
+    2002
+</b></div>
+        <div id="ref_ea767cd71d4326f6c8bb8bdc2db58fa7f0a9bbd5853a4a360c0a649979c23027" class="mt-1" style="display:none">        Reigber, Christoph, Balmino, Georges, Schwintzer, Peter, Biancale, Richard, Bode, Albert, Lemoine, Jean-Michel, König, Rolf, Loyer, Sylvain, Neumayer, Hans, Marty, Jean-Charles, Barthelmes, Franz, Perosanz, Felix, Zhu, Shen Yuan;<br>
+    <b>A high-quality global gravity field model from CHAMP GPS tracking data and accelerometry (EIGEN-1S);</b>
+    <br>
+        Geophysical Research Letters,
+            Vol 29,
+            No. 14,
+            p. 37-1-37-4,
+        doi: <a href="http://doi.org/10.1029/2002gl015064" target="_blank">10.1029/2002gl015064</a>,
+    2002
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/ea767cd71d4326f6c8bb8bdc2db58fa7f0a9bbd5853a4a360c0a649979c23027/EIGEN-1s.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/ea767cd71d4326f6c8bb8bdc2db58fa7f0a9bbd5853a4a360c0a649979c23027/EIGEN-1s.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=ea767cd71d4326f6c8bb8bdc2db58fa7f0a9bbd5853a4a360c0a649979c23027" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=ea767cd71d4326f6c8bb8bdc2db58fa7f0a9bbd5853a4a360c0a649979c23027" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>78</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="http://bowie.gsfc.nasa.gov/926/PGM2000A/index.html" target="_blank">PGM2000a</a>
+</td>
+    <td>2000</td>
+    <td>        360
+</td>
+    <td>            A,             G,             S</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_7b3892a214fa7903bb92a6a0a5df099bd660e347c54d2bb14ac8f83ea706c88c').toggle(); "><b>        Pavlis, N.K. et al,
+    2000
+</b></div>
+        <div id="ref_7b3892a214fa7903bb92a6a0a5df099bd660e347c54d2bb14ac8f83ea706c88c" class="mt-1" style="display:none">
+        Pavlis, N.K., Chinn, D.S., Cox, C.M., Lemoine, F.G.;<br>
+    <b>Geopotential Model Improvement Using POCM_4B Dynamic Ocean Topography Information: PGM2000A;</b>
+    <br>
+        Miami, Florida, USA,
+    2000
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/7b3892a214fa7903bb92a6a0a5df099bd660e347c54d2bb14ac8f83ea706c88c/PGM2000a.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/7b3892a214fa7903bb92a6a0a5df099bd660e347c54d2bb14ac8f83ea706c88c/PGM2000a.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=7b3892a214fa7903bb92a6a0a5df099bd660e347c54d2bb14ac8f83ea706c88c" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=7b3892a214fa7903bb92a6a0a5df099bd660e347c54d2bb14ac8f83ea706c88c" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>77</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        TEG4
+</td>
+    <td>2000</td>
+    <td>        200
+</td>
+    <td>            A,             G,             S</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_4e2d8cd72b3f4f1238c10ab859203a1d70bf1c6a6d3719d7e4f32e572c9c3e32').toggle(); "><b>        Tapley, B.D. et al,
+    2000
+</b></div>
+        <div id="ref_4e2d8cd72b3f4f1238c10ab859203a1d70bf1c6a6d3719d7e4f32e572c9c3e32" class="mt-1" style="display:none">
+        Tapley, B.D., Chambers, D.P., Cheng, M.K., Kim, M.C., Poole, S.R., Ries, J.C.;<br>
+    <b>The TEG-4 Earth Gravity Field Model;</b>
+    <br>
+        Nice, France,
+    2000
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/4e2d8cd72b3f4f1238c10ab859203a1d70bf1c6a6d3719d7e4f32e572c9c3e32/TEG4.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/4e2d8cd72b3f4f1238c10ab859203a1d70bf1c6a6d3719d7e4f32e572c9c3e32/TEG4.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=4e2d8cd72b3f4f1238c10ab859203a1d70bf1c6a6d3719d7e4f32e572c9c3e32" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=4e2d8cd72b3f4f1238c10ab859203a1d70bf1c6a6d3719d7e4f32e572c9c3e32" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>76</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        GRIM5c1
+</td>
+    <td>1999</td>
+    <td>        120
+</td>
+    <td>            A,             G,             S</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_80b4b93da67044f3dec1f393858943d2e88489e01a7c388d138448b6b8627c07').toggle(); "><b>        Gruber, T. et al,
+    1999
+</b></div>
+        <div id="ref_80b4b93da67044f3dec1f393858943d2e88489e01a7c388d138448b6b8627c07" class="mt-1" style="display:none">        Gruber, T., Reigber, C., Schwintzer, P.;<br>
+    <b>The 1999 GFZ pre-CHAMP high resolution gravity model;</b>
+    <br>
+        Springer Verlag,
+            Vol 121,
+            p. 89-95,
+        doi: <a href="http://doi.org/10.1007/978-3-642-59742-8_14" target="_blank">10.1007/978-3-642-59742-8_14</a>,
+        Birmingham,
+    1999
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/80b4b93da67044f3dec1f393858943d2e88489e01a7c388d138448b6b8627c07/GRIM5c1.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/80b4b93da67044f3dec1f393858943d2e88489e01a7c388d138448b6b8627c07/GRIM5c1.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=80b4b93da67044f3dec1f393858943d2e88489e01a7c388d138448b6b8627c07" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=80b4b93da67044f3dec1f393858943d2e88489e01a7c388d138448b6b8627c07" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>75</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        GRIM5s1
+</td>
+    <td>1999</td>
+    <td>        99
+</td>
+    <td>        S
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_3b1fe9e4419e55e5b664fa1f09f0997103d3569a54c5f7f78f6caf632af31d86').toggle(); "><b>        Biancale, R. et al,
+    2000
+</b></div>
+        <div id="ref_3b1fe9e4419e55e5b664fa1f09f0997103d3569a54c5f7f78f6caf632af31d86" class="mt-1" style="display:none">
+        Biancale, R., Balmino, G., Lemoine, J. M., Marty, J. C., Moynot, B., Barlier, F., Exertier, P., Laurain, O., Gegout, P., Schwintzer, P., Reigber, C., Bode, A., Konig, R., Massmann, F. H., Raimondo, J. C., Schmidt, R., Zhu, S. Y.;<br>
+    <b>A new global Earth's gravity field model from satellite orbit perturbations: GRIM5-S1;</b>
+    <br>
+        Geophysical Research Letters,
+            Vol 27,
+            No. 22,
+            p. 3611-3614,
+        doi: <a href="http://doi.org/10.1029/2000gl011721" target="_blank">10.1029/2000gl011721</a>,
+    2000
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/3b1fe9e4419e55e5b664fa1f09f0997103d3569a54c5f7f78f6caf632af31d86/GRIM5s1.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/3b1fe9e4419e55e5b664fa1f09f0997103d3569a54c5f7f78f6caf632af31d86/GRIM5s1.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=3b1fe9e4419e55e5b664fa1f09f0997103d3569a54c5f7f78f6caf632af31d86" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=3b1fe9e4419e55e5b664fa1f09f0997103d3569a54c5f7f78f6caf632af31d86" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>74</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        GRIM4S4G
+</td>
+    <td>1999</td>
+    <td>        70
+</td>
+    <td>            GRIM4S4,             S(GFZ-1)</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_c26268777120d71cf682e31a06d520503c29c3fb6600d2d0535487f63ca0b01d').toggle(); "><b>        König, R. et al,
+    1999
+</b></div>
+        <div id="ref_c26268777120d71cf682e31a06d520503c29c3fb6600d2d0535487f63ca0b01d" class="mt-1" style="display:none">
+        König, R., Chen, Z., Reigber, C., Schwintzer, P.;<br>
+    <b>Improvement in global gravity field recovery using GFZ-1 satellite laser tracking data;</b>
+    <br>
+        Journal of Geodesy,
+            Vol 73,
+            No. 8,
+            p. 398-406,
+        doi: <a href="http://doi.org/10.1007/s001900050259" target="_blank">10.1007/s001900050259</a>,
+    1999
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/c26268777120d71cf682e31a06d520503c29c3fb6600d2d0535487f63ca0b01d/GRIM4S4G.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/c26268777120d71cf682e31a06d520503c29c3fb6600d2d0535487f63ca0b01d/GRIM4S4G.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=c26268777120d71cf682e31a06d520503c29c3fb6600d2d0535487f63ca0b01d" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=c26268777120d71cf682e31a06d520503c29c3fb6600d2d0535487f63ca0b01d" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>73</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        GFZ97
+</td>
+    <td>1997</td>
+    <td>        359
+</td>
+    <td>            A,             G,             PGM062w</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_f48d76aca478540f70e4e3ff40a01ae883852ccb568ef29f1e2d241278db9417').toggle(); "><b>        Gruber, T. et al,
+    1997
+</b></div>
+        <div id="ref_f48d76aca478540f70e4e3ff40a01ae883852ccb568ef29f1e2d241278db9417" class="mt-1" style="display:none">
+        Gruber, T., Bode, A., Reigber, C., Schwintzer, P.;<br>
+    <b>DPAF Global Earth Models Based on ERS;</b>
+    <br>
+        ESTEC Publishing Division,
+        Florenz,
+    1997
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/f48d76aca478540f70e4e3ff40a01ae883852ccb568ef29f1e2d241278db9417/GFZ97.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/f48d76aca478540f70e4e3ff40a01ae883852ccb568ef29f1e2d241278db9417/GFZ97.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=f48d76aca478540f70e4e3ff40a01ae883852ccb568ef29f1e2d241278db9417" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=f48d76aca478540f70e4e3ff40a01ae883852ccb568ef29f1e2d241278db9417" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>72</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="http://cddis.nasa.gov/926/egm96/egm96.html/egm96.html" target="_blank">EGM96</a>
+</td>
+    <td>1996</td>
+    <td>        360
+</td>
+    <td>            A,             EGM96S,             G</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_971b0a3b49a497910aad23cd85e066d4cd9af0aeafe7ce6301a696bed8570be3').toggle(); "><b>        Lemoine, F.G. et al,
+    1998
+</b></div>
+        <div id="ref_971b0a3b49a497910aad23cd85e066d4cd9af0aeafe7ce6301a696bed8570be3" class="mt-1" style="display:none">        Lemoine, F.G., Kenyon, S.C., Factor, J.K., Trimmer, R.G., Pavlis, N.K., Chinn, D.S., Cox, C.M., Klosko, S.M., Luthcke, S.B., Torrence, M.H., Wang, Y.M., Williamson, R.G., Pavlis, E.C., Rapp, R.H., Olson, T.R., GSFC Goddard Space Flight Center;<br>
+    <b>The Development of the Joint NASA GSFC and the National IMagery and Mapping Agency (NIMA) Geopotential Model EGM96;</b>
+    <br>
+        Greenbelt, Md,
+    1998
+
+        doi: <a href="https://ntrs.nasa.gov/citations/19980218814"target="_blank">https://ntrs.nasa.gov/citations/19980218814
+</a>
+
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/971b0a3b49a497910aad23cd85e066d4cd9af0aeafe7ce6301a696bed8570be3/EGM96.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/971b0a3b49a497910aad23cd85e066d4cd9af0aeafe7ce6301a696bed8570be3/EGM96.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=971b0a3b49a497910aad23cd85e066d4cd9af0aeafe7ce6301a696bed8570be3" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=971b0a3b49a497910aad23cd85e066d4cd9af0aeafe7ce6301a696bed8570be3" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>71</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        GFZ96
+</td>
+    <td>1996</td>
+    <td>        359
+</td>
+    <td>            A,             G,             PGM055</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_4b9115a354863738e68b0e76bdb1c9948b39de5af7ec90d91eb5ac335f7f18ae').toggle(); "><b>        Gruber, Th. et al,
+    1996
+</b></div>
+        <div id="ref_4b9115a354863738e68b0e76bdb1c9948b39de5af7ec90d91eb5ac335f7f18ae" class="mt-1" style="display:none">
+        Gruber, Th., Anzenhofer, M., Rentsch, M., Schwintzer, P., Segawa, Fujimoto, Okubo;<br>
+    <b>Improvements in High Resolution Gravity Field Modeling at GFZ;</b>
+    <br>
+        Springer Verlag,
+            Vol 117,
+            p. 445-452,
+        doi: <a href="http://doi.org/10.1007/978-3-662-03482-8_60" target="_blank">10.1007/978-3-662-03482-8_60</a>,
+        Tokyo, Japan,
+    1996
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/4b9115a354863738e68b0e76bdb1c9948b39de5af7ec90d91eb5ac335f7f18ae/GFZ96.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/4b9115a354863738e68b0e76bdb1c9948b39de5af7ec90d91eb5ac335f7f18ae/GFZ96.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=4b9115a354863738e68b0e76bdb1c9948b39de5af7ec90d91eb5ac335f7f18ae" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=4b9115a354863738e68b0e76bdb1c9948b39de5af7ec90d91eb5ac335f7f18ae" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>70</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        TEG3
+</td>
+    <td>1996</td>
+    <td>        70
+</td>
+    <td>            A,             G,             S</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_bf24e145e388c8aed5fb9109d7c2f5c6409a85bfd8b22a8db027b980591033cb').toggle(); "><b>        Tapley, B.D. et al,
+    1997
+</b></div>
+        <div id="ref_bf24e145e388c8aed5fb9109d7c2f5c6409a85bfd8b22a8db027b980591033cb" class="mt-1" style="display:none">
+        Tapley, B.D., Shum, C.K., Ries, J.C., Poole, S.R., Abusali, P.A.M., Bettadpur, S.V., Eanes, R.J., Kim, M.C., Rim, H.J., Schutz, B.E., Segawa, J., Fujimoto, H., Okubo, S.;<br>
+    <b>The TEG-3 Geopotential Model;</b>
+    <br>
+        Springer Verlag,
+            Vol 117,
+            p. 453-460,
+        doi: <a href="http://doi.org/10.1007/978-3-662-03482-8_61" target="_blank">10.1007/978-3-662-03482-8_61</a>,
+        Tokyo, Japan,
+    1997
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/bf24e145e388c8aed5fb9109d7c2f5c6409a85bfd8b22a8db027b980591033cb/TEG3.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/bf24e145e388c8aed5fb9109d7c2f5c6409a85bfd8b22a8db027b980591033cb/TEG3.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=bf24e145e388c8aed5fb9109d7c2f5c6409a85bfd8b22a8db027b980591033cb" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=bf24e145e388c8aed5fb9109d7c2f5c6409a85bfd8b22a8db027b980591033cb" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>69</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        EGM96s
+</td>
+    <td>1996</td>
+    <td>        70
+</td>
+    <td>        S
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_0c8a799f3afc1bd14539b7b8be8892935490f67e6ad5e7765c8873ba0b5c6359').toggle(); "><b>        Lemoine, F.G. et al,
+    1998
+</b></div>
+        <div id="ref_0c8a799f3afc1bd14539b7b8be8892935490f67e6ad5e7765c8873ba0b5c6359" class="mt-1" style="display:none">
+        Lemoine, F.G., Kenyon, S.C., Factor, J.K., Trimmer, R.G., Pavlis, N.K., Chinn, D.S., Cox, C.M., Klosko, S.M., Luthcke, S.B., Torrence, M.H., Wang, Y.M., Williamson, R.G., Pavlis, E.C., Rapp, R.H., Olson, T.R., GSFC Goddard Space Flight Center;<br>
+    <b>The Development of the Joint NASA GSFC and the National IMagery and Mapping Agency (NIMA) Geopotential Model EGM96;</b>
+    <br>
+        Greenbelt, Md,
+    1998
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/0c8a799f3afc1bd14539b7b8be8892935490f67e6ad5e7765c8873ba0b5c6359/EGM96s.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/0c8a799f3afc1bd14539b7b8be8892935490f67e6ad5e7765c8873ba0b5c6359/EGM96s.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=0c8a799f3afc1bd14539b7b8be8892935490f67e6ad5e7765c8873ba0b5c6359" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=0c8a799f3afc1bd14539b7b8be8892935490f67e6ad5e7765c8873ba0b5c6359" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>68</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        GFZ95A
+</td>
+    <td>1995</td>
+    <td>        360
+</td>
+    <td>            A,             G,             GRIM4C4</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_d13a17c5fcc40068e289a39f063e72ed9b6872c797d8b5e230755b3b3baa480e').toggle(); "><b>        Gruber, Thomas et al,
+    1996
+</b></div>
+        <div id="ref_d13a17c5fcc40068e289a39f063e72ed9b6872c797d8b5e230755b3b3baa480e" class="mt-1" style="display:none">
+        Gruber, Thomas, Anzenhofer, Michael, Rentsch, Matthias, RappCazenaveNerem;<br>
+    <b>The 1995 GFZ High Resolution Gravity Model;</b>
+    <br>
+        Springer Verlag,
+            Vol 116,
+            p. 61-70,
+        doi: <a href="http://doi.org/10.1007/978-3-642-61140-7_7" target="_blank">10.1007/978-3-642-61140-7_7</a>,
+        Boulder, CO, USA,
+    1996
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/d13a17c5fcc40068e289a39f063e72ed9b6872c797d8b5e230755b3b3baa480e/GFZ95A.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/d13a17c5fcc40068e289a39f063e72ed9b6872c797d8b5e230755b3b3baa480e/GFZ95A.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=d13a17c5fcc40068e289a39f063e72ed9b6872c797d8b5e230755b3b3baa480e" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=d13a17c5fcc40068e289a39f063e72ed9b6872c797d8b5e230755b3b3baa480e" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>67</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="/getmodel/doc/65f5370ad1a6af82bb24ffb5ecb941166f86b2c2324677c900e58abb0a633686" target="_blank">GRIM4c4</a>
+</td>
+    <td>1995</td>
+    <td>        72
+</td>
+    <td>            A,             G,             S</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_65f5370ad1a6af82bb24ffb5ecb941166f86b2c2324677c900e58abb0a633686').toggle(); "><b>        Schwintzer, P. et al,
+    1997
+</b></div>
+        <div id="ref_65f5370ad1a6af82bb24ffb5ecb941166f86b2c2324677c900e58abb0a633686" class="mt-1" style="display:none">        Schwintzer, P., Reigber, C., Bode, A., Kang, Z., Zhu, S. Y., Massmann, F. H., Raimondo, J. C., Biancale, R., Balmino, G., Lemoine, J. M., Moynot, B., Marty, J. C., Boudon, Y., Barlier, F.;<br>
+    <b>Long-wavelength global gravity field models: GRIM4-S4, GRIM4-C4;</b>
+    <br>
+        Journal of Geodesy,
+            Vol 71,
+            No. 4,
+            p. 189-208,
+        doi: <a href="http://doi.org/10.1007/s001900050087" target="_blank">10.1007/s001900050087</a>,
+    1997
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/65f5370ad1a6af82bb24ffb5ecb941166f86b2c2324677c900e58abb0a633686/GRIM4c4.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/65f5370ad1a6af82bb24ffb5ecb941166f86b2c2324677c900e58abb0a633686/GRIM4c4.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=65f5370ad1a6af82bb24ffb5ecb941166f86b2c2324677c900e58abb0a633686" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=65f5370ad1a6af82bb24ffb5ecb941166f86b2c2324677c900e58abb0a633686" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>66</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="/getmodel/doc/1b188d842a81ab4c57cf92e449c8324960fbec154ae8316fac40689c59992e60" target="_blank">GRIM4s4</a>
+</td>
+    <td>1995</td>
+    <td>        70
+</td>
+    <td>            S</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_1b188d842a81ab4c57cf92e449c8324960fbec154ae8316fac40689c59992e60').toggle(); "><b>        Schwintzer, P. et al,
+    1997
+</b></div>
+        <div id="ref_1b188d842a81ab4c57cf92e449c8324960fbec154ae8316fac40689c59992e60" class="mt-1" style="display:none">        Schwintzer, P., Reigber, C., Bode, A., Kang, Z., Zhu, S. Y., Massmann, F. H., Raimondo, J. C., Biancale, R., Balmino, G., Lemoine, J. M., Moynot, B., Marty, J. C., Boudon, Y., Barlier, F.;<br>
+    <b>Long-wavelength global gravity field models: GRIM4-S4, GRIM4-C4;</b>
+    <br>
+        Journal of Geodesy,
+            Vol 71,
+            No. 4,
+            p. 189-208,
+        doi: <a href="http://doi.org/10.1007/s001900050087" target="_blank">10.1007/s001900050087</a>,
+    1997
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/1b188d842a81ab4c57cf92e449c8324960fbec154ae8316fac40689c59992e60/GRIM4s4.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/1b188d842a81ab4c57cf92e449c8324960fbec154ae8316fac40689c59992e60/GRIM4s4.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=1b188d842a81ab4c57cf92e449c8324960fbec154ae8316fac40689c59992e60" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=1b188d842a81ab4c57cf92e449c8324960fbec154ae8316fac40689c59992e60" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>65</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        JGM3
+</td>
+    <td>1994</td>
+    <td>        70
+</td>
+    <td>            A,             G,             S</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_a3375e01a717ac162962138a5e94f10466b71aa4a130d7f7d5b18ab3d5f90c3d').toggle(); "><b>        Tapley, B. D. et al,
+    1996
+</b></div>
+        <div id="ref_a3375e01a717ac162962138a5e94f10466b71aa4a130d7f7d5b18ab3d5f90c3d" class="mt-1" style="display:none">
+        Tapley, B. D., Watkins, M. M., Ries, J. C., Davis, G. W., Eanes, R. J., Poole, S. R., Rim, H. J., Schutz, B. E., Shum, C. K., Nerem, R. S., Lerch, F. J., Marshall, J. A., Klosko, S. M., Pavlis, N. K., Williamson, R. G.;<br>
+    <b>The Joint Gravity Model 3;</b>
+    <br>
+        Journal of Geophysical Research-Solid Earth,
+            Vol 101,
+            No. B12,
+            p. 28029-28049,
+        doi: <a href="http://doi.org/10.1029/96jb01645" target="_blank">10.1029/96jb01645</a>,
+    1996
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/a3375e01a717ac162962138a5e94f10466b71aa4a130d7f7d5b18ab3d5f90c3d/JGM3.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/a3375e01a717ac162962138a5e94f10466b71aa4a130d7f7d5b18ab3d5f90c3d/JGM3.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=a3375e01a717ac162962138a5e94f10466b71aa4a130d7f7d5b18ab3d5f90c3d" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=a3375e01a717ac162962138a5e94f10466b71aa4a130d7f7d5b18ab3d5f90c3d" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>64</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        JGM2
+</td>
+    <td>1994</td>
+    <td>        70
+</td>
+    <td>            A,             G,             S</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_291f7d127f49fe3bcb4a633a06e8b50f461d4b13ff8e7f2046644a8148b57fc6').toggle(); "><b>        Nerem, R. S. et al,
+    1994
+</b></div>
+        <div id="ref_291f7d127f49fe3bcb4a633a06e8b50f461d4b13ff8e7f2046644a8148b57fc6" class="mt-1" style="display:none">
+        Nerem, R. S., Lerch, F. J., Marshall, J. A., Pavlis, E. C., Putney, B. H., Tapley, B. D., Eanes, R. J., Ries, J. C., Schutz, B. E., Shum, C. K., Watkins, M. M., Klosko, S. M., Chan, J. C., Luthcke, S. B., Patel, G. B., Pavlis, N. K., Williamson, R. G., Rapp, R. H., Biancale, R., Nouel, F.;<br>
+    <b>Gravity model development for TOPEX/POSEIDON: Joint Gravity Models 1 and 2;</b>
+    <br>
+        Journal of Geophysical Research,
+            Vol 99,
+            No. C12,
+            p. 24421-24447,
+        doi: <a href="http://doi.org/10.1029/94jc01376" target="_blank">10.1029/94jc01376</a>,
+    1994
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/291f7d127f49fe3bcb4a633a06e8b50f461d4b13ff8e7f2046644a8148b57fc6/JGM2.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/291f7d127f49fe3bcb4a633a06e8b50f461d4b13ff8e7f2046644a8148b57fc6/JGM2.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=291f7d127f49fe3bcb4a633a06e8b50f461d4b13ff8e7f2046644a8148b57fc6" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=291f7d127f49fe3bcb4a633a06e8b50f461d4b13ff8e7f2046644a8148b57fc6" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>63</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        JGM2s
+</td>
+    <td>1994</td>
+    <td>        70
+</td>
+    <td>        S
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_65e1a59ebffd694c3c658e742723548a450e01809617e6fb58259fe09f2e293a').toggle(); "><b>        Nerem, R. S. et al,
+    1994
+</b></div>
+        <div id="ref_65e1a59ebffd694c3c658e742723548a450e01809617e6fb58259fe09f2e293a" class="mt-1" style="display:none">
+        Nerem, R. S., Lerch, F. J., Marshall, J. A., Pavlis, E. C., Putney, B. H., Tapley, B. D., Eanes, R. J., Ries, J. C., Schutz, B. E., Shum, C. K., Watkins, M. M., Klosko, S. M., Chan, J. C., Luthcke, S. B., Patel, G. B., Pavlis, N. K., Williamson, R. G., Rapp, R. H., Biancale, R., Nouel, F.;<br>
+    <b>Gravity model development for TOPEX/POSEIDON: Joint Gravity Models 1 and 2;</b>
+    <br>
+        Journal of Geophysical Research,
+            Vol 99,
+            No. C12,
+            p. 24421-24447,
+        doi: <a href="http://doi.org/10.1029/94jc01376" target="_blank">10.1029/94jc01376</a>,
+    1994
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/65e1a59ebffd694c3c658e742723548a450e01809617e6fb58259fe09f2e293a/JGM2s.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/65e1a59ebffd694c3c658e742723548a450e01809617e6fb58259fe09f2e293a/JGM2s.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=65e1a59ebffd694c3c658e742723548a450e01809617e6fb58259fe09f2e293a" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=65e1a59ebffd694c3c658e742723548a450e01809617e6fb58259fe09f2e293a" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>62</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        GFZ93B
+</td>
+    <td>1993</td>
+    <td>        360
+</td>
+    <td>            A,             G,             GRIM4C3</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_a7cf74de2c1e466f920e660946686048').toggle(); "><b>        Gruber, T. et al,
+    1993
+</b></div>
+        <div id="ref_a7cf74de2c1e466f920e660946686048" class="mt-1" style="display:none">
+        Gruber, T., Anzenhofer, M., Forsberg, Denker;<br>
+    <b>The GFZ 360 Gravity Field Model;</b>
+    <br>
+        Geodetic Division Kort og Matrikelstyrelsen,
+        Wiesbaden,
+    1993
+
+</div>
+    </td>
+    <td></td>
+    <td></td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>61</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        GFZ93a
+</td>
+    <td>1993</td>
+    <td>        360
+</td>
+    <td>            A,             G,             GRIM4C3</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_cf3f5274bc5ef079b60f3d4d33eaaa57b7ffef5472af57db6556623d4958d1eb').toggle(); "><b>        Gruber, T. et al,
+    1993
+</b></div>
+        <div id="ref_cf3f5274bc5ef079b60f3d4d33eaaa57b7ffef5472af57db6556623d4958d1eb" class="mt-1" style="display:none">
+        Gruber, T., Anzenhofer, M., Forsberg, Denker;<br>
+    <b>The GFZ 360 Gravity Field Model;</b>
+    <br>
+        Geodetic Division Kort og Matrikelstyrelsen,
+        Wiesbaden,
+    1993
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/cf3f5274bc5ef079b60f3d4d33eaaa57b7ffef5472af57db6556623d4958d1eb/GFZ93a.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/cf3f5274bc5ef079b60f3d4d33eaaa57b7ffef5472af57db6556623d4958d1eb/GFZ93a.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=cf3f5274bc5ef079b60f3d4d33eaaa57b7ffef5472af57db6556623d4958d1eb" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=cf3f5274bc5ef079b60f3d4d33eaaa57b7ffef5472af57db6556623d4958d1eb" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>60</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        JGM1
+</td>
+    <td>1993</td>
+    <td>        70
+</td>
+    <td>            A,             G,             S</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_f833e046c4154cf6bbc05bb96ceb2fe5').toggle(); "><b>        Nerem, R. S. et al,
+    1994
+</b></div>
+        <div id="ref_f833e046c4154cf6bbc05bb96ceb2fe5" class="mt-1" style="display:none">
+        Nerem, R. S., Lerch, F. J., Marshall, J. A., Pavlis, E. C., Putney, B. H., Tapley, B. D., Eanes, R. J., Ries, J. C., Schutz, B. E., Shum, C. K., Watkins, M. M., Klosko, S. M., Chan, J. C., Luthcke, S. B., Patel, G. B., Pavlis, N. K., Williamson, R. G., Rapp, R. H., Biancale, R., Nouel, F.;<br>
+    <b>Gravity model development for TOPEX/POSEIDON: Joint Gravity Models 1 and 2;</b>
+    <br>
+        Journal of Geophysical Research,
+            Vol 99,
+            No. C12,
+            p. 24421-24447,
+        doi: <a href="http://doi.org/10.1029/94jc01376" target="_blank">10.1029/94jc01376</a>,
+    1994
+
+</div>
+    </td>
+    <td></td>
+    <td></td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>59</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        JGM1s
+</td>
+    <td>1993</td>
+    <td>        60
+</td>
+    <td>        S
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_f0a847d10d72be294cbe5f2dd6a2da8fc6569e996e1d924f3c99541b0b62d548').toggle(); "><b>        Nerem, R. S. et al,
+    1994
+</b></div>
+        <div id="ref_f0a847d10d72be294cbe5f2dd6a2da8fc6569e996e1d924f3c99541b0b62d548" class="mt-1" style="display:none">
+        Nerem, R. S., Lerch, F. J., Marshall, J. A., Pavlis, E. C., Putney, B. H., Tapley, B. D., Eanes, R. J., Ries, J. C., Schutz, B. E., Shum, C. K., Watkins, M. M., Klosko, S. M., Chan, J. C., Luthcke, S. B., Patel, G. B., Pavlis, N. K., Williamson, R. G., Rapp, R. H., Biancale, R., Nouel, F.;<br>
+    <b>Gravity model development for TOPEX/POSEIDON: Joint Gravity Models 1 and 2;</b>
+    <br>
+        Journal of Geophysical Research,
+            Vol 99,
+            No. C12,
+            p. 24421-24447,
+        doi: <a href="http://doi.org/10.1029/94jc01376" target="_blank">10.1029/94jc01376</a>,
+    1994
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/f0a847d10d72be294cbe5f2dd6a2da8fc6569e996e1d924f3c99541b0b62d548/JGM1s.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/f0a847d10d72be294cbe5f2dd6a2da8fc6569e996e1d924f3c99541b0b62d548/JGM1s.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=f0a847d10d72be294cbe5f2dd6a2da8fc6569e996e1d924f3c99541b0b62d548" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=f0a847d10d72be294cbe5f2dd6a2da8fc6569e996e1d924f3c99541b0b62d548" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>58</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        OGE12
+</td>
+    <td>1992</td>
+    <td>        360
+</td>
+    <td>            A,             G,             GRIM4C2</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_94afba81d2a64abeb61d893ab2c5b3a2').toggle(); "><b>        Gruber, T. et al,
+    1992
+</b></div>
+        <div id="ref_94afba81d2a64abeb61d893ab2c5b3a2" class="mt-1" style="display:none">
+        Gruber, T., Bosch, W., Montag, Reigber, Wolfgang Torge;<br>
+    <b>OGE12, A New 360 Gravity Field Model;</b>
+    <br>
+        Springer Verlag,
+            Vol 112,
+        doi: <a href="http://doi.org/10.1007/978-3-642-78149-0_22" target="_blank">10.1007/978-3-642-78149-0_22</a>,
+        Potsdam,
+    1992
+
+</div>
+    </td>
+    <td></td>
+    <td></td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>57</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        GRIM4C3
+</td>
+    <td>1992</td>
+    <td>        60
+</td>
+    <td>            A,             G,             S</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_6c210aed521142eb8299577420a43a76').toggle(); "><b>        Schwintzer, P. et al,
+    1993
+</b></div>
+        <div id="ref_6c210aed521142eb8299577420a43a76" class="mt-1" style="display:none">
+        Schwintzer, P., Reigber, Ch, Bode, A., Chen, Z., Massmann, F. H., Raimondo, J. C., Lemoine, J. M., Balmino, G., Biancale, R., Moynot, B., Marty, J. C., Barlier, F., Boudon, Y.;<br>
+    <b>Improvement of GRIM4 Earth Gravity Models Using Geosat Altimeter and SPOT-2 and ERS-1 Tracking Data;</b>
+    <br>
+        doi: <a href="http://doi.org/10.1007/978-3-642-78149-0_20" target="_blank">10.1007/978-3-642-78149-0_20</a>,
+    1993
+
+</div>
+    </td>
+    <td></td>
+    <td></td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>56</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        GRIM4s3
+</td>
+    <td>1992</td>
+    <td>        60
+</td>
+    <td>        S
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_e0c04a2aa85865e9e4bff0298aae16661850f4205d45f7ee4a7da27aa40744e9').toggle(); "><b>        Schwintzer, P. et al,
+    1993
+</b></div>
+        <div id="ref_e0c04a2aa85865e9e4bff0298aae16661850f4205d45f7ee4a7da27aa40744e9" class="mt-1" style="display:none">
+        Schwintzer, P., Reigber, Ch, Bode, A., Chen, Z., Massmann, F. H., Raimondo, J. C., Lemoine, J. M., Balmino, G., Biancale, R., Moynot, B., Marty, J. C., Barlier, F., Boudon, Y.;<br>
+    <b>Improvement of GRIM4 Earth Gravity Models Using Geosat Altimeter and SPOT-2 and ERS-1 Tracking Data;</b>
+    <br>
+        doi: <a href="http://doi.org/10.1007/978-3-642-78149-0_20" target="_blank">10.1007/978-3-642-78149-0_20</a>,
+    1993
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/e0c04a2aa85865e9e4bff0298aae16661850f4205d45f7ee4a7da27aa40744e9/GRIM4s3.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/e0c04a2aa85865e9e4bff0298aae16661850f4205d45f7ee4a7da27aa40744e9/GRIM4s3.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=e0c04a2aa85865e9e4bff0298aae16661850f4205d45f7ee4a7da27aa40744e9" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=e0c04a2aa85865e9e4bff0298aae16661850f4205d45f7ee4a7da27aa40744e9" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>55</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        OSU91a
+</td>
+    <td>1991</td>
+    <td>        360
+</td>
+    <td>            A,             G,             GEMT2</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_5daa0b1034149011fad23ab020f91bc7ed9b1d1a13cb6467d5769dcce95f7072').toggle(); "><b>        Rapp, R.H. et al,
+    1991
+</b></div>
+        <div id="ref_5daa0b1034149011fad23ab020f91bc7ed9b1d1a13cb6467d5769dcce95f7072" class="mt-1" style="display:none">
+        Rapp, R.H., Wang, Y.M., Pavlis, N.K., Ohio State University, Department of Geodetic Science;<br>
+    <b>The Ohio State 1991 Geopotential and Sea Surface Topography Harmonic Coefficient Models;</b>
+    <br>
+        The Ohio State University, Department of Geodetic Science,
+            Vol 410,
+            p. 94,
+        Columbus, Oh,
+    1991
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/5daa0b1034149011fad23ab020f91bc7ed9b1d1a13cb6467d5769dcce95f7072/OSU91a.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/5daa0b1034149011fad23ab020f91bc7ed9b1d1a13cb6467d5769dcce95f7072/OSU91a.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=5daa0b1034149011fad23ab020f91bc7ed9b1d1a13cb6467d5769dcce95f7072" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=5daa0b1034149011fad23ab020f91bc7ed9b1d1a13cb6467d5769dcce95f7072" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>54</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        GRIM4c2
+</td>
+    <td>1991</td>
+    <td>        50
+</td>
+    <td>            A,             G,             S</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_66038e0f69161adb61e344566e439ca1a5a8664d1f1eca81cd501502a438f865').toggle(); "><b>        Schwintzer, P. et al,
+    1992
+</b></div>
+        <div id="ref_66038e0f69161adb61e344566e439ca1a5a8664d1f1eca81cd501502a438f865" class="mt-1" style="display:none">
+        Schwintzer, P., Reigber, C., Barth, W., Massmann, F.H., Raimondo, J.C., Gerstl, M., Bode, A., Li, H., Biancale, R., Balmino, G., Moynot, B., Lemoine, J.M., Marty, J.C., Barlier, F., Boudon, Y.;<br>
+    <b>GRIM4 Globale Erdschwerefeldmodelle;</b>
+    <br>
+        Zeitschrift für Vermessungswesen,
+            Vol 117,
+            p. 227-247,
+    1992
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/66038e0f69161adb61e344566e439ca1a5a8664d1f1eca81cd501502a438f865/GRIM4c2.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/66038e0f69161adb61e344566e439ca1a5a8664d1f1eca81cd501502a438f865/GRIM4c2.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=66038e0f69161adb61e344566e439ca1a5a8664d1f1eca81cd501502a438f865" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=66038e0f69161adb61e344566e439ca1a5a8664d1f1eca81cd501502a438f865" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>53</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        GRIM4s2
+</td>
+    <td>1991</td>
+    <td>        50
+</td>
+    <td>        S
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_7616137660a891cd1875f3c280ef790ee5032f9a1cebb4841d1c4349e6734016').toggle(); "><b>        Schwintzer, P. et al,
+    1992
+</b></div>
+        <div id="ref_7616137660a891cd1875f3c280ef790ee5032f9a1cebb4841d1c4349e6734016" class="mt-1" style="display:none">
+        Schwintzer, P., Reigber, C., Barth, W., Massmann, F.H., Raimondo, J.C., Gerstl, M., Bode, A., Li, H., Biancale, R., Balmino, G., Moynot, B., Lemoine, J.M., Marty, J.C., Barlier, F., Boudon, Y.;<br>
+    <b>GRIM4 Globale Erdschwerefeldmodelle;</b>
+    <br>
+        Zeitschrift für Vermessungswesen,
+            Vol 117,
+            p. 227-247,
+    1992
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/7616137660a891cd1875f3c280ef790ee5032f9a1cebb4841d1c4349e6734016/GRIM4s2.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/7616137660a891cd1875f3c280ef790ee5032f9a1cebb4841d1c4349e6734016/GRIM4s2.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=7616137660a891cd1875f3c280ef790ee5032f9a1cebb4841d1c4349e6734016" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=7616137660a891cd1875f3c280ef790ee5032f9a1cebb4841d1c4349e6734016" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>52</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        GEMT3
+</td>
+    <td>1991</td>
+    <td>        50
+</td>
+    <td>            A,             G,             S</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_7460b208e796c9ce86ea1ec8fd8853ffd7589300b7ba3c2ddd0dedb69989146b').toggle(); "><b>        Lerch, F.J. et al,
+    1992
+</b></div>
+        <div id="ref_7460b208e796c9ce86ea1ec8fd8853ffd7589300b7ba3c2ddd0dedb69989146b" class="mt-1" style="display:none"><p>
+Lerch, F.J., Nerem, R.S., Putney, B.H., Felsentreger, T.L., Sanchez, B.V., Klosko, S.M., Patel, G.B., Williamson, R.G., Chinn, D.S., Chan, J.C., Rachlin, K.E., Chandler, N.L., McCarthy, J.J., Marshall, J.A., Luthcke, S.B., Pavlis, D.W., Robbins, J.W., Kapoor, S., Pavlis, E.C., GSFC Goddard Space Flight Center;<br>
+<b>Geopotential Models of the Earth from Satellite Tracking, Altimeter and Surface Gravity Observations: GEMT3 and GEMT3S;</b><br>
+Greenbelt, Md, 1992, <a href="https://ntrs.nasa.gov/citations/19920009511" target="_blank">https://ntrs.nasa.gov/citations/19920009511</a>
+</p><p>
+F. J. Lerch, R. S. Nerem, B. H. Putney, T. L. Felsentreger, B. V. Sanchez, J. A. Marshall, S. M. Klosko, G. B. Patel, R. G. Williamson, D. S. Chinn, J. C. Chan, K. E. Rachlin, N. L. Chandler, J. J. McCarthy, S. B. Luthcke, N. K. Pavlis, D. E. Pavlis, J. W. Robbins, S. Kapoor, E. C. Pavlis,<br>
+<b>A geopotential model from satellite tracking, altimeter, and surface gravity data: GEM-T3</b><br>
+Journal of Geophysical Research [0148-0227] yr:1994 vol:99 iss:B2 pg:2815 -2839, <a href="https://doi.org/10.1029/93JB02759" target="_blank">10.1029/93JB02759</a>
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/7460b208e796c9ce86ea1ec8fd8853ffd7589300b7ba3c2ddd0dedb69989146b/GEMT3.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/7460b208e796c9ce86ea1ec8fd8853ffd7589300b7ba3c2ddd0dedb69989146b/GEMT3.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=7460b208e796c9ce86ea1ec8fd8853ffd7589300b7ba3c2ddd0dedb69989146b" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=7460b208e796c9ce86ea1ec8fd8853ffd7589300b7ba3c2ddd0dedb69989146b" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>51</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        GEMT3s
+</td>
+    <td>1991</td>
+    <td>        50
+</td>
+    <td>            S</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_e5b8b2a67ee35e7f53dc4e6af9e38de2290a2a3eb45cdae2d8a4e9792c8cde7e').toggle(); "><b>        Lerch, F.J. et al,
+    1992
+</b></div>
+        <div id="ref_e5b8b2a67ee35e7f53dc4e6af9e38de2290a2a3eb45cdae2d8a4e9792c8cde7e" class="mt-1" style="display:none">Lerch, F.J., Nerem, R.S., Putney, B.H., Felsentreger, T.L., Sanchez, B.V., Klosko, S.M., Patel, G.B., Williamson, R.G., Chinn, D.S., Chan, J.C., Rachlin, K.E., Chandler, N.L., McCarthy, J.J., Marshall, J.A., Luthcke, S.B., Pavlis, D.W., Robbins, J.W., Kapoor, S., Pavlis, E.C., GSFC Goddard Space Flight Center;<br>
+<b>Geopotential Models of the Earth from Satellite Tracking, Altimeter and Surface Gravity Observations: GEMT3 and GEMT3S;</b><br>
+Greenbelt, Md, 1992, <a href="https://ntrs.nasa.gov/citations/19920009511" target="_blank">https://ntrs.nasa.gov/citations/19920009511</a>
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/e5b8b2a67ee35e7f53dc4e6af9e38de2290a2a3eb45cdae2d8a4e9792c8cde7e/GEMT3s.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/e5b8b2a67ee35e7f53dc4e6af9e38de2290a2a3eb45cdae2d8a4e9792c8cde7e/GEMT3s.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=e5b8b2a67ee35e7f53dc4e6af9e38de2290a2a3eb45cdae2d8a4e9792c8cde7e" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=e5b8b2a67ee35e7f53dc4e6af9e38de2290a2a3eb45cdae2d8a4e9792c8cde7e" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>50</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        TEG2B
+</td>
+    <td>1991</td>
+    <td>        54
+</td>
+    <td>            A,             G,             S</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_8109ae5e4116441da8af5d2487a2f24b').toggle(); "><b>        Tapley, B.D. et al,
+    1991
+</b></div>
+        <div id="ref_8109ae5e4116441da8af5d2487a2f24b" class="mt-1" style="display:none">
+        Tapley, B.D., Shum, C.K., Yuan, D.N., Ries, J.C., Eanes, R.J., Watkins, M.M., Schutz, B.E.;<br>
+    <b>The University of Texas Earth Gravity Field Model;</b>
+    <br>
+        Wien,
+    1991
+
+</div>
+    </td>
+    <td></td>
+    <td></td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>49</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        TEG2
+</td>
+    <td>1990</td>
+    <td>        54
+</td>
+    <td>            A,             G,             S</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_a8888e923e164051904840c4d95d3e29').toggle(); "><b>        Tapley, B.D. et al,
+    1991
+</b></div>
+        <div id="ref_a8888e923e164051904840c4d95d3e29" class="mt-1" style="display:none">
+        Tapley, B.D., Shum, C.K., Yuan, D.N., Ries, J.C., Eanes, R.J., Watkins, M.M., Schutz, B.E.;<br>
+    <b>The University of Texas Earth Gravity Field Model;</b>
+    <br>
+        Wien,
+    1991
+
+</div>
+    </td>
+    <td></td>
+    <td></td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>48</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        GRIM4c1
+</td>
+    <td>1990</td>
+    <td>        50
+</td>
+    <td>            A,             G,             S</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_d0e6d344e993d231a10b90af559861189b3197205b0b0f10265303c408839492').toggle(); "><b>        Schwintzer, P. et al,
+    1991
+</b></div>
+        <div id="ref_d0e6d344e993d231a10b90af559861189b3197205b0b0f10265303c408839492" class="mt-1" style="display:none">
+        Schwintzer, P., Reigber, C., Massmann, F.H., Barth, W., Raimondo, J.C., Gerstl, M., Li, H., Biancale, R., Balmino, G., Moynot, B., Lemoine, J.M., Marty, J.C., Boudon, Y., Barlier, F., DGFI;<br>
+    <b>A new earth gravity field model in support of ERS-1 and SPOT-2:, GRIM4-S1/C1;</b>
+    <br>
+        Deutsches Geodätisches Forschungsinstitut, Abt. I (DFG), München ; Group de Recherche de Géodésie Spatiale (GRGS), Toulouse, France,
+            p. 177,
+        München,
+    1991
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/d0e6d344e993d231a10b90af559861189b3197205b0b0f10265303c408839492/GRIM4c1.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/d0e6d344e993d231a10b90af559861189b3197205b0b0f10265303c408839492/GRIM4c1.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=d0e6d344e993d231a10b90af559861189b3197205b0b0f10265303c408839492" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=d0e6d344e993d231a10b90af559861189b3197205b0b0f10265303c408839492" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>47</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        GRIM4s1
+</td>
+    <td>1990</td>
+    <td>        50
+</td>
+    <td>        S
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_e5872f782a951c30e37ae5d52aa61b3f939c586ac7fb7218e118200b714db1af').toggle(); "><b>        Schwintzer, P. et al,
+    1991
+</b></div>
+        <div id="ref_e5872f782a951c30e37ae5d52aa61b3f939c586ac7fb7218e118200b714db1af" class="mt-1" style="display:none">
+        Schwintzer, P., Reigber, C., Massmann, F.H., Barth, W., Raimondo, J.C., Gerstl, M., Li, H., Biancale, R., Balmino, G., Moynot, B., Lemoine, J.M., Marty, J.C., Boudon, Y., Barlier, F., DGFI;<br>
+    <b>A new earth gravity field model in support of ERS-1 and SPOT-2:, GRIM4-S1/C1;</b>
+    <br>
+        Deutsches Geodätisches Forschungsinstitut, Abt. I (DFG), München ; Group de Recherche de Géodésie Spatiale (GRGS), Toulouse, France,
+            p. 177,
+        München,
+    1991
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/e5872f782a951c30e37ae5d52aa61b3f939c586ac7fb7218e118200b714db1af/GRIM4s1.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/e5872f782a951c30e37ae5d52aa61b3f939c586ac7fb7218e118200b714db1af/GRIM4s1.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=e5872f782a951c30e37ae5d52aa61b3f939c586ac7fb7218e118200b714db1af" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=e5872f782a951c30e37ae5d52aa61b3f939c586ac7fb7218e118200b714db1af" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>46</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        GEMT2
+</td>
+    <td>1989</td>
+    <td>        50
+</td>
+    <td>            A,             G,             S</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_50c47737eaffda3f1686d03cb3bf1f25ff440907a429f8103f717ced8d50fe78').toggle(); "><b>        Marsh, J. G. et al,
+    1990
+</b></div>
+        <div id="ref_50c47737eaffda3f1686d03cb3bf1f25ff440907a429f8103f717ced8d50fe78" class="mt-1" style="display:none">
+        Marsh, J. G., Lerch, F. J., Putney, B. H., Felsentreger, T. L., Sanchez, B. V., Klosko, S. M., Patel, G. B., Robbins, J. W., Williamson, R. G., Engelis, T. L., Eddy, W. F., Chandler, N. L., Chinn, D. S., Kapoor, S., Rachlin, K. E., Braatz, L. E., Pavlis, E. C.;<br>
+    <b>The GEM-T2 Gravitational Model;</b>
+    <br>
+        Journal of Geophysical Research,
+            Vol 95,
+            No. B13,
+            p. 22043-22071,
+        doi: <a href="http://doi.org/10.1029/JB095iB13p22043" target="_blank">10.1029/JB095iB13p22043</a>,
+    1990
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/50c47737eaffda3f1686d03cb3bf1f25ff440907a429f8103f717ced8d50fe78/GEMT2.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/50c47737eaffda3f1686d03cb3bf1f25ff440907a429f8103f717ced8d50fe78/GEMT2.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=50c47737eaffda3f1686d03cb3bf1f25ff440907a429f8103f717ced8d50fe78" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=50c47737eaffda3f1686d03cb3bf1f25ff440907a429f8103f717ced8d50fe78" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>45</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        GEMT2S
+</td>
+    <td>1989</td>
+    <td>        50
+</td>
+    <td>        S
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_81dc2860f29540d49c9df83d9bee7d15').toggle(); "><b>        Marsh, J. G. et al,
+    1990
+</b></div>
+        <div id="ref_81dc2860f29540d49c9df83d9bee7d15" class="mt-1" style="display:none">
+        Marsh, J. G., Lerch, F. J., Putney, B. H., Felsentreger, T. L., Sanchez, B. V., Klosko, S. M., Patel, G. B., Robbins, J. W., Williamson, R. G., Engelis, T. L., Eddy, W. F., Chandler, N. L., Chinn, D. S., Kapoor, S., Rachlin, K. E., Braatz, L. E., Pavlis, E. C.;<br>
+    <b>The GEM-T2 Gravitational Model;</b>
+    <br>
+        Journal of Geophysical Research,
+            Vol 95,
+            No. B13,
+            p. 22043-22071,
+        doi: <a href="http://doi.org/10.1029/JB095iB13p22043" target="_blank">10.1029/JB095iB13p22043</a>,
+    1990
+
+</div>
+    </td>
+    <td></td>
+    <td></td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>44</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        <a href="/getmodel/doc/a87cd417531c9eee72b9cc323544d1aa0f15caa6947f870eeea7e0a12e37c085" target="_blank">POEM-L1</a>
+</td>
+    <td>1989</td>
+    <td>        20
+</td>
+    <td>        S(Lageos)
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_a87cd417531c9eee72b9cc323544d1aa0f15caa6947f870eeea7e0a12e37c085').toggle(); "><b>        Dietrich, R. et al,
+    1989
+</b></div>
+        <div id="ref_a87cd417531c9eee72b9cc323544d1aa0f15caa6947f870eeea7e0a12e37c085" class="mt-1" style="display:none">
+        Dietrich, R., Gendt, G., Der Direktor des Zentralinstituts Physik der Erde;<br>
+    <b>A Gravity Field Model from LAGEOS Based on Point Masses (POEM-L1);</b>
+    <br>
+        Akademie der Wissenschaften der DDR Zentralinstitut für Physik der Erde,
+            Vol 102,
+            No. Part 2,
+        Potsdam,
+    1989
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/a87cd417531c9eee72b9cc323544d1aa0f15caa6947f870eeea7e0a12e37c085/POEM-L1.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/a87cd417531c9eee72b9cc323544d1aa0f15caa6947f870eeea7e0a12e37c085/POEM-L1.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=a87cd417531c9eee72b9cc323544d1aa0f15caa6947f870eeea7e0a12e37c085" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=a87cd417531c9eee72b9cc323544d1aa0f15caa6947f870eeea7e0a12e37c085" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>43</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        TEG1
+</td>
+    <td>1988</td>
+    <td>        50
+</td>
+    <td>            G,             S</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_4ecea63f9073436385320b388bde0ca2').toggle(); "><b>        Tapley, B.D. et al,
+    1991
+</b></div>
+        <div id="ref_4ecea63f9073436385320b388bde0ca2" class="mt-1" style="display:none">
+        Tapley, B.D., Shum, C.K., Yuan, D.N., Ries, J.C., Eanes, R.J., Watkins, M.M., Schutz, B.E.;<br>
+    <b>The University of Texas Earth Gravity Field Model;</b>
+    <br>
+        Wien,
+    1991
+
+</div>
+    </td>
+    <td></td>
+    <td></td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>42</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        OSU89b
+</td>
+    <td>1989</td>
+    <td>        360
+</td>
+    <td>            A,             G,             GEMT2</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_1e0a27d22947e679639531cd1599325f84bbf80a0acfab1f379df782cffe0cf4').toggle(); "><b>        Rapp, Richard H. and Pavlis, Nikolaos K.,
+    1990
+</b></div>
+        <div id="ref_1e0a27d22947e679639531cd1599325f84bbf80a0acfab1f379df782cffe0cf4" class="mt-1" style="display:none">
+        Rapp, Richard H., Pavlis, Nikolaos K.;<br>
+    <b>The development and analysis of geopotential coefficient models to spherical harmonic degree 360;</b>
+    <br>
+        Journal of Geophysical Research,
+            Vol 95,
+            No. B13,
+            p. 21885-21911,
+        doi: <a href="http://doi.org/10.1029/JB095iB13p21885" target="_blank">10.1029/JB095iB13p21885</a>,
+    1990
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/1e0a27d22947e679639531cd1599325f84bbf80a0acfab1f379df782cffe0cf4/OSU89b.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/1e0a27d22947e679639531cd1599325f84bbf80a0acfab1f379df782cffe0cf4/OSU89b.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=1e0a27d22947e679639531cd1599325f84bbf80a0acfab1f379df782cffe0cf4" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=1e0a27d22947e679639531cd1599325f84bbf80a0acfab1f379df782cffe0cf4" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>41</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        OSU89a
+</td>
+    <td>1989</td>
+    <td>        360
+</td>
+    <td>            A,             G,             GEMT2</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_ff92eb9121977a5f7488ef73e7801608fbfcae10923ce4adac1b4f673992cdaa').toggle(); "><b>        Rapp, Richard H. and Pavlis, Nikolaos K.,
+    1990
+</b></div>
+        <div id="ref_ff92eb9121977a5f7488ef73e7801608fbfcae10923ce4adac1b4f673992cdaa" class="mt-1" style="display:none">
+        Rapp, Richard H., Pavlis, Nikolaos K.;<br>
+    <b>The development and analysis of geopotential coefficient models to spherical harmonic degree 360;</b>
+    <br>
+        Journal of Geophysical Research,
+            Vol 95,
+            No. B13,
+            p. 21885-21911,
+        doi: <a href="http://doi.org/10.1029/JB095iB13p21885" target="_blank">10.1029/JB095iB13p21885</a>,
+    1990
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/ff92eb9121977a5f7488ef73e7801608fbfcae10923ce4adac1b4f673992cdaa/OSU89a.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/ff92eb9121977a5f7488ef73e7801608fbfcae10923ce4adac1b4f673992cdaa/OSU89a.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=ff92eb9121977a5f7488ef73e7801608fbfcae10923ce4adac1b4f673992cdaa" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=ff92eb9121977a5f7488ef73e7801608fbfcae10923ce4adac1b4f673992cdaa" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>40</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        GEMT1
+</td>
+    <td>1987</td>
+    <td>        36
+</td>
+    <td>        S
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_1229da8e38d35db33d5b9d30e030418156bd37d0206cc00b2c6c083c9beaa56a').toggle(); "><b>        Marsh, J. G. et al,
+    1988
+</b></div>
+        <div id="ref_1229da8e38d35db33d5b9d30e030418156bd37d0206cc00b2c6c083c9beaa56a" class="mt-1" style="display:none">
+        Marsh, J. G., Lerch, F. J., Putney, B. H., Christodoulidis, D. C., Smith, D. E., Felsentreger, T. L., Sanchez, B. V., Klosko, S. M., Pavlis, E. C., Martin, T. V., Robbins, J. W., Williamson, R. G., Colombo, O. L., Rowlands, D. D., Eddy, W. F., Chandler, N. L., Rachlin, K. E., Patel, G. B., Bhati, S., Chinn, D. S.;<br>
+    <b>A new gravitational model for the Earth from satellite tracking data: GEM-T1;</b>
+    <br>
+        Journal of Geophysical Research,
+            Vol 93,
+            No. B6,
+            p. 6169-6215,
+        doi: <a href="http://doi.org/10.1029/JB093iB06p06169" target="_blank">10.1029/JB093iB06p06169</a>,
+    1988
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/1229da8e38d35db33d5b9d30e030418156bd37d0206cc00b2c6c083c9beaa56a/GEMT1.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/1229da8e38d35db33d5b9d30e030418156bd37d0206cc00b2c6c083c9beaa56a/GEMT1.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=1229da8e38d35db33d5b9d30e030418156bd37d0206cc00b2c6c083c9beaa56a" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=1229da8e38d35db33d5b9d30e030418156bd37d0206cc00b2c6c083c9beaa56a" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>39</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        OSU86f
+</td>
+    <td>1986</td>
+    <td>        360
+</td>
+    <td>            A,             G,             GEML2</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_a44b3ad56045b76f37b539ba7092dd370d32da9e79f83d46114af992f54494fa').toggle(); "><b>        Rapp, R.H. et al,
+    1986
+</b></div>
+        <div id="ref_a44b3ad56045b76f37b539ba7092dd370d32da9e79f83d46114af992f54494fa" class="mt-1" style="display:none">
+        Rapp, R.H., Cruz, J.Y., Ohio State University, Department of Geodetic Science;<br>
+    <b>Spherical Harmonic Expansion of the Earth's Gravitational Potential to Degree 360 Using 30' Mean Anomalies;</b>
+    <br>
+        The Ohio State University, Department of Geodetic Science,
+            Vol 376,
+            p. 22,
+        Columbus, Oh,
+    1986
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/a44b3ad56045b76f37b539ba7092dd370d32da9e79f83d46114af992f54494fa/OSU86f.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/a44b3ad56045b76f37b539ba7092dd370d32da9e79f83d46114af992f54494fa/OSU86f.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=a44b3ad56045b76f37b539ba7092dd370d32da9e79f83d46114af992f54494fa" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=a44b3ad56045b76f37b539ba7092dd370d32da9e79f83d46114af992f54494fa" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>38</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        OSU86e
+</td>
+    <td>1986</td>
+    <td>        360
+</td>
+    <td>            A,             G,             GEML2</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_194845ef6d61a5e24b80184a66a5ff0a2dbf222529603307f047128530d624ae').toggle(); "><b>        Rapp, R.H. et al,
+    1986
+</b></div>
+        <div id="ref_194845ef6d61a5e24b80184a66a5ff0a2dbf222529603307f047128530d624ae" class="mt-1" style="display:none">
+        Rapp, R.H., Cruz, J.Y., Ohio State University, Department of Geodetic Science;<br>
+    <b>Spherical Harmonic Expansion of the Earth's Gravitational Potential to Degree 360 Using 30' Mean Anomalies;</b>
+    <br>
+        The Ohio State University, Department of Geodetic Science,
+            Vol 376,
+            p. 22,
+        Columbus, Oh,
+    1986
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/194845ef6d61a5e24b80184a66a5ff0a2dbf222529603307f047128530d624ae/OSU86e.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/194845ef6d61a5e24b80184a66a5ff0a2dbf222529603307f047128530d624ae/OSU86e.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=194845ef6d61a5e24b80184a66a5ff0a2dbf222529603307f047128530d624ae" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=194845ef6d61a5e24b80184a66a5ff0a2dbf222529603307f047128530d624ae" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>37</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        OSU86d
+</td>
+    <td>1986</td>
+    <td>        250
+</td>
+    <td>            A,             G,             GEML2</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_704da9facd63484e85ee749cc63a0fc2').toggle(); "><b>        Rapp, R.H.Cruz, J.Y. et al,
+    1986
+</b></div>
+        <div id="ref_704da9facd63484e85ee749cc63a0fc2" class="mt-1" style="display:none">
+        Rapp, R.H.Cruz, J.Y., Ohio State University, Department of Geodetic Science;<br>
+    <b>The Representation of the Earth’s Gravitational Potential in a Spherical Harmonic Expansion to Degree 250;</b>
+    <br>
+        The Ohio State University, Department of Geodetic Science,
+            Vol 372,
+            p. 64,
+        Columbus, Oh.,
+    1986
+
+</div>
+    </td>
+    <td></td>
+    <td></td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>36</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        OSU86c
+</td>
+    <td>1986</td>
+    <td>        250
+</td>
+    <td>            A,             G,             GEML2</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_65e327946671448cb0ff857360749be2').toggle(); "><b>        Rapp, R.H.Cruz, J.Y. et al,
+    1986
+</b></div>
+        <div id="ref_65e327946671448cb0ff857360749be2" class="mt-1" style="display:none">
+        Rapp, R.H.Cruz, J.Y., Ohio State University, Department of Geodetic Science;<br>
+    <b>The Representation of the Earth’s Gravitational Potential in a Spherical Harmonic Expansion to Degree 250;</b>
+    <br>
+        The Ohio State University, Department of Geodetic Science,
+            Vol 372,
+            p. 64,
+        Columbus, Oh.,
+    1986
+
+</div>
+    </td>
+    <td></td>
+    <td></td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>35</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        GPM2
+</td>
+    <td>1984</td>
+    <td>        200
+</td>
+    <td>            A,             G,             GEML2</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_f8e3e26e0f65217c83759e727000447569c0b78cbc09529e44020cac99d4b763').toggle(); "><b>        Wenzel, H.G.,
+    1985
+</b></div>
+        <div id="ref_f8e3e26e0f65217c83759e727000447569c0b78cbc09529e44020cac99d4b763" class="mt-1" style="display:none">
+        Wenzel, H.G.;<br>
+    <b>Hochauflösende Kugelfunktionsmodelle für das Gravitationspotential der Erde;</b>
+    <br>
+        Fachrichtung Vermessungswesen der Universität Hannover,
+            Vol 137,
+        Hannover,
+    1985
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/f8e3e26e0f65217c83759e727000447569c0b78cbc09529e44020cac99d4b763/GPM2.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/f8e3e26e0f65217c83759e727000447569c0b78cbc09529e44020cac99d4b763/GPM2.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=f8e3e26e0f65217c83759e727000447569c0b78cbc09529e44020cac99d4b763" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=f8e3e26e0f65217c83759e727000447569c0b78cbc09529e44020cac99d4b763" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>34</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        GRIM3L1
+</td>
+    <td>1984</td>
+    <td>        36
+</td>
+    <td>            A,             G,             S</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_3ae6e52c2b5d90f2b6e7412ce9eb2f9fcf9b6309d2e69bceb0dcb9f9f9aea4eb').toggle(); "><b>        Reigber, C. et al,
+    1985
+</b></div>
+        <div id="ref_3ae6e52c2b5d90f2b6e7412ce9eb2f9fcf9b6309d2e69bceb0dcb9f9f9aea4eb" class="mt-1" style="display:none">
+        Reigber, C., Balmino, G., Müller, H., Bosch, W., Moynot, B.;<br>
+    <b>GRIM gravity model improvement using LAGEOS (GRIM3-L1);</b>
+    <br>
+        Journal of Geophysical Research,
+            Vol 90,
+            No. B11,
+            p. 9285,
+        doi: <a href="http://doi.org/10.1029/JB090iB11p09285" target="_blank">10.1029/JB090iB11p09285</a>,
+    1985
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/3ae6e52c2b5d90f2b6e7412ce9eb2f9fcf9b6309d2e69bceb0dcb9f9f9aea4eb/GRIM3L1.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/3ae6e52c2b5d90f2b6e7412ce9eb2f9fcf9b6309d2e69bceb0dcb9f9f9aea4eb/GRIM3L1.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=3ae6e52c2b5d90f2b6e7412ce9eb2f9fcf9b6309d2e69bceb0dcb9f9f9aea4eb" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=3ae6e52c2b5d90f2b6e7412ce9eb2f9fcf9b6309d2e69bceb0dcb9f9f9aea4eb" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>33</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        HAJELA84
+</td>
+    <td>1983</td>
+    <td>        250
+</td>
+    <td>        G
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_9f8a7f7635534f7a99617fcaad7cc7b3').toggle(); "><b>        Hajela, D.P. et al,
+    1984
+</b></div>
+        <div id="ref_9f8a7f7635534f7a99617fcaad7cc7b3" class="mt-1" style="display:none">
+        Hajela, D.P., Ohio State University, Department of Geodetic Science;<br>
+    <b>Optimal Estimation of High Degree Field from a Global Set of 1x1 Anomalies to Degree and Order 250;</b>
+    <br>
+        The Ohio State University, Department of Geodetic Science,
+            Vol 358,
+            p. 60,
+        Columbus, Oh,
+    1984
+
+</div>
+    </td>
+    <td></td>
+    <td></td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>32</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        GPM1
+</td>
+    <td>1983</td>
+    <td>        200
+</td>
+    <td>            A,             G,             GEM9</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_89e72bfb8e3c47c5a0fafa06e5621a08').toggle(); "><b>        Wenzel, H.G.,
+    1985
+</b></div>
+        <div id="ref_89e72bfb8e3c47c5a0fafa06e5621a08" class="mt-1" style="display:none">
+        Wenzel, H.G.;<br>
+    <b>Hochauflösende Kugelfunktionsmodelle für das Gravitationspotential der Erde;</b>
+    <br>
+        Fachrichtung Vermessungswesen der Universität Hannover,
+            Vol 137,
+        Hannover,
+    1985
+
+</div>
+    </td>
+    <td></td>
+    <td></td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>31</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        GRIM3B
+</td>
+    <td>1983</td>
+    <td>        36
+</td>
+    <td>            A,             G,             S</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_b413d5d390174f91a8b3d9ed9450a690').toggle(); "><b>        Reigber, C. et al,
+    1983
+</b></div>
+        <div id="ref_b413d5d390174f91a8b3d9ed9450a690" class="mt-1" style="display:none">
+        Reigber, C., Rizos, C., Bosch, W., Balmino, G., Moynot, B.;<br>
+    <b>An Improved GRIM3 Earth Gravity Field (GRIM3B);</b>
+    <br>
+        Hamburg,
+    1983
+
+</div>
+    </td>
+    <td></td>
+    <td></td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>30</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        GEML2
+</td>
+    <td>1982</td>
+    <td>        30
+</td>
+    <td>        S
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_20d7a8f33dc5af5815ec4857dc9cf9015c0ee5f239d43b6359a1648deff8e842').toggle(); "><b>        Lerch, F.J. et al,
+    1983
+</b></div>
+        <div id="ref_20d7a8f33dc5af5815ec4857dc9cf9015c0ee5f239d43b6359a1648deff8e842" class="mt-1" style="display:none">
+        Lerch, F.J., Klosko, S.M., Patel, G.B., GSFC Goddard Space Flight Center;<br>
+    <b>A Refined Gravity Model from Lageos (GEM-L2);</b>
+    <br>
+        Auch hier erschienen: 10.1029/GL009i011p01263,
+        Greenbelt, Md,
+    1983
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/20d7a8f33dc5af5815ec4857dc9cf9015c0ee5f239d43b6359a1648deff8e842/GEML2.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/20d7a8f33dc5af5815ec4857dc9cf9015c0ee5f239d43b6359a1648deff8e842/GEML2.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=20d7a8f33dc5af5815ec4857dc9cf9015c0ee5f239d43b6359a1648deff8e842" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=20d7a8f33dc5af5815ec4857dc9cf9015c0ee5f239d43b6359a1648deff8e842" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>29</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        GRIM3
+</td>
+    <td>1981</td>
+    <td>        36
+</td>
+    <td>            A,             G,             S</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_7b2ae80283eb48e766f70c39de530d9eb07df7a7d0592eaeab919efc95502a56').toggle(); "><b>        Reigber, C. et al,
+    1983
+</b></div>
+        <div id="ref_7b2ae80283eb48e766f70c39de530d9eb07df7a7d0592eaeab919efc95502a56" class="mt-1" style="display:none">
+        Reigber, C., Balmino, G., Moynot, B., Müller, H.;<br>
+    <b>The GRIM3 Earth Gravity Field Model;</b>
+    <br>
+        Manuscripta Geodaetica,
+            Vol 8,
+            p. 93-138,
+    1983
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/7b2ae80283eb48e766f70c39de530d9eb07df7a7d0592eaeab919efc95502a56/GRIM3.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/7b2ae80283eb48e766f70c39de530d9eb07df7a7d0592eaeab919efc95502a56/GRIM3.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=7b2ae80283eb48e766f70c39de530d9eb07df7a7d0592eaeab919efc95502a56" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=7b2ae80283eb48e766f70c39de530d9eb07df7a7d0592eaeab919efc95502a56" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>28</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        OSU81
+</td>
+    <td>1981</td>
+    <td>        180
+</td>
+    <td>            A,             G,             GEM9</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_10a17ba18f56b814576cd33e8fe6d0cc4a38320f2197c416e93d735ceae69661').toggle(); "><b>        Rapp, R.H. et al,
+    1981
+</b></div>
+        <div id="ref_10a17ba18f56b814576cd33e8fe6d0cc4a38320f2197c416e93d735ceae69661" class="mt-1" style="display:none">
+        Rapp, R.H., Ohio State University, Department of Geodetic Science;<br>
+    <b>The Earth’s Gravity Field to Degree and Order 180 Using SEASAT Altimeter Data, Terrestrial Gravity Data, and Other Data;</b>
+    <br>
+        The Ohio State University, Department of Geodetic Science,
+            Vol 322,
+            p. 53,
+        Columbus, Oh,
+    1981
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/10a17ba18f56b814576cd33e8fe6d0cc4a38320f2197c416e93d735ceae69661/OSU81.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/10a17ba18f56b814576cd33e8fe6d0cc4a38320f2197c416e93d735ceae69661/OSU81.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=10a17ba18f56b814576cd33e8fe6d0cc4a38320f2197c416e93d735ceae69661" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=10a17ba18f56b814576cd33e8fe6d0cc4a38320f2197c416e93d735ceae69661" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>27</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        GEM10C
+</td>
+    <td>1981</td>
+    <td>        180
+</td>
+    <td>            A,             G,             GEM10B</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_60c54f723cbb4dc2b49a0f50614f6a69').toggle(); "><b>        Lerch, Francis J. et al,
+    1981
+</b></div>
+        <div id="ref_60c54f723cbb4dc2b49a0f50614f6a69" class="mt-1" style="display:none">
+        Lerch, Francis J., Putney, Barbara H., Wagner, Carl A., Klosko, Steven M.;<br>
+    <b>Goddard earth models for oceanographic applications (GEM 10B and IOC);</b>
+    <br>
+        Marine Geodesy,
+            Vol 5,
+            No. 2,
+            p. 145-187,
+        doi: <a href="http://doi.org/10.1080/15210608109379416" target="_blank">10.1080/15210608109379416</a>,
+    1981
+
+</div>
+    </td>
+    <td></td>
+    <td></td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>26</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        OSU78
+</td>
+    <td>1978</td>
+    <td>        180
+</td>
+    <td>            A,             G,             GEM9</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_60e3cff02966452a9fefa70c849a07f7').toggle(); "><b>        Rapp, R.H. et al,
+    1978
+</b></div>
+        <div id="ref_60e3cff02966452a9fefa70c849a07f7" class="mt-1" style="display:none">
+        Rapp, R.H., Ohio State University, Department of Geodetic Science;<br>
+    <b>A Global 1x1 Anomaly Field Combining Satellite, GEOS3 Altimeter Data;</b>
+    <br>
+        The Ohio State University, Department of Geodetic Science,
+            Vol 278,
+        Columbus, Oh,
+    1978
+
+</div>
+    </td>
+    <td></td>
+    <td></td>
+    <td>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>25</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        GEM10b
+</td>
+    <td>1978</td>
+    <td>        36
+</td>
+    <td>            A,             GEM10</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_f546226a6c0fc92b61fdb2425e3c8cdeabb2a7a0ef3ef4283baf76a780020ece').toggle(); "><b>        Lerch, F.J. et al,
+    1978
+</b></div>
+        <div id="ref_f546226a6c0fc92b61fdb2425e3c8cdeabb2a7a0ef3ef4283baf76a780020ece" class="mt-1" style="display:none">
+        Lerch, F.J., Wagner, C.A., Klosko, S.M., Belott, R.P., Laubscher, R.E., Raylor, W.A.;<br>
+    <b>Gravity Model Improvement Using Geos3 Altimetry (GEM10A and 10B);</b>
+    <br>
+        Miami,
+    1978
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/f546226a6c0fc92b61fdb2425e3c8cdeabb2a7a0ef3ef4283baf76a780020ece/GEM10b.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/f546226a6c0fc92b61fdb2425e3c8cdeabb2a7a0ef3ef4283baf76a780020ece/GEM10b.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=f546226a6c0fc92b61fdb2425e3c8cdeabb2a7a0ef3ef4283baf76a780020ece" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=f546226a6c0fc92b61fdb2425e3c8cdeabb2a7a0ef3ef4283baf76a780020ece" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>24</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        GEM10a
+</td>
+    <td>1978</td>
+    <td>        30
+</td>
+    <td>            A,             GEM10</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_6d5e868035ce1b07fc4adab5020341dda83e15b1eb3980da5e16dc95c9b8d9d7').toggle(); "><b>        Lerch, F.J. et al,
+    1978
+</b></div>
+        <div id="ref_6d5e868035ce1b07fc4adab5020341dda83e15b1eb3980da5e16dc95c9b8d9d7" class="mt-1" style="display:none">
+        Lerch, F.J., Wagner, C.A., Klosko, S.M., Belott, R.P., Laubscher, R.E., Raylor, W.A.;<br>
+    <b>Gravity Model Improvement Using Geos3 Altimetry (GEM10A and 10B);</b>
+    <br>
+        Miami,
+    1978
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/6d5e868035ce1b07fc4adab5020341dda83e15b1eb3980da5e16dc95c9b8d9d7/GEM10a.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/6d5e868035ce1b07fc4adab5020341dda83e15b1eb3980da5e16dc95c9b8d9d7/GEM10a.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=6d5e868035ce1b07fc4adab5020341dda83e15b1eb3980da5e16dc95c9b8d9d7" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=6d5e868035ce1b07fc4adab5020341dda83e15b1eb3980da5e16dc95c9b8d9d7" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>23</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        GEM10
+</td>
+    <td>1977</td>
+    <td>        30
+</td>
+    <td>            G,             S</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_84e7b3a46b06ea0f4a4ec82668e74658a57d433738a7ec86b7f77074158c8d04').toggle(); "><b>        Lerch, Fancis J. et al,
+    1979
+</b></div>
+        <div id="ref_84e7b3a46b06ea0f4a4ec82668e74658a57d433738a7ec86b7f77074158c8d04" class="mt-1" style="display:none">
+        Lerch, Fancis J., Klosko, Steven M., Laubscher, Roy E., Wagner, Carl A.;<br>
+    <b>Gravity model improvement using Geos 3 (GEM 9 and 10);</b>
+    <br>
+        Journal of Geophysical Research,
+            Vol 84,
+            No. B8,
+            p. 3897,
+        doi: <a href="http://doi.org/10.1029/JB084iB08p03897" target="_blank">10.1029/JB084iB08p03897</a>,
+    1979
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/84e7b3a46b06ea0f4a4ec82668e74658a57d433738a7ec86b7f77074158c8d04/GEM10.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/84e7b3a46b06ea0f4a4ec82668e74658a57d433738a7ec86b7f77074158c8d04/GEM10.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=84e7b3a46b06ea0f4a4ec82668e74658a57d433738a7ec86b7f77074158c8d04" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=84e7b3a46b06ea0f4a4ec82668e74658a57d433738a7ec86b7f77074158c8d04" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>22</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        GEM9
+</td>
+    <td>1977</td>
+    <td>        30
+</td>
+    <td>        S
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_142c79b29e4293cc4cedbd7c5e8331c3ba9e089226316437210fe2470db7ad2a').toggle(); "><b>        Lerch, Fancis J. et al,
+    1979
+</b></div>
+        <div id="ref_142c79b29e4293cc4cedbd7c5e8331c3ba9e089226316437210fe2470db7ad2a" class="mt-1" style="display:none">
+        Lerch, Fancis J., Klosko, Steven M., Laubscher, Roy E., Wagner, Carl A.;<br>
+    <b>Gravity model improvement using Geos 3 (GEM 9 and 10);</b>
+    <br>
+        Journal of Geophysical Research,
+            Vol 84,
+            No. B8,
+            p. 3897,
+        doi: <a href="http://doi.org/10.1029/JB084iB08p03897" target="_blank">10.1029/JB084iB08p03897</a>,
+    1979
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/142c79b29e4293cc4cedbd7c5e8331c3ba9e089226316437210fe2470db7ad2a/GEM9.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/142c79b29e4293cc4cedbd7c5e8331c3ba9e089226316437210fe2470db7ad2a/GEM9.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=142c79b29e4293cc4cedbd7c5e8331c3ba9e089226316437210fe2470db7ad2a" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=142c79b29e4293cc4cedbd7c5e8331c3ba9e089226316437210fe2470db7ad2a" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>21</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        GRIM2
+</td>
+    <td>1976</td>
+    <td>        23
+</td>
+    <td>            G,             S</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_e3fe9ed7adc28842113b6a9b8c437d202647974c9017c215def63b4d6dba9ff7').toggle(); "><b>        Balmino, G. et al,
+    1976
+</b></div>
+        <div id="ref_e3fe9ed7adc28842113b6a9b8c437d202647974c9017c215def63b4d6dba9ff7" class="mt-1" style="display:none">
+        Balmino, G., Reigber, C., Moynot, B.;<br>
+    <b>The GRIM2 Earth Gravity Field Model;</b>
+    <br>
+        Deutsche Geodätische Kommission,
+            Vol 86,
+        München,
+    1976
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/e3fe9ed7adc28842113b6a9b8c437d202647974c9017c215def63b4d6dba9ff7/GRIM2.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/e3fe9ed7adc28842113b6a9b8c437d202647974c9017c215def63b4d6dba9ff7/GRIM2.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=e3fe9ed7adc28842113b6a9b8c437d202647974c9017c215def63b4d6dba9ff7" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=e3fe9ed7adc28842113b6a9b8c437d202647974c9017c215def63b4d6dba9ff7" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>20</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        GEM8
+</td>
+    <td>1976</td>
+    <td>        25
+</td>
+    <td>            G,             S</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_55e37a6b1b3d009f7cf26f01b1a90d398b3026789f1a077d6a1be8cc9ab63f9a').toggle(); "><b>        Wagner, C.A. et al,
+    1976
+</b></div>
+        <div id="ref_55e37a6b1b3d009f7cf26f01b1a90d398b3026789f1a077d6a1be8cc9ab63f9a" class="mt-1" style="display:none">
+        Wagner, C.A., Lerch, F.J., Brownd, J.E., Richardson, J.E., GSFC Goddard Space Flight Center;<br>
+    <b>Improvement in the Geopotential Derived from Satellite and Surface Data (GEM 7 and 8);</b>
+    <br>
+        Erschien ein Jahr später hier: 10.1029/JB082i005p00901,
+        Greenbelt, Md,
+    1976
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/55e37a6b1b3d009f7cf26f01b1a90d398b3026789f1a077d6a1be8cc9ab63f9a/GEM8.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/55e37a6b1b3d009f7cf26f01b1a90d398b3026789f1a077d6a1be8cc9ab63f9a/GEM8.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=55e37a6b1b3d009f7cf26f01b1a90d398b3026789f1a077d6a1be8cc9ab63f9a" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=55e37a6b1b3d009f7cf26f01b1a90d398b3026789f1a077d6a1be8cc9ab63f9a" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>19</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        GEM7
+</td>
+    <td>1976</td>
+    <td>        16
+</td>
+    <td>        S
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_606bf32fc85e914102ea2f62bbf4a8f1a42d3eb87cd61f93f9213caefe37e4bf').toggle(); "><b>        Wagner, C.A. et al,
+    1976
+</b></div>
+        <div id="ref_606bf32fc85e914102ea2f62bbf4a8f1a42d3eb87cd61f93f9213caefe37e4bf" class="mt-1" style="display:none">
+        Wagner, C.A., Lerch, F.J., Brownd, J.E., Richardson, J.E., GSFC Goddard Space Flight Center;<br>
+    <b>Improvement in the Geopotential Derived from Satellite and Surface Data (GEM 7 and 8);</b>
+    <br>
+        Erschien ein Jahr später hier: 10.1029/JB082i005p00901,
+        Greenbelt, Md,
+    1976
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/606bf32fc85e914102ea2f62bbf4a8f1a42d3eb87cd61f93f9213caefe37e4bf/GEM7.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/606bf32fc85e914102ea2f62bbf4a8f1a42d3eb87cd61f93f9213caefe37e4bf/GEM7.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=606bf32fc85e914102ea2f62bbf4a8f1a42d3eb87cd61f93f9213caefe37e4bf" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=606bf32fc85e914102ea2f62bbf4a8f1a42d3eb87cd61f93f9213caefe37e4bf" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>18</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        HARMOGRAV
+</td>
+    <td>1975</td>
+    <td>        36
+</td>
+    <td>        G
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_5dcada64eb51dcb648f64aca10a1c8664087540c2e729d2cbde88f23fbcfe792').toggle(); "><b>        Dimitrijevich, V.,
+    1975
+</b></div>
+        <div id="ref_5dcada64eb51dcb648f64aca10a1c8664087540c2e729d2cbde88f23fbcfe792" class="mt-1" style="display:none">
+        Dimitrijevich, V.;<br>
+    <b>Harmograv: A Spherical Harmonic Function to Represent the Earth’s Gravitational Potential;</b>
+    <br>
+        Defense Mapping Agency Aerospace Center,
+            p. 46,
+        St. Louis, Mo,
+    1975
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/5dcada64eb51dcb648f64aca10a1c8664087540c2e729d2cbde88f23fbcfe792/HARMOGRAV.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/5dcada64eb51dcb648f64aca10a1c8664087540c2e729d2cbde88f23fbcfe792/HARMOGRAV.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=5dcada64eb51dcb648f64aca10a1c8664087540c2e729d2cbde88f23fbcfe792" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=5dcada64eb51dcb648f64aca10a1c8664087540c2e729d2cbde88f23fbcfe792" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>17</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        GRIM1
+</td>
+    <td>1975</td>
+    <td>        31
+</td>
+    <td>        S
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_7bfe8efd2e820d49c2d5334c5b9a66552ddfe6db4f989c04762fb9ef66d6fd10').toggle(); "><b>        Balmino, G. et al,
+    1976
+</b></div>
+        <div id="ref_7bfe8efd2e820d49c2d5334c5b9a66552ddfe6db4f989c04762fb9ef66d6fd10" class="mt-1" style="display:none">
+        Balmino, G., Reigber, C., Moynot, B.;<br>
+    <b>A Geopotential Model Determined from Recent Satellite Observation Campaigns (GRIM1);</b>
+    <br>
+        Manuscripta Geodaetica,
+            Vol 1,
+            p. 41-69,
+    1976
+
+        <br><br>
+        <b>Related References:</b><br>
+        Wagner, Carl A.;<br>
+    <b>Zonal gravity harmonics from long satellite arcs by a seminumeric method;</b>
+    <br>
+        Journal of Geophysical Research,
+            Vol 78,
+            No. 17,
+            p. 3271-3280,
+        doi: <a href="http://doi.org/10.1029/JB078i017p03271" target="_blank">10.1029/JB078i017p03271</a>,
+    1973
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/7bfe8efd2e820d49c2d5334c5b9a66552ddfe6db4f989c04762fb9ef66d6fd10/GRIM1.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/7bfe8efd2e820d49c2d5334c5b9a66552ddfe6db4f989c04762fb9ef66d6fd10/GRIM1.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=7bfe8efd2e820d49c2d5334c5b9a66552ddfe6db4f989c04762fb9ef66d6fd10" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=7bfe8efd2e820d49c2d5334c5b9a66552ddfe6db4f989c04762fb9ef66d6fd10" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>16</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        KOCH74
+</td>
+    <td>1974</td>
+    <td>        15
+</td>
+    <td>            G,             S</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_c6af3248c30fce61c88a8a7e075aba7027c81cefd21ff70eddd28f4603839f20').toggle(); "><b>        Koch, K.R.,
+    1974
+</b></div>
+        <div id="ref_c6af3248c30fce61c88a8a7e075aba7027c81cefd21ff70eddd28f4603839f20" class="mt-1" style="display:none">
+        Koch, K.R.;<br>
+    <b>Earth’s Gravity Field and Station Coordinates from Doppler Data, Satellite Triangulation, and Gravity Anomalies;</b>
+    <br>
+        National Oceanic and Atmospheric Administration,
+            Vol 62,
+            p. 29,
+        Rockville, Md.,
+    1974
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/c6af3248c30fce61c88a8a7e075aba7027c81cefd21ff70eddd28f4603839f20/KOCH74.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/c6af3248c30fce61c88a8a7e075aba7027c81cefd21ff70eddd28f4603839f20/KOCH74.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=c6af3248c30fce61c88a8a7e075aba7027c81cefd21ff70eddd28f4603839f20" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=c6af3248c30fce61c88a8a7e075aba7027c81cefd21ff70eddd28f4603839f20" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>15</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        GEM6
+</td>
+    <td>1974</td>
+    <td>        16
+</td>
+    <td>            G,             S</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_5d13bac798f2054c01233a69fb44c7469f8a3d8275b27000804580d3d56c36f3').toggle(); "><b>        Lerch, F.J. et al,
+    1974
+</b></div>
+        <div id="ref_5d13bac798f2054c01233a69fb44c7469f8a3d8275b27000804580d3d56c36f3" class="mt-1" style="display:none">
+        Lerch, F.J., Wagner, C.A., Richardson, J.A., Brownd, J.E., GSFC Goddard Space Flight Center;<br>
+    <b>Goddard Earth Models (5 and 6);</b>
+    <br>
+        Goddard Space Flight Center, Greenbelt/Maryland,
+            p. 100, A1-B29,
+        Greenbelt, Md,
+    1974
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/5d13bac798f2054c01233a69fb44c7469f8a3d8275b27000804580d3d56c36f3/GEM6.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/5d13bac798f2054c01233a69fb44c7469f8a3d8275b27000804580d3d56c36f3/GEM6.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=5d13bac798f2054c01233a69fb44c7469f8a3d8275b27000804580d3d56c36f3" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=5d13bac798f2054c01233a69fb44c7469f8a3d8275b27000804580d3d56c36f3" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>14</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        GEM5
+</td>
+    <td>1974</td>
+    <td>        12
+</td>
+    <td>        S
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_378069c6186f0d96180491f020b69751e495018325a070fe8fb386bdf9f3fed1').toggle(); "><b>        Lerch, F.J. et al,
+    1974
+</b></div>
+        <div id="ref_378069c6186f0d96180491f020b69751e495018325a070fe8fb386bdf9f3fed1" class="mt-1" style="display:none">
+        Lerch, F.J., Wagner, C.A., Richardson, J.A., Brownd, J.E., GSFC Goddard Space Flight Center;<br>
+    <b>Goddard Earth Models (5 and 6);</b>
+    <br>
+        Goddard Space Flight Center, Greenbelt/Maryland,
+            p. 100, A1-B29,
+        Greenbelt, Md,
+    1974
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/378069c6186f0d96180491f020b69751e495018325a070fe8fb386bdf9f3fed1/GEM5.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/378069c6186f0d96180491f020b69751e495018325a070fe8fb386bdf9f3fed1/GEM5.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=378069c6186f0d96180491f020b69751e495018325a070fe8fb386bdf9f3fed1" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=378069c6186f0d96180491f020b69751e495018325a070fe8fb386bdf9f3fed1" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>13</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        OSU73
+</td>
+    <td>1973</td>
+    <td>        20
+</td>
+    <td>            G,             GEM3</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_03ba1f566b80be84d0df9db6ec701cdaa4238e19bdf4bf5038e30b9d4ebd8418').toggle(); "><b>        Rapp, R.H. et al,
+    1973
+</b></div>
+        <div id="ref_03ba1f566b80be84d0df9db6ec701cdaa4238e19bdf4bf5038e30b9d4ebd8418" class="mt-1" style="display:none">
+        Rapp, R.H., Ohio State University, Department of Geodetic Science;<br>
+    <b>Numerical Results from the Combination of Gravimetric and Satellite Data Using the Principles of Least Squares Collocation;</b>
+    <br>
+        The Ohio State University, Department of Geodetic Science,
+            Vol 200,
+            p. 58,
+        Columbus, Oh,
+    1973
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/03ba1f566b80be84d0df9db6ec701cdaa4238e19bdf4bf5038e30b9d4ebd8418/OSU73.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/03ba1f566b80be84d0df9db6ec701cdaa4238e19bdf4bf5038e30b9d4ebd8418/OSU73.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=03ba1f566b80be84d0df9db6ec701cdaa4238e19bdf4bf5038e30b9d4ebd8418" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=03ba1f566b80be84d0df9db6ec701cdaa4238e19bdf4bf5038e30b9d4ebd8418" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>12</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        SE3
+</td>
+    <td>1973</td>
+    <td>        24
+</td>
+    <td>            G,             S</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_aeb857ffc49b9b70111dfe71c8b4e9e4b76fe66d452e3c8491ebe5a3161409a0').toggle(); "><b>        Gaposchkin, E.M. and Smithsonian Astrophysical Observatory,
+    1973
+</b></div>
+        <div id="ref_aeb857ffc49b9b70111dfe71c8b4e9e4b76fe66d452e3c8491ebe5a3161409a0" class="mt-1" style="display:none">
+        Gaposchkin, E.M., Smithsonian Astrophysical Observatory;<br>
+    <b>1973 Smithsonian Standard Earth (III);</b>
+    <br>
+        Smithsonian Astrophysical Observatory,
+            Vol 353,
+        Cambridge, Mass.,
+    1973
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/aeb857ffc49b9b70111dfe71c8b4e9e4b76fe66d452e3c8491ebe5a3161409a0/SE3.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/aeb857ffc49b9b70111dfe71c8b4e9e4b76fe66d452e3c8491ebe5a3161409a0/SE3.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=aeb857ffc49b9b70111dfe71c8b4e9e4b76fe66d452e3c8491ebe5a3161409a0" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=aeb857ffc49b9b70111dfe71c8b4e9e4b76fe66d452e3c8491ebe5a3161409a0" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>11</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        WGS72
+</td>
+    <td>1972</td>
+    <td>        28
+</td>
+    <td>            G,             S</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_e9285ae179453f7d6b0a24bb1bca3e001a413e2c9bd52c3b97fbe6369c90bbd2').toggle(); "><b>        Seppelin, T.O. and WGS Committee,,
+    1974
+</b></div>
+        <div id="ref_e9285ae179453f7d6b0a24bb1bca3e001a413e2c9bd52c3b97fbe6369c90bbd2" class="mt-1" style="display:none">
+        Seppelin, T.O., WGS Committee,;<br>
+    <b>The Department of Defense World Geodetic System 1972;</b>
+    <br>
+        U.S. Department of Commerce, National Technical Information Service,
+        Fredrickton, New Brunswick, Canada,
+    1974
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/e9285ae179453f7d6b0a24bb1bca3e001a413e2c9bd52c3b97fbe6369c90bbd2/WGS72.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/e9285ae179453f7d6b0a24bb1bca3e001a413e2c9bd52c3b97fbe6369c90bbd2/WGS72.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=e9285ae179453f7d6b0a24bb1bca3e001a413e2c9bd52c3b97fbe6369c90bbd2" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=e9285ae179453f7d6b0a24bb1bca3e001a413e2c9bd52c3b97fbe6369c90bbd2" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>10</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        GEM4
+</td>
+    <td>1972</td>
+    <td>        16
+</td>
+    <td>            G,             S</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_3beba4b09c6e4c3196592a8801648fe5e71c0f32d9c5d14a531b15a76542fdc8').toggle(); "><b>        Lerch, F.J. et al,
+    1972
+</b></div>
+        <div id="ref_3beba4b09c6e4c3196592a8801648fe5e71c0f32d9c5d14a531b15a76542fdc8" class="mt-1" style="display:none">
+        Lerch, F.J., Wagner, C.A., Putney, M.L., Sandson, M.L., Brownd, J.E., Richardson, J.A., Taylor, W.A.;<br>
+    <b>Gravitational Field Models GEM 3 and 4;</b>
+    <br>
+        GSFC Goddard Space Flight Center,
+            p. 26, A1-A12,
+        St. Louis, MO; United States,
+    1972
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/3beba4b09c6e4c3196592a8801648fe5e71c0f32d9c5d14a531b15a76542fdc8/GEM4.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/3beba4b09c6e4c3196592a8801648fe5e71c0f32d9c5d14a531b15a76542fdc8/GEM4.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=3beba4b09c6e4c3196592a8801648fe5e71c0f32d9c5d14a531b15a76542fdc8" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=3beba4b09c6e4c3196592a8801648fe5e71c0f32d9c5d14a531b15a76542fdc8" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>9</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        GEM3
+</td>
+    <td>1972</td>
+    <td>        12
+</td>
+    <td>        S
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_c687c7ac22f60b5201c4de3fdaf2d629544fabda8f56241aae01de56f9c62491').toggle(); "><b>        Lerch, F.J. et al,
+    1972
+</b></div>
+        <div id="ref_c687c7ac22f60b5201c4de3fdaf2d629544fabda8f56241aae01de56f9c62491" class="mt-1" style="display:none">
+        Lerch, F.J., Wagner, C.A., Putney, M.L., Sandson, M.L., Brownd, J.E., Richardson, J.A., Taylor, W.A.;<br>
+    <b>Gravitational Field Models GEM 3 and 4;</b>
+    <br>
+        GSFC Goddard Space Flight Center,
+            p. 26, A1-A12,
+        St. Louis, MO; United States,
+    1972
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/c687c7ac22f60b5201c4de3fdaf2d629544fabda8f56241aae01de56f9c62491/GEM3.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/c687c7ac22f60b5201c4de3fdaf2d629544fabda8f56241aae01de56f9c62491/GEM3.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=c687c7ac22f60b5201c4de3fdaf2d629544fabda8f56241aae01de56f9c62491" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=c687c7ac22f60b5201c4de3fdaf2d629544fabda8f56241aae01de56f9c62491" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>8</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        GEM2
+</td>
+    <td>1972</td>
+    <td>        22
+</td>
+    <td>            G,             S</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_fcef2ac775943cc41acda092af1c3cbde39125b2c59e6e4d811ecb69b7cbb10a').toggle(); "><b>        Lerch, F.J. et al,
+    1972
+</b></div>
+        <div id="ref_fcef2ac775943cc41acda092af1c3cbde39125b2c59e6e4d811ecb69b7cbb10a" class="mt-1" style="display:none">
+        Lerch, F.J., Wagner, C.A., Smith, D.E., Sandson, M.L., Brownd, J.E., Richardson, J.A., GSFC Goddard Space Flight Center;<br>
+    <b>Gravitational Field Models for the Earth (GEM 1 & 2);</b>
+    <br>
+        A version of this paper was presented at COSPAR, Working Group 1, Madrid, May 1972.,
+        Greenbelt, Md.,
+    1972
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/fcef2ac775943cc41acda092af1c3cbde39125b2c59e6e4d811ecb69b7cbb10a/GEM2.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/fcef2ac775943cc41acda092af1c3cbde39125b2c59e6e4d811ecb69b7cbb10a/GEM2.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=fcef2ac775943cc41acda092af1c3cbde39125b2c59e6e4d811ecb69b7cbb10a" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=fcef2ac775943cc41acda092af1c3cbde39125b2c59e6e4d811ecb69b7cbb10a" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>7</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        GEM1
+</td>
+    <td>1972</td>
+    <td>        22
+</td>
+    <td>        S
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_dd5c5cfb0f2ab27bb3f56f9e2f3c7fdf9081f0115b1a6b47fd06612b9216ae64').toggle(); "><b>        Lerch, F.J. et al,
+    1972
+</b></div>
+        <div id="ref_dd5c5cfb0f2ab27bb3f56f9e2f3c7fdf9081f0115b1a6b47fd06612b9216ae64" class="mt-1" style="display:none">
+        Lerch, F.J., Wagner, C.A., Smith, D.E., Sandson, M.L., Brownd, J.E., Richardson, J.A., GSFC Goddard Space Flight Center;<br>
+    <b>Gravitational Field Models for the Earth (GEM 1 & 2);</b>
+    <br>
+        A version of this paper was presented at COSPAR, Working Group 1, Madrid, May 1972.,
+        Greenbelt, Md.,
+    1972
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/dd5c5cfb0f2ab27bb3f56f9e2f3c7fdf9081f0115b1a6b47fd06612b9216ae64/GEM1.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/dd5c5cfb0f2ab27bb3f56f9e2f3c7fdf9081f0115b1a6b47fd06612b9216ae64/GEM1.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=dd5c5cfb0f2ab27bb3f56f9e2f3c7fdf9081f0115b1a6b47fd06612b9216ae64" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=dd5c5cfb0f2ab27bb3f56f9e2f3c7fdf9081f0115b1a6b47fd06612b9216ae64" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>6</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        KOCH71
+</td>
+    <td>1971</td>
+    <td>        11
+</td>
+    <td>            G,             S</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_0aedffec5b6a7f24f22779548246dd012961c4ec742cee5384f45ff690735242').toggle(); "><b>        Koch, Karl-Rudolf and Witte, Bertold U.,
+    1971
+</b></div>
+        <div id="ref_0aedffec5b6a7f24f22779548246dd012961c4ec742cee5384f45ff690735242" class="mt-1" style="display:none">
+        Koch, Karl-Rudolf, Witte, Bertold U.;<br>
+    <b>Earth's gravity field represented by a simple-layer potential from Doppler tracking of satellites;</b>
+    <br>
+        Journal of Geophysical Research,
+            Vol 76,
+            No. 35,
+            p. 8471-8479,
+        doi: <a href="http://doi.org/10.1029/JB076i035p08471" target="_blank">10.1029/JB076i035p08471</a>,
+    1971
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/0aedffec5b6a7f24f22779548246dd012961c4ec742cee5384f45ff690735242/KOCH71.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/0aedffec5b6a7f24f22779548246dd012961c4ec742cee5384f45ff690735242/KOCH71.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=0aedffec5b6a7f24f22779548246dd012961c4ec742cee5384f45ff690735242" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=0aedffec5b6a7f24f22779548246dd012961c4ec742cee5384f45ff690735242" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>5</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        KOCH70
+</td>
+    <td>1970</td>
+    <td>        8
+</td>
+    <td>            G,             S</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_c7a39409b2d10d37e6f3a83f29fec77f27a734ddcdfbaa1241e12a1e0e394cfc').toggle(); "><b>        Koch, Karl-Rudolf and Morrison, Foster,
+    1970
+</b></div>
+        <div id="ref_c7a39409b2d10d37e6f3a83f29fec77f27a734ddcdfbaa1241e12a1e0e394cfc" class="mt-1" style="display:none">
+        Koch, Karl-Rudolf, Morrison, Foster;<br>
+    <b>A simple layer model of the geopotential from a combination of satellite and gravity data;</b>
+    <br>
+        Journal of Geophysical Research,
+            Vol 75,
+            No. 8,
+            p. 1483-1492,
+        doi: <a href="http://doi.org/10.1029/JB075i008p01483" target="_blank">10.1029/JB075i008p01483</a>,
+    1970
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/c7a39409b2d10d37e6f3a83f29fec77f27a734ddcdfbaa1241e12a1e0e394cfc/KOCH70.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/c7a39409b2d10d37e6f3a83f29fec77f27a734ddcdfbaa1241e12a1e0e394cfc/KOCH70.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=c7a39409b2d10d37e6f3a83f29fec77f27a734ddcdfbaa1241e12a1e0e394cfc" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=c7a39409b2d10d37e6f3a83f29fec77f27a734ddcdfbaa1241e12a1e0e394cfc" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>4</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        SE2
+</td>
+    <td>1969</td>
+    <td>        22
+</td>
+    <td>            G,             S</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_8de2a50875da49fc596cb9fa852754861b0e271162248b9ef04df6ab9d8379be').toggle(); "><b>        Gaposchkin, E.M.Lambeck, K.,
+    1970
+</b></div>
+        <div id="ref_8de2a50875da49fc596cb9fa852754861b0e271162248b9ef04df6ab9d8379be" class="mt-1" style="display:none">
+        Gaposchkin, E.M.Lambeck, K.;<br>
+    <b>1969 Smithsonian Standard Earth (II);</b>
+    <br>
+        Smithsonian Astrophysical Observatory,
+            Vol 315,
+        Cambridge, Mass.,
+    1970
+
+        <br><br>
+        <b>Related References:</b><br>
+        Gaposchkin, E.M., Lambeck, K.;<br>
+    <b>Earth's gravity field to the sixteenth degree and station coordinates from satellite and terrestrial data;</b>
+    <br>
+        Journal of Geophysical Research,
+            Vol 76,
+            No. 20,
+            p. 4855-4883,
+        doi: <a href="http://doi.org/10.1029/JB076i020p04855" target="_blank">10.1029/JB076i020p04855</a>,
+    1971
+
+        <br><br>
+        Kozai, Y., Smithsonian Astrophysical Observatory;<br>
+    <b>Revised values for coefficients of zonal spherical harmonics in the geopotential;</b>
+    <br>
+        Smithsonian Astrophysical Observatory,
+            Vol 295,
+            p. 17,
+        Cambridge, Mass.,
+    1969
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/8de2a50875da49fc596cb9fa852754861b0e271162248b9ef04df6ab9d8379be/SE2.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/8de2a50875da49fc596cb9fa852754861b0e271162248b9ef04df6ab9d8379be/SE2.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=8de2a50875da49fc596cb9fa852754861b0e271162248b9ef04df6ab9d8379be" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=8de2a50875da49fc596cb9fa852754861b0e271162248b9ef04df6ab9d8379be" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>3</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        OSU68
+</td>
+    <td>1968</td>
+    <td>        14
+</td>
+    <td>            G,             S</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_3cbccbdcb076b43077d5889eaf7d1badf951306a735c54158451a0a772b5868c').toggle(); "><b>        Rapp, Richard H.,
+    1968
+</b></div>
+        <div id="ref_3cbccbdcb076b43077d5889eaf7d1badf951306a735c54158451a0a772b5868c" class="mt-1" style="display:none">
+        Rapp, Richard H.;<br>
+    <b>Gravitational potential of the Earth determined from a combination of satellite, observed, and model anomalies;</b>
+    <br>
+        Journal of Geophysical Research,
+            Vol 73,
+            No. 20,
+            p. 6555-6562,
+        doi: <a href="http://doi.org/10.1029/JB073i020p06555" target="_blank">10.1029/JB073i020p06555</a>,
+    1968
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/3cbccbdcb076b43077d5889eaf7d1badf951306a735c54158451a0a772b5868c/OSU68.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/3cbccbdcb076b43077d5889eaf7d1badf951306a735c54158451a0a772b5868c/OSU68.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=3cbccbdcb076b43077d5889eaf7d1badf951306a735c54158451a0a772b5868c" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=3cbccbdcb076b43077d5889eaf7d1badf951306a735c54158451a0a772b5868c" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>2</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        WGS66
+</td>
+    <td>1966</td>
+    <td>        24
+</td>
+    <td>        G
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_8cbd6e2334c106dc5db0546790d87ac08db79949b08fde47d1dae2003d6cf627').toggle(); "><b>        WGS Committee,
+    1966
+</b></div>
+        <div id="ref_8cbd6e2334c106dc5db0546790d87ac08db79949b08fde47d1dae2003d6cf627" class="mt-1" style="display:none">
+        WGS Committee;<br>
+    <b>The Department of Defense World Geodetic System 1966;</b>
+    <br>
+        Defense Mapping Agency,
+        Washington, D. C.,
+    1966
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/8cbd6e2334c106dc5db0546790d87ac08db79949b08fde47d1dae2003d6cf627/WGS66.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/8cbd6e2334c106dc5db0546790d87ac08db79949b08fde47d1dae2003d6cf627/WGS66.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=8cbd6e2334c106dc5db0546790d87ac08db79949b08fde47d1dae2003d6cf627" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=8cbd6e2334c106dc5db0546790d87ac08db79949b08fde47d1dae2003d6cf627" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+        <tr>
+    <td>1</td>
+    <td class="fw-bold"></td>
+    <td class="fw-bold">        SE1
+</td>
+    <td>1966</td>
+    <td>        15
+</td>
+    <td>        S
+</td>
+    <td>
+        <div class="d-block w-100 cursor-pointer" onclick=" $( '#ref_3cf592095893358cf08264d93af36b6932563f5b15dd64b349964562e015ee9d').toggle(); "><b>        Lundquist, C.A. et al,
+    1966
+</b></div>
+        <div id="ref_3cf592095893358cf08264d93af36b6932563f5b15dd64b349964562e015ee9d" class="mt-1" style="display:none">
+        Lundquist, C.A., Veis, G., Smithsonian Astrophysical Observatory;<br>
+    <b>Geodetic Parameters for a 1966 Smithonian Institution Standard Earth;</b>
+    <br>
+        Smithonian Astrophysical Observatory,
+            Vol 200,
+        Cambridge, Mass.,
+    1966
+
+</div>
+    </td>
+    <td>        <a href="/getmodel/gfc/3cf592095893358cf08264d93af36b6932563f5b15dd64b349964562e015ee9d/SE1.gfc" target="_blank">gfc</a>
+            <a href="/getmodel/zip/3cf592095893358cf08264d93af36b6932563f5b15dd64b349964562e015ee9d/SE1.zip" target="_blank">zip</a>
+</td>
+    <td>        <a href="/calcgrid?modeltype=longtime&modelid=3cf592095893358cf08264d93af36b6932563f5b15dd64b349964562e015ee9d" target="_blank">Calculate</a>
+</td>
+    <td>
+            <a href="/vis3d/longtime?modelid=3cf592095893358cf08264d93af36b6932563f5b15dd64b349964562e015ee9d" target="_blank">Show</a>
+    </td>
+    <td>
+    </td>
+</tr>
+
+    </tbody>
+</table>
+
+</div>
+<script src="/libs/sortable.min.js"></script>
+<script>
+    $('table').each(function() {
+        let empty_cols = [];
+        let cols = $(this).find("thead tr th").length;
+        let col;
+        for (col=0; col < cols; col++) {
+            let empty = true;
+            let line;
+            for (line of $(this).find("tbody tr")) {
+                if ($($(line).children()[col]).html().trim() != "") {
+                    empty = false;
+                    continue;
+                }
+            }
+            if (empty) {
+                empty_cols.push(col);
+            }
+        }
+        for (col of empty_cols.reverse()) {
+            console.log("Column " + col + " empty.")
+            $(this).find("tbody tr").each(function() {
+                $(this).children("td:eq(" + col + ")").remove();
+            });
+            $(this).find("thead tr").each(function() {
+                $(this).children("th:eq(" + col + ")").remove();
+            });
+        }
+    });
+</script>
+
+            </div>
+        </div>
+        <div id="footer_outer">
+            <div id="footer_inner">
+                <i>icgem (at) gfz.de</i>
+            </div>
+        </div>
+<div id='popup'>
+    <a class="x" href="javascript:hidePopup();" title="Hide this message and set a cookie">X</a>
+    <h4><b><a target="_blank" href="https://www.listserv.dfn.de/sympa/subscribe/icgemusers">Subscribe</a> to the<br>ICGEM-users mailinglist.</b></h4>
+</div>
+<!--<div id='popup'>
+    <a class="x" href="javascript:hidePopup();" title="Hide this message and set a cookie">X</a>
+    <h4>We appreciate your feedback. Please use our <a target="_blank" href="/survey">user survey</a> to send us your opinion.</h4>
+</div>-->
+<script type="text/javascript">
+    var hidemax = 7*24*60*60;
+    function hidePopup() {
+        document.getElementById('popup').style.display="none";
+        if ( getCookie("cookieconsent_status") == "accept" ) {
+            var htime = Math.min(parseInt(getCookie("popuphide")) * 2, hidemax) || 60*60;
+            console.log(htime);
+            setCookie("popuphide", htime, 30);
+            setCookie("popupnext", new Date() / 1000 + htime, 30);
+        }
+    }
+    if ( getCookie("cookieconsent_status") == "accept" ) {
+        if ( parseInt(getCookie("popupnext")) > (new Date() / 1000) ) {
+            document.getElementById('popup').style.display="none";
+            if ( parseInt(getCookie("popuphide")) >= hidemax ) {
+                setCookie("popupnext", new Date() / 1000 + hidemax, 30);
+            }
+        }
+    } else {
+        delCookie("popuphide");
+        delCookie("popupnext");
+        if (Math.random() > 0.05) { // hide popup most of the time
+            document.getElementById('popup').style.display="none";
+        }
+    }
+</script><div id="cookiebanner" class="modal show fade" data-bs-backdrop="static" style="display:block;">
+    <div class="position-fixed top-0 left-0 w-100 h-100" style="background-color:rgba(0,0,0,.5)"></div>
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Privacy Settings</h5>
+                <button type="button" class="btn-close" aria-label="Close" onclick="$('#cookiebanner').hide();"></button>
+            </div>
+            <div class="modal-body">
+                <p>
+                We use cookies that are necessary for the basic functionality of our website so that it can be continuously optimized for you and its user-friendliness
+                improved. We also use the Matomo web analysis tool, which tracks data anonymously. This enables us to statistically evaluate the use of our website.
+                Your consent to the use of Matomo can be revoked at any time via the <a href="/dataprotection">privacy policy</a>.
+                </p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" onclick="setCookie('cookieconsent_status', 'deny'); $('#cookiebanner').hide();">Refuse</button>
+                <button type="button" class="btn btn-primary" onclick="setCookie('cookieconsent_status', 'accept'); $('#cookiebanner').hide();">Accept</button>
+            </div>
+        </div>
+    </div>
+</div>
+<script>
+    if ( getCookie("cookieconsent_status") != "" ) {
+        $('#cookiebanner').hide()
+    }
+    var _paq = window._paq = window._paq || [];
+    _paq.push(['requireCookieConsent']);
+    if ( getCookie("cookieconsent_status") == "accept" ) {
+        _paq.push(['setCookieConsentGiven']);
+    }
+    // tracker methods like "setCustomDimension" should be called before "trackPageView"
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+        var u="https://webstats.gfz.de/";
+        _paq.push(['setTrackerUrl', u+'matomo.php']);
+        _paq.push(['setSiteId', '45']);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+    })();
+</script>    </body>
+</html>

--- a/tests/cli/datasets/test_icgem_cli.py
+++ b/tests/cli/datasets/test_icgem_cli.py
@@ -96,6 +96,40 @@ def test_cli_list_single_body_failure_exits_nonzero(tmp_path, monkeypatch):
 
 
 @pytest.mark.ci
+def test_cli_refresh_body_all_dispatches_to_all_indexes(tmp_path, monkeypatch):
+    """`refresh --body all` must dispatch to refresh_all_indexes(), not silently
+    refresh only the celestial index (which is what ICGEMBody::Other("all") would do).
+
+    Mirrors `list --body all` semantics so users don't get a stale Earth index when
+    they expected both indexes refreshed.
+    """
+    monkeypatch.setenv("BRAHE_CACHE", str(tmp_path))
+    import brahe.datasets as datasets
+
+    calls: dict[str, list] = {"refresh_index": [], "refresh_all_indexes": []}
+
+    def fake_refresh_index(body):
+        calls["refresh_index"].append(body)
+
+    def fake_refresh_all_indexes():
+        calls["refresh_all_indexes"].append(True)
+
+    monkeypatch.setattr(datasets.icgem, "refresh_index", fake_refresh_index)
+    monkeypatch.setattr(datasets.icgem, "refresh_all_indexes", fake_refresh_all_indexes)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["icgem", "refresh", "--body", "all"])
+
+    assert result.exit_code == 0, result.output
+    assert calls["refresh_all_indexes"] == [True], (
+        f"expected refresh_all_indexes() to be called once, got {calls}"
+    )
+    assert "all" not in calls["refresh_index"], (
+        f"refresh_index('all') would silently refresh only the celestial index; got {calls}"
+    )
+
+
+@pytest.mark.ci
 def test_cli_list_body_all_tolerates_per_body_failure(tmp_path, monkeypatch):
     """In --body all mode, an individual body's failure is logged and skipped,
     not raised — the multi-body listing still succeeds for the bodies that work.

--- a/tests/cli/datasets/test_icgem_cli.py
+++ b/tests/cli/datasets/test_icgem_cli.py
@@ -1,0 +1,118 @@
+"""CLI tests for `brahe datasets icgem`."""
+
+import json
+import shutil
+import time
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from brahe.cli.datasets import app
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+@pytest.fixture
+def isolated_cache(tmp_path, monkeypatch):
+    monkeypatch.setenv("BRAHE_CACHE", str(tmp_path))
+    icgem_dir = tmp_path / "icgem"
+    icgem_dir.mkdir()
+    (icgem_dir / "index_earth.json").write_text(
+        json.dumps(
+            {
+                "fetched_at": int(time.time()),
+                "entries": [
+                    {
+                        "body": "Earth",
+                        "name": "JGM3",
+                        "year": 1996,
+                        "degree": 70,
+                        "download_path": "/getmodel/gfc/seed/JGM3.gfc",
+                    }
+                ],
+            }
+        )
+    )
+    models_dir = icgem_dir / "models" / "earth"
+    models_dir.mkdir(parents=True)
+    shutil.copy(
+        REPO_ROOT / "data" / "gravity_models" / "JGM3.gfc",
+        models_dir / "JGM3-70-seed.gfc",
+    )
+    return tmp_path
+
+
+@pytest.mark.ci
+def test_cli_list(isolated_cache):
+    runner = CliRunner()
+    result = runner.invoke(app, ["icgem", "list", "--body", "earth"])
+    assert result.exit_code == 0, result.output
+    assert "JGM3" in result.output
+
+
+@pytest.mark.ci
+def test_cli_download(isolated_cache):
+    runner = CliRunner()
+    result = runner.invoke(app, ["icgem", "download", "JGM3", "--body", "earth"])
+    assert result.exit_code == 0, result.output
+    assert "JGM3-70-seed.gfc" in result.output
+
+
+@pytest.mark.ci
+def test_cli_download_rejects_body_all(isolated_cache):
+    runner = CliRunner()
+    result = runner.invoke(app, ["icgem", "download", "JGM3", "--body", "all"])
+    assert result.exit_code != 0
+    # Error may appear in stderr or output depending on typer version.
+    combined = result.output + (result.stderr if result.stderr else "")
+    assert "not valid" in combined or "BadParameter" in combined or "all" in combined
+
+
+@pytest.mark.ci
+def test_cli_list_single_body_failure_exits_nonzero(tmp_path, monkeypatch):
+    """A single-body `list` failure must exit non-zero, not silently print '0 model(s)'.
+
+    Previously, the loop swallowed exceptions even in single-body mode, which
+    hid offline/missing-cache errors behind a successful empty result.
+    """
+    # Point at an empty cache dir AND an unreachable URL so the listing has
+    # neither a cache file to fall back to nor a network to fetch from.
+    monkeypatch.setenv("BRAHE_CACHE", str(tmp_path))
+    # Force the in-process icgem module to fail by monkeypatching the lookup.
+    import brahe.datasets as datasets
+
+    def boom(_body):
+        raise RuntimeError("simulated ICGEM lookup failure")
+
+    monkeypatch.setattr(datasets.icgem, "list_models", boom)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["icgem", "list", "--body", "earth"])
+    assert result.exit_code == 1, result.output
+    combined = result.output + (result.stderr if result.stderr else "")
+    assert "simulated ICGEM lookup failure" in combined
+
+
+@pytest.mark.ci
+def test_cli_list_body_all_tolerates_per_body_failure(tmp_path, monkeypatch):
+    """In --body all mode, an individual body's failure is logged and skipped,
+    not raised — the multi-body listing still succeeds for the bodies that work.
+    """
+    monkeypatch.setenv("BRAHE_CACHE", str(tmp_path))
+    import brahe.datasets as datasets
+
+    real_list = datasets.icgem.list_models
+
+    def selective_fail(body):
+        if body == "mars":
+            raise RuntimeError("mars cache cannot be read")
+        return real_list(body)
+
+    monkeypatch.setattr(datasets.icgem, "list_models", selective_fail)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["icgem", "list", "--body", "all"])
+    # Multi-body should not abort on a single body's failure.
+    assert result.exit_code == 0, result.output

--- a/tests/datasets/test_icgem.py
+++ b/tests/datasets/test_icgem.py
@@ -1,0 +1,91 @@
+"""CI-gated tests for brahe.datasets.icgem and GravityModelType.icgem(...)."""
+
+import json
+import shutil
+import time
+from pathlib import Path
+
+import pytest
+
+import brahe
+import brahe.datasets as datasets
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture
+def isolated_cache(tmp_path, monkeypatch):
+    """Point BRAHE_CACHE at a tempdir and pre-seed an icgem entry + gfc file."""
+    monkeypatch.setenv("BRAHE_CACHE", str(tmp_path))
+
+    icgem_dir = tmp_path / "icgem"
+    icgem_dir.mkdir()
+    models_dir = icgem_dir / "models" / "earth"
+    models_dir.mkdir(parents=True)
+
+    # Pre-place a known gfc so we never hit the network.
+    src_gfc = REPO_ROOT / "data" / "gravity_models" / "JGM3.gfc"
+    shutil.copy(src_gfc, models_dir / "JGM3-70-seed.gfc")
+
+    # Pre-place a fresh index pointing at JGM3.
+    index = {
+        "fetched_at": int(time.time()),
+        "entries": [
+            {
+                "body": "Earth",
+                "name": "JGM3",
+                "year": 1996,
+                "degree": 70,
+                "download_path": "/getmodel/gfc/seed/JGM3.gfc",
+            }
+        ],
+    }
+    (icgem_dir / "index_earth.json").write_text(json.dumps(index))
+
+    yield tmp_path
+
+
+@pytest.mark.ci
+def test_list_models_returns_seeded_entry(isolated_cache):
+    entries = datasets.icgem.list_models("earth")
+    assert any(e.name == "JGM3" for e in entries)
+
+
+@pytest.mark.ci
+def test_download_model_returns_cached_path(isolated_cache):
+    path = datasets.icgem.download_model("earth", "JGM3")
+    assert Path(path).exists()
+    assert path.endswith("JGM3-70-seed.gfc")
+
+
+@pytest.mark.ci
+def test_gravity_model_type_icgem_classmethod(isolated_cache):
+    t = brahe.GravityModelType.icgem("earth", "JGM3")
+    model = brahe.GravityModel.from_model_type(t)
+    assert model.n_max == 70
+
+
+@pytest.mark.ci
+def test_gravity_model_type_icgem_equality_distinguishes_body_and_name():
+    """Two ICGEMModel values must compare equal only when body and name both match.
+    """
+    a = brahe.GravityModelType.icgem("earth", "JGM3")
+    b = brahe.GravityModelType.icgem("earth", "JGM3")
+    c = brahe.GravityModelType.icgem("earth", "GEM6")
+    d = brahe.GravityModelType.icgem("moon", "GRGM1200B")
+
+    # Same body + same name → equal.
+    assert a == b
+    assert not (a != b)
+
+    # Same body, different names → not equal.
+    assert a != c
+    assert not (a == c)
+
+    # Different body, different name → not equal.
+    assert a != d
+    assert not (a == d)
+
+    # ICGEMModel must not collapse to equality with non-ICGEM variants either.
+    assert a != brahe.GravityModelType.JGM3

--- a/tests/datasets/test_icgem.py
+++ b/tests/datasets/test_icgem.py
@@ -89,3 +89,56 @@ def test_gravity_model_type_icgem_equality_distinguishes_body_and_name():
 
     # ICGEMModel must not collapse to equality with non-ICGEM variants either.
     assert a != brahe.GravityModelType.JGM3
+
+
+@pytest.mark.ci
+def test_numerical_orbit_propagator_with_icgem_jgm3(isolated_cache):
+    """End-to-end: NumericalOrbitPropagator initializes and runs with an
+    ICGEM-sourced gravity model, exercising the full path from
+    GravityModelType.icgem(...) through GravityConfiguration into the propagator.
+    """
+    import numpy as np
+
+    # JGM3 from the seeded cache → no network fetch.
+    gravity_model = brahe.GravityModelType.icgem("earth", "JGM3")
+    gravity_cfg = brahe.GravityConfiguration.spherical_harmonic(
+        degree=20, order=20, model_type=gravity_model
+    )
+    force_cfg = brahe.ForceModelConfig(gravity=gravity_cfg)
+
+    epoch = brahe.Epoch.from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, brahe.TimeSystem.UTC)
+    oe = np.array(
+        [
+            brahe.R_EARTH + 500e3,
+            0.01,
+            np.radians(97.8),
+            np.radians(15.0),
+            np.radians(30.0),
+            np.radians(45.0),
+        ]
+    )
+    state0 = brahe.state_koe_to_eci(oe, brahe.AngleFormat.RADIANS)
+
+    prop = brahe.NumericalOrbitPropagator(
+        epoch,
+        state0,
+        brahe.NumericalPropagationConfig.default(),
+        force_cfg,
+        None,
+    )
+
+    # Construction succeeded → the ICGEM model loaded and was wired into the
+    # gravity force evaluator.
+    assert prop is not None
+    assert prop.initial_epoch == epoch
+    assert prop.state_dim == 6
+
+    # Step one minute and confirm the state actually evolves.
+    prop.step_by(60.0)
+    state1 = prop.current_state()
+
+    assert len(state1) == 6
+    assert all(np.isfinite(state1)), f"non-finite state: {state1}"
+
+    drift = float(np.linalg.norm(np.asarray(state1[:3]) - np.asarray(state0[:3])))
+    assert drift > 100e3, f"state barely moved over 60 s: drift = {drift} m"


### PR DESCRIPTION
# Pull Request

## Description

This PR adds the ability to list and download gravity field models directly from [ICGEM](https://icgem.gfz.de/home). Given that the rust crate size is limited, there is as upper bound on the size and number of gravity field models we can directly package. To work around this this PR adds a new `datasets.icgem` module with methods to list and download new gravity field models for both Earth and other planetary bodies. It also integrates with `GravityModelType` to allow automatic downloading/loading of specific ICGEM models.

## Changelog

### Added
- Added `datasets.icgem` submodule to integrate with ICGEM gravity field model distribution network. Listing and downloading models uses the local brahe cache to minimize network traffic
  - Provides `download_icgem_model` to download models
  - Provides `list_icgem_models` to list available models to download
  - Provides `refresh_all_icgem_indexes` to force refresh ICGEM website model index detailing available models.
  
### Changed
- Added `ICGEMModel(body, model_name)` to `GravityModelType` enabling ICGEM models to be specified for numerical orbit propagators.