### PR TITLE
Change PR python test matrix

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -43,6 +43,11 @@ jobs:
     uses: ./.github/workflows/test_python.yml
     with:
       is-fork-pr: ${{ github.event.pull_request.head.repo.fork == true || github.actor == 'dependabot[bot]' }}
+      # PR runs test only the oldest supported Python (the declared floor in pyproject.toml)
+      # across all 3 OSes to catch breakage of the minimum-supported version.
+      # The full matrix runs on push to main.
+      python-versions: '["3.10"]'
+      coverage-python-version: '3.10'
     secrets: inherit
 
   test-examples:

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -7,6 +7,16 @@ on:
                 required: false
                 type: boolean
                 default: false
+            python-versions:
+                description: 'JSON array of Python versions to test'
+                required: false
+                type: string
+                default: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
+            coverage-python-version:
+                description: 'Python version used for the coverage-instrumented build'
+                required: false
+                type: string
+                default: '3.13'
 jobs:
     test-python:
         runs-on: ${{ matrix.os }}
@@ -15,10 +25,8 @@ jobs:
             id-token: write
         strategy:
             matrix:
-                # os: [ubuntu-latest]
-                # python-version: [ '3.13', '3.14' ]
                 os: [ubuntu-latest, macos-latest, windows-latest]
-                python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
+                python-version: ${{ fromJSON(inputs.python-versions) }}
                 rust-toolchain: [stable]
         env:
             TEST_SPACETRACK_USER: ${{ !inputs.is-fork-pr && secrets.TEST_SPACETRACK_USER || '' }}
@@ -43,14 +51,14 @@ jobs:
             -   name: Install dependencies
                 run: uv sync --group test --all-extras --frozen --python ${{ matrix.python-version }}
 
-            # ── Coverage-instrumented build (ubuntu + Python 3.13 only) ──
+            # ── Coverage-instrumented build (ubuntu + coverage-python-version only) ──
 
             -   name: Install cargo-llvm-cov
-                if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
+                if: matrix.os == 'ubuntu-latest' && matrix.python-version == inputs.coverage-python-version
                 uses: taiki-e/install-action@cargo-llvm-cov
 
             -   name: Build, test, and generate coverage
-                if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
+                if: matrix.os == 'ubuntu-latest' && matrix.python-version == inputs.coverage-python-version
                 run: |
                     cargo llvm-cov clean --workspace
                     eval "$(cargo llvm-cov show-env --export-prefix)"
@@ -64,15 +72,15 @@ jobs:
                     cargo llvm-cov report --lcov --output-path python-rust-coverage.lcov
 
             -   name: Build extension (standard)
-                if: matrix.os != 'ubuntu-latest' || matrix.python-version != '3.13'
+                if: matrix.os != 'ubuntu-latest' || matrix.python-version != inputs.coverage-python-version
                 run: uv pip install -e .
 
             -   name: Test with python ${{ matrix.python-version }}
-                if: matrix.os != 'ubuntu-latest' || matrix.python-version != '3.13'
+                if: matrix.os != 'ubuntu-latest' || matrix.python-version != inputs.coverage-python-version
                 run: uv run --frozen pytest tests/ -v -m '${{ inputs.is-fork-pr && 'not ci' || '' }}'
 
             -   name: Upload Python coverage to Codecov
-                if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
+                if: matrix.os == 'ubuntu-latest' && matrix.python-version == inputs.coverage-python-version
                 uses: codecov/codecov-action@v6.0.0
                 env:
                     CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -84,7 +92,7 @@ jobs:
                     use_oidc: true
 
             -   name: Upload Python-Rust coverage to Codecov
-                if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
+                if: matrix.os == 'ubuntu-latest' && matrix.python-version == inputs.coverage-python-version
                 uses: codecov/codecov-action@v6.0.0
                 env:
                     CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

To reduce load from integration tests on 3rd-party dependencies as well as reduce runtime, this scales back tests run on PRs to just the minimum supported python version. This is an experiment of finding the right balance of speed, coverage, and stability for the package CI.

## Changelog

### Changed
- Scaled back python-version test matrix on PRs to minimum supported python version.