### PR TITLE
fix: accept custom access constraint computers

### DIFF
--- a/crates/brahe-py/src/access.rs
+++ b/crates/brahe-py/src/access.rs
@@ -895,39 +895,39 @@ pub struct PyConstraintAll {
     pub composite: ConstraintComposite,
 }
 
+fn py_constraint_to_rust(py: Python, py_obj: Py<PyAny>) -> PyResult<Box<dyn AccessConstraint>> {
+    if let Ok(c) = py_obj.extract::<PyRef<PyElevationConstraint>>(py) {
+        Ok(Box::new(c.constraint.clone()))
+    } else if let Ok(c) = py_obj.extract::<PyRef<PyElevationMaskConstraint>>(py) {
+        Ok(Box::new(c.constraint.clone()))
+    } else if let Ok(c) = py_obj.extract::<PyRef<PyOffNadirConstraint>>(py) {
+        Ok(Box::new(c.constraint.clone()))
+    } else if let Ok(c) = py_obj.extract::<PyRef<PyLocalTimeConstraint>>(py) {
+        Ok(Box::new(c.constraint.clone()))
+    } else if let Ok(c) = py_obj.extract::<PyRef<PyLookDirectionConstraint>>(py) {
+        Ok(Box::new(c.constraint.clone()))
+    } else if let Ok(c) = py_obj.extract::<PyRef<PyAscDscConstraint>>(py) {
+        Ok(Box::new(c.constraint.clone()))
+    } else if py_obj.bind(py).is_instance_of::<PyAccessConstraintComputer>() {
+        Ok(Box::new(AccessConstraintComputerWrapper::new(
+            RustAccessConstraintComputerWrapper::new(py_obj),
+        )))
+    } else {
+        Err(exceptions::PyTypeError::new_err(
+            "All constraints must be valid constraint objects",
+        ))
+    }
+}
+
 #[pymethods]
 impl PyConstraintAll {
     #[new]
     fn new(constraints: Vec<Py<PyAny>>) -> PyResult<Self> {
-        // Convert Python objects to Rust constraint trait objects
-        // For now, we'll store them as-is and handle evaluation in Rust
-        // This requires implementing conversion logic for each constraint type
-
-        // Note: This is a simplified version. Full implementation would need
-        // to check the type of each Py<PyAny> and convert to the appropriate
-        // Rust constraint type
         Python::attach(|py| {
             let mut rust_constraints: Vec<Box<dyn AccessConstraint>> = Vec::new();
 
             for py_obj in constraints {
-                // Try to extract each constraint type
-                if let Ok(c) = py_obj.extract::<PyRef<PyElevationConstraint>>(py) {
-                    rust_constraints.push(Box::new(c.constraint.clone()));
-                } else if let Ok(c) = py_obj.extract::<PyRef<PyElevationMaskConstraint>>(py) {
-                    rust_constraints.push(Box::new(c.constraint.clone()));
-                } else if let Ok(c) = py_obj.extract::<PyRef<PyOffNadirConstraint>>(py) {
-                    rust_constraints.push(Box::new(c.constraint.clone()));
-                } else if let Ok(c) = py_obj.extract::<PyRef<PyLocalTimeConstraint>>(py) {
-                    rust_constraints.push(Box::new(c.constraint.clone()));
-                } else if let Ok(c) = py_obj.extract::<PyRef<PyLookDirectionConstraint>>(py) {
-                    rust_constraints.push(Box::new(c.constraint.clone()));
-                } else if let Ok(c) = py_obj.extract::<PyRef<PyAscDscConstraint>>(py) {
-                    rust_constraints.push(Box::new(c.constraint.clone()));
-                } else {
-                    return Err(exceptions::PyTypeError::new_err(
-                        "All constraints must be valid constraint objects"
-                    ));
-                }
+                rust_constraints.push(py_constraint_to_rust(py, py_obj)?);
             }
 
             Ok(PyConstraintAll {
@@ -1001,23 +1001,7 @@ impl PyConstraintAny {
             let mut rust_constraints: Vec<Box<dyn AccessConstraint>> = Vec::new();
 
             for py_obj in constraints {
-                if let Ok(c) = py_obj.extract::<PyRef<PyElevationConstraint>>(py) {
-                    rust_constraints.push(Box::new(c.constraint.clone()));
-                } else if let Ok(c) = py_obj.extract::<PyRef<PyElevationMaskConstraint>>(py) {
-                    rust_constraints.push(Box::new(c.constraint.clone()));
-                } else if let Ok(c) = py_obj.extract::<PyRef<PyOffNadirConstraint>>(py) {
-                    rust_constraints.push(Box::new(c.constraint.clone()));
-                } else if let Ok(c) = py_obj.extract::<PyRef<PyLocalTimeConstraint>>(py) {
-                    rust_constraints.push(Box::new(c.constraint.clone()));
-                } else if let Ok(c) = py_obj.extract::<PyRef<PyLookDirectionConstraint>>(py) {
-                    rust_constraints.push(Box::new(c.constraint.clone()));
-                } else if let Ok(c) = py_obj.extract::<PyRef<PyAscDscConstraint>>(py) {
-                    rust_constraints.push(Box::new(c.constraint.clone()));
-                } else {
-                    return Err(exceptions::PyTypeError::new_err(
-                        "All constraints must be valid constraint objects"
-                    ));
-                }
+                rust_constraints.push(py_constraint_to_rust(py, py_obj)?);
             }
 
             Ok(PyConstraintAny {
@@ -1087,24 +1071,9 @@ impl PyConstraintNot {
     #[new]
     fn new(constraint: Py<PyAny>) -> PyResult<Self> {
         Python::attach(|py| {
-            let rust_constraint: Box<dyn AccessConstraint> =
-                if let Ok(c) = constraint.extract::<PyRef<PyElevationConstraint>>(py) {
-                    Box::new(c.constraint.clone())
-                } else if let Ok(c) = constraint.extract::<PyRef<PyElevationMaskConstraint>>(py) {
-                    Box::new(c.constraint.clone())
-                } else if let Ok(c) = constraint.extract::<PyRef<PyOffNadirConstraint>>(py) {
-                    Box::new(c.constraint.clone())
-                } else if let Ok(c) = constraint.extract::<PyRef<PyLocalTimeConstraint>>(py) {
-                    Box::new(c.constraint.clone())
-                } else if let Ok(c) = constraint.extract::<PyRef<PyLookDirectionConstraint>>(py) {
-                    Box::new(c.constraint.clone())
-                } else if let Ok(c) = constraint.extract::<PyRef<PyAscDscConstraint>>(py) {
-                    Box::new(c.constraint.clone())
-                } else {
-                    return Err(exceptions::PyTypeError::new_err(
-                        "Constraint must be a valid constraint object"
-                    ));
-                };
+            let rust_constraint = py_constraint_to_rust(py, constraint).map_err(|_| {
+                exceptions::PyTypeError::new_err("Constraint must be a valid constraint object")
+            })?;
 
             Ok(PyConstraintNot {
                 composite: ConstraintComposite::Not(rust_constraint),
@@ -4805,6 +4774,7 @@ fn py_location_accesses(
     let search_config = config.map(|c| c.config).unwrap_or_default();
 
     // Extract constraint as trait object
+    let custom_constraint;
     let constraint_trait: &dyn AccessConstraint = if let Ok(c) = constraint.cast::<PyElevationConstraint>() {
         &c.borrow().constraint
     } else if let Ok(c) = constraint.cast::<PyOffNadirConstraint>() {
@@ -4823,6 +4793,11 @@ fn py_location_accesses(
         &c.borrow().composite
     } else if let Ok(c) = constraint.cast::<PyConstraintNot>() {
         &c.borrow().composite
+    } else if constraint.is_instance_of::<PyAccessConstraintComputer>() {
+        custom_constraint = AccessConstraintComputerWrapper::new(
+            RustAccessConstraintComputerWrapper::new(constraint.clone().unbind()),
+        );
+        &custom_constraint
     } else {
         return Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
             "constraint must be an AccessConstraint type"

--- a/tests/access/test_custom_constraint_computer_integration.py
+++ b/tests/access/test_custom_constraint_computer_integration.py
@@ -39,6 +39,69 @@ class NorthernHemisphereConstraint(bh.AccessConstraintComputer):
         return "NorthernHemisphereConstraint"
 
 
+class CountingConstraint(bh.AccessConstraintComputer):
+    def __init__(self, value=True):
+        self.value = value
+        self.calls = 0
+
+    def evaluate(self, epoch, satellite_state_ecef, location_ecef):
+        self.calls += 1
+        return self.value
+
+    def name(self):
+        return "CountingConstraint"
+
+
+def _access_scenario():
+    epoch = bh.Epoch(2024, 1, 1, 0, 0, 0.0)
+    oe = np.array([bh.R_EARTH + 500e3, 0.001, 97.8, 0.0, 0.0, 0.0])
+    propagator = bh.KeplerianPropagator.from_keplerian(
+        epoch, oe, bh.AngleFormat.DEGREES, step_size=60.0
+    )
+    location = bh.PointLocation(-75.0, 40.0, 0.0)
+    builtin_constraint = bh.ElevationConstraint(
+        min_elevation_deg=None, max_elevation_deg=85.0
+    )
+    return epoch, propagator, location, builtin_constraint
+
+
+def test_custom_constraint_computer_location_accesses():
+    epoch, propagator, location, _ = _access_scenario()
+    custom_constraint = CountingConstraint()
+
+    windows = bh.location_accesses(
+        location, propagator, epoch, epoch + 3600.0, custom_constraint
+    )
+
+    assert isinstance(windows, list)
+    assert custom_constraint.calls > 0
+
+
+def test_custom_constraint_computer_composite_constraints():
+    epoch, propagator, location, builtin_constraint = _access_scenario()
+
+    all_constraint = CountingConstraint()
+    any_constraint = CountingConstraint()
+    not_constraint = CountingConstraint()
+    not_constraint.value = False
+
+    cases = [
+        bh.ConstraintAll([builtin_constraint, all_constraint]),
+        bh.ConstraintAny([any_constraint, builtin_constraint]),
+        bh.ConstraintNot(not_constraint),
+    ]
+
+    for constraint in cases:
+        windows = bh.location_accesses(
+            location, propagator, epoch, epoch + 3600.0, constraint
+        )
+        assert isinstance(windows, list)
+
+    assert all_constraint.calls > 0
+    assert any_constraint.calls > 0
+    assert not_constraint.calls > 0
+
+
 def test_custom_constraint_computer_polar_orbit():
     """
     Test custom constraint computer filters access windows correctly.


### PR DESCRIPTION
# Pull Request

## Description

Accept Python subclasses of `AccessConstraintComputer` anywhere the Python access APIs expect an access constraint. This allows custom constraints to be passed directly to `location_accesses` and inside composite constraints.

## Changelog

**Fill in at least one section below.** At release time, these entries are aggregated across all merged PRs to produce `CHANGELOG.md` and the GitHub Release notes; each is attributed to its author and PR. Sections follow the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) convention; see the [versioning policy](https://duncaneddy.github.io/brahe/latest/about/versioning/) for how deprecations and removals flow across releases.

### Added
- n/a

### Changed
- n/a

### Deprecated / Future Warning
- n/a

### Removed
- n/a

### Fixed
- Fixed Python `AccessConstraintComputer` subclasses being rejected by `location_accesses` and composite access constraints.

## Related Issue

Fixes #352

## Note to Reviewers

Validated with:

- `cargo check -p brahe-py`
- `cargo fmt --package brahe-py --check`
- `uv run maturin develop --uv --features pyo3/extension-module`
- `uv run pytest tests/access/test_custom_constraint_computer_integration.py -q`
