### PR TITLE
fix(access): Python bindings didn't fully wire-through custom accesses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ CLAUDE.md
 .superpowers
 *.dSYM/
 *dSYM/
+scratch.py
 
 # Coverage
 lcov.info

--- a/crates/brahe-py/src/access.rs
+++ b/crates/brahe-py/src/access.rs
@@ -923,6 +923,10 @@ impl PyConstraintAll {
                     rust_constraints.push(Box::new(c.constraint.clone()));
                 } else if let Ok(c) = py_obj.extract::<PyRef<PyAscDscConstraint>>(py) {
                     rust_constraints.push(Box::new(c.constraint.clone()));
+                } else if py_obj.bind(py).is_instance_of::<PyAccessConstraintComputer>() {
+                    rust_constraints.push(Box::new(AccessConstraintComputerWrapper::new(
+                        RustAccessConstraintComputerWrapper::new(py, py_obj),
+                    )));
                 } else {
                     return Err(exceptions::PyTypeError::new_err(
                         "All constraints must be valid constraint objects"
@@ -1013,6 +1017,10 @@ impl PyConstraintAny {
                     rust_constraints.push(Box::new(c.constraint.clone()));
                 } else if let Ok(c) = py_obj.extract::<PyRef<PyAscDscConstraint>>(py) {
                     rust_constraints.push(Box::new(c.constraint.clone()));
+                } else if py_obj.bind(py).is_instance_of::<PyAccessConstraintComputer>() {
+                    rust_constraints.push(Box::new(AccessConstraintComputerWrapper::new(
+                        RustAccessConstraintComputerWrapper::new(py, py_obj),
+                    )));
                 } else {
                     return Err(exceptions::PyTypeError::new_err(
                         "All constraints must be valid constraint objects"
@@ -4169,15 +4177,24 @@ impl PyAccessConstraintComputer {
     }
 }
 
-#[allow(dead_code)]
 pub(crate) struct RustAccessConstraintComputerWrapper {
     py_computer: Py<PyAny>,
+    /// Name cached from the Python `name()` method at construction time.
+    ///
+    /// The `AccessConstraintComputer::name` trait method returns `&str`, so we
+    /// cannot synthesize a Python string on each call; instead we query the
+    /// subclass's `name()` once and store the result.
+    name: String,
 }
 
-#[allow(dead_code)]
 impl RustAccessConstraintComputerWrapper {
-    pub fn new(py_computer: Py<PyAny>) -> Self {
-        RustAccessConstraintComputerWrapper { py_computer }
+    pub fn new(py: Python, py_computer: Py<PyAny>) -> Self {
+        let name = py_computer
+            .bind(py)
+            .call_method0("name")
+            .and_then(|n| n.extract::<String>())
+            .unwrap_or_else(|_| "PythonConstraintComputer".to_string());
+        RustAccessConstraintComputerWrapper { py_computer, name }
     }
 }
 
@@ -4230,8 +4247,7 @@ impl AccessConstraintComputer for RustAccessConstraintComputerWrapper {
     }
 
     fn name(&self) -> &str {
-        // Return a static string - we can't return Python strings from this trait method
-        "PythonConstraintComputer"
+        &self.name
     }
 }
 
@@ -4804,6 +4820,12 @@ fn py_location_accesses(
     // Use provided config or create default
     let search_config = config.map(|c| c.config).unwrap_or_default();
 
+    // Owned wrapper kept alive for the duration of this function when the caller
+    // passes a custom Python constraint (a subclass of AccessConstraintComputer).
+    // Built-in constraints borrow their stored Rust constraint directly; a custom
+    // Python constraint has no pre-existing Rust object, so we construct one here.
+    let custom_constraint_holder: AccessConstraintComputerWrapper<RustAccessConstraintComputerWrapper>;
+
     // Extract constraint as trait object
     let constraint_trait: &dyn AccessConstraint = if let Ok(c) = constraint.cast::<PyElevationConstraint>() {
         &c.borrow().constraint
@@ -4823,6 +4845,11 @@ fn py_location_accesses(
         &c.borrow().composite
     } else if let Ok(c) = constraint.cast::<PyConstraintNot>() {
         &c.borrow().composite
+    } else if constraint.is_instance_of::<PyAccessConstraintComputer>() {
+        custom_constraint_holder = AccessConstraintComputerWrapper::new(
+            RustAccessConstraintComputerWrapper::new(py, constraint.clone().unbind()),
+        );
+        &custom_constraint_holder
     } else {
         return Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
             "constraint must be an AccessConstraint type"

--- a/crates/brahe-py/src/access.rs
+++ b/crates/brahe-py/src/access.rs
@@ -895,39 +895,39 @@ pub struct PyConstraintAll {
     pub composite: ConstraintComposite,
 }
 
+fn py_constraint_to_rust(py: Python, py_obj: Py<PyAny>) -> PyResult<Box<dyn AccessConstraint>> {
+    if let Ok(c) = py_obj.extract::<PyRef<PyElevationConstraint>>(py) {
+        Ok(Box::new(c.constraint.clone()))
+    } else if let Ok(c) = py_obj.extract::<PyRef<PyElevationMaskConstraint>>(py) {
+        Ok(Box::new(c.constraint.clone()))
+    } else if let Ok(c) = py_obj.extract::<PyRef<PyOffNadirConstraint>>(py) {
+        Ok(Box::new(c.constraint.clone()))
+    } else if let Ok(c) = py_obj.extract::<PyRef<PyLocalTimeConstraint>>(py) {
+        Ok(Box::new(c.constraint.clone()))
+    } else if let Ok(c) = py_obj.extract::<PyRef<PyLookDirectionConstraint>>(py) {
+        Ok(Box::new(c.constraint.clone()))
+    } else if let Ok(c) = py_obj.extract::<PyRef<PyAscDscConstraint>>(py) {
+        Ok(Box::new(c.constraint.clone()))
+    } else if py_obj.bind(py).is_instance_of::<PyAccessConstraintComputer>() {
+        Ok(Box::new(AccessConstraintComputerWrapper::new(
+            RustAccessConstraintComputerWrapper::new(py_obj),
+        )))
+    } else {
+        Err(exceptions::PyTypeError::new_err(
+            "All constraints must be valid constraint objects",
+        ))
+    }
+}
+
 #[pymethods]
 impl PyConstraintAll {
     #[new]
     fn new(constraints: Vec<Py<PyAny>>) -> PyResult<Self> {
-        // Convert Python objects to Rust constraint trait objects
-        // For now, we'll store them as-is and handle evaluation in Rust
-        // This requires implementing conversion logic for each constraint type
-
-        // Note: This is a simplified version. Full implementation would need
-        // to check the type of each Py<PyAny> and convert to the appropriate
-        // Rust constraint type
         Python::attach(|py| {
             let mut rust_constraints: Vec<Box<dyn AccessConstraint>> = Vec::new();
 
             for py_obj in constraints {
-                // Try to extract each constraint type
-                if let Ok(c) = py_obj.extract::<PyRef<PyElevationConstraint>>(py) {
-                    rust_constraints.push(Box::new(c.constraint.clone()));
-                } else if let Ok(c) = py_obj.extract::<PyRef<PyElevationMaskConstraint>>(py) {
-                    rust_constraints.push(Box::new(c.constraint.clone()));
-                } else if let Ok(c) = py_obj.extract::<PyRef<PyOffNadirConstraint>>(py) {
-                    rust_constraints.push(Box::new(c.constraint.clone()));
-                } else if let Ok(c) = py_obj.extract::<PyRef<PyLocalTimeConstraint>>(py) {
-                    rust_constraints.push(Box::new(c.constraint.clone()));
-                } else if let Ok(c) = py_obj.extract::<PyRef<PyLookDirectionConstraint>>(py) {
-                    rust_constraints.push(Box::new(c.constraint.clone()));
-                } else if let Ok(c) = py_obj.extract::<PyRef<PyAscDscConstraint>>(py) {
-                    rust_constraints.push(Box::new(c.constraint.clone()));
-                } else {
-                    return Err(exceptions::PyTypeError::new_err(
-                        "All constraints must be valid constraint objects"
-                    ));
-                }
+                rust_constraints.push(py_constraint_to_rust(py, py_obj)?);
             }
 
             Ok(PyConstraintAll {
@@ -1001,23 +1001,7 @@ impl PyConstraintAny {
             let mut rust_constraints: Vec<Box<dyn AccessConstraint>> = Vec::new();
 
             for py_obj in constraints {
-                if let Ok(c) = py_obj.extract::<PyRef<PyElevationConstraint>>(py) {
-                    rust_constraints.push(Box::new(c.constraint.clone()));
-                } else if let Ok(c) = py_obj.extract::<PyRef<PyElevationMaskConstraint>>(py) {
-                    rust_constraints.push(Box::new(c.constraint.clone()));
-                } else if let Ok(c) = py_obj.extract::<PyRef<PyOffNadirConstraint>>(py) {
-                    rust_constraints.push(Box::new(c.constraint.clone()));
-                } else if let Ok(c) = py_obj.extract::<PyRef<PyLocalTimeConstraint>>(py) {
-                    rust_constraints.push(Box::new(c.constraint.clone()));
-                } else if let Ok(c) = py_obj.extract::<PyRef<PyLookDirectionConstraint>>(py) {
-                    rust_constraints.push(Box::new(c.constraint.clone()));
-                } else if let Ok(c) = py_obj.extract::<PyRef<PyAscDscConstraint>>(py) {
-                    rust_constraints.push(Box::new(c.constraint.clone()));
-                } else {
-                    return Err(exceptions::PyTypeError::new_err(
-                        "All constraints must be valid constraint objects"
-                    ));
-                }
+                rust_constraints.push(py_constraint_to_rust(py, py_obj)?);
             }
 
             Ok(PyConstraintAny {
@@ -1087,24 +1071,9 @@ impl PyConstraintNot {
     #[new]
     fn new(constraint: Py<PyAny>) -> PyResult<Self> {
         Python::attach(|py| {
-            let rust_constraint: Box<dyn AccessConstraint> =
-                if let Ok(c) = constraint.extract::<PyRef<PyElevationConstraint>>(py) {
-                    Box::new(c.constraint.clone())
-                } else if let Ok(c) = constraint.extract::<PyRef<PyElevationMaskConstraint>>(py) {
-                    Box::new(c.constraint.clone())
-                } else if let Ok(c) = constraint.extract::<PyRef<PyOffNadirConstraint>>(py) {
-                    Box::new(c.constraint.clone())
-                } else if let Ok(c) = constraint.extract::<PyRef<PyLocalTimeConstraint>>(py) {
-                    Box::new(c.constraint.clone())
-                } else if let Ok(c) = constraint.extract::<PyRef<PyLookDirectionConstraint>>(py) {
-                    Box::new(c.constraint.clone())
-                } else if let Ok(c) = constraint.extract::<PyRef<PyAscDscConstraint>>(py) {
-                    Box::new(c.constraint.clone())
-                } else {
-                    return Err(exceptions::PyTypeError::new_err(
-                        "Constraint must be a valid constraint object"
-                    ));
-                };
+            let rust_constraint = py_constraint_to_rust(py, constraint).map_err(|_| {
+                exceptions::PyTypeError::new_err("Constraint must be a valid constraint object")
+            })?;
 
             Ok(PyConstraintNot {
                 composite: ConstraintComposite::Not(rust_constraint),
@@ -4805,6 +4774,7 @@ fn py_location_accesses(
     let search_config = config.map(|c| c.config).unwrap_or_default();
 
     // Extract constraint as trait object
+    let custom_constraint;
     let constraint_trait: &dyn AccessConstraint = if let Ok(c) = constraint.cast::<PyElevationConstraint>() {
         &c.borrow().constraint
     } else if let Ok(c) = constraint.cast::<PyOffNadirConstraint>() {
@@ -4823,6 +4793,11 @@ fn py_location_accesses(
         &c.borrow().composite
     } else if let Ok(c) = constraint.cast::<PyConstraintNot>() {
         &c.borrow().composite
+    } else if constraint.is_instance_of::<PyAccessConstraintComputer>() {
+        custom_constraint = AccessConstraintComputerWrapper::new(
+            RustAccessConstraintComputerWrapper::new(constraint.clone().unbind()),
+        );
+        &custom_constraint
     } else {
         return Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
             "constraint must be an AccessConstraint type"

--- a/tests/access/test_custom_constraint_computer_integration.py
+++ b/tests/access/test_custom_constraint_computer_integration.py
@@ -39,6 +39,69 @@ class NorthernHemisphereConstraint(bh.AccessConstraintComputer):
         return "NorthernHemisphereConstraint"
 
 
+class CountingConstraint(bh.AccessConstraintComputer):
+    def __init__(self, value=True):
+        self.value = value
+        self.calls = 0
+
+    def evaluate(self, epoch, satellite_state_ecef, location_ecef):
+        self.calls += 1
+        return self.value
+
+    def name(self):
+        return "CountingConstraint"
+
+
+def _access_scenario():
+    epoch = bh.Epoch(2024, 1, 1, 0, 0, 0.0)
+    oe = np.array([bh.R_EARTH + 500e3, 0.001, 97.8, 0.0, 0.0, 0.0])
+    propagator = bh.KeplerianPropagator.from_keplerian(
+        epoch, oe, bh.AngleFormat.DEGREES, step_size=60.0
+    )
+    location = bh.PointLocation(-75.0, 40.0, 0.0)
+    builtin_constraint = bh.ElevationConstraint(
+        min_elevation_deg=None, max_elevation_deg=85.0
+    )
+    return epoch, propagator, location, builtin_constraint
+
+
+def test_custom_constraint_computer_location_accesses():
+    epoch, propagator, location, _ = _access_scenario()
+    custom_constraint = CountingConstraint()
+
+    windows = bh.location_accesses(
+        location, propagator, epoch, epoch + 3600.0, custom_constraint
+    )
+
+    assert isinstance(windows, list)
+    assert custom_constraint.calls > 0
+
+
+def test_custom_constraint_computer_composite_constraints():
+    epoch, propagator, location, builtin_constraint = _access_scenario()
+
+    all_constraint = CountingConstraint()
+    any_constraint = CountingConstraint()
+    not_constraint = CountingConstraint()
+    not_constraint.value = False
+
+    cases = [
+        bh.ConstraintAll([builtin_constraint, all_constraint]),
+        bh.ConstraintAny([any_constraint, builtin_constraint]),
+        bh.ConstraintNot(not_constraint),
+    ]
+
+    for constraint in cases:
+        windows = bh.location_accesses(
+            location, propagator, epoch, epoch + 3600.0, constraint
+        )
+        assert isinstance(windows, list)
+
+    assert all_constraint.calls > 0
+    assert any_constraint.calls > 0
+    assert not_constraint.calls > 0
+
+
 def test_custom_constraint_computer_polar_orbit():
     """
     Test custom constraint computer filters access windows correctly.

--- a/tests/access/test_custom_constraint_computer_integration.py
+++ b/tests/access/test_custom_constraint_computer_integration.py
@@ -7,6 +7,7 @@ the location access computation pipeline and correctly filter access windows.
 
 import brahe as bh
 import numpy as np
+import pytest
 
 
 class NorthernHemisphereConstraint(bh.AccessConstraintComputer):
@@ -292,3 +293,151 @@ def test_constraint_computer_hemisphere_detection():
     )
 
     print("\n✓ Hemisphere constraint correctly identifies satellite hemisphere")
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for issue #352
+#
+# Custom Python constraints (subclasses of bh.AccessConstraintComputer) must be
+# usable directly in location_accesses and inside ConstraintAll / ConstraintAny
+# composites, exactly like the built-in constraints.
+#
+# See: https://github.com/duncaneddy/brahe/issues/352
+# ---------------------------------------------------------------------------
+
+
+class AlwaysTrueConstraint(bh.AccessConstraintComputer):
+    """Constraint that is always satisfied."""
+
+    def evaluate(self, epoch, satellite_state_ecef, location_ecef):
+        return True
+
+    def name(self):
+        return "AlwaysTrue"
+
+
+class AlwaysFalseConstraint(bh.AccessConstraintComputer):
+    """Constraint that is never satisfied."""
+
+    def evaluate(self, epoch, satellite_state_ecef, location_ecef):
+        return False
+
+    def name(self):
+        return "AlwaysFalse"
+
+
+@pytest.fixture
+def issue_352_scenario():
+    """Reproducer scenario from issue #352."""
+    epoch = bh.Epoch(2024, 1, 1, 0, 0, 0.0)
+    oe = np.array([bh.R_EARTH + 500e3, 0.001, 97.8, 0.0, 0.0, 0.0])
+    propagator = bh.KeplerianPropagator.from_keplerian(
+        epoch,
+        oe,
+        bh.AngleFormat.DEGREES,
+        step_size=60.0,
+    )
+    location = bh.PointLocation(-75.0, 40.0, 0.0)
+    return epoch, propagator, location
+
+
+def test_custom_constraint_in_location_accesses_does_not_raise(
+    issue_352_scenario,
+):
+    """Custom constraint passed directly to location_accesses must be accepted."""
+    epoch, propagator, location = issue_352_scenario
+    custom_constraint = NorthernHemisphereConstraint()
+
+    windows = bh.location_accesses(
+        location, propagator, epoch, epoch + 3600.0, custom_constraint
+    )
+
+    assert isinstance(windows, list)
+
+
+def test_custom_constraint_in_constraint_all_does_not_raise(
+    issue_352_scenario,
+):
+    """Custom constraint inside ConstraintAll must be accepted."""
+    epoch, propagator, location = issue_352_scenario
+    builtin = bh.ElevationConstraint(min_elevation_deg=None, max_elevation_deg=5.0)
+    custom = NorthernHemisphereConstraint()
+
+    combined = bh.ConstraintAll([builtin, custom])
+    windows = bh.location_accesses(
+        location, propagator, epoch, epoch + 3600.0, combined
+    )
+
+    assert isinstance(windows, list)
+
+
+def test_custom_constraint_in_constraint_any_does_not_raise(
+    issue_352_scenario,
+):
+    """Custom constraint inside ConstraintAny must be accepted."""
+    epoch, propagator, location = issue_352_scenario
+    builtin = bh.ElevationConstraint(min_elevation_deg=5.0, max_elevation_deg=None)
+    custom = NorthernHemisphereConstraint()
+
+    combined = bh.ConstraintAny([builtin, custom])
+    windows = bh.location_accesses(
+        location, propagator, epoch, epoch + 7200.0, combined
+    )
+
+    assert isinstance(windows, list)
+    assert len(windows) > 0, "Expected some access windows with ConstraintAny"
+
+
+def test_always_false_custom_constraint_yields_no_windows(
+    issue_352_scenario,
+):
+    """An always-false custom constraint must produce zero access windows."""
+    epoch, propagator, location = issue_352_scenario
+
+    windows = bh.location_accesses(
+        location, propagator, epoch, epoch + 6000.0, AlwaysFalseConstraint()
+    )
+
+    assert windows == []
+
+
+def test_always_true_custom_constraint_yields_windows(issue_352_scenario):
+    """An always-true custom constraint must produce access windows."""
+    epoch, propagator, location = issue_352_scenario
+
+    windows = bh.location_accesses(
+        location, propagator, epoch, epoch + 7200.0, AlwaysTrueConstraint()
+    )
+
+    assert len(windows) > 0
+
+
+def test_custom_constraint_all_gates_builtin(issue_352_scenario):
+    """ConstraintAll([elevation, always_false]) must filter out all windows.
+
+    A full-day search is used so the station actually has elevation passes to
+    gate; over short spans this SSO geometry has no access at all.
+    """
+    epoch, propagator, location = issue_352_scenario
+    elevation = bh.ElevationConstraint(min_elevation_deg=0.0, max_elevation_deg=None)
+    search_end = epoch + 86400.0
+
+    baseline = bh.location_accesses(location, propagator, epoch, search_end, elevation)
+    gated = bh.location_accesses(
+        location,
+        propagator,
+        epoch,
+        search_end,
+        bh.ConstraintAll([elevation, AlwaysFalseConstraint()]),
+    )
+
+    assert len(baseline) > 0
+    assert gated == []
+
+
+def test_custom_constraint_name_propagates_to_composite():
+    """The Python name() must be reflected in composite string output."""
+    custom = NorthernHemisphereConstraint()
+    combined = bh.ConstraintAll([custom])
+
+    assert "NorthernHemisphereConstraint" in str(combined)


### PR DESCRIPTION
# Pull Request

## Description

Fix issue with python `AccessConstraintComputer` classes not fully wiring through to the Rust access pipeline. This would cause errors when they would be initialized.

## Changelog

### Fixed
- Regression in use of custom python-based access constraints where they would give an error at use.

## Related Issue
- https://github.com/duncaneddy/brahe/issues/352
