### PR TITLE
Optimize Spherical Harmonic Gravity Calculation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["crates/brahe-py"]
 # `version.workspace = true` so `brahe-py` (the Python extension) stays in sync
 # with the root `brahe` crate.
 [workspace.package]
-version = "1.6.0"
+version = "1.6.1"
 
 [package]
 name = "brahe"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,49 +41,49 @@ exclude = [# We need to keep the size down for crates.io these don't need to be 
 name = "brahe"
 
 [dependencies]
-rsofa = "0.5.0"
-nalgebra = { version = ">=0.34.1, <0.36", features = ["serde-serialize"] }
-numpy = { version = "0.28.0", optional = true }
-once_cell = "1.21.3"
-num-traits = "0.2.19"
-regex = "1.12.3"
-is_close = "0.1.3"
-ureq = { version = "3.2.0", features = ["cookies", "multipart"] }
-strum = "0.28.0"
-strum_macros = "0.28.0"
+rsofa = "0.5"
+nalgebra = { version = ">=0.34, <0.36", features = ["serde-serialize"] }
+numpy = { version = "0.28", optional = true }
+once_cell = "1.21"
+num-traits = "0.2"
+regex = "1"
+is_close = "0.1"
+ureq = { version = "3", features = ["cookies", "multipart"] }
+strum = "0.28"
+strum_macros = "0.28"
 scraper = "0.27"
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 quick-xml = { version = "0.40", features = ["serialize"] }
-sgp4 = "2.3.0"
+sgp4 = "2.4"
 uuid = { version = "1.20.0", features = ["v4", "v7", "serde"] }
 rayon = "1.11"
 num_cpus = "1.17"
-dirs = "6.0.0"
+dirs = "6"
 polars = { version = "0.54", default-features = false, features = ["lazy"] }
 # default-features disabled to drop anise's `analysis` feature, which pulls in
 # `hyperdual`. hyperdual pins an exact nalgebra version, so enabling it forces
 # brahe's nalgebra to match anise's (and broke the build when hyperdual 1.5.0
 # moved to nalgebra 0.35 while anise stayed on 0.34). brahe only uses anise's
 # core ephemeris APIs, which need no features.
-anise = { version = "0.10.0", default-features = false }
+anise = { version = "0.10", default-features = false }
 
 # pyo3 is an optional dependency used only by the `python` feature, which enables
 # the `python_interop` module holding the `BraheError` PyErr conversion. The
 # extension module itself is built from the `brahe-py` workspace crate.
 [dependencies.pyo3]
-version = "0.28.2"
+version = "0.28"
 optional = true
 
 [dev-dependencies]
-dhat = "0.3.3"
-approx = "0.5.1"
-rstest = "0.26.1"
-serial_test = "3.3.1"
-httpmock = "0.8.3"
-tempfile = "3.24.0"
-cargo-deny = "0.19.0"
-mockall = "0.14.0"
+dhat = "0.3"
+approx = "0.5"
+rstest = "0.26"
+serial_test = "3"
+httpmock = "0.8"
+tempfile = "3"
+cargo-deny = "0.19"
+mockall = "0.14"
 rv = "0.19"
 rand = "0.9"
 criterion = { version = "0.8", features = ["html_reports"] }
@@ -122,6 +122,11 @@ harness = false
 [[bench]]
 name = "propagator_benchmarks"
 path = "benchmarks/propagator_benchmarks.rs"
+harness = false
+
+[[bench]]
+name = "gravity_benchmarks"
+path = "benchmarks/gravity_benchmarks.rs"
 harness = false
 
 [lints.rust]

--- a/benchmarks/comparative/implementations/rust/src/force_model.rs
+++ b/benchmarks/comparative/implementations/rust/src/force_model.rs
@@ -1,7 +1,7 @@
 use brahe::frames::rotation_eci_to_ecef;
 use brahe::orbit_dynamics::{
     accel_gravity_spherical_harmonics, accel_point_mass_gravity, accel_third_body_moon_de,
-    accel_third_body_sun_de, GravityModel, GravityModelType,
+    accel_third_body_sun_de, GravityModel, GravityModelType, ParallelMode,
 };
 use brahe::propagators::EphemerisSource;
 use brahe::time::{Epoch, TimeSystem};
@@ -106,7 +106,7 @@ fn accel_spherical_harmonics_run(
 
     run_force_model(params, iterations, move |epc, r| {
         let rot = rotation_eci_to_ecef(epc);
-        accel_gravity_spherical_harmonics(r, rot, &gravity_model, degree, order)
+        accel_gravity_spherical_harmonics(r, rot, &gravity_model, degree, order, ParallelMode::Auto)
     })
 }
 

--- a/benchmarks/comparative/implementations/rust/src/propagation.rs
+++ b/benchmarks/comparative/implementations/rust/src/propagation.rs
@@ -370,6 +370,7 @@ fn force_config_from_params(p: &Rk4ForceParams) -> ForceModelConfig {
         source: GravityModelSource::default(),
         degree: p.gravity_degree,
         order: p.gravity_order,
+        parallel: brahe::orbit_dynamics::ParallelMode::Auto,
     };
 
     let mut bodies = Vec::new();

--- a/benchmarks/gpu_comparison/implementations/rust/src/tasks_force_model.rs
+++ b/benchmarks/gpu_comparison/implementations/rust/src/tasks_force_model.rs
@@ -36,6 +36,7 @@ pub fn grav_5x5(input: &BenchmarkInput) -> Result<BenchmarkOutput, String> {
             source: GravityModelSource::default(),
             degree: p.gravity_degree,
             order: p.gravity_order,
+            parallel: brahe::orbit_dynamics::ParallelMode::Auto,
         },
         drag: None,
         srp: None,

--- a/benchmarks/gravity_benchmarks.rs
+++ b/benchmarks/gravity_benchmarks.rs
@@ -4,14 +4,14 @@ use std::hint::black_box;
 
 use brahe::gravity::{GravityModel, GravityModelType, ParallelMode};
 use criterion::Criterion;
-use nalgebra::Vector3;
+use nalgebra::{DMatrix, Vector3};
 
 fn bench_spherical_harmonics(c: &mut Criterion) {
     let model = GravityModel::from_model_type(&GravityModelType::EGM2008_360).unwrap();
     let r_body = Vector3::new(6.5e6_f64, 1.2e6_f64, 3.1e6_f64);
 
     let mut group = c.benchmark_group("spherical_harmonics");
-    for &n in &[2usize, 20, 50, 90, 120, 180, 360] {
+    for &n in &[2usize, 20, 50, 90, 120, 180, 240, 360] {
         group.bench_with_input(
             criterion::BenchmarkId::new("serial", n),
             &n,
@@ -38,8 +38,59 @@ fn bench_spherical_harmonics(c: &mut Criterion) {
     group.finish();
 }
 
+/// Isolates the small-n serial path common to LEO propagation (n = 5, 20, 80).
+///
+/// Two variants per degree:
+/// - `alloc`: `compute_spherical_harmonics` — includes the two per-call
+///   `DMatrix::zeros((n+2)²)` allocations.
+/// - `workspace`: `compute_spherical_harmonics_with_workspace` reusing a
+///   pre-sized workspace — this is what the propagator hot path actually does,
+///   so it measures compute overhead with allocation amortized away.
+///
+/// Comparing the two tells us whether small-n cost is allocation-bound or
+/// compute-bound before we optimize the recurrence/accumulation loops.
+fn bench_small_n_serial(c: &mut Criterion) {
+    let model = GravityModel::from_model_type(&GravityModelType::EGM2008_360).unwrap();
+    let r_body = Vector3::new(6.5e6_f64, 1.2e6_f64, 3.1e6_f64);
+
+    let mut group = c.benchmark_group("spherical_harmonics_small_n");
+    for &n in &[5usize, 20, 80] {
+        group.bench_with_input(criterion::BenchmarkId::new("alloc", n), &n, |b, &n| {
+            b.iter(|| {
+                model
+                    .compute_spherical_harmonics(
+                        black_box(r_body),
+                        black_box(n),
+                        black_box(n),
+                        ParallelMode::Never,
+                    )
+                    .unwrap()
+            });
+        });
+
+        let mut v = DMatrix::<f64>::zeros(n + 2, n + 2);
+        let mut w = DMatrix::<f64>::zeros(n + 2, n + 2);
+        group.bench_with_input(criterion::BenchmarkId::new("workspace", n), &n, |b, &n| {
+            b.iter(|| {
+                model
+                    .compute_spherical_harmonics_with_workspace(
+                        black_box(r_body),
+                        black_box(n),
+                        black_box(n),
+                        ParallelMode::Never,
+                        &mut v,
+                        &mut w,
+                    )
+                    .unwrap()
+            });
+        });
+    }
+    group.finish();
+}
+
 fn main() {
     let mut c = criterion::Criterion::default().configure_from_args();
     bench_spherical_harmonics(&mut c);
+    bench_small_n_serial(&mut c);
     c.final_summary();
 }

--- a/benchmarks/gravity_benchmarks.rs
+++ b/benchmarks/gravity_benchmarks.rs
@@ -1,0 +1,45 @@
+#![allow(missing_docs)]
+
+use std::hint::black_box;
+
+use brahe::gravity::{GravityModel, GravityModelType, ParallelMode};
+use criterion::Criterion;
+use nalgebra::Vector3;
+
+fn bench_spherical_harmonics(c: &mut Criterion) {
+    let model = GravityModel::from_model_type(&GravityModelType::EGM2008_360).unwrap();
+    let r_body = Vector3::new(6.5e6_f64, 1.2e6_f64, 3.1e6_f64);
+
+    let mut group = c.benchmark_group("spherical_harmonics");
+    for &n in &[2usize, 20, 50, 90, 120, 180, 360] {
+        group.bench_with_input(
+            criterion::BenchmarkId::new("serial", n),
+            &n,
+            |b, &n| {
+                b.iter(|| {
+                    model
+                        .compute_spherical_harmonics(black_box(r_body), black_box(n), black_box(n), ParallelMode::Never)
+                        .unwrap()
+                });
+            },
+        );
+        group.bench_with_input(
+            criterion::BenchmarkId::new("parallel", n),
+            &n,
+            |b, &n| {
+                b.iter(|| {
+                    model
+                        .compute_spherical_harmonics(black_box(r_body), black_box(n), black_box(n), ParallelMode::Always)
+                        .unwrap()
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+fn main() {
+    let mut c = criterion::Criterion::default().configure_from_args();
+    bench_spherical_harmonics(&mut c);
+    c.final_summary();
+}

--- a/benchmarks/propagator_benchmarks.rs
+++ b/benchmarks/propagator_benchmarks.rs
@@ -160,6 +160,7 @@ fn bench_spherical_harmonic_j6_equivalent_24hour(
             source: GravityModelSource::default(),
             degree: degree.into(),
             order: 0,
+            parallel: brahe::orbit_dynamics::ParallelMode::Auto,
         },
         drag: None,
         srp: None,

--- a/brahe/propagators.py
+++ b/brahe/propagators.py
@@ -16,6 +16,7 @@ This module provides:
 - AtmosphericModel: Atmospheric density model selection
 - EclipseModel: Eclipse model for SRP calculations
 - ZonalHarmonicsDegree: Maximum zonal harmonic degree (J2..=J6)
+- ParallelMode: Parallelization mode for spherical harmonic gravity (Auto, Always, Never)
 - FrameTransformationModel: ECI-to-body-fixed rotation precision selector
 - NumericalPropagationConfig: Configuration for numerical integration
 - VariationalConfig: STM/sensitivity configuration
@@ -46,6 +47,7 @@ from brahe._brahe import (
     AtmosphericModel,
     EclipseModel,
     ZonalHarmonicsDegree,
+    ParallelMode,
     FrameTransformationModel,
     NumericalPropagationConfig,
     VariationalConfig,
@@ -72,6 +74,7 @@ __all__ = [
     "AtmosphericModel",
     "EclipseModel",
     "ZonalHarmonicsDegree",
+    "ParallelMode",
     "FrameTransformationModel",
     "NumericalPropagationConfig",
     "VariationalConfig",

--- a/crates/brahe-py/src/lib.rs
+++ b/crates/brahe-py/src/lib.rs
@@ -894,6 +894,7 @@ pub fn _brahe(py: Python<'_>, module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_class::<PyAtmosphericModel>()?;
     module.add_class::<PyEclipseModel>()?;
     module.add_class::<PyZonalHarmonicsDegree>()?;
+    module.add_class::<PyParallelMode>()?;
     module.add_class::<PyFrameTransformationModel>()?;
     module.add_class::<PyNumericalPropagationConfig>()?;
     module.add_class::<PyVariationalConfig>()?;

--- a/crates/brahe-py/src/orbit_dynamics.rs
+++ b/crates/brahe-py/src/orbit_dynamics.rs
@@ -1611,7 +1611,7 @@ impl PyGravityModel {
         m_max: usize,
     ) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
         let r = numpy_to_vector3!(r_body);
-        let a = self.model.compute_spherical_harmonics(r, n_max, m_max)
+        let a = self.model.compute_spherical_harmonics(r, n_max, m_max, orbit_dynamics::ParallelMode::Auto)
             .map_err(|e| exceptions::PyValueError::new_err(format!("Failed to compute spherical harmonics: {}", e)))?;
         Ok(vector_to_numpy!(py, a, 3, f64))
     }
@@ -1719,10 +1719,10 @@ fn py_accel_gravity_spherical_harmonics<'py>(
     let rot = numpy_to_smatrix3!(R_i2b);
     let a = if len == 3 {
         let r = numpy_to_vector3!(r_eci);
-        orbit_dynamics::accel_gravity_spherical_harmonics(r, rot, &gravity_model.model, n_max, m_max)
+        orbit_dynamics::accel_gravity_spherical_harmonics(r, rot, &gravity_model.model, n_max, m_max, orbit_dynamics::ParallelMode::Auto)
     } else if len == 6 {
         let x = numpy_to_vector6!(r_eci);
-        orbit_dynamics::accel_gravity_spherical_harmonics(x, rot, &gravity_model.model, n_max, m_max)
+        orbit_dynamics::accel_gravity_spherical_harmonics(x, rot, &gravity_model.model, n_max, m_max, orbit_dynamics::ParallelMode::Auto)
     } else {
         return Err(pyo3::exceptions::PyValueError::new_err(
             "r_eci must be length 3 (position) or 6 (state)"

--- a/crates/brahe-py/src/propagators.rs
+++ b/crates/brahe-py/src/propagators.rs
@@ -3268,6 +3268,56 @@ impl PyParameterSource {
 }
 
 // =============================================================================
+// Parallel Mode
+// =============================================================================
+
+/// Parallelization mode for spherical harmonic gravity evaluation.
+///
+/// Controls whether the spherical-harmonic computation runs in parallel
+/// (via Brahe's managed Rayon thread pool) or serially.
+///
+/// Example:
+///     ```python
+///     import brahe as bh
+///
+///     mode = bh.ParallelMode.Auto
+///     mode = bh.ParallelMode.Always
+///     mode = bh.ParallelMode.Never
+///     ```
+#[pyclass(module = "brahe._brahe", from_py_object)]
+#[pyo3(name = "ParallelMode")]
+#[derive(Clone)]
+pub struct PyParallelMode {
+    pub mode: brahe::orbit_dynamics::ParallelMode,
+}
+
+#[pymethods]
+#[allow(non_snake_case)]
+impl PyParallelMode {
+    /// Parallelize only when the expansion degree meets the auto-threshold (default).
+    #[classattr]
+    fn Auto() -> Self {
+        PyParallelMode { mode: brahe::orbit_dynamics::ParallelMode::Auto }
+    }
+
+    /// Always parallelize via the global thread pool.
+    #[classattr]
+    fn Always() -> Self {
+        PyParallelMode { mode: brahe::orbit_dynamics::ParallelMode::Always }
+    }
+
+    /// Always run serially.
+    #[classattr]
+    fn Never() -> Self {
+        PyParallelMode { mode: brahe::orbit_dynamics::ParallelMode::Never }
+    }
+
+    fn __repr__(&self) -> String {
+        format!("ParallelMode.{:?}", self.mode)
+    }
+}
+
+// =============================================================================
 // Gravity Configuration
 // =============================================================================
 
@@ -3284,6 +3334,8 @@ impl PyParameterSource {
 ///         Defaults to EGM2008_360.
 ///     use_global (bool, optional): If True, use global gravity model.
 ///         Defaults to False.
+///     parallel (ParallelMode, optional): Parallelization mode for the
+///         spherical-harmonic acceleration computation. Defaults to Auto.
 ///
 /// Example:
 ///     ```python
@@ -3325,6 +3377,8 @@ impl PyGravityConfiguration {
     ///         Defaults to EGM2008_360.
     ///     use_global (bool, optional): If True, use global gravity model.
     ///         Defaults to False.
+    ///     parallel (ParallelMode, optional): Parallelization mode for the
+    ///         spherical-harmonic acceleration computation. Defaults to Auto.
     ///
     /// Returns:
     ///     GravityConfiguration: Gravity configuration (point mass or spherical harmonic).
@@ -3345,8 +3399,8 @@ impl PyGravityConfiguration {
     ///     )
     ///     ```
     #[new]
-    #[pyo3(signature = (degree=None, order=None, model_type=None, use_global=false))]
-    fn new(degree: Option<usize>, order: Option<usize>, model_type: Option<&PyGravityModelType>, use_global: bool) -> Self {
+    #[pyo3(signature = (degree=None, order=None, model_type=None, use_global=false, parallel=None))]
+    fn new(degree: Option<usize>, order: Option<usize>, model_type: Option<&PyGravityModelType>, use_global: bool, parallel: Option<&PyParallelMode>) -> Self {
         match (degree, order) {
             (Some(d), Some(o)) => {
                 let source = if use_global {
@@ -3357,8 +3411,9 @@ impl PyGravityConfiguration {
                         .unwrap_or(brahe::orbit_dynamics::gravity::GravityModelType::EGM2008_360);
                     propagators::GravityModelSource::ModelType(model)
                 };
+                let parallel_mode = parallel.map(|p| p.mode).unwrap_or(brahe::orbit_dynamics::ParallelMode::Auto);
                 PyGravityConfiguration {
-                    config: propagators::GravityConfiguration::SphericalHarmonic { source, degree: d, order: o },
+                    config: propagators::GravityConfiguration::SphericalHarmonic { source, degree: d, order: o, parallel: parallel_mode },
                 }
             }
             _ => PyGravityConfiguration {
@@ -3387,6 +3442,8 @@ impl PyGravityConfiguration {
     ///         Defaults to EGM2008_360.
     ///     use_global (bool, optional): If True, use global gravity model.
     ///         Defaults to False.
+    ///     parallel (ParallelMode, optional): Parallelization mode for the
+    ///         spherical-harmonic acceleration computation. Defaults to Auto.
     ///
     /// Returns:
     ///     GravityConfiguration: Spherical harmonic gravity.
@@ -3404,8 +3461,8 @@ impl PyGravityConfiguration {
     ///     )
     ///     ```
     #[classmethod]
-    #[pyo3(signature = (degree, order, model_type=None, use_global=false))]
-    fn spherical_harmonic(_cls: &Bound<'_, PyType>, degree: usize, order: usize, model_type: Option<&PyGravityModelType>, use_global: bool) -> Self {
+    #[pyo3(signature = (degree, order, model_type=None, use_global=false, parallel=None))]
+    fn spherical_harmonic(_cls: &Bound<'_, PyType>, degree: usize, order: usize, model_type: Option<&PyGravityModelType>, use_global: bool, parallel: Option<&PyParallelMode>) -> Self {
         let source = if use_global {
             propagators::GravityModelSource::Global
         } else {
@@ -3414,8 +3471,9 @@ impl PyGravityConfiguration {
                 .unwrap_or(brahe::orbit_dynamics::gravity::GravityModelType::EGM2008_360);
             propagators::GravityModelSource::ModelType(model)
         };
+        let parallel_mode = parallel.map(|p| p.mode).unwrap_or(brahe::orbit_dynamics::ParallelMode::Auto);
         PyGravityConfiguration {
-            config: propagators::GravityConfiguration::SphericalHarmonic { source, degree, order },
+            config: propagators::GravityConfiguration::SphericalHarmonic { source, degree, order, parallel: parallel_mode },
         }
     }
 
@@ -3485,6 +3543,19 @@ impl PyGravityConfiguration {
         }
     }
 
+    /// Get the parallel mode (for spherical harmonic).
+    ///
+    /// Returns:
+    ///     ParallelMode or None: Parallel mode if spherical harmonic, None otherwise.
+    fn get_parallel(&self) -> Option<PyParallelMode> {
+        match &self.config {
+            propagators::GravityConfiguration::SphericalHarmonic { parallel, .. } => {
+                Some(PyParallelMode { mode: *parallel })
+            }
+            _ => None,
+        }
+    }
+
     /// Get the zonal degree (for Earth zonal gravity).
     ///
     /// Returns:
@@ -3501,8 +3572,11 @@ impl PyGravityConfiguration {
     fn __repr__(&self) -> String {
         match &self.config {
             propagators::GravityConfiguration::PointMass => "GravityConfiguration.point_mass()".to_string(),
-            propagators::GravityConfiguration::SphericalHarmonic { degree, order, .. } => {
-                format!("GravityConfiguration.spherical_harmonic(degree={}, order={})", degree, order)
+            propagators::GravityConfiguration::SphericalHarmonic { degree, order, parallel, .. } => {
+                format!(
+                    "GravityConfiguration.spherical_harmonic(degree={}, order={}, parallel=ParallelMode.{:?})",
+                    degree, order, parallel
+                )
             }
             propagators::GravityConfiguration::EarthZonal { degree, .. } => {
                 format!("GravityConfiguration.earth_zonal(degree={})", degree)

--- a/examples/numerical_propagation/force_model_drag_exponential.rs
+++ b/examples/numerical_propagation/force_model_drag_exponential.rs
@@ -22,6 +22,7 @@ fn main() {
             source: bh::GravityModelSource::ModelType(GravityModelType::EGM2008_360),
             degree: 20,
             order: 20,
+            parallel: bh::orbit_dynamics::ParallelMode::Auto,
         },
         drag: Some(drag_config),
         srp: None,

--- a/examples/numerical_propagation/force_model_gravity_icgem.rs
+++ b/examples/numerical_propagation/force_model_gravity_icgem.rs
@@ -25,6 +25,7 @@ fn main() {
             source: bh::GravityModelSource::ModelType(grav_type),
             degree: 20,
             order: 20,
+            parallel: bh::orbit_dynamics::ParallelMode::Auto,
         },
         drag: None,
         srp: None,

--- a/examples/numerical_propagation/force_model_gravity_spherical.rs
+++ b/examples/numerical_propagation/force_model_gravity_spherical.rs
@@ -14,6 +14,7 @@ fn main() {
         source: bh::GravityModelSource::ModelType(GravityModelType::EGM2008_360),
         degree: 20,
         order: 20,
+        parallel: bh::orbit_dynamics::ParallelMode::Auto,
     };
 
     // GGM05S - GRACE mission model (180x180 max)
@@ -21,6 +22,7 @@ fn main() {
         source: bh::GravityModelSource::ModelType(GravityModelType::GGM05S),
         degree: 20,
         order: 20,
+        parallel: bh::orbit_dynamics::ParallelMode::Auto,
     };
 
     // JGM3 - Legacy model, fast computation (70x70 max)
@@ -28,6 +30,7 @@ fn main() {
         source: bh::GravityModelSource::ModelType(GravityModelType::JGM3),
         degree: 20,
         order: 20,
+        parallel: bh::orbit_dynamics::ParallelMode::Auto,
     };
 
     // ==========================================================================
@@ -42,6 +45,7 @@ fn main() {
         source: bh::GravityModelSource::ModelType(custom_model_type),
         degree: 20,
         order: 20,
+        parallel: bh::orbit_dynamics::ParallelMode::Auto,
     };
 }
 

--- a/examples/numerical_propagation/force_model_overview.rs
+++ b/examples/numerical_propagation/force_model_overview.rs
@@ -13,6 +13,7 @@ fn main() {
             source: bh::GravityModelSource::ModelType(GravityModelType::EGM2008_360),
             degree: 20,
             order: 20,
+            parallel: bh::orbit_dynamics::ParallelMode::Auto,
         },
         // Atmospheric drag: Harris-Priester model with parameter indices
         drag: Some(bh::DragConfiguration {

--- a/examples/numerical_propagation/force_model_parameter_value.rs
+++ b/examples/numerical_propagation/force_model_parameter_value.rs
@@ -29,6 +29,7 @@ fn main() {
             source: bh::GravityModelSource::ModelType(GravityModelType::EGM2008_360),
             degree: 20,
             order: 20,
+            parallel: bh::orbit_dynamics::ParallelMode::Auto,
         },
         drag: Some(drag_config),
         srp: Some(srp_config),

--- a/examples/numerical_propagation/force_model_third_body.rs
+++ b/examples/numerical_propagation/force_model_third_body.rs
@@ -55,6 +55,7 @@ fn main() {
             source: bh::GravityModelSource::ModelType(GravityModelType::EGM2008_360),
             degree: 20,
             order: 20,
+            parallel: bh::orbit_dynamics::ParallelMode::Auto,
         },
         drag: None,
         srp: None,

--- a/examples/orbit_dynamics/spherical_harmonics.rs
+++ b/examples/orbit_dynamics/spherical_harmonics.rs
@@ -49,7 +49,7 @@ fn main() {
     let n_max = 10;
     let m_max = 10;
     let accel_sh = bh::orbit_dynamics::accel_gravity_spherical_harmonics(
-        r_eci, r_eci_ecef, &gravity_model, n_max, m_max
+        r_eci, r_eci_ecef, &gravity_model, n_max, m_max, bh::orbit_dynamics::ParallelMode::Auto
     );
 
     println!("\nSpherical harmonic acceleration (degree {}, order {}):", n_max, m_max);

--- a/profiles/rust/src/bin/rk4_20x20_thirdbody.rs
+++ b/profiles/rust/src/bin/rk4_20x20_thirdbody.rs
@@ -28,6 +28,7 @@ fn main() {
             source: GravityModelSource::default(),
             degree: 20,
             order: 20,
+            parallel: brahe::orbit_dynamics::ParallelMode::Auto,
         },
         drag: None,
         srp: None,

--- a/profiles/rust/src/bin/rk4_5x5_gravity.rs
+++ b/profiles/rust/src/bin/rk4_5x5_gravity.rs
@@ -29,6 +29,7 @@ fn main() {
             source: GravityModelSource::default(),
             degree: 5,
             order: 5,
+            parallel: brahe::orbit_dynamics::ParallelMode::Auto,
         },
         drag: None,
         srp: None,

--- a/profiles/rust/src/bin/rk4_80x80_full.rs
+++ b/profiles/rust/src/bin/rk4_80x80_full.rs
@@ -37,6 +37,7 @@ fn main() {
             source: GravityModelSource::default(),
             degree: 80,
             order: 80,
+            parallel: brahe::orbit_dynamics::ParallelMode::Auto,
         },
         drag: Some(DragConfiguration {
             model: AtmosphericModel::NRLMSISE00,

--- a/src/orbit_dynamics/gravity.rs
+++ b/src/orbit_dynamics/gravity.rs
@@ -399,22 +399,27 @@ pub enum ParallelMode {
 /// evaluation beats serial on a typical multi-core host. Machine-approximate;
 /// see `benchmarks/gravity_benchmarks.rs`.
 ///
-/// Measured on a 10-core Apple M1 Max. Serial vs parallel median times:
+/// Measured on a 10-core Apple M1 Max after the serial-path optimization
+/// (precomputed reciprocal recurrence coefficients + bounds-check-free column
+/// slices in the recurrence and accumulation). Serial vs parallel median times:
 ///
 /// | n_max | serial    | parallel  |
 /// |-------|-----------|-----------|
-/// |     2 |   107 ns  |  30.1 µs  |
-/// |    20 |  2.49 µs  |  36.4 µs  |
-/// |    50 |  15.1 µs  |  53.1 µs  |
-/// |    90 |  53.0 µs  |  90.8 µs  |
-/// |   120 |  89.8 µs  |   128 µs  |
-/// |   180 |   193 µs  |   155 µs  |
-/// |   360 |   788 µs  |   291 µs  |
+/// |     2 |   114 ns  |  27.6 µs  |
+/// |    20 |  1.51 µs  |  38.4 µs  |
+/// |    50 |  8.75 µs  |  55.3 µs  |
+/// |    90 |  32.6 µs  |   107 µs  |
+/// |   120 |  59.7 µs  |   127 µs  |
+/// |   180 |   121 µs  |   153 µs  |
+/// |   210 |   156 µs  |   154 µs  |
+/// |   240 |   212 µs  |   177 µs  |
+/// |   360 |   495 µs  |   310 µs  |
 ///
-/// Parallel first wins at n=180 (1.25×). Set to 150 as a clean round value
-/// just below the first winning tested point, ensuring parallel is reliably
-/// faster when engaged. This value is machine-approximate.
-pub(crate) const PARALLEL_THRESHOLD_NMAX: usize = 150;
+/// The serial path is now ~1.6× faster than before, which pushed the crossover
+/// out: parallel breaks even at n≈210 and wins reliably from n=240 (1.20×).
+/// Set to 210 — the break-even point — so parallel only engages where it is at
+/// least as fast as serial. This value is machine-approximate.
+pub(crate) const PARALLEL_THRESHOLD_NMAX: usize = 210;
 
 /// Decide whether to run the spherical-harmonic computation in parallel.
 ///
@@ -549,6 +554,19 @@ pub struct GravityModel {
     /// entries with `m >= 1` are populated and read. See `coeff_c` for
     /// invalidation rules.
     fac: DMatrix<f64>,
+    /// Precomputed V/W recurrence multiplier `(2n - 1) / (n - m)` indexed as
+    /// `rec_a[(n, m)]`. Hoists the integer→float casts and — critically — the
+    /// floating-point division out of the column-fill inner loop, which sits on
+    /// a serial dependency chain (`V[n]` needs `V[n-1]`, `V[n-2]`) where the
+    /// division latency cannot be hidden. The same coefficients serve the zonal
+    /// column (m = 0, where `(n+m-1) = n-1` and `(n-m) = n`) and the tesseral
+    /// columns. Sized `(n_max + 2) × (n_max + 2)` to cover the recurrence's
+    /// `n_max + 1` top row. Only entries with `n > m` are populated/read.
+    /// See `coeff_c` for invalidation rules.
+    rec_a: DMatrix<f64>,
+    /// Precomputed V/W recurrence multiplier `(n + m - 1) / (n - m)` indexed as
+    /// `rec_b[(n, m)]`. Companion to `rec_a`; see it for details.
+    rec_b: DMatrix<f64>,
 }
 
 impl GravityModel {
@@ -568,6 +586,8 @@ impl GravityModel {
             coeff_c: DMatrix::zeros(1, 1),
             coeff_s: DMatrix::zeros(1, 1),
             fac: DMatrix::zeros(1, 1),
+            rec_a: DMatrix::zeros(1, 1),
+            rec_b: DMatrix::zeros(1, 1),
         }
     }
 
@@ -621,9 +641,29 @@ impl GravityModel {
             }
         }
 
+        // V/W recurrence multipliers. These depend only on the integer indices
+        // (n, m), not on position or coefficients, so hoisting them here removes
+        // a float division and two int→float casts from every inner-loop cell.
+        // Size to (n_max + 2) so the recurrence's top row (index n_max + 1) is
+        // covered; only entries with n > m are ever read.
+        let rsize = self.n_max + 2;
+        let mut rec_a = DMatrix::zeros(rsize, rsize);
+        let mut rec_b = DMatrix::zeros(rsize, rsize);
+        for m in 0..rsize {
+            for n in (m + 1)..rsize {
+                let nf = n as f64;
+                let mf = m as f64;
+                let inv = 1.0 / (nf - mf);
+                rec_a[(n, m)] = (2.0 * nf - 1.0) * inv;
+                rec_b[(n, m)] = (nf + mf - 1.0) * inv;
+            }
+        }
+
         self.coeff_c = coeff_c;
         self.coeff_s = coeff_s;
         self.fac = fac;
+        self.rec_a = rec_a;
+        self.rec_b = rec_b;
     }
 
     fn from_bufreader<T: Read>(reader: BufReader<T>) -> Result<Self, BraheError> {
@@ -744,6 +784,8 @@ impl GravityModel {
             coeff_c: DMatrix::zeros(1, 1),
             coeff_s: DMatrix::zeros(1, 1),
             fac: DMatrix::zeros(1, 1),
+            rec_a: DMatrix::zeros(1, 1),
+            rec_b: DMatrix::zeros(1, 1),
         };
         model.precompute_coefficients();
         Ok(model)
@@ -1111,9 +1153,8 @@ impl GravityModel {
         V[(1, 0)] = z0 * V[(0, 0)];
         W[(1, 0)] = 0.0;
         for n in 2..(n_max + 2) {
-            let nf = n as f64;
-            V[(n, 0)] =
-                ((2.0 * nf - 1.0) * z0 * V[(n - 1, 0)] - (nf - 1.0) * rho * V[(n - 2, 0)]) / nf;
+            V[(n, 0)] = self.rec_a[(n, 0)] * z0 * V[(n - 1, 0)]
+                - self.rec_b[(n, 0)] * rho * V[(n - 2, 0)];
             W[(n, 0)] = 0.0;
         }
 
@@ -1141,6 +1182,8 @@ impl GravityModel {
             let ncols_used = m_max + 2;
             let v_slice = &mut V.as_mut_slice()[..ncols_used * stride];
             let w_slice = &mut W.as_mut_slice()[..ncols_used * stride];
+            let rec_a = &self.rec_a;
+            let rec_b = &self.rec_b;
             get_thread_pool().install(|| {
                 v_slice
                     .par_chunks_mut(stride)
@@ -1150,21 +1193,29 @@ impl GravityModel {
                         if m == 0 {
                             return; // zonal column already filled
                         }
-                        let mf = m as f64;
                         for n in m + 2..n_max + 2 {
-                            let nf = n as f64;
-                            v_col[n] = ((2.0 * nf - 1.0) * z0 * v_col[n - 1]
-                                - (nf + mf - 1.0) * rho * v_col[n - 2])
-                                / (nf - mf);
-                            w_col[n] = ((2.0 * nf - 1.0) * z0 * w_col[n - 1]
-                                - (nf + mf - 1.0) * rho * w_col[n - 2])
-                                / (nf - mf);
+                            let a = rec_a[(n, m)];
+                            let b = rec_b[(n, m)];
+                            v_col[n] = a * z0 * v_col[n - 1] - b * rho * v_col[n - 2];
+                            w_col[n] = a * z0 * w_col[n - 1] - b * rho * w_col[n - 2];
                         }
                     });
             });
         } else {
+            // Column strides differ: the V/W workspace may be oversized from a
+            // prior larger call, while rec_a/rec_b are sized to the model. Each
+            // column is sliced to exactly `col_len = n_max + 2` elements so the
+            // inner-loop index `n < n_max + 2` is provably in-bounds and LLVM
+            // elides the per-access bounds checks on the serial hot path.
+            let col_len = n_max + 2;
+            let v_stride = V.nrows();
+            let r_stride = self.rec_a.nrows();
+            let rec_a = self.rec_a.as_slice();
+            let rec_b = self.rec_b.as_slice();
             for m in 1..m_max + 2 {
                 let mf = m as f64;
+                // Diagonal + sub-diagonal seeds read column m-1 (cross-column),
+                // so they stay on the matrix API rather than the column slices.
                 V[(m, m)] =
                     (2.0 * mf - 1.0) * (x0 * V[(m - 1, m - 1)] - y0 * W[(m - 1, m - 1)]);
                 W[(m, m)] =
@@ -1173,14 +1224,17 @@ impl GravityModel {
                     V[(m + 1, m)] = (2.0 * mf + 1.0) * z0 * V[(m, m)];
                     W[(m + 1, m)] = (2.0 * mf + 1.0) * z0 * W[(m, m)];
                 }
+                let v_lo = m * v_stride;
+                let r_lo = m * r_stride;
+                let v_col = &mut V.as_mut_slice()[v_lo..v_lo + col_len];
+                let w_col = &mut W.as_mut_slice()[v_lo..v_lo + col_len];
+                let ra = &rec_a[r_lo..r_lo + col_len];
+                let rb = &rec_b[r_lo..r_lo + col_len];
                 for n in m + 2..n_max + 2 {
-                    let nf = n as f64;
-                    V[(n, m)] = ((2.0 * nf - 1.0) * z0 * V[(n - 1, m)]
-                        - (nf + mf - 1.0) * rho * V[(n - 2, m)])
-                        / (nf - mf);
-                    W[(n, m)] = ((2.0 * nf - 1.0) * z0 * W[(n - 1, m)]
-                        - (nf + mf - 1.0) * rho * W[(n - 2, m)])
-                        / (nf - mf);
+                    let a = ra[n];
+                    let b = rb[n];
+                    v_col[n] = a * z0 * v_col[n - 1] - b * rho * v_col[n - 2];
+                    w_col[n] = a * z0 * w_col[n - 1] - b * rho * w_col[n - 2];
                 }
             }
         }
@@ -1191,25 +1245,61 @@ impl GravityModel {
         // `par_iter` requires `Sync`). The Phase 1 mutable borrows have ended.
         let v_ref: &DMatrix<f64> = V;
         let w_ref: &DMatrix<f64> = W;
+        // Column-slice the V/W workspaces and coefficient matrices so the
+        // accumulation reads are bounds-check-free (same technique as the
+        // recurrence above). The accumulation touches columns m-1, m, m+1 at
+        // row n+1, and coefficient column m at row n. `vw_len = n_max + 2`
+        // bounds the V/W row index n+1; `cf_len = n_max + 1` bounds the
+        // coefficient row index n. Strides may differ between the (possibly
+        // oversized) workspaces and the model-sized coefficient matrices.
+        let v_stride = v_ref.nrows();
+        let c_stride = self.coeff_c.nrows();
+        let v_buf = v_ref.as_slice();
+        let w_buf = w_ref.as_slice();
+        let c_buf = self.coeff_c.as_slice();
+        let s_buf = self.coeff_s.as_slice();
+        let f_buf = self.fac.as_slice();
+        let vw_len = n_max + 2;
+        let cf_len = n_max + 1;
         let accumulate_m = |m: usize| -> (f64, f64, f64) {
             let mf = m as f64;
             let (mut ax, mut ay, mut az) = (0.0, 0.0, 0.0);
-            for n in m..n_max + 1 {
-                let nf = n as f64;
-                if m == 0 {
-                    let c = self.coeff_c[(n, 0)];
-                    ax -= c * v_ref[(n + 1, 1)];
-                    ay -= c * w_ref[(n + 1, 1)];
-                    az -= (nf + 1.0) * c * v_ref[(n + 1, 0)];
-                } else {
-                    let c = self.coeff_c[(n, m)];
-                    let s = self.coeff_s[(n, m)];
-                    let fac = self.fac[(n, m)];
-                    ax += 0.5 * (-c * v_ref[(n + 1, m + 1)] - s * w_ref[(n + 1, m + 1)])
-                        + fac * (c * v_ref[(n + 1, m - 1)] + s * w_ref[(n + 1, m - 1)]);
-                    ay += 0.5 * (-c * w_ref[(n + 1, m + 1)] + s * v_ref[(n + 1, m + 1)])
-                        + fac * (-c * w_ref[(n + 1, m - 1)] + s * v_ref[(n + 1, m - 1)]);
-                    az += (nf - mf + 1.0) * (-c * v_ref[(n + 1, m)] - s * w_ref[(n + 1, m)]);
+            if m == 0 {
+                let c_col = &c_buf[0..cf_len];
+                let v0 = &v_buf[0..vw_len];
+                let v1 = &v_buf[v_stride..v_stride + vw_len];
+                let w1 = &w_buf[v_stride..v_stride + vw_len];
+                for n in 0..n_max + 1 {
+                    let nf = n as f64;
+                    let c = c_col[n];
+                    ax -= c * v1[n + 1];
+                    ay -= c * w1[n + 1];
+                    az -= (nf + 1.0) * c * v0[n + 1];
+                }
+            } else {
+                let cbase = m * c_stride;
+                let c_col = &c_buf[cbase..cbase + cf_len];
+                let s_col = &s_buf[cbase..cbase + cf_len];
+                let f_col = &f_buf[cbase..cbase + cf_len];
+                // Columns m-1, m, m+1 are contiguous starting at (m-1)*stride.
+                let vbase = (m - 1) * v_stride;
+                let v_lo = &v_buf[vbase..vbase + vw_len];
+                let v_mid = &v_buf[vbase + v_stride..vbase + v_stride + vw_len];
+                let v_hi = &v_buf[vbase + 2 * v_stride..vbase + 2 * v_stride + vw_len];
+                let w_lo = &w_buf[vbase..vbase + vw_len];
+                let w_mid = &w_buf[vbase + v_stride..vbase + v_stride + vw_len];
+                let w_hi = &w_buf[vbase + 2 * v_stride..vbase + 2 * v_stride + vw_len];
+                for n in m..n_max + 1 {
+                    let nf = n as f64;
+                    let c = c_col[n];
+                    let s = s_col[n];
+                    let fac = f_col[n];
+                    let p = n + 1;
+                    ax += 0.5 * (-c * v_hi[p] - s * w_hi[p])
+                        + fac * (c * v_lo[p] + s * w_lo[p]);
+                    ay += 0.5 * (-c * w_hi[p] + s * v_hi[p])
+                        + fac * (-c * w_lo[p] + s * v_lo[p]);
+                    az += (nf - mf + 1.0) * (-c * v_mid[p] - s * w_mid[p]);
                 }
             }
             (ax, ay, az)
@@ -2324,6 +2414,91 @@ mod tests {
                     "r={r_body:?} n={n} m={m}: parallel/serial mismatch rel={rel:e}"
                 );
             }
+        }
+    }
+
+    #[test]
+    fn test_serial_spherical_harmonics_characterization() {
+        // Golden values captured from the reference (pre-optimization) serial
+        // implementation. This guards the optimized serial recurrence and
+        // accumulation against numerical regressions at the small degrees
+        // common to LEO propagation (5, 20, 80). The relative tolerance (1e-12)
+        // is loose enough to absorb the ~1e-15 FP-reordering introduced by
+        // replacing the inner-loop division with a precomputed reciprocal
+        // multiply, but far tighter than any real algorithmic bug would survive.
+        let model = GravityModel::from_model_type(&GravityModelType::EGM2008_360).unwrap();
+
+        // (position, n_max==m_max, [expected ax, ay, az])
+        let cases: [(Vector3<f64>, usize, [f64; 3]); 6] = [
+            (
+                Vector3::new(6.5e6, 1.2e6, 3.1e6),
+                5,
+                [
+                    -6.659_157_617_724_3,
+                    -1.229_429_462_451_389_3,
+                    -3.183_740_444_887_946_3,
+                ],
+            ),
+            (
+                Vector3::new(6.5e6, 1.2e6, 3.1e6),
+                20,
+                [
+                    -6.659_131_615_693_394,
+                    -1.229_413_486_834_888,
+                    -3.183_743_631_333_252,
+                ],
+            ),
+            (
+                Vector3::new(6.5e6, 1.2e6, 3.1e6),
+                80,
+                [
+                    -6.659_131_583_250_136_5,
+                    -1.229_414_674_519_354_8,
+                    -3.183_746_816_300_017_5,
+                ],
+            ),
+            (
+                Vector3::new(0.0, 0.0, 7.0e6),
+                5,
+                [
+                    4.832_073_418_678_780_7e-5,
+                    -2.144_848_603_164_800_2e-5,
+                    -8.112_882_851_092_754,
+                ],
+            ),
+            (
+                Vector3::new(0.0, 0.0, 7.0e6),
+                20,
+                [
+                    8.160_586_191_674_914e-5,
+                    -1.987_917_874_597_063e-5,
+                    -8.112_905_372_087_614,
+                ],
+            ),
+            (
+                Vector3::new(0.0, 0.0, 7.0e6),
+                80,
+                [
+                    8.241_307_452_961_249e-5,
+                    -1.812_120_022_312_316e-5,
+                    -8.112_900_111_910_852,
+                ],
+            ),
+        ];
+
+        for (r_body, n, expected) in cases {
+            let a = model
+                .compute_spherical_harmonics(r_body, n, n, ParallelMode::Never)
+                .unwrap();
+            let exp = Vector3::new(expected[0], expected[1], expected[2]);
+            let rel = (a - exp).norm() / a.norm();
+            assert!(
+                rel < 1e-12,
+                "n={n} r={r_body:?}: got [{:.17e}, {:.17e}, {:.17e}] rel={rel:e}",
+                a[0],
+                a[1],
+                a[2]
+            );
         }
     }
 }

--- a/src/orbit_dynamics/gravity.rs
+++ b/src/orbit_dynamics/gravity.rs
@@ -12,9 +12,12 @@ use nalgebra::{DMatrix, Vector3};
 use crate::math::{SMatrix3, traits::IntoPosition};
 use once_cell::sync::Lazy;
 
+use rayon::prelude::*;
+
 use crate::constants::{GM_EARTH, J2_EARTH, J3_EARTH, J4_EARTH, J5_EARTH, J6_EARTH, R_EARTH};
 use crate::math::kronecker_delta;
 use crate::utils::BraheError;
+use crate::utils::threading::get_thread_pool;
 
 /// Packaged EGM2008_360 Data File
 static PACKAGED_EGM2008_360: &[u8] = include_bytes!("../../data/gravity_models/EGM2008_360.gfc");
@@ -373,6 +376,62 @@ pub enum GravityModelNormalization {
     /// Unnormalized spherical harmonics. Used in older models and some theoretical
     /// applications. Coefficients decrease rapidly with increasing degree/order.
     Unnormalized,
+}
+
+/// Execution policy for the spherical-harmonic acceleration computation.
+///
+/// Controls whether [`GravityModel::compute_spherical_harmonics_with_workspace`]
+/// and its callers parallelize the recurrence column-fill and the acceleration
+/// accumulation across Brahe's managed thread pool.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, Default)]
+pub enum ParallelMode {
+    /// Parallelize only when `n_max >= PARALLEL_THRESHOLD_NMAX`. Below that, the
+    /// rayon dispatch overhead outweighs the gain, so the serial path is used.
+    #[default]
+    Auto,
+    /// Always parallelize (via the configured global thread pool).
+    Always,
+    /// Always run serially.
+    Never,
+}
+
+/// Benchmark-calibrated crossover degree. At or above this `n_max`, parallel
+/// evaluation beats serial on a typical multi-core host. Machine-approximate;
+/// see `benchmarks/gravity_benchmarks.rs`.
+///
+/// Measured on a 10-core Apple M1 Max. Serial vs parallel median times:
+///
+/// | n_max | serial    | parallel  |
+/// |-------|-----------|-----------|
+/// |     2 |   107 ns  |  30.1 µs  |
+/// |    20 |  2.49 µs  |  36.4 µs  |
+/// |    50 |  15.1 µs  |  53.1 µs  |
+/// |    90 |  53.0 µs  |  90.8 µs  |
+/// |   120 |  89.8 µs  |   128 µs  |
+/// |   180 |   193 µs  |   155 µs  |
+/// |   360 |   788 µs  |   291 µs  |
+///
+/// Parallel first wins at n=180 (1.25×). Set to 150 as a clean round value
+/// just below the first winning tested point, ensuring parallel is reliably
+/// faster when engaged. This value is machine-approximate.
+pub(crate) const PARALLEL_THRESHOLD_NMAX: usize = 150;
+
+/// Decide whether to run the spherical-harmonic computation in parallel.
+///
+/// `Auto` parallelizes only for large expansions (`n_max >= PARALLEL_THRESHOLD_NMAX`)
+/// AND only when not already executing on a rayon worker thread. The latter check
+/// prevents nested parallelism: batch propagation (`par_propagate_to_*`) already
+/// saturates the managed thread pool with one propagation per worker, so an inner
+/// `install` per gravity eval would only add split/reduce overhead. `Always` still
+/// forces parallelism (an explicit opt-in escape hatch); `Never` always serial.
+pub(crate) fn should_parallelize(mode: ParallelMode, n_max: usize) -> bool {
+    match mode {
+        ParallelMode::Always => true,
+        ParallelMode::Never => false,
+        ParallelMode::Auto => {
+            n_max >= PARALLEL_THRESHOLD_NMAX && rayon::current_thread_index().is_none()
+        }
+    }
 }
 
 /// Type of spherical harmonic gravity model
@@ -963,6 +1022,7 @@ impl GravityModel {
         r_body: Vector3<f64>,
         n_max: usize,
         m_max: usize,
+        parallel: ParallelMode,
     ) -> Result<Vector3<f64>, BraheError> {
         let mut v_workspace = DMatrix::<f64>::zeros(n_max + 2, n_max + 2);
         let mut w_workspace = DMatrix::<f64>::zeros(n_max + 2, n_max + 2);
@@ -970,6 +1030,7 @@ impl GravityModel {
             r_body,
             n_max,
             m_max,
+            parallel,
             &mut v_workspace,
             &mut w_workspace,
         )
@@ -1002,6 +1063,7 @@ impl GravityModel {
         r_body: Vector3<f64>,
         n_max: usize,
         m_max: usize,
+        parallel: ParallelMode,
         v_workspace: &mut DMatrix<f64>,
         w_workspace: &mut DMatrix<f64>,
     ) -> Result<Vector3<f64>, BraheError> {
@@ -1040,72 +1102,135 @@ impl GravityModel {
         let V = v_workspace;
         let W = w_workspace;
 
-        // Calculate zonal terms V(n,0); set W(n,0)=0.0
+        let run_parallel = should_parallelize(parallel, n_max);
+
+        // ---- Phase 1: V/W recurrence ----
+        // Zonal column m = 0 (independent, sequential either way).
         V[(0, 0)] = self.radius / r_sqr.sqrt();
         W[(0, 0)] = 0.0;
-
         V[(1, 0)] = z0 * V[(0, 0)];
         W[(1, 0)] = 0.0;
-
         for n in 2..(n_max + 2) {
             let nf = n as f64;
             V[(n, 0)] =
                 ((2.0 * nf - 1.0) * z0 * V[(n - 1, 0)] - (nf - 1.0) * rho * V[(n - 2, 0)]) / nf;
-            W[(n, 0)] = 0.0
+            W[(n, 0)] = 0.0;
         }
 
-        // Calculate tesseral and sectorial terms
-        for m in 1..m_max + 2 {
-            let mf = m as f64;
-            // Calculate V(m,m) .. V(n_max+1,m)
-            V[(m, m)] = (2.0 * mf - 1.0) * (x0 * V[(m - 1, m - 1)] - y0 * W[(m - 1, m - 1)]);
-            W[(m, m)] = (2.0 * mf - 1.0) * (x0 * W[(m - 1, m - 1)] + y0 * V[(m - 1, m - 1)]);
-
-            if m <= n_max {
-                V[(m + 1, m)] = (2.0 * mf + 1.0) * z0 * V[(m, m)];
-                W[(m + 1, m)] = (2.0 * mf + 1.0) * z0 * W[(m, m)];
+        if run_parallel {
+            // Sequential diagonal chain (the only cross-column dependency) plus
+            // the first sub-diagonal seed for each column.
+            for m in 1..m_max + 2 {
+                let mf = m as f64;
+                V[(m, m)] =
+                    (2.0 * mf - 1.0) * (x0 * V[(m - 1, m - 1)] - y0 * W[(m - 1, m - 1)]);
+                W[(m, m)] =
+                    (2.0 * mf - 1.0) * (x0 * W[(m - 1, m - 1)] + y0 * V[(m - 1, m - 1)]);
+                if m <= n_max {
+                    V[(m + 1, m)] = (2.0 * mf + 1.0) * z0 * V[(m, m)];
+                    W[(m + 1, m)] = (2.0 * mf + 1.0) * z0 * W[(m, m)];
+                }
             }
 
-            for n in m + 2..n_max + 2 {
-                let nf = n as f64;
-                V[(n, m)] = ((2.0 * nf - 1.0) * z0 * V[(n - 1, m)]
-                    - (nf + mf - 1.0) * rho * V[(n - 2, m)])
-                    / (nf - mf);
-
-                W[(n, m)] = ((2.0 * nf - 1.0) * z0 * W[(n - 1, m)]
-                    - (nf + mf - 1.0) * rho * W[(n - 2, m)])
-                    / (nf - mf);
-            }
-        }
-
-        // Calculate accelerations ax,ay,az
-        let mut ax = 0.0;
-        let mut ay = 0.0;
-        let mut az = 0.0;
-
-        for m in 0..m_max + 1 {
-            let mf = m as f64;
-            for n in m..n_max + 1 {
-                let nf = n as f64;
-                // Consider only zonal harmonics, ignore longitude coeff S
-                if m == 0 {
-                    let C = self.coeff_c[(n, 0)];
-                    ax -= C * V[(n + 1, 1)];
-                    ay -= C * W[(n + 1, 1)];
-                    az -= (nf + 1.0) * C * V[(n + 1, 0)];
-                } else {
-                    // sectoral / tesseral, use coeff S
-                    let C = self.coeff_c[(n, m)];
-                    let S = self.coeff_s[(n, m)];
-                    let Fac = self.fac[(n, m)];
-                    ax += 0.5 * (-C * V[(n + 1, m + 1)] - S * W[(n + 1, m + 1)])
-                        + Fac * (C * V[(n + 1, m - 1)] + S * W[(n + 1, m - 1)]);
-                    ay += 0.5 * (-C * W[(n + 1, m + 1)] + S * V[(n + 1, m + 1)])
-                        + Fac * (-C * W[(n + 1, m - 1)] + S * V[(n + 1, m - 1)]);
-                    az += (nf - mf + 1.0) * (-C * V[(n + 1, m)] - S * W[(n + 1, m)]);
+            // Parallel column fill. DMatrix is column-major, so each column is a
+            // contiguous slice of length `stride`. The first `m_max + 2` columns
+            // occupy the first `(m_max + 2) * stride` contiguous elements; slice
+            // to exactly those so `par_chunks_mut` yields one chunk per column.
+            // (rayon's parallel iterator has no `take`, so bound via the slice.)
+            let stride = V.nrows();
+            let ncols_used = m_max + 2;
+            let v_slice = &mut V.as_mut_slice()[..ncols_used * stride];
+            let w_slice = &mut W.as_mut_slice()[..ncols_used * stride];
+            get_thread_pool().install(|| {
+                v_slice
+                    .par_chunks_mut(stride)
+                    .zip(w_slice.par_chunks_mut(stride))
+                    .enumerate()
+                    .for_each(|(m, (v_col, w_col))| {
+                        if m == 0 {
+                            return; // zonal column already filled
+                        }
+                        let mf = m as f64;
+                        for n in m + 2..n_max + 2 {
+                            let nf = n as f64;
+                            v_col[n] = ((2.0 * nf - 1.0) * z0 * v_col[n - 1]
+                                - (nf + mf - 1.0) * rho * v_col[n - 2])
+                                / (nf - mf);
+                            w_col[n] = ((2.0 * nf - 1.0) * z0 * w_col[n - 1]
+                                - (nf + mf - 1.0) * rho * w_col[n - 2])
+                                / (nf - mf);
+                        }
+                    });
+            });
+        } else {
+            for m in 1..m_max + 2 {
+                let mf = m as f64;
+                V[(m, m)] =
+                    (2.0 * mf - 1.0) * (x0 * V[(m - 1, m - 1)] - y0 * W[(m - 1, m - 1)]);
+                W[(m, m)] =
+                    (2.0 * mf - 1.0) * (x0 * W[(m - 1, m - 1)] + y0 * V[(m - 1, m - 1)]);
+                if m <= n_max {
+                    V[(m + 1, m)] = (2.0 * mf + 1.0) * z0 * V[(m, m)];
+                    W[(m + 1, m)] = (2.0 * mf + 1.0) * z0 * W[(m, m)];
+                }
+                for n in m + 2..n_max + 2 {
+                    let nf = n as f64;
+                    V[(n, m)] = ((2.0 * nf - 1.0) * z0 * V[(n - 1, m)]
+                        - (nf + mf - 1.0) * rho * V[(n - 2, m)])
+                        / (nf - mf);
+                    W[(n, m)] = ((2.0 * nf - 1.0) * z0 * W[(n - 1, m)]
+                        - (nf + mf - 1.0) * rho * W[(n - 2, m)])
+                        / (nf - mf);
                 }
             }
         }
+
+        // ---- Phase 2: acceleration accumulation ----
+        // Reborrow the workspaces immutably so the accumulation closure is
+        // `Sync` (a closure capturing `&mut DMatrix` is not, and rayon's
+        // `par_iter` requires `Sync`). The Phase 1 mutable borrows have ended.
+        let v_ref: &DMatrix<f64> = V;
+        let w_ref: &DMatrix<f64> = W;
+        let accumulate_m = |m: usize| -> (f64, f64, f64) {
+            let mf = m as f64;
+            let (mut ax, mut ay, mut az) = (0.0, 0.0, 0.0);
+            for n in m..n_max + 1 {
+                let nf = n as f64;
+                if m == 0 {
+                    let c = self.coeff_c[(n, 0)];
+                    ax -= c * v_ref[(n + 1, 1)];
+                    ay -= c * w_ref[(n + 1, 1)];
+                    az -= (nf + 1.0) * c * v_ref[(n + 1, 0)];
+                } else {
+                    let c = self.coeff_c[(n, m)];
+                    let s = self.coeff_s[(n, m)];
+                    let fac = self.fac[(n, m)];
+                    ax += 0.5 * (-c * v_ref[(n + 1, m + 1)] - s * w_ref[(n + 1, m + 1)])
+                        + fac * (c * v_ref[(n + 1, m - 1)] + s * w_ref[(n + 1, m - 1)]);
+                    ay += 0.5 * (-c * w_ref[(n + 1, m + 1)] + s * v_ref[(n + 1, m + 1)])
+                        + fac * (-c * w_ref[(n + 1, m - 1)] + s * v_ref[(n + 1, m - 1)]);
+                    az += (nf - mf + 1.0) * (-c * v_ref[(n + 1, m)] - s * w_ref[(n + 1, m)]);
+                }
+            }
+            (ax, ay, az)
+        };
+
+        let (ax, ay, az) = if run_parallel {
+            get_thread_pool().install(|| {
+                (0..m_max + 1)
+                    .into_par_iter()
+                    .map(accumulate_m)
+                    .reduce(
+                        || (0.0, 0.0, 0.0),
+                        |a, b| (a.0 + b.0, a.1 + b.1, a.2 + b.2),
+                    )
+            })
+        } else {
+            (0..m_max + 1).fold((0.0, 0.0, 0.0), |acc, m| {
+                let (ax, ay, az) = accumulate_m(m);
+                (acc.0 + ax, acc.1 + ay, acc.2 + az)
+            })
+        };
 
         // Body-fixed acceleration
         Ok((self.gm / (self.radius * self.radius)) * Vector3::new(ax, ay, az))
@@ -1157,7 +1282,7 @@ impl std::fmt::Debug for GravityModel {
 /// Using a position vector:
 /// ```
 /// use nalgebra::{Vector3, Vector6};
-/// use brahe::gravity::{GravityModel, GravityModelType};
+/// use brahe::gravity::{GravityModel, GravityModelType, ParallelMode};
 /// use brahe::frames::rotation_eci_to_ecef;
 /// use brahe::time::Epoch;
 /// use brahe::eop::{set_global_eop_provider, FileEOPProvider, EOPExtrapolation};
@@ -1179,13 +1304,13 @@ impl std::fmt::Debug for GravityModel {
 /// let r_eci: Vector3<f64> = x_eci.fixed_rows::<3>(0).into();
 ///
 /// // Compute the acceleration due to gravity
-/// let a_grav = brahe::gravity::accel_gravity_spherical_harmonics(r_eci, R_i2b, &gravity_model, 20, 20);
+/// let a_grav = brahe::gravity::accel_gravity_spherical_harmonics(r_eci, R_i2b, &gravity_model, 20, 20, ParallelMode::Auto);
 /// ```
 ///
 /// Using a state vector:
 /// ```
 /// use nalgebra::Vector6;
-/// use brahe::gravity::{GravityModel, GravityModelType};
+/// use brahe::gravity::{GravityModel, GravityModelType, ParallelMode};
 /// use brahe::frames::rotation_eci_to_ecef;
 /// use brahe::time::Epoch;
 /// use brahe::eop::{set_global_eop_provider, FileEOPProvider, EOPExtrapolation};
@@ -1206,7 +1331,7 @@ impl std::fmt::Debug for GravityModel {
 /// let x_eci = state_koe_to_eci(oe, AngleFormat::Degrees);
 ///
 /// // Pass state vector directly - no need to extract position
-/// let a_grav = brahe::gravity::accel_gravity_spherical_harmonics(x_eci, R_i2b, &gravity_model, 20, 20);
+/// let a_grav = brahe::gravity::accel_gravity_spherical_harmonics(x_eci, R_i2b, &gravity_model, 20, 20, ParallelMode::Auto);
 /// ```
 #[allow(non_snake_case)]
 pub fn accel_gravity_spherical_harmonics<P: IntoPosition>(
@@ -1215,6 +1340,7 @@ pub fn accel_gravity_spherical_harmonics<P: IntoPosition>(
     gravity_model: &GravityModel,
     n_max: usize,
     m_max: usize,
+    parallel: ParallelMode,
 ) -> Vector3<f64> {
     // Extract position and compute body-fixed position
     let r = r_eci.position();
@@ -1222,7 +1348,7 @@ pub fn accel_gravity_spherical_harmonics<P: IntoPosition>(
 
     // Compute spherical harmonic acceleration
     let a_ecef = gravity_model
-        .compute_spherical_harmonics(r_bf, n_max, m_max)
+        .compute_spherical_harmonics(r_bf, n_max, m_max, parallel)
         .unwrap();
 
     // Inertial acceleration
@@ -1240,12 +1366,16 @@ pub fn accel_gravity_spherical_harmonics<P: IntoPosition>(
 /// pair of `DMatrix<f64>` once at construction and reuse them across every
 /// integrator stage.
 #[allow(non_snake_case)]
+// Workspace-reuse variant: the V/W buffers plus model/degree/order/mode are all
+// load-bearing, so the 8-arg count is intentional.
+#[allow(clippy::too_many_arguments)]
 pub fn accel_gravity_spherical_harmonics_with_workspace<P: IntoPosition>(
     r_eci: P,
     R_i2b: SMatrix3,
     gravity_model: &GravityModel,
     n_max: usize,
     m_max: usize,
+    parallel: ParallelMode,
     v_workspace: &mut DMatrix<f64>,
     w_workspace: &mut DMatrix<f64>,
 ) -> Vector3<f64> {
@@ -1253,7 +1383,7 @@ pub fn accel_gravity_spherical_harmonics_with_workspace<P: IntoPosition>(
     let r_bf = R_i2b * r;
 
     let a_ecef = gravity_model
-        .compute_spherical_harmonics_with_workspace(r_bf, n_max, m_max, v_workspace, w_workspace)
+        .compute_spherical_harmonics_with_workspace(r_bf, n_max, m_max, parallel, v_workspace, w_workspace)
         .unwrap();
 
     R_i2b.transpose() * a_ecef
@@ -1610,7 +1740,7 @@ mod tests {
 
         // Simple test confirming point-mass equivalence
         let a_grav = gravity_model
-            .compute_spherical_harmonics(r_body, 0, 0)
+            .compute_spherical_harmonics(r_body, 0, 0, ParallelMode::Auto)
             .unwrap();
         assert_abs_diff_eq!(a_grav[0], -GM_EARTH / R_EARTH.powi(2), epsilon = 1e-12);
         assert_abs_diff_eq!(a_grav[1], 0.0, epsilon = 1e-12);
@@ -1618,7 +1748,7 @@ mod tests {
 
         // Test a more complex case
         let a_grav = gravity_model
-            .compute_spherical_harmonics(r_body, 60, 60)
+            .compute_spherical_harmonics(r_body, 60, 60, ParallelMode::Auto)
             .unwrap();
         assert_abs_diff_eq!(a_grav[0], -9.81433239, epsilon = 1e-8);
         assert_abs_diff_eq!(a_grav[1], 1.813976e-6, epsilon = 1e-12);
@@ -1649,6 +1779,7 @@ mod tests {
                     source: GravityModelSource::default(),
                     degree: (&degree).into(),
                     order: 0,
+                    parallel: crate::orbit_dynamics::ParallelMode::Auto,
                 },
                 drag: None,
                 srp: None,
@@ -1750,6 +1881,7 @@ mod tests {
             source: GravityModelSource::default(),
             degree: (&degree).into(),
             order: 0,
+            parallel: crate::orbit_dynamics::ParallelMode::Auto,
         });
         let mut prop_zonal = make_prop(GravityConfiguration::EarthZonal { degree });
 
@@ -1802,7 +1934,7 @@ mod tests {
         let gravity_model = GravityModel::from_model_type(&GravityModelType::JGM3).unwrap();
         let r_body = Vector3::new(6525.919e3, 1710.416e3, 2508.886e3);
 
-        let a_grav = accel_gravity_spherical_harmonics(r_body, rot, &gravity_model, n, m);
+        let a_grav = accel_gravity_spherical_harmonics(r_body, rot, &gravity_model, n, m, ParallelMode::Auto);
 
         // This could potentially be validated to a higher degree of accuracy, but currently the
         // parameters provided by the Satellite Orbits book are only accurate to seven decimal
@@ -1961,10 +2093,10 @@ mod tests {
 
         // Compute spherical harmonics up to 20x20 on both
         let a_truncated = truncated_model
-            .compute_spherical_harmonics(r_body, 20, 20)
+            .compute_spherical_harmonics(r_body, 20, 20, ParallelMode::Auto)
             .unwrap();
         let a_full = full_model
-            .compute_spherical_harmonics(r_body, 20, 20)
+            .compute_spherical_harmonics(r_body, 20, 20, ParallelMode::Auto)
             .unwrap();
 
         // Results should be identical
@@ -2097,6 +2229,7 @@ mod tests {
                 source: GravityModelSource::ModelType(icgem_model),
                 degree: 20,
                 order: 20,
+                parallel: crate::orbit_dynamics::ParallelMode::Auto,
             },
             drag: None,
             srp: None,
@@ -2144,5 +2277,53 @@ mod tests {
         assert!(drift > 100e3, "state barely moved: drift = {} m", drift);
 
         unsafe { std::env::remove_var("BRAHE_CACHE"); }
+    }
+
+    #[test]
+    fn test_should_parallelize_modes() {
+        // Always / Never ignore n_max
+        assert!(should_parallelize(ParallelMode::Always, 0));
+        assert!(should_parallelize(ParallelMode::Always, 1000));
+        assert!(!should_parallelize(ParallelMode::Never, 0));
+        assert!(!should_parallelize(ParallelMode::Never, 1000));
+
+        // Runs on the main thread (off-pool), so Auto's nested-parallelism guard
+        // is satisfied and Auto reduces to the degree-threshold check.
+        assert!(!should_parallelize(ParallelMode::Auto, PARALLEL_THRESHOLD_NMAX - 1));
+        assert!(should_parallelize(ParallelMode::Auto, PARALLEL_THRESHOLD_NMAX));
+        assert!(should_parallelize(ParallelMode::Auto, PARALLEL_THRESHOLD_NMAX + 1));
+    }
+
+    #[test]
+    fn test_parallel_mode_default_is_auto() {
+        assert_eq!(ParallelMode::default(), ParallelMode::Auto);
+    }
+
+    #[test]
+    fn test_parallel_matches_serial_spherical_harmonics() {
+        let model = GravityModel::from_model_type(&GravityModelType::EGM2008_360).unwrap();
+
+        // Off-axis and on-axis (x0=y0=0 zeroes the sectoral/tesseral seeds).
+        let positions = [
+            Vector3::new(6.5e6, 1.2e6, 3.1e6),
+            Vector3::new(0.0, 0.0, 7.0e6),
+        ];
+
+        for r_body in positions {
+            // Cover below-threshold and above-threshold sizes, square and m<n.
+            for &(n, m) in &[(10usize, 10usize), (60, 60), (90, 45), (120, 120)] {
+                let serial = model
+                    .compute_spherical_harmonics(r_body, n, m, ParallelMode::Never)
+                    .unwrap();
+                let parallel = model
+                    .compute_spherical_harmonics(r_body, n, m, ParallelMode::Always)
+                    .unwrap();
+                let rel = (serial - parallel).norm() / serial.norm();
+                assert!(
+                    rel < 1e-12,
+                    "r={r_body:?} n={n} m={m}: parallel/serial mismatch rel={rel:e}"
+                );
+            }
+        }
     }
 }

--- a/src/propagators/dnumerical_orbit_propagator.rs
+++ b/src/propagators/dnumerical_orbit_propagator.rs
@@ -727,6 +727,7 @@ impl DNumericalOrbitPropagator {
                 source: GravityModelSource::ModelType(model_type),
                 degree,
                 order,
+                ..
             } => {
                 let mut arc = GravityModel::shared(model_type)?;
                 if *degree < arc.n_max || *order < arc.m_max {
@@ -1599,6 +1600,7 @@ impl DNumericalOrbitPropagator {
                 source,
                 degree,
                 order,
+                parallel,
             } => {
                 // Use the per-propagator V/W workspace so the spherical-
                 // harmonic recurrence doesn't allocate two `DMatrix`es of
@@ -1615,6 +1617,7 @@ impl DNumericalOrbitPropagator {
                             &global_model,
                             *degree,
                             *order,
+                            *parallel,
                             sh_v,
                             sh_w,
                         );
@@ -1628,6 +1631,7 @@ impl DNumericalOrbitPropagator {
                                 model.as_ref(),
                                 *degree,
                                 *order,
+                                *parallel,
                                 sh_v,
                                 sh_w,
                             );
@@ -3039,6 +3043,7 @@ mod tests {
                 ),
                 degree,
                 order,
+                parallel: crate::orbit_dynamics::ParallelMode::Auto,
             },
             drag: None,
             srp: None,
@@ -8136,6 +8141,7 @@ mod tests {
                 source: GravityModelSource::ModelType(GravityModelType::EGM2008_360),
                 degree: 4,
                 order: 4,
+                parallel: crate::orbit_dynamics::ParallelMode::Auto,
             },
             drag: None,
             srp: None,
@@ -8191,6 +8197,7 @@ mod tests {
                 source: GravityModelSource::ModelType(GravityModelType::EGM2008_360),
                 degree: 2,
                 order: 0,
+                parallel: crate::orbit_dynamics::ParallelMode::Auto,
             },
             drag: None,
             srp: None,
@@ -8260,6 +8267,7 @@ mod tests {
                     source: GravityModelSource::ModelType(GravityModelType::EGM2008_360),
                     degree,
                     order,
+                    parallel: crate::orbit_dynamics::ParallelMode::Auto,
                 },
                 drag: None,
                 srp: None,
@@ -8321,6 +8329,7 @@ mod tests {
                 source: GravityModelSource::ModelType(GravityModelType::EGM2008_360),
                 degree: 4,
                 order: 4,
+                parallel: crate::orbit_dynamics::ParallelMode::Auto,
             },
             drag: None,
             srp: None,
@@ -8348,6 +8357,7 @@ mod tests {
                 source: GravityModelSource::Global,
                 degree: 4,
                 order: 4,
+                parallel: crate::orbit_dynamics::ParallelMode::Auto,
             },
             drag: None,
             srp: None,
@@ -10153,6 +10163,7 @@ mod tests {
                 source: GravityModelSource::ModelType(GravityModelType::EGM2008_360),
                 degree: 2,
                 order: 0,
+                parallel: crate::orbit_dynamics::ParallelMode::Auto,
             },
             drag: None,
             srp: None,

--- a/src/propagators/force_model_config.rs
+++ b/src/propagators/force_model_config.rs
@@ -15,6 +15,7 @@ use std::fmt::Display;
 use serde::{Deserialize, Serialize};
 
 use crate::orbit_dynamics::gravity::GravityModelType;
+use crate::orbit_dynamics::ParallelMode;
 use crate::spice::SPKKernel;
 use crate::utils::BraheError;
 
@@ -146,6 +147,7 @@ impl Default for ForceModelConfig {
                 source: GravityModelSource::default(),
                 degree: 20,
                 order: 20,
+                parallel: ParallelMode::Auto,
             },
             drag: Some(DragConfiguration {
                 model: AtmosphericModel::NRLMSISE00,
@@ -352,6 +354,7 @@ impl ForceModelConfig {
                 source: GravityModelSource::ModelType(GravityModelType::EGM2008_360),
                 degree: 120,
                 order: 120,
+                parallel: ParallelMode::Auto,
             },
             drag: Some(DragConfiguration {
                 model: AtmosphericModel::NRLMSISE00,
@@ -390,6 +393,7 @@ impl ForceModelConfig {
                 source: GravityModelSource::ModelType(GravityModelType::EGM2008_360),
                 degree: 20,
                 order: 20,
+                parallel: ParallelMode::Auto,
             },
             drag: None,
             srp: None,
@@ -424,6 +428,7 @@ impl ForceModelConfig {
                 source: GravityModelSource::ModelType(GravityModelType::EGM2008_360),
                 degree: 80,
                 order: 80,
+                parallel: ParallelMode::Auto,
             },
             drag: None,
             srp: None,
@@ -447,6 +452,7 @@ impl ForceModelConfig {
                 source: GravityModelSource::ModelType(GravityModelType::EGM2008_360),
                 degree: 30,
                 order: 30,
+                parallel: ParallelMode::Auto,
             },
             drag: Some(DragConfiguration {
                 model: AtmosphericModel::NRLMSISE00,
@@ -478,6 +484,7 @@ impl ForceModelConfig {
                 source: GravityModelSource::ModelType(GravityModelType::EGM2008_360),
                 degree: 8,
                 order: 8,
+                parallel: ParallelMode::Auto,
             },
             drag: None,
             srp: Some(SolarRadiationPressureConfiguration {
@@ -624,6 +631,9 @@ pub enum GravityConfiguration {
         degree: usize,
         /// Maximum order (m) of expansion
         order: usize,
+        /// Parallelization policy for the acceleration computation.
+        #[serde(default)]
+        parallel: ParallelMode,
     },
 
     /// Earth zonal harmonics (J_2..J_n) only.
@@ -1121,5 +1131,23 @@ mod tests {
         };
 
         assert!(!config.requires_params());
+    }
+
+    #[test]
+    fn test_spherical_harmonic_parallel_serde_default() {
+        // A JSON config missing `parallel` deserializes to Auto.
+        let json = r#"{"SphericalHarmonic":{"source":{"ModelType":"JGM3"},"degree":20,"order":20}}"#;
+        let cfg: GravityConfiguration = serde_json::from_str(json).unwrap();
+        match &cfg {
+            GravityConfiguration::SphericalHarmonic { parallel, .. } => {
+                assert_eq!(*parallel, ParallelMode::Auto);
+            }
+            _ => panic!("expected SphericalHarmonic"),
+        }
+        // Field round-trips when present (guards against a ParallelMode rename
+        // silently breaking serialization).
+        let roundtrip: GravityConfiguration =
+            serde_json::from_str(&serde_json::to_string(&cfg).unwrap()).unwrap();
+        assert_eq!(roundtrip, cfg);
     }
 }


### PR DESCRIPTION
# Pull Request

## Description

From previous profiling numerical propagation time is dominated by two operations: spherical harmonic gravity calculation and third-body ephemeris prediction. This PR implements a set of performance optimizations for spherical harmonic acceleration calculation to speed numerical propagation as much as possible.

## Changelog

### Added

- Added a `ParallelMode` parameter (`Auto`, `Always`, `Never`) to the spherical-harmonic gravity routines, enabling the recurrence column-fill and acceleration accumulation to run across Brahe's managed thread pool. `Auto` parallelizes only above a calibrated degree threshold and never nests inside an existing parallel propagation.
- Added `benchmarks/gravity_benchmarks.rs` measuring serial vs parallel spherical-harmonic evaluation.

### Changed
- Optimized the serial spherical-harmonic gravity evaluation (`GravityModel::compute_spherical_harmonics` / `compute_spherical_harmonics_with_workspace`) by precomputing the V/W recurrence reciprocal coefficients and reading the recurrence and accumulation buffers through bounds-check-free column slices. The workspace path is ~1.7–1.8× faster at degree/order 20–80 (the range common to LEO propagation) and ~1.6× faster at 360×360, with results unchanged to within 1e-12 relative. Measured on a 10-core Apple M1 Max.
- Raised the `ParallelMode::Auto` parallelization threshold for spherical-harmonic gravity from degree 150 to 210. The faster serial path moved the serial/parallel break-even point, so `Auto` now stays serial until parallel evaluation is at least as fast.
- `compute_spherical_harmonics`, `compute_spherical_harmonics_with_workspace`, `accel_gravity_spherical_harmonics`, and `accel_gravity_spherical_harmonics_with_workspace` now take a `parallel: ParallelMode` argument; `GravityConfiguration::SphericalHarmonic` gained a `parallel` field (defaults to `Auto`).