### PR TITLE
NRLMSISE-00 interpretation fixes 

### DIFF
--- a/src/earth_models/nrlmsise00.rs
+++ b/src/earth_models/nrlmsise00.rs
@@ -2308,7 +2308,8 @@ pub fn density_nrlmsise00_geod(epoch: &Epoch, geod: &[f64; 3]) -> Result<f64, Br
     input.g_lon = lon;
     input.lst = seconds / 3600.0 + lon / 15.0; // Local solar time
     input.f107a = get_global_f107_obs_avg81(mjd_ut1)?;
-    input.f107 = get_global_f107_observed(mjd_ut1)?;
+    // NRLMSISE-00 requires the previous day's observed F10.7 (1-day MJD offset)
+    input.f107 = get_global_f107_observed(mjd_ut1 - 1.0)?;
     input.ap = ap_array[0];
     input.ap_array = ap_array;
 

--- a/src/space_weather/file_provider.rs
+++ b/src/space_weather/file_provider.rs
@@ -517,8 +517,7 @@ impl SpaceWeatherProvider for FileSpaceWeatherProvider {
 
     fn get_f107_adjusted(&self, mjd: f64) -> Result<f64, BraheError> {
         let data = self.get_data(mjd)?;
-        // Use the adjusted 81-day centered average as "adjusted" F10.7
-        Ok(data.f107_adj_ctr81)
+        Ok(data.f107_adj)
     }
 
     fn get_f107_obs_avg81(&self, mjd: f64) -> Result<f64, BraheError> {
@@ -1157,9 +1156,11 @@ mod tests {
         // MJD 36112.0 = 1957-10-01
         let mjd = 36112.0;
 
-        // Known F10.7 adjusted: 269.8 (from data line)
-        // Note: get_f107_observed returns the adjusted value in CSSI format
-        assert_abs_diff_eq!(sw.get_f107_observed(mjd).unwrap(), 269.8, epsilon = 1e-10);
+        // Known observed daily F10.7: 269.3
+        assert_abs_diff_eq!(sw.get_f107_observed(mjd).unwrap(), 269.3, epsilon = 1e-10);
+
+        // Known adjusted daily F10.7: 269.8
+        assert_abs_diff_eq!(sw.get_f107_adjusted(mjd).unwrap(), 269.8, epsilon = 1e-10);
 
         // Known International Sunspot Number: 334
         assert_eq!(sw.get_sunspot_number(mjd).unwrap(), 334);

--- a/src/space_weather/parser.rs
+++ b/src/space_weather/parser.rs
@@ -116,20 +116,22 @@ pub fn parse_cssi_line_with_section(
     // Parse ISN (at position 88, width 4)
     let isn = parse_field::<u32>(line, 88, 92, "ISN")?;
 
-    // Parse F10.7 observed (at position 92, width 6)
-    let f107_obs = parse_field::<f64>(line, 92, 98, "F10.7 obs")?;
+    // Parse F10.7 adjusted daily (at position 92, width 6)
+    let f107_adj = parse_field::<f64>(line, 92, 98, "F10.7 adj")?;
 
     // Parse qualifier (at position 98, width 2) - may be blank for monthly predicted
     let qualifier = parse_field_optional::<u8>(line, 98, 100).unwrap_or(0);
 
-    // Parse the remaining F10.7 values (each width 6)
+    // Parse adjusted 81-day averages
     let f107_adj_ctr81 = parse_field::<f64>(line, 100, 106, "F10.7 adj ctr81")?;
     let f107_adj_lst81 = parse_field::<f64>(line, 106, 112, "F10.7 adj lst81")?;
-    let f107_obs_ctr81 = parse_field::<f64>(line, 112, 118, "F10.7 obs ctr81")?;
-    let f107_obs_lst81 = parse_field::<f64>(line, 118, 124, "F10.7 obs lst81")?;
 
-    // Note: The adjusted F10.7 daily value would be at position 124-130, but it seems
-    // to be the same as the observed value based on file documentation
+    // Parse F10.7 observed daily (at position 112, width 6)
+    let f107_obs = parse_field::<f64>(line, 112, 118, "F10.7 obs")?;
+
+    // Parse observed 81-day averages
+    let f107_obs_ctr81 = parse_field::<f64>(line, 118, 124, "F10.7 obs ctr81")?;
+    let f107_obs_lst81 = parse_field::<f64>(line, 124, 130, "F10.7 obs lst81")?;
 
     let data = SpaceWeatherData {
         year,
@@ -144,10 +146,11 @@ pub fn parse_cssi_line_with_section(
         cp,
         c9,
         isn,
-        f107_obs,
+        f107_adj,
         qualifier,
         f107_adj_ctr81,
         f107_adj_lst81,
+        f107_obs,
         f107_obs_ctr81,
         f107_obs_lst81,
         section,
@@ -326,12 +329,13 @@ mod tests {
         assert_eq!(data.isn, 334);
 
         // Check F10.7 values
-        assert_abs_diff_eq!(data.f107_obs, 269.8, epsilon = 1e-10);
+        assert_abs_diff_eq!(data.f107_adj, 269.8, epsilon = 1e-10);
         assert_eq!(data.qualifier, 0);
         assert_abs_diff_eq!(data.f107_adj_ctr81, 266.8, epsilon = 1e-10);
         assert_abs_diff_eq!(data.f107_adj_lst81, 235.5, epsilon = 1e-10);
-        assert_abs_diff_eq!(data.f107_obs_ctr81, 269.3, epsilon = 1e-10);
-        assert_abs_diff_eq!(data.f107_obs_lst81, 266.6, epsilon = 1e-10);
+        assert_abs_diff_eq!(data.f107_obs, 269.3, epsilon = 1e-10);
+        assert_abs_diff_eq!(data.f107_obs_ctr81, 266.6, epsilon = 1e-10);
+        assert_abs_diff_eq!(data.f107_obs_lst81, 230.9, epsilon = 1e-10);
     }
 
     #[test]
@@ -438,11 +442,12 @@ mod tests {
 
         // Check ISN and F10.7 are parsed correctly
         assert_eq!(data.isn, 10);
-        assert_abs_diff_eq!(data.f107_obs, 70.0, epsilon = 1e-10);
+        assert_abs_diff_eq!(data.f107_adj, 70.0, epsilon = 1e-10);
         assert_abs_diff_eq!(data.f107_adj_ctr81, 69.2, epsilon = 1e-10);
         assert_abs_diff_eq!(data.f107_adj_lst81, 70.5, epsilon = 1e-10);
-        assert_abs_diff_eq!(data.f107_obs_ctr81, 69.8, epsilon = 1e-10);
-        assert_abs_diff_eq!(data.f107_obs_lst81, 68.8, epsilon = 1e-10);
+        assert_abs_diff_eq!(data.f107_obs, 69.8, epsilon = 1e-10);
+        assert_abs_diff_eq!(data.f107_obs_ctr81, 68.8, epsilon = 1e-10);
+        assert_abs_diff_eq!(data.f107_obs_lst81, 69.0, epsilon = 1e-10);
 
         // Check section is set correctly
         assert_eq!(data.section, SpaceWeatherSection::MonthlyPredicted);

--- a/src/space_weather/types.rs
+++ b/src/space_weather/types.rs
@@ -155,14 +155,16 @@ pub struct SpaceWeatherData {
     pub c9: u8,
     /// International Sunspot Number
     pub isn: u32,
-    /// Observed 10.7 cm solar radio flux. Units: solar flux units (sfu)
-    pub f107_obs: f64,
+    /// Adjusted 10.7 cm solar radio flux. Units: solar flux units (sfu)
+    pub f107_adj: f64,
     /// Data qualifier (0 = observed)
     pub qualifier: u8,
     /// Adjusted 81-day centered average F10.7. Units: sfu
     pub f107_adj_ctr81: f64,
     /// Adjusted 81-day last average F10.7. Units: sfu
     pub f107_adj_lst81: f64,
+    /// Observed 10.7 cm solar radio flux. Units: sfu
+    pub f107_obs: f64,
     /// Observed 81-day centered average F10.7. Units: sfu
     pub f107_obs_ctr81: f64,
     /// Observed 81-day last average F10.7. Units: sfu
@@ -186,10 +188,11 @@ impl Default for SpaceWeatherData {
             cp: 0.0,
             c9: 0,
             isn: 0,
-            f107_obs: 0.0,
+            f107_adj: 0.0,
             qualifier: 0,
             f107_adj_ctr81: 0.0,
             f107_adj_lst81: 0.0,
+            f107_obs: 0.0,
             f107_obs_ctr81: 0.0,
             f107_obs_lst81: 0.0,
             section: SpaceWeatherSection::Observed,
@@ -246,6 +249,7 @@ mod tests {
         assert_eq!(data.day, 0);
         assert_eq!(data.kp, [0.0; 8]);
         assert_eq!(data.ap, [0.0; 8]);
+        assert_eq!(data.f107_adj, 0.0);
         assert_eq!(data.f107_obs, 0.0);
     }
 
@@ -264,10 +268,11 @@ mod tests {
             cp: 0.5,
             c9: 2,
             isn: 120,
-            f107_obs: 150.5,
+            f107_adj: 148.0,
             qualifier: 0,
             f107_adj_ctr81: 148.0,
             f107_adj_lst81: 147.0,
+            f107_obs: 150.5,
             f107_obs_ctr81: 149.0,
             f107_obs_lst81: 148.0,
             section: SpaceWeatherSection::Observed,

--- a/tests/space_weather/test_global_sw.py
+++ b/tests/space_weather/test_global_sw.py
@@ -30,7 +30,10 @@ def test_get_global_known_values(sw_test_filepath):
     assert brahe.get_global_ap_daily(mjd) == pytest.approx(21.0, abs=1e-10)
 
     # Known F10.7 adjusted: 269.8
-    assert brahe.get_global_f107_observed(mjd) == pytest.approx(269.8, abs=1e-10)
+    assert brahe.get_global_f107_adjusted(mjd) == pytest.approx(269.8, abs=1e-10)
+
+    # Known F10.7 observed: 269.8
+    assert brahe.get_global_f107_observed(mjd) == pytest.approx(269.3, abs=1e-10)
 
     # Known International Sunspot Number: 334
     assert brahe.get_global_sunspot_number(mjd) == 334

--- a/tests/space_weather/test_sw_file_provider.py
+++ b/tests/space_weather/test_sw_file_provider.py
@@ -63,8 +63,11 @@ def test_from_file_known_values(sw_test_filepath):
     # Known Ap daily average: 21
     assert sw.get_ap_daily(mjd) == pytest.approx(21.0, abs=1e-10)
 
-    # Known F10.7 adjusted: 269.8 (get_f107_observed returns adjusted value)
-    assert sw.get_f107_observed(mjd) == pytest.approx(269.8, abs=1e-10)
+    # Known F10.7 adjusted: 269.8
+    assert sw.get_f107_adjusted(mjd) == pytest.approx(269.8, abs=1e-10)
+
+    # Known F10.7 observed: 269.3
+    assert sw.get_f107_observed(mjd) == pytest.approx(269.3, abs=1e-10)
 
     # Known International Sunspot Number: 334
     assert sw.get_sunspot_number(mjd) == 334

--- a/uv.lock
+++ b/uv.lock
@@ -116,8 +116,6 @@ all = [
 ]
 gpu-comparison = [
     { name = "psutil" },
-    { name = "rich" },
-    { name = "typer" },
 ]
 plots = [
     { name = "cartopy" },
@@ -193,11 +191,9 @@ requires-dist = [
     { name = "psutil", marker = "extra == 'gpu-comparison'", specifier = ">=5.9" },
     { name = "pyshp", marker = "extra == 'plots'", specifier = ">=2.3.0" },
     { name = "rich", specifier = ">=14.0.0" },
-    { name = "rich", marker = "extra == 'gpu-comparison'", specifier = ">=13.0" },
     { name = "scienceplots", marker = "extra == 'plots'", specifier = ">=2.0.0" },
     { name = "shapely", marker = "extra == 'plots'", specifier = ">=2.0.0" },
     { name = "typer", specifier = ">=0.16.0" },
-    { name = "typer", marker = "extra == 'gpu-comparison'", specifier = ">=0.9" },
     { name = "typing-extensions", specifier = ">=4.0.0" },
 ]
 provides-extras = ["all", "gpu-comparison", "plots"]


### PR DESCRIPTION
# Pull Request

## Description

The current implementation for loading the CSSI space weather data loads up the adjusted f107 as the observed f107. This leads to slight differences in the atmospheric modelling compared with some other implementations. See the header of the file below:

```
DATATYPE CssiSpaceWeather
VERSION 1.2
UPDATED 2026 Jun 14 05:32:28 UTC
# --------------------------------------------------------------------------------------------------------------------------------
#                              SPACE WEATHER DATA
# --------------------------------------------------------------------------------------------------------------------------------
#
# See https://celestrak.org/SpaceData/SpaceWx-format.php for format details.
#
# FORMAT(I4,I3,I3,I5,I3,8I3,I4,8I4,I4,F4.1,I2,I4,F6.1,I2,5F6.1)
# --------------------------------------------------------------------------------------------------------------------------------
#                                                                                             Adj     Adj   Adj   Obs   Obs   Obs 
# yy mm dd BSRN ND Kp Kp Kp Kp Kp Kp Kp Kp Sum Ap  Ap  Ap  Ap  Ap  Ap  Ap  Ap  Avg Cp C9 ISN F10.7 Q Ctr81 Lst81 F10.7 Ctr81 Lst81
# --------------------------------------------------------------------------------------------------------------------------------
#
NUM_OBSERVED_POINTS 25093
BEGIN OBSERVED
1957 10 01 1700 19 43 40 30 20 37 23 43 37 273  32  27  15   7  22   9  32  22  21 1.1 5 334 269.8 0 266.8 235.5 269.3 266.6 230.9
1957 10 02 1700 20 37 37 17 17 27 23 17 30 203  22  22   6   6  12   9   6  15  12 0.7 3 331 253.6 0 267.5 236.2 253.3 267.4 231.7
```
The previous implementation took line index 92-98 as the observed f107 when it should have been 112-118.

Additionally, the NRLMSISE-00 implementation has been updated to use the previous day observed f107 rather than the current day, as is standard. 

## Changelog

### Fixed
- CSSI space weather data loader has been fixed to use the observed f107 rather than the adjusted f107
- The NRLMSISE-00 implementation has been updated to use the previous day observed f107 as is standard
