### PR TITLE
fix: Fix ignored examples breaking

### DIFF
--- a/crates/brahe-py/src/propagators.rs
+++ b/crates/brahe-py/src/propagators.rs
@@ -2605,8 +2605,10 @@ impl PyKeplerianPropagator {
 /// in parallel using the global thread pool. Each propagator's internal state is updated
 /// to reflect the new epoch.
 ///
-/// All propagators in the list must be of the same type (either all `KeplerianPropagator`,
-/// all `SGPPropagator`, or all `NumericalOrbitPropagator`). Mixing propagator types is not supported.
+/// The list may freely mix `KeplerianPropagator`, `SGPPropagator`, and
+/// `NumericalOrbitPropagator` instances. Propagators are grouped by type and each
+/// group is propagated in parallel; results are written back to the original objects
+/// in place, preserving their order.
 ///
 /// Note: `NumericalPropagator` (with user-defined Python dynamics) is NOT supported because
 /// Python callbacks cannot safely execute in parallel due to the GIL. Use `NumericalOrbitPropagator`
@@ -2665,14 +2667,44 @@ fn py_par_propagate_to(
         return Ok(()); // No propagators to process
     }
 
-    // Determine propagator type from first element
-    let first = prop_list.get_item(0)?;
+    // Classify every element by type up front. The whole list is validated before
+    // any propagation runs, so a list containing an unsupported propagator fails
+    // cleanly without partially mutating the others. Indices are recorded per type
+    // so each homogeneous group can be propagated in parallel and results written
+    // back to the correct original objects.
+    let mut kep_idx: Vec<usize> = Vec::new();
+    let mut sgp_idx: Vec<usize> = Vec::new();
+    let mut num_orbit_idx: Vec<usize> = Vec::new();
 
-    if first.is_instance_of::<PyKeplerianPropagator>() {
-        // Process as Keplerian propagators
-        let mut props: Vec<propagators::KeplerianPropagator> = Vec::new();
+    for (i, item) in prop_list.iter().enumerate() {
+        if item.is_instance_of::<PyKeplerianPropagator>() {
+            kep_idx.push(i);
+        } else if item.is_instance_of::<PySGPPropagator>() {
+            sgp_idx.push(i);
+        } else if item.is_instance_of::<PyNumericalOrbitPropagator>() {
+            num_orbit_idx.push(i);
+        } else if item.is_instance_of::<PyNumericalPropagator>() {
+            // NumericalPropagator uses Python callbacks for dynamics, which cannot
+            // safely execute in parallel due to the GIL. Provide a helpful message.
+            return Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+                "NumericalPropagator cannot be used with par_propagate_to because its Python \
+                 dynamics callback cannot safely execute in parallel due to the GIL. \
+                 Use NumericalOrbitPropagator for parallel propagation of orbital dynamics, \
+                 or call propagate_to() sequentially on each NumericalPropagator.",
+            ));
+        } else {
+            return Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+                "propagators must be a list of KeplerianPropagator, SGPPropagator, or NumericalOrbitPropagator",
+            ));
+        }
+    }
 
-        for item in prop_list.iter() {
+    // Process Keplerian propagators as a group.
+    if !kep_idx.is_empty() {
+        let mut props: Vec<propagators::KeplerianPropagator> = Vec::with_capacity(kep_idx.len());
+
+        for &i in &kep_idx {
+            let item = prop_list.get_item(i)?;
             let py_prop = item.cast::<PyKeplerianPropagator>()?;
             props.push(py_prop.borrow().propagator.clone());
         }
@@ -2681,20 +2713,22 @@ fn py_par_propagate_to(
         propagators::par_propagate_to_s(&mut props, target_epoch.obj);
 
         // Update Python objects with new state
-        for (i, item) in prop_list.iter().enumerate() {
+        for (k, &i) in kep_idx.iter().enumerate() {
+            let item = prop_list.get_item(i)?;
             let mut py_prop = item.cast::<PyKeplerianPropagator>()?.borrow_mut();
-            py_prop.propagator = props[i].clone();
+            py_prop.propagator = props[k].clone();
         }
+    }
 
-        Ok(())
-    } else if first.is_instance_of::<PySGPPropagator>() {
-        // Process as SGP propagators
+    // Process SGP propagators as a group.
+    if !sgp_idx.is_empty() {
         // Note: SGPPropagator::Clone does NOT clone event_detectors (trait objects can't be cloned)
         // We must extract them before cloning and reattach after parallel propagation
-        let mut props: Vec<propagators::SGPPropagator> = Vec::new();
+        let mut props: Vec<propagators::SGPPropagator> = Vec::with_capacity(sgp_idx.len());
         let mut extracted_detectors: Vec<Vec<Box<dyn events::DEventDetector>>> = Vec::new();
 
-        for item in prop_list.iter() {
+        for &i in &sgp_idx {
+            let item = prop_list.get_item(i)?;
             let mut py_prop = item.cast::<PySGPPropagator>()?.borrow_mut();
             // Take ownership of event detectors BEFORE cloning (they would be lost on clone)
             extracted_detectors.push(py_prop.propagator.take_event_detectors());
@@ -2702,25 +2736,26 @@ fn py_par_propagate_to(
         }
 
         // Reattach event detectors to the cloned propagators
-        for (i, detectors) in extracted_detectors.into_iter().enumerate() {
-            props[i].set_event_detectors(detectors);
+        for (k, detectors) in extracted_detectors.into_iter().enumerate() {
+            props[k].set_event_detectors(detectors);
         }
 
         // Call Rust parallel propagation function
         propagators::par_propagate_to_s(&mut props, target_epoch.obj);
 
         // Transfer results back to Python objects
-        for (i, item) in prop_list.iter().enumerate() {
+        for (k, &i) in sgp_idx.iter().enumerate() {
+            let item = prop_list.get_item(i)?;
             let mut py_prop = item.cast::<PySGPPropagator>()?.borrow_mut();
 
             // Take event state from propagated clone before transferring
-            let detectors = props[i].take_event_detectors();
-            let event_log = props[i].take_event_log();
-            let terminated = props[i].is_terminated();
-            let termination_error = props[i].take_termination_error();
+            let detectors = props[k].take_event_detectors();
+            let event_log = props[k].take_event_log();
+            let terminated = props[k].is_terminated();
+            let termination_error = props[k].take_termination_error();
 
             // Transfer full propagator state (trajectory, epoch_current, state_current, etc.)
-            py_prop.propagator = props[i].clone();
+            py_prop.propagator = props[k].clone();
 
             // Restore event detection state lost in clone
             py_prop.propagator.set_event_detectors(detectors);
@@ -2728,10 +2763,10 @@ fn py_par_propagate_to(
             py_prop.propagator.set_terminated(terminated);
             py_prop.propagator.set_termination_error(termination_error);
         }
+    }
 
-        Ok(())
-    } else if first.is_instance_of::<PyNumericalOrbitPropagator>() {
-        // Process as NumericalOrbitPropagator
+    // Process NumericalOrbitPropagator instances as a group.
+    if !num_orbit_idx.is_empty() {
         // Note: DNumericalOrbitPropagator cannot be cloned (has Box<dyn DIntegrator>),
         // so we work directly with mutable references using raw pointers
 
@@ -2742,9 +2777,11 @@ fn py_par_propagate_to(
         unsafe impl Sync for SendPtr {}
 
         // Collect borrow guards (must stay alive while we use raw pointers)
-        let mut borrow_guards: Vec<PyRefMut<'_, PyNumericalOrbitPropagator>> = Vec::new();
+        let mut borrow_guards: Vec<PyRefMut<'_, PyNumericalOrbitPropagator>> =
+            Vec::with_capacity(num_orbit_idx.len());
 
-        for item in prop_list.iter() {
+        for &i in &num_orbit_idx {
+            let item = prop_list.get_item(i)?;
             borrow_guards.push(item.cast::<PyNumericalOrbitPropagator>()?.borrow_mut());
         }
 
@@ -2770,21 +2807,9 @@ fn py_par_propagate_to(
         });
 
         // borrow_guards are dropped here, releasing the borrows
-        Ok(())
-    } else if first.is_instance_of::<PyNumericalPropagator>() {
-        // NumericalPropagator uses Python callbacks for dynamics, which cannot safely
-        // execute in parallel due to the GIL. Provide a helpful error message.
-        Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
-            "NumericalPropagator cannot be used with par_propagate_to because its Python \
-             dynamics callback cannot safely execute in parallel due to the GIL. \
-             Use NumericalOrbitPropagator for parallel propagation of orbital dynamics, \
-             or call propagate_to() sequentially on each NumericalPropagator."
-        ))
-    } else {
-        Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
-            "propagators must be a list of KeplerianPropagator, SGPPropagator, or NumericalOrbitPropagator"
-        ))
     }
+
+    Ok(())
 }
 
 // =============================================================================

--- a/docs/learn/orbit_propagation/parallel_propagation.md
+++ b/docs/learn/orbit_propagation/parallel_propagation.md
@@ -38,19 +38,26 @@ This example creates a constellation of 10 satellites and propagates them 24 hou
 
 ## Mixing Propagator Types
 
-All propagators in the list must be the same type (either all `KeplerianPropagator` or all `SGPPropagator`). Mixing types will raise a `TypeError`:
+In Python, a single list may mix `KeplerianPropagator`, `SGPPropagator`, and
+`NumericalOrbitPropagator` instances. Propagators are grouped by type internally,
+each group is propagated in parallel, and the results are written back to the
+original objects in place, preserving list order:
 
 === "Python"
     ```python
     import brahe as bh
 
-    # Example propgator intiailization
+    # Example propagator initialization
     kep_prop = bh.KeplerianPropagator.from_eci(epoch, state, 60.0)
     sgp_prop = bh.SGPPropagator.from_tle(line1, line2, 60.0)
 
-    # This will raise TypeError
+    # A mixed-type list is propagated correctly
     bh.par_propagate_to([kep_prop, sgp_prop], target)
     ```
+
+In Rust, `par_propagate_to_s` is generic over a single propagator type, so each
+call operates on a homogeneous slice. Group propagators by type and make one call
+per type to achieve the same result.
 
 ## Memory Considerations
 

--- a/examples/TEMPLATE.py
+++ b/examples/TEMPLATE.py
@@ -1,7 +1,7 @@
 # /// script
 # dependencies = ["brahe", "pytest"]
 # ///
-# FLAGS = ["IGNORE"]
+# FLAGS = ["MANUAL"]
 """
 TODO: Write a brief description of what this example demonstrates.
 """

--- a/examples/TEMPLATE.rs
+++ b/examples/TEMPLATE.rs
@@ -1,5 +1,5 @@
 //! TODO: Write a brief description of what this example demonstrates.
-// FLAGS = ["IGNORE"]
+// FLAGS = ["MANUAL"]
 
 #[allow(unused_imports)]
 use brahe as bh;

--- a/examples/common/starlink_propagation.py
+++ b/examples/common/starlink_propagation.py
@@ -2,6 +2,7 @@
 # /// script
 # dependencies = ["brahe"]
 # FLAGS = ["IGNORE"]
+# TIMEOUT = 600
 # ///
 
 import time

--- a/examples/examples/starlink_propagation.py
+++ b/examples/examples/starlink_propagation.py
@@ -1,6 +1,7 @@
 # /// script
 # dependencies = ["brahe", "plotly"]
 # FLAGS = ["IGNORE"]
+# TIMEOUT = 600
 # ///
 
 import time

--- a/examples/getting_started/clients_spacetrack.py
+++ b/examples/getting_started/clients_spacetrack.py
@@ -1,6 +1,6 @@
 # /// script
 # dependencies = ["brahe"]
-# FLAGS = ["IGNORE"]
+# FLAGS = ["MANUAL"]
 
 import brahe as bh
 import os

--- a/examples/getting_started/clients_spacetrack.rs
+++ b/examples/getting_started/clients_spacetrack.rs
@@ -1,4 +1,4 @@
-// FLAGS = ["IGNORE"]
+// FLAGS = ["MANUAL"]
 use brahe as bh;
 use bh::spacetrack::{RequestClass, SortOrder, SpaceTrackClient, SpaceTrackQuery};
 use brahe::traits::SStatePropagator;

--- a/examples/orbit_propagation/functions/mixed_parallel_propagation.py
+++ b/examples/orbit_propagation/functions/mixed_parallel_propagation.py
@@ -1,48 +1,42 @@
 # /// script
 # dependencies = ["brahe", "numpy"]
-# FLAGS = ["IGNORE"]
 # ///
 """
-Parallel propagation of multiple satellites
+Parallel propagation of mixed satellite types
 
-This example demonstrates using par_propagate_to() to efficiently propagate
-multiple satellites to a target epoch in parallel, useful for constellation
-analysis and Monte Carlo simulations.
+This example demonstrates using par_propagate_to() with a list that mixes
+propagator types. Propagators are grouped by type internally and each group is
+propagated in parallel, which is useful for constellation analysis and Monte
+Carlo simulations that combine analytic and SGP4 orbit models.
 """
 
 import brahe as bh
 import numpy as np
-import time
 
 bh.initialize_eop()
 
-# Create initial epoch
-epoch = bh.Epoch.from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, bh.TimeSystem.UTC)
-
-# Create propagators of different types
-propagators = []
-
-# Create Keplerian propagator
-oe = np.array([bh.R_EARTH + 500e3, 0.001, 98.0, 36.0, 10.0, 36.0])
-state = bh.state_koe_to_eci(oe, bh.AngleFormat.DEGREES)
-prop = bh.KeplerianPropagator.from_eci(epoch, state, 60.0)
-propagators.append(prop)
-
-# Add SGP propagator
+# Anchor every propagator to a common epoch so a single target propagates them
+# all by the same time span. Here we use an ISS TLE and its epoch.
 line1 = "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927"
 line2 = "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537"
-prop = bh.SGPPropagator.from_tle(line1, line2, 60.0)
-propagators.append(prop)
+sgp = bh.SGPPropagator.from_tle(line1, line2, 60.0)
+epoch = sgp.epoch
 
+# Build a Keplerian propagator at the same epoch.
+oe = np.array([bh.R_EARTH + 500e3, 0.001, 98.0, 36.0, 10.0, 36.0])
+state = bh.state_koe_to_eci(oe, bh.AngleFormat.DEGREES)
+kep = bh.KeplerianPropagator.from_eci(epoch, state, 60.0)
 
-# Propagate all satellites in parallel
-start = time.time()
-bh.par_propagate_to(propagators, epoch + 86400.0)
-parallel_time = time.time() - start
+# A single list mixing Keplerian and SGP propagators.
+propagators = [kep, sgp]
 
-# STDERR:
-# Traceback (most recent call last):
-#   File ".../brahe/examples/orbit_propagation/functions/mixed_parallel_propagation.py", line 43, in <module>
-#     bh.par_propagate_to(propagators, epoch + 86400.0)
-#     ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# TypeError: 'SGPPropagator' object cannot be converted to 'KeplerianPropagator'
+# Propagate every satellite forward one hour, in parallel, in place.
+target = epoch + 3600.0
+bh.par_propagate_to(propagators, target)
+
+for prop in propagators:
+    assert prop.current_epoch() == target
+
+print(f"Propagated {len(propagators)} mixed-type propagators one hour to {target}.")
+print(f"  Keplerian position (m): {kep.current_state()[:3]}")
+print(f"  SGP position (m):       {sgp.current_state()[:3]}")

--- a/scripts/_build_utils.py
+++ b/scripts/_build_utils.py
@@ -177,6 +177,11 @@ def check_flags(
                 flags_str = match.group(1)
                 flags = [f.strip().strip('"').strip("'") for f in flags_str.split(",")]
 
+                # MANUAL examples are never run automatically — not even by
+                # --ignore. Used for scaffolding templates and examples that
+                # require credentials/services that are never wired into CI.
+                if "MANUAL" in flags:
+                    return True, "manual", timeout_seconds
                 if "IGNORE" in flags and not enable_ignore:
                     return True, "ignored", timeout_seconds
                 if "CI-ONLY" in flags and not enable_ci_only:

--- a/tests/propagators/test_functions.py
+++ b/tests/propagators/test_functions.py
@@ -162,25 +162,39 @@ def test_par_propagate_to_single_propagator():
     assert propagators[0].current_epoch() == target
 
 
-def test_par_propagate_to_mixed_types_raises_error():
-    """Test that mixing propagator types raises an error"""
-    epoch = Epoch.from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, TimeSystem.UTC)
-    target = epoch + 3600.0
+def test_par_propagate_to_mixed_types():
+    """Test that a list mixing propagator types is propagated correctly"""
+    line1 = "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927"
+    line2 = "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537"
+
+    # Anchor both propagators to the SGP epoch so the single shared target is a
+    # short, well-behaved propagation for both types.
+    epoch = SGPPropagator.from_tle(line1, line2, 60.0).epoch
+    target = epoch + 3600.0  # 1 hour later
 
     oe = np.array([7000e3, 0.001, 98.0, 0.0, 0.0, 0.0])
     state = state_koe_to_eci(oe, AngleFormat.DEGREES)
     kep_prop = KeplerianPropagator.from_eci(epoch, state, 60.0)
-
-    line1 = "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927"
-    line2 = "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537"
     sgp_prop = SGPPropagator.from_tle(line1, line2, 60.0)
 
-    # Create mixed list - first is Keplerian, second is SGP
-    # This should raise a TypeError because types don't match
-    propagators = [kep_prop, sgp_prop]
+    # Independent references propagated sequentially to compare against.
+    kep_ref = KeplerianPropagator.from_eci(epoch, state, 60.0)
+    kep_ref.propagate_to(target)
+    sgp_ref = SGPPropagator.from_tle(line1, line2, 60.0)
+    sgp_ref.propagate_to(target)
 
-    with pytest.raises(TypeError):
-        par_propagate_to(propagators, target)
+    # Mixed list with a Keplerian propagator first and an SGP propagator second.
+    propagators = [kep_prop, sgp_prop]
+    par_propagate_to(propagators, target)
+
+    # Each propagator reaches the target and matches its sequential reference,
+    # regardless of position in the list or type ordering.
+    assert kep_prop.current_epoch() == target
+    assert sgp_prop.current_epoch() == target
+
+    for i in range(6):
+        assert abs(kep_prop.current_state()[i] - kep_ref.current_state()[i]) < 1e-9
+        assert abs(sgp_prop.current_state()[i] - sgp_ref.current_state()[i]) < 1e-9
 
 
 def test_par_propagate_to_not_a_list_raises_error():


### PR DESCRIPTION
# Pull Request

## Description

The v1.6.1 release surfaced a batch of failing `test-examples` runs in the integration job, which exercises the live-network examples at release time via `example_args: "--ignore"`. None were library regressions — the root cause was that `FLAGS = ["IGNORE"]` had become an overloaded "don't run on PRs" bucket, so opting into it (`--ignore`) also swept in examples that can't pass there for unrelated reasons:

- **Templates** (`TEMPLATE.rs` / `TEMPLATE.py`) — scaffolding skeletons that should never run (TEMPLATE.rs was timing out on cold compile).
- **Credential-gated** (`clients_spacetrack.rs` / `.py`) — require `SPACETRACK_USERNAME` / `SPACETRACK_PASSWORD`, which are never wired into any workflow.
- **Slow** (`common/` and `examples/` `starlink_propagation.py`) — download the full Starlink group from Celestrak and exceeded the default 180s timeout.
- **Broken** (`mixed_parallel_propagation.py`) — demonstrated a mixed-type `par_propagate_to` call the binding never supported, raising `TypeError`.

This PR separates those concerns and fixes the one real defect:

- Adds a `MANUAL` flag to the example harness that is **never** auto-run (not even by `--ignore`), and re-tags the templates and credential-gated examples to it. `IGNORE` now cleanly means "live-network only."
- Bumps the per-file `TIMEOUT` for the Starlink examples (which stay `IGNORE`).
- Makes `par_propagate_to` actually support mixed propagator-type lists by grouping elements by type and propagating each homogeneous group in parallel, writing results back to the original objects in place.

## Changelog

### Added
- `par_propagate_to` (Python) now accepts a list that mixes `KeplerianPropagator`, `SGPPropagator`, and `NumericalOrbitPropagator` instances. Propagators are grouped by type and each group is propagated in parallel; results are written back to the original objects in place, preserving list order.
- `MANUAL` example flag for examples that must never run automatically (scaffolding templates and credential-gated examples), so the `--ignore` live-network run no longer sweeps them in.

### Changed
- Tagged `TEMPLATE.{py,rs}` and `getting_started/clients_spacetrack.{py,rs}` as `MANUAL` so they are excluded from all automated example runs.
- Raised the per-example `TIMEOUT` to 600s for the `starlink_propagation.py` examples, which propagate the full live Starlink constellation and exceeded the default 180s limit during the weekly/release live-network run.

### Fixed
- `par_propagate_to` (Python) no longer raises `TypeError` when given a list containing more than one propagator type; mixed-type lists are now propagated correctly.
- Fixed the release `test-examples` integration job failing on `--ignore`: `IGNORE` was an overloaded bucket that mixed live-network examples with templates, credential-gated, slow, and broken examples, so opting into the live-network set pulled in examples that could never pass there.