### PR TITLE
Rename SPICE kernel registry functions for specificity

### DIFF
--- a/.github/brahe-data-manifest.txt
+++ b/.github/brahe-data-manifest.txt
@@ -3,7 +3,7 @@
 # workflows and warm_data_cache.yml, so any change here invalidates and
 # reseeds the cache.
 #
-# NAIF kernels (name resolved via brahe.load_kernel):
+# NAIF kernels (name resolved via brahe.load_spice_kernel):
 de440s
 moon_pa_de440
 mar099s

--- a/.github/workflows/docs_only.yml
+++ b/.github/workflows/docs_only.yml
@@ -72,6 +72,14 @@ jobs:
       - name: Install just
         uses: extractions/setup-just@v4
 
+      - name: Cache brahe data (kernels, gravity models)
+        uses: actions/cache@v6.1.0
+        with:
+          path: ~/.cache/brahe
+          key: brahe-data-v1-${{ hashFiles('.github/brahe-data-manifest.txt') }}
+          restore-keys: |
+            brahe-data-v1-
+
       - name: Test examples (including CI-ONLY)
         run: just test-examples --ci-only
 

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -25,6 +25,13 @@ jobs:
                     rustup default ${{ matrix.rust-toolchain }}
             -   name: Install cargo-llvm-cov
                 uses: taiki-e/install-action@cargo-llvm-cov
+            -   name: Cache brahe data (kernels, gravity models)
+                uses: actions/cache@v6.1.0
+                with:
+                    path: ~/.cache/brahe
+                    key: brahe-data-v1-${{ hashFiles('.github/brahe-data-manifest.txt') }}
+                    restore-keys: |
+                        brahe-data-v1-
             -   name: Run Rust tests with coverage
                 # Limit rust-unit coverage to the core `brahe` crate. The `brahe-py`
                 # workspace member has no Rust unit tests (it's exercised by pytest),
@@ -75,6 +82,13 @@ jobs:
                 run: |
                     rustup update ${{ matrix.rust-toolchain }}
                     rustup default ${{ matrix.rust-toolchain }}
+            -   name: Cache brahe data (kernels, gravity models)
+                uses: actions/cache@v6.1.0
+                with:
+                    path: ~/.cache/brahe
+                    key: brahe-data-v1-${{ hashFiles('.github/brahe-data-manifest.txt') }}
+                    restore-keys: |
+                        brahe-data-v1-
             -   name: Run Rust doc tests
                 run: cargo test --doc -- --test-threads=1
     

--- a/benchmarks/spice_benchmarks.rs
+++ b/benchmarks/spice_benchmarks.rs
@@ -32,14 +32,14 @@ fn kernel_path() -> PathBuf {
 }
 
 fn setup_native() {
-    // Seed the NAIF cache from the test asset (so `load_kernel("de440s")`
+    // Seed the NAIF cache from the test asset (so `load_spice_kernel("de440s")`
     // resolves locally) and register it in the global kernel registry.
     let cache_dir = get_naif_cache_dir().unwrap();
     let cache_path = PathBuf::from(cache_dir).join("de440s.bsp");
     if !cache_path.exists() {
         std::fs::copy(kernel_path(), &cache_path).unwrap();
     }
-    spice::load_kernel("de440s").unwrap();
+    spice::load_spice_kernel("de440s").unwrap();
 }
 
 fn setup_anise() -> Almanac {

--- a/brahe/orbit_dynamics.py
+++ b/brahe/orbit_dynamics.py
@@ -56,7 +56,6 @@ Ephemerides:
 - ssb_position_spice: Convenience alias for solar_system_barycenter_position_spice
 - ssb_velocity_spice: Convenience alias for solar_system_barycenter_velocity_spice
 - ssb_state_spice: Convenience alias for solar_system_barycenter_state_spice
-- initialize_ephemeris: Pre-initialize the DE ephemeris kernel
 
 Acceleration Models:
 -------------------
@@ -163,7 +162,6 @@ from brahe._brahe import (
     ssb_position_spice,
     ssb_velocity_spice,
     ssb_state_spice,
-    initialize_ephemeris,
     # Third-Body Accelerations
     accel_third_body_sun,
     accel_third_body_moon,
@@ -270,7 +268,6 @@ __all__ = [
     "ssb_position_spice",
     "ssb_velocity_spice",
     "ssb_state_spice",
-    "initialize_ephemeris",
     # Third-Body Accelerations
     "accel_third_body_sun",
     "accel_third_body_moon",

--- a/brahe/spice.py
+++ b/brahe/spice.py
@@ -6,8 +6,8 @@ Provides access to the native SPICE kernel registry: loading/unloading SPK
 queries against the registry.
 
 This module provides:
-- load_kernel / unload_kernel / clear_kernels / loaded_kernels / kernel_is_loaded: Kernel registry management
-- load_common_kernels / load_all_kernels: Bulk kernel pre-loading helpers
+- load_spice_kernel / unload_spice_kernel / clear_spice_kernels / loaded_spice_kernels / kernel_is_loaded: Kernel registry management
+- load_common_spice_kernels / load_all_spice_kernels: Bulk kernel pre-loading helpers
 - spk_position / spk_velocity / spk_state: Generic SPK queries against all loaded kernels
 - spk_position_from_kernel / spk_velocity_from_kernel / spk_state_from_kernel: SPK queries scoped to a single named kernel
 - pck_euler_angles / pck_euler_angle / pck_euler_rates / pck_euler_angle_and_rates / pck_quaternion / pck_rotation_matrix: Generic binary PCK orientation queries
@@ -17,7 +17,7 @@ Example:
     ```python
     import brahe as bh
 
-    bh.load_kernel("de440s")
+    bh.load_spice_kernel("de440s")
     epc = bh.Epoch.from_date(2025, 1, 1, bh.TimeSystem.UTC)
     r_moon = bh.spk_position(bh.NAIFId.MOON, bh.NAIFId.EARTH, epc)
     ```
@@ -26,13 +26,13 @@ Example:
 from enum import IntEnum
 
 from brahe._brahe import (
-    load_kernel,
-    unload_kernel,
-    clear_kernels,
-    loaded_kernels,
+    load_spice_kernel,
+    unload_spice_kernel,
+    clear_spice_kernels,
+    loaded_spice_kernels,
     kernel_is_loaded,
-    load_common_kernels,
-    load_all_kernels,
+    load_common_spice_kernels,
+    load_all_spice_kernels,
     spk_position,
     spk_velocity,
     spk_state,
@@ -100,13 +100,13 @@ class FrameId(IntEnum):
 
 
 __all__ = [
-    "load_kernel",
-    "unload_kernel",
-    "clear_kernels",
-    "loaded_kernels",
+    "load_spice_kernel",
+    "unload_spice_kernel",
+    "clear_spice_kernels",
+    "loaded_spice_kernels",
     "kernel_is_loaded",
-    "load_common_kernels",
-    "load_all_kernels",
+    "load_common_spice_kernels",
+    "load_all_spice_kernels",
     "spk_position",
     "spk_velocity",
     "spk_state",

--- a/crates/brahe-py/src/lib.rs
+++ b/crates/brahe-py/src/lib.rs
@@ -1150,7 +1150,6 @@ pub fn _brahe(py: Python<'_>, module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_function(wrap_pyfunction!(py_ssb_position_spice, module)?)?;
     module.add_function(wrap_pyfunction!(py_ssb_velocity_spice, module)?)?;
     module.add_function(wrap_pyfunction!(py_ssb_state_spice, module)?)?;
-    module.add_function(wrap_pyfunction!(py_initialize_ephemeris, module)?)?;
 
     //* Orbit Dynamics - Acceleration Models *//
 

--- a/crates/brahe-py/src/orbit_dynamics.rs
+++ b/crates/brahe-py/src/orbit_dynamics.rs
@@ -115,7 +115,7 @@ fn py_moon_position<'py>(
 ///
 /// If the ephemeris has not been initialized, it will be automatically loaded on the
 /// first call. For more control over initialization and error handling, use
-/// `initialize_ephemeris()` explicitly.
+/// `load_common_spice_kernels()` explicitly.
 ///
 /// Args:
 ///     epc (Epoch): Epoch at which to calculate the Sun's position
@@ -132,7 +132,7 @@ fn py_moon_position<'py>(
 ///     import brahe as bh
 ///
 ///     # Optional: Pre-initialize for better error handling
-///     bh.initialize_ephemeris()
+///     bh.load_common_spice_kernels()
 ///
 ///     epc = bh.Epoch.from_date(2024, 2, 25, bh.TimeSystem.UTC)
 ///     r_sun = bh.sun_position_spice(epc, bh.EphemerisSource.DE440s)
@@ -222,7 +222,7 @@ fn py_sun_state_spice<'py>(
 ///
 /// If the ephemeris has not been initialized, it will be automatically loaded on the
 /// first call. For more control over initialization and error handling, use
-/// `initialize_ephemeris()` explicitly.
+/// `load_common_spice_kernels()` explicitly.
 ///
 /// Args:
 ///     epc (Epoch): Epoch at which to calculate the Moon's position
@@ -239,7 +239,7 @@ fn py_sun_state_spice<'py>(
 ///     import brahe as bh
 ///
 ///     # Optional: Pre-initialize for better error handling
-///     bh.initialize_ephemeris()
+///     bh.load_common_spice_kernels()
 ///
 ///     epc = bh.Epoch.from_date(2024, 2, 25, bh.TimeSystem.UTC)
 ///     r_moon = bh.moon_position_spice(epc, bh.EphemerisSource.DE440s)
@@ -329,7 +329,7 @@ fn py_moon_state_spice<'py>(
 ///
 /// If the ephemeris has not been initialized, it will be automatically loaded on the
 /// first call. For more control over initialization and error handling, use
-/// `initialize_ephemeris()` explicitly.
+/// `load_common_spice_kernels()` explicitly.
 ///
 /// Args:
 ///     epc (Epoch): Epoch at which to calculate Mercury's position
@@ -346,7 +346,7 @@ fn py_moon_state_spice<'py>(
 ///     import brahe as bh
 ///
 ///     # Optional: Pre-initialize for better error handling
-///     bh.initialize_ephemeris()
+///     bh.load_common_spice_kernels()
 ///
 ///     epc = bh.Epoch.from_date(2024, 2, 25, bh.TimeSystem.UTC)
 ///     r_mercury = bh.mercury_position_spice(epc, bh.EphemerisSource.DE440s)
@@ -436,7 +436,7 @@ fn py_mercury_state_spice<'py>(
 ///
 /// If the ephemeris has not been initialized, it will be automatically loaded on the
 /// first call. For more control over initialization and error handling, use
-/// `initialize_ephemeris()` explicitly.
+/// `load_common_spice_kernels()` explicitly.
 ///
 /// Args:
 ///     epc (Epoch): Epoch at which to calculate Venus's position
@@ -453,7 +453,7 @@ fn py_mercury_state_spice<'py>(
 ///     import brahe as bh
 ///
 ///     # Optional: Pre-initialize for better error handling
-///     bh.initialize_ephemeris()
+///     bh.load_common_spice_kernels()
 ///
 ///     epc = bh.Epoch.from_date(2024, 2, 25, bh.TimeSystem.UTC)
 ///     r_venus = bh.venus_position_spice(epc, bh.EphemerisSource.DE440s)
@@ -547,7 +547,7 @@ fn py_venus_state_spice<'py>(
 ///
 /// If the ephemeris has not been initialized, it will be automatically loaded on the
 /// first call. For more control over initialization and error handling, use
-/// `initialize_ephemeris()` explicitly.
+/// `load_common_spice_kernels()` explicitly.
 ///
 /// Args:
 ///     epc (Epoch): Epoch at which to calculate Mars's position
@@ -564,7 +564,7 @@ fn py_venus_state_spice<'py>(
 ///     import brahe as bh
 ///
 ///     # Optional: Pre-initialize for better error handling
-///     bh.initialize_ephemeris()
+///     bh.load_common_spice_kernels()
 ///
 ///     epc = bh.Epoch.from_date(2024, 2, 25, bh.TimeSystem.UTC)
 ///     r_mars = bh.mars_position_spice(epc, bh.EphemerisSource.DE440s)
@@ -672,7 +672,7 @@ fn py_mars_state_spice<'py>(
 ///
 /// If the ephemeris has not been initialized, it will be automatically loaded on the
 /// first call. For more control over initialization and error handling, use
-/// `initialize_ephemeris()` explicitly.
+/// `load_common_spice_kernels()` explicitly.
 ///
 /// Args:
 ///     epc (Epoch): Epoch at which to calculate Jupiter's position
@@ -689,7 +689,7 @@ fn py_mars_state_spice<'py>(
 ///     import brahe as bh
 ///
 ///     # Optional: Pre-initialize for better error handling
-///     bh.initialize_ephemeris()
+///     bh.load_common_spice_kernels()
 ///
 ///     epc = bh.Epoch.from_date(2024, 2, 25, bh.TimeSystem.UTC)
 ///     r_jupiter = bh.jupiter_position_spice(epc, bh.EphemerisSource.DE440s)
@@ -797,7 +797,7 @@ fn py_jupiter_state_spice<'py>(
 ///
 /// If the ephemeris has not been initialized, it will be automatically loaded on the
 /// first call. For more control over initialization and error handling, use
-/// `initialize_ephemeris()` explicitly.
+/// `load_common_spice_kernels()` explicitly.
 ///
 /// Args:
 ///     epc (Epoch): Epoch at which to calculate Saturn's position
@@ -814,7 +814,7 @@ fn py_jupiter_state_spice<'py>(
 ///     import brahe as bh
 ///
 ///     # Optional: Pre-initialize for better error handling
-///     bh.initialize_ephemeris()
+///     bh.load_common_spice_kernels()
 ///
 ///     epc = bh.Epoch.from_date(2024, 2, 25, bh.TimeSystem.UTC)
 ///     r_saturn = bh.saturn_position_spice(epc, bh.EphemerisSource.DE440s)
@@ -922,7 +922,7 @@ fn py_saturn_state_spice<'py>(
 ///
 /// If the ephemeris has not been initialized, it will be automatically loaded on the
 /// first call. For more control over initialization and error handling, use
-/// `initialize_ephemeris()` explicitly.
+/// `load_common_spice_kernels()` explicitly.
 ///
 /// Args:
 ///     epc (Epoch): Epoch at which to calculate Uranus's position
@@ -939,7 +939,7 @@ fn py_saturn_state_spice<'py>(
 ///     import brahe as bh
 ///
 ///     # Optional: Pre-initialize for better error handling
-///     bh.initialize_ephemeris()
+///     bh.load_common_spice_kernels()
 ///
 ///     epc = bh.Epoch.from_date(2024, 2, 25, bh.TimeSystem.UTC)
 ///     r_uranus = bh.uranus_position_spice(epc, bh.EphemerisSource.DE440s)
@@ -1047,7 +1047,7 @@ fn py_uranus_state_spice<'py>(
 ///
 /// If the ephemeris has not been initialized, it will be automatically loaded on the
 /// first call. For more control over initialization and error handling, use
-/// `initialize_ephemeris()` explicitly.
+/// `load_common_spice_kernels()` explicitly.
 ///
 /// Args:
 ///     epc (Epoch): Epoch at which to calculate Neptune's position
@@ -1064,7 +1064,7 @@ fn py_uranus_state_spice<'py>(
 ///     import brahe as bh
 ///
 ///     # Optional: Pre-initialize for better error handling
-///     bh.initialize_ephemeris()
+///     bh.load_common_spice_kernels()
 ///
 ///     epc = bh.Epoch.from_date(2024, 2, 25, bh.TimeSystem.UTC)
 ///     r_neptune = bh.neptune_position_spice(epc, bh.EphemerisSource.DE440s)
@@ -1698,7 +1698,7 @@ fn py_neptune_barycenter_state_spice<'py>(
 ///
 /// If the ephemeris has not been initialized, it will be automatically loaded on the
 /// first call. For more control over initialization and error handling, use
-/// `initialize_ephemeris()` explicitly.
+/// `load_common_spice_kernels()` explicitly.
 ///
 /// Args:
 ///     epc (Epoch): Epoch at which to calculate the Solar System Barycenter position
@@ -1715,7 +1715,7 @@ fn py_neptune_barycenter_state_spice<'py>(
 ///     import brahe as bh
 ///
 ///     # Optional: Pre-initialize for better error handling
-///     bh.initialize_ephemeris()
+///     bh.load_common_spice_kernels()
 ///
 ///     epc = bh.Epoch.from_date(2024, 2, 25, bh.TimeSystem.UTC)
 ///     r_ssb = bh.solar_system_barycenter_position_spice(epc, bh.EphemerisSource.DE440s)
@@ -1817,7 +1817,7 @@ fn py_solar_system_barycenter_state_spice<'py>(
 ///     import brahe as bh
 ///
 ///     # Optional: Pre-initialize for better error handling
-///     bh.initialize_ephemeris()
+///     bh.load_common_spice_kernels()
 ///
 ///     epc = bh.Epoch.from_date(2024, 2, 25, bh.TimeSystem.UTC)
 ///     r_ssb = bh.ssb_position_spice(epc, bh.EphemerisSource.DE440s)
@@ -1903,44 +1903,6 @@ fn py_ssb_state_spice<'py>(
     let x = spice::ssb_state_spice(epc.obj, kernel)
         .map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))?;
     Ok(vector_to_numpy!(py, x, 6, f64))
-}
-
-/// Initialize the global ephemeris provider with the default DE440s kernel.
-///
-/// This function downloads (or uses a cached copy of) the NAIF DE440s ephemeris
-/// kernel and sets it as the global Almanac provider. This initialization is
-/// optional - if not called, the Almanac will be lazily initialized on the first
-/// call to `sun_position_spice()` or `moon_position_spice()`.
-///
-/// Calling this function explicitly is recommended when you want to:
-/// - Control when the kernel download/loading occurs (avoid latency on first use)
-/// - Handle initialization errors explicitly
-/// - Pre-load the kernel during application startup
-///
-/// Returns:
-///     None: Successfully initialized the ephemeris
-///
-/// Raises:
-///     Exception: If kernel download or loading failed
-///
-/// Example:
-///     ```python
-///     import brahe as bh
-///
-///     # Initialize at application startup
-///     bh.initialize_ephemeris()
-///
-///     # Now use DE440s ephemeris functions
-///     epc = bh.Epoch.from_date(2024, 2, 25, bh.TimeSystem.UTC)
-///     r_sun = bh.sun_position_spice(epc)
-///     r_moon = bh.moon_position_spice(epc)
-///     ```
-#[pyfunction]
-#[pyo3(name = "initialize_ephemeris")]
-fn py_initialize_ephemeris() -> PyResult<()> {
-    spice::initialize_ephemeris().map_err(|e| {
-        exceptions::PyRuntimeError::new_err(format!("Failed to initialize ephemeris: {}", e))
-    })
 }
 
 // ============================================================================
@@ -2054,7 +2016,7 @@ fn py_accel_third_body_moon<'py>(
 ///     import brahe as bh
 ///     import numpy as np
 ///
-///     bh.initialize_ephemeris()
+///     bh.load_common_spice_kernels()
 ///     epc = bh.Epoch.from_date(2024, 2, 25, bh.TimeSystem.UTC)
 ///     r_object = np.array([bh.R_EARTH + 500e3, 0.0, 0.0])
 ///     a = bh.accel_third_body_sun_spice(epc, r_object, bh.EphemerisSource.DE440s)
@@ -2099,7 +2061,7 @@ fn py_accel_third_body_sun_spice<'py>(
 ///     import brahe as bh
 ///     import numpy as np
 ///
-///     bh.initialize_ephemeris()
+///     bh.load_common_spice_kernels()
 ///     epc = bh.Epoch.from_date(2024, 2, 25, bh.TimeSystem.UTC)
 ///     r_object = np.array([bh.R_EARTH + 500e3, 0.0, 0.0])
 ///     a = bh.accel_third_body_moon_spice(epc, r_object, bh.EphemerisSource.DE440s)
@@ -2406,7 +2368,7 @@ fn py_accel_third_body_neptune_spice<'py>(
 ///     import brahe as bh
 ///     import numpy as np
 ///
-///     bh.initialize_ephemeris()
+///     bh.load_common_spice_kernels()
 ///     epc = bh.Epoch.from_date(2024, 2, 25, bh.TimeSystem.UTC)
 ///     r_object = np.array([bh.R_MOON + 100e3, 0.0, 0.0])
 ///     a_earth = bh.accel_third_body_for_body(

--- a/crates/brahe-py/src/spice.rs
+++ b/crates/brahe-py/src/spice.rs
@@ -23,13 +23,13 @@
 ///     ```python
 ///     import brahe as bh
 ///
-///     bh.load_kernel("de440s")
-///     print(bh.loaded_kernels())
+///     bh.load_spice_kernel("de440s")
+///     print(bh.loaded_spice_kernels())
 ///     ```
 #[pyfunction]
-#[pyo3(name = "load_kernel")]
+#[pyo3(name = "load_spice_kernel")]
 fn py_load_kernel(name_or_path: &str) -> PyResult<()> {
-    spice::load_kernel(name_or_path).map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))
+    spice::load_spice_kernel(name_or_path).map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))
 }
 
 /// Unload a SPICE kernel from the global registry.
@@ -44,13 +44,13 @@ fn py_load_kernel(name_or_path: &str) -> PyResult<()> {
 ///     ```python
 ///     import brahe as bh
 ///
-///     bh.load_kernel("de440s")
-///     bh.unload_kernel("de440s")
+///     bh.load_spice_kernel("de440s")
+///     bh.unload_spice_kernel("de440s")
 ///     ```
 #[pyfunction]
-#[pyo3(name = "unload_kernel")]
+#[pyo3(name = "unload_spice_kernel")]
 fn py_unload_kernel(name_or_path: &str) -> PyResult<()> {
-    spice::unload_kernel(name_or_path)
+    spice::unload_spice_kernel(name_or_path)
         .map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))
 }
 
@@ -60,13 +60,13 @@ fn py_unload_kernel(name_or_path: &str) -> PyResult<()> {
 ///     ```python
 ///     import brahe as bh
 ///
-///     bh.clear_kernels()
-///     assert bh.loaded_kernels() == []
+///     bh.clear_spice_kernels()
+///     assert bh.loaded_spice_kernels() == []
 ///     ```
 #[pyfunction]
-#[pyo3(name = "clear_kernels")]
+#[pyo3(name = "clear_spice_kernels")]
 fn py_clear_kernels() {
-    spice::clear_kernels()
+    spice::clear_spice_kernels()
 }
 
 /// List the kernels currently loaded in the global registry, in load order.
@@ -78,13 +78,13 @@ fn py_clear_kernels() {
 ///     ```python
 ///     import brahe as bh
 ///
-///     bh.initialize_ephemeris()
-///     assert "de440s" in bh.loaded_kernels()
+///     bh.load_common_spice_kernels()
+///     assert "de440s" in bh.loaded_spice_kernels()
 ///     ```
 #[pyfunction]
-#[pyo3(name = "loaded_kernels")]
+#[pyo3(name = "loaded_spice_kernels")]
 fn py_loaded_kernels() -> Vec<String> {
-    spice::loaded_kernels()
+    spice::loaded_spice_kernels()
 }
 
 /// Check whether a loaded kernel's registry key contains `fragment`.
@@ -104,7 +104,7 @@ fn py_loaded_kernels() -> Vec<String> {
 ///     ```python
 ///     import brahe as bh
 ///
-///     bh.initialize_ephemeris()
+///     bh.load_common_spice_kernels()
 ///     assert bh.kernel_is_loaded("de440s")
 ///     ```
 #[pyfunction]
@@ -117,7 +117,7 @@ fn py_kernel_is_loaded(fragment: &str) -> bool {
 /// and "moon_pa_de440" (lunar principal-axes orientation).
 ///
 /// ~46 MB total on first download; cached thereafter. Each kernel load is
-/// idempotent, so calling this alongside other `load_kernel` calls is safe.
+/// idempotent, so calling this alongside other `load_spice_kernel` calls is safe.
 ///
 /// Loading is not atomic: on error, kernels already loaded before the
 /// failure remain resident, so the call can be safely retried.
@@ -129,13 +129,13 @@ fn py_kernel_is_loaded(fragment: &str) -> bool {
 ///     ```python
 ///     import brahe as bh
 ///
-///     bh.load_common_kernels()
-///     print(bh.loaded_kernels())
+///     bh.load_common_spice_kernels()
+///     print(bh.loaded_spice_kernels())
 ///     ```
 #[pyfunction]
-#[pyo3(name = "load_common_kernels")]
+#[pyo3(name = "load_common_spice_kernels")]
 fn py_load_common_kernels() -> PyResult<()> {
-    spice::load_common_kernels().map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))
+    spice::load_common_spice_kernels().map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))
 }
 
 /// Load every kernel brahe knows how to download: "de440s", "moon_pa_de440",
@@ -143,7 +143,7 @@ fn py_load_common_kernels() -> PyResult<()> {
 /// "nep097", "plu060".
 ///
 /// ~2.5 GB total on first download; cached thereafter. Prefer
-/// `load_common_kernels` unless outer-planet body centers or moons are
+/// `load_common_spice_kernels` unless outer-planet body centers or moons are
 /// needed.
 ///
 /// Loading is not atomic: on error, kernels already loaded before the
@@ -156,13 +156,13 @@ fn py_load_common_kernels() -> PyResult<()> {
 ///     ```python
 ///     import brahe as bh
 ///
-///     bh.load_all_kernels()
-///     print(bh.loaded_kernels())
+///     bh.load_all_spice_kernels()
+///     print(bh.loaded_spice_kernels())
 ///     ```
 #[pyfunction]
-#[pyo3(name = "load_all_kernels")]
+#[pyo3(name = "load_all_spice_kernels")]
 fn py_load_all_kernels() -> PyResult<()> {
-    spice::load_all_kernels().map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))
+    spice::load_all_spice_kernels().map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))
 }
 
 /// Position of a target body relative to a center body from loaded SPK kernels.
@@ -414,7 +414,7 @@ fn py_spk_state_from_kernel<'py>(
 /// 3-1-3 Euler angles and rates of a PCK body-fixed frame relative to ICRF.
 ///
 /// PCKs are never auto-initialized; a PCK kernel must be explicitly loaded
-/// via `bh.load_kernel(...)` first.
+/// via `bh.load_spice_kernel(...)` first.
 ///
 /// Args:
 ///     frame_id (int): Body-frame class ID (e.g. 31008 for MOON_PA_DE440)
@@ -431,7 +431,7 @@ fn py_spk_state_from_kernel<'py>(
 ///     ```python
 ///     import brahe as bh
 ///
-///     bh.load_kernel("moon_pa_de440")
+///     bh.load_spice_kernel("moon_pa_de440")
 ///     epc = bh.Epoch.from_date(2025, 1, 1, bh.TimeSystem.UTC)
 ///     angles, rates = bh.pck_euler_angles(31008, epc)
 ///     ```
@@ -454,7 +454,7 @@ fn py_pck_euler_angles<'py>(
 /// 3-1-3 Euler angle of a PCK body-fixed frame relative to ICRF.
 ///
 /// PCKs are never auto-initialized; a PCK kernel must be explicitly loaded
-/// via `bh.load_kernel(...)` first.
+/// via `bh.load_spice_kernel(...)` first.
 ///
 /// Args:
 ///     frame_id (int): Body-frame class ID (e.g. 31008 for MOON_PA_DE440)
@@ -470,7 +470,7 @@ fn py_pck_euler_angles<'py>(
 ///     ```python
 ///     import brahe as bh
 ///
-///     bh.load_kernel("moon_pa_de440")
+///     bh.load_spice_kernel("moon_pa_de440")
 ///     epc = bh.Epoch.from_date(2025, 1, 1, bh.TimeSystem.UTC)
 ///     e = bh.pck_euler_angle(31008, epc)
 ///     ```
@@ -485,7 +485,7 @@ fn py_pck_euler_angle(frame_id: i32, epc: &PyEpoch) -> PyResult<PyEulerAngle> {
 /// Time derivatives of the 3-1-3 Euler angles of a PCK body-fixed frame.
 ///
 /// PCKs are never auto-initialized; a PCK kernel must be explicitly loaded
-/// via `bh.load_kernel(...)` first.
+/// via `bh.load_spice_kernel(...)` first.
 ///
 /// Args:
 ///     frame_id (int): Body-frame class ID (e.g. 31008 for MOON_PA_DE440)
@@ -501,7 +501,7 @@ fn py_pck_euler_angle(frame_id: i32, epc: &PyEpoch) -> PyResult<PyEulerAngle> {
 ///     ```python
 ///     import brahe as bh
 ///
-///     bh.load_kernel("moon_pa_de440")
+///     bh.load_spice_kernel("moon_pa_de440")
 ///     epc = bh.Epoch.from_date(2025, 1, 1, bh.TimeSystem.UTC)
 ///     rates = bh.pck_euler_rates(31008, epc)
 ///     ```
@@ -521,7 +521,7 @@ fn py_pck_euler_rates<'py>(
 /// single shared segment lookup.
 ///
 /// PCKs are never auto-initialized; a PCK kernel must be explicitly loaded
-/// via `bh.load_kernel(...)` first.
+/// via `bh.load_spice_kernel(...)` first.
 ///
 /// Args:
 ///     frame_id (int): Body-frame class ID (e.g. 31008 for MOON_PA_DE440)
@@ -538,7 +538,7 @@ fn py_pck_euler_rates<'py>(
 ///     ```python
 ///     import brahe as bh
 ///
-///     bh.load_kernel("moon_pa_de440")
+///     bh.load_spice_kernel("moon_pa_de440")
 ///     epc = bh.Epoch.from_date(2025, 1, 1, bh.TimeSystem.UTC)
 ///     angle, rates = bh.pck_euler_angle_and_rates(31008, epc)
 ///     ```
@@ -558,7 +558,7 @@ fn py_pck_euler_angle_and_rates<'py>(
 /// quaternion.
 ///
 /// PCKs are never auto-initialized; a PCK kernel must be explicitly loaded
-/// via `bh.load_kernel(...)` first.
+/// via `bh.load_spice_kernel(...)` first.
 ///
 /// Args:
 ///     frame_id (int): Body-frame class ID (e.g. 31008 for MOON_PA_DE440)
@@ -574,7 +574,7 @@ fn py_pck_euler_angle_and_rates<'py>(
 ///     ```python
 ///     import brahe as bh
 ///
-///     bh.load_kernel("moon_pa_de440")
+///     bh.load_spice_kernel("moon_pa_de440")
 ///     epc = bh.Epoch.from_date(2025, 1, 1, bh.TimeSystem.UTC)
 ///     q = bh.pck_quaternion(31008, epc)
 ///     ```
@@ -589,7 +589,7 @@ fn py_pck_quaternion(frame_id: i32, epc: &PyEpoch) -> PyResult<PyQuaternion> {
 /// Rotation matrix from ICRF to a PCK body-fixed frame.
 ///
 /// PCKs are never auto-initialized; a PCK kernel must be explicitly loaded
-/// via `bh.load_kernel(...)` first.
+/// via `bh.load_spice_kernel(...)` first.
 ///
 /// Args:
 ///     frame_id (int): Body-frame class ID (e.g. 31008 for MOON_PA_DE440)
@@ -605,7 +605,7 @@ fn py_pck_quaternion(frame_id: i32, epc: &PyEpoch) -> PyResult<PyQuaternion> {
 ///     ```python
 ///     import brahe as bh
 ///
-///     bh.load_kernel("moon_pa_de440")
+///     bh.load_spice_kernel("moon_pa_de440")
 ///     epc = bh.Epoch.from_date(2025, 1, 1, bh.TimeSystem.UTC)
 ///     R = bh.pck_rotation_matrix(31008, epc)
 ///     ```

--- a/docs/learn/datasets/naif.md
+++ b/docs/learn/datasets/naif.md
@@ -40,7 +40,7 @@ function both accept any of these — by name (`str`) in Python, by
 !!! info "Binary PCK Kernels"
     Brahe also downloads and caches the `moon_pa_de440` binary PCK (lunar
     principal-axis orientation) the same way. Load it with
-    `bh.load_kernel("moon_pa_de440")`, or with `bh.load_common_kernels()`,
+    `bh.load_spice_kernel("moon_pa_de440")`, or with `bh.load_common_spice_kernels()`,
     which loads `de440s` and `moon_pa_de440` together — see
     [SPICE Kernels](../spice/index.md) for orientation queries against it.
 

--- a/docs/learn/frames/frame_transformations.md
+++ b/docs/learn/frames/frame_transformations.md
@@ -76,7 +76,7 @@ Four variants cover bodies without a dedicated named frame:
 | `LFPA`, `LFME` | `moon_pa_de440` binary PCK | Yes, on first LCI &harr; LFPA/LFME conversion |
 | `MCMF` (rotation only) | None (compiled-in WGCCRE polynomial) | N/A |
 | `BodyFixedIAU(naif_id)` | None (compiled-in), if `naif_id` is in `iau_rotation_model_ids()` | N/A |
-| `BodyFixedPCK { .. }` | The named binary PCK | No; must be loaded explicitly with `load_kernel` |
+| `BodyFixedPCK { .. }` | The named binary PCK | No; must be loaded explicitly with `load_spice_kernel` |
 | `BodyFixedCustom { .. }` | None (user callback) | N/A |
 
 The lunar PCK auto-load is a narrow exception to the general SPICE registry rule that binary PCKs are never auto-initialized (see [SPICE Kernels](../spice/index.md)); it exists because `LFPA`/`LFME` have no meaning without `moon_pa_de440` loaded, so every lunar body-fixed conversion loads it transparently on first use. `MCI`/`MCMF` are centered on the Mars body center (NAIF 499); a translation to or from another center resolves the body-center leg through the `mar099s` satellite ephemeris kernel, which is auto-loaded the same way.

--- a/docs/learn/frames/lunar_frames.md
+++ b/docs/learn/frames/lunar_frames.md
@@ -4,11 +4,11 @@ Brahe provides three Moon-centered reference frames: **LCI** (inertial), **LFPA*
 
 ## LCI (Lunar-Centered Inertial)
 
-LCI axes are ICRF-aligned (treated as equivalent to J2000, consistent with the rest of Brahe) and centered on the Moon (NAIF ID 301). No kernel is required for the LCI orientation itself, since it shares axes with GCRF. Converting between LCI and ECI requires the Moon's position relative to Earth, which is looked up from the `de440s` SPK kernel (auto-loaded on first use of any of the functions in the [Function Reference](#function-reference) below, or via `initialize_ephemeris`).
+LCI axes are ICRF-aligned (treated as equivalent to J2000, consistent with the rest of Brahe) and centered on the Moon (NAIF ID 301). No kernel is required for the LCI orientation itself, since it shares axes with GCRF. Converting between LCI and ECI requires the Moon's position relative to Earth, which is looked up from the `de440s` SPK kernel (auto-loaded on first use of any of the functions in the [Function Reference](#function-reference) below, or via `load_common_spice_kernels`).
 
 ## LFPA (Lunar-Fixed Principal Axis)
 
-LFPA is the DE440 lunar principal-axis frame[^park2021], distributed by NAIF as the binary PCK `moon_pa_de440` (frame class ID 31008). It is evaluated live from that kernel, which is downloaded and cached automatically the first time any LCI &harr; LFPA/LFME function is called &mdash; no explicit `load_kernel` call is required for this specific frame pair (see [Kernel Requirements](frame_transformations.md#kernel-requirements-per-frame) for the general rule this is an exception to).
+LFPA is the DE440 lunar principal-axis frame[^park2021], distributed by NAIF as the binary PCK `moon_pa_de440` (frame class ID 31008). It is evaluated live from that kernel, which is downloaded and cached automatically the first time any LCI &harr; LFPA/LFME function is called &mdash; no explicit `load_spice_kernel` call is required for this specific frame pair (see [Kernel Requirements](frame_transformations.md#kernel-requirements-per-frame) for the general rule this is an exception to).
 
 ## LFME (Lunar-Fixed Mean-Earth/Polar-Axis)
 

--- a/docs/learn/spice/index.md
+++ b/docs/learn/spice/index.md
@@ -19,7 +19,7 @@ For downloading and caching the underlying kernel files, see
 
 ## Loading Kernels
 
-`load_kernel` accepts either a known kernel name or a filesystem path, and
+`load_spice_kernel` accepts either a known kernel name or a filesystem path, and
 auto-detects SPK vs. binary PCK from the file header:
 
 === "Python"
@@ -82,10 +82,10 @@ filesystem path to a local `.bsp` or `.bpc` file.
 
 Registry behavior:
 
-- **Idempotent**: calling `load_kernel` with a name/path that is already
+- **Idempotent**: calling `load_spice_kernel` with a name/path that is already
   loaded is a no-op.
-- **Persistent**: kernels stay resident until `unload_kernel` or
-  `clear_kernels` is called.
+- **Persistent**: kernels stay resident until `unload_spice_kernel` or
+  `clear_spice_kernels` is called.
 - **Precedence**: `spk_*` queries resolve across every loaded SPK kernel; for
   body pairs covered by more than one kernel, the most recently loaded
   kernel wins (matching SPICE's own "last loaded wins" convention). `pck_*`
@@ -93,26 +93,26 @@ Registry behavior:
   at the requested epoch.
 - **Auto-initialization**: `spk_position`/`spk_velocity`/`spk_state` load
   `de440s` automatically if no SPK kernel has been loaded yet. Binary PCKs
-  are never auto-loaded through this generic interface — `load_kernel("moon_pa_de440")`
+  are never auto-loaded through this generic interface — `load_spice_kernel("moon_pa_de440")`
   (or an explicit path) must be called first. The Moon's `LFPA`/`LFME` frame
   functions (see [Lunar Reference Frames](../frames/lunar_frames.md)) are a
   narrow exception: they auto-load `moon_pa_de440` on first use.
 
 ### Loading Multiple Kernels at Once
 
-`load_common_kernels` and `load_all_kernels` pre-load a curated set of
+`load_common_spice_kernels` and `load_all_spice_kernels` pre-load a curated set of
 kernels in one call, so a session does not pay per-kernel download latency
 the first time each body is queried:
 
 | Function | Loads | Download size |
 |---|---|---|
-| `load_common_kernels()` | `de440s`, `moon_pa_de440` | ~46 MB |
-| `load_all_kernels()` | `de440s`, `moon_pa_de440`, `mar099s`, `jup365`, `sat441`, `ura184`, `nep097`, `plu060` | ~2.5 GB |
+| `load_common_spice_kernels()` | `de440s`, `moon_pa_de440` | ~46 MB |
+| `load_all_spice_kernels()` | `de440s`, `moon_pa_de440`, `mar099s`, `jup365`, `sat441`, `ura184`, `nep097`, `plu060` | ~2.5 GB |
 
 Each kernel load within these calls is idempotent, so calling either
-alongside individual `load_kernel` calls is safe. Prefer
-`load_common_kernels` unless outer-planet body centers, their moons, or
-Pluto are needed — `load_all_kernels` downloads over 2 GB on first use.
+alongside individual `load_spice_kernel` calls is safe. Prefer
+`load_common_spice_kernels` unless outer-planet body centers, their moons, or
+Pluto are needed — `load_all_spice_kernels` downloads over 2 GB on first use.
 
 ## Querying Ephemeris Data
 
@@ -265,7 +265,7 @@ values from `spk_*`/`*_spice` queries are GCRF-compatible directly.
 
 ## Performance
 
-SPK and PCK kernels are parsed once, at `load_kernel` time, into an
+SPK and PCK kernels are parsed once, at `load_spice_kernel` time, into an
 in-memory segment table. Queries take a short-lived read lock on the shared
 registry only to look up the relevant segment chain; the Chebyshev
 evaluation itself runs outside any lock. Repeated queries for the same

--- a/docs/library_api/orbit_dynamics/ephemerides.md
+++ b/docs/library_api/orbit_dynamics/ephemerides.md
@@ -10,8 +10,6 @@ Celestial body position calculations for Sun, Moon, and planets.
 
 ## DE440 Ephemerides
 
-::: brahe.initialize_ephemeris
-
 ::: brahe.sun_position_spice
 
 ::: brahe.sun_velocity_spice

--- a/docs/library_api/spice/index.md
+++ b/docs/library_api/spice/index.md
@@ -7,17 +7,17 @@ convenience functions, see the
 
 ## Kernel Registry
 
-::: brahe.load_kernel
+::: brahe.load_spice_kernel
 
-::: brahe.unload_kernel
+::: brahe.unload_spice_kernel
 
-::: brahe.clear_kernels
+::: brahe.clear_spice_kernels
 
-::: brahe.loaded_kernels
+::: brahe.loaded_spice_kernels
 
-::: brahe.load_common_kernels
+::: brahe.load_common_spice_kernels
 
-::: brahe.load_all_kernels
+::: brahe.load_all_spice_kernels
 
 ## Generic SPK Queries
 

--- a/examples/frames/frame_router.py
+++ b/examples/frames/frame_router.py
@@ -11,7 +11,7 @@ import numpy as np
 # Initialize EOP and the DE440s ephemeris used to re-center GCRF (Earth) to
 # LCI (Moon) inside the router.
 bh.initialize_eop()
-bh.initialize_ephemeris()
+bh.load_common_spice_kernels()
 
 epc = bh.Epoch.from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, bh.TimeSystem.UTC)
 

--- a/examples/frames/frame_router.rs
+++ b/examples/frames/frame_router.rs
@@ -8,7 +8,7 @@ fn main() {
     // Initialize EOP and the DE440s ephemeris used to re-center GCRF (Earth)
     // to LCI (Moon) inside the router.
     bh::initialize_eop().unwrap();
-    bh::initialize_ephemeris().unwrap();
+    bh::load_common_spice_kernels().unwrap();
 
     let epc = bh::Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, bh::TimeSystem::UTC);
 

--- a/examples/numerical_propagation/lunar_orbit.py
+++ b/examples/numerical_propagation/lunar_orbit.py
@@ -22,7 +22,7 @@ import brahe as bh
 # Initialize EOP data and the DE440s planetary ephemeris used for third-body
 # perturbations and LCI <-> LFPA frame conversions.
 bh.initialize_eop()
-bh.initialize_ephemeris()
+bh.load_common_spice_kernels()
 
 # Initial epoch
 epoch = bh.Epoch.from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, bh.TimeSystem.UTC)

--- a/examples/numerical_propagation/lunar_orbit.rs
+++ b/examples/numerical_propagation/lunar_orbit.rs
@@ -20,7 +20,7 @@ fn main() {
     // Initialize EOP data and the DE440s planetary ephemeris used for
     // third-body perturbations and LCI <-> LFPA frame conversions.
     bh::initialize_eop().unwrap();
-    bh::initialize_ephemeris().unwrap();
+    bh::load_common_spice_kernels().unwrap();
 
     // Initial epoch
     let epoch = bh::Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, bh::TimeSystem::UTC);

--- a/examples/numerical_propagation/mars_orbit.py
+++ b/examples/numerical_propagation/mars_orbit.py
@@ -22,7 +22,7 @@ import brahe as bh
 # Initialize EOP data and the DE440s planetary ephemeris used for third-body
 # perturbations and ECI <-> MCI frame conversions.
 bh.initialize_eop()
-bh.initialize_ephemeris()
+bh.load_common_spice_kernels()
 
 # Initial epoch
 epoch = bh.Epoch.from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, bh.TimeSystem.UTC)

--- a/examples/numerical_propagation/mars_orbit.rs
+++ b/examples/numerical_propagation/mars_orbit.rs
@@ -20,7 +20,7 @@ fn main() {
     // Initialize EOP data and the DE440s planetary ephemeris used for
     // third-body perturbations and ECI <-> MCI frame conversions.
     bh::initialize_eop().unwrap();
-    bh::initialize_ephemeris().unwrap();
+    bh::load_common_spice_kernels().unwrap();
 
     // Initial epoch
     let epoch = bh::Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, bh::TimeSystem::UTC);

--- a/examples/spice/spice_kernel_registry.py
+++ b/examples/spice/spice_kernel_registry.py
@@ -18,8 +18,8 @@ epc = bh.Epoch.from_date(2025, 1, 1, bh.TimeSystem.UTC)
 
 # Loading is idempotent and explicit; spk_* queries also auto-load de440s if
 # no kernel has been loaded yet.
-bh.load_kernel("de440s")
-print(f"Loaded kernels: {bh.loaded_kernels()}")
+bh.load_spice_kernel("de440s")
+print(f"Loaded kernels: {bh.loaded_spice_kernels()}")
 
 # Generic queries take NAIF IDs and resolve across all loaded SPK kernels.
 r_moon = bh.spk_position(bh.NAIFId.MOON, bh.NAIFId.EARTH, epc)

--- a/examples/spice/spice_kernel_registry.rs
+++ b/examples/spice/spice_kernel_registry.rs
@@ -15,8 +15,8 @@ fn main() {
 
     // Loading is idempotent and explicit; spk_* queries also auto-load de440s
     // if no kernel has been loaded yet.
-    bh::spice::load_kernel("de440s").unwrap();
-    println!("Loaded kernels: {:?}", bh::spice::loaded_kernels());
+    bh::spice::load_spice_kernel("de440s").unwrap();
+    println!("Loaded kernels: {:?}", bh::spice::loaded_spice_kernels());
 
     // Generic queries take NAIF IDs and resolve across all loaded SPK kernels.
     let r_moon = bh::spice::spk_position(NAIFId::Moon, NAIFId::Earth, epc).unwrap();

--- a/examples/spice/spice_pck_orientation.py
+++ b/examples/spice/spice_pck_orientation.py
@@ -16,7 +16,7 @@ import numpy as np
 bh.initialize_eop()
 
 # PCKs are never auto-initialized; they must be loaded explicitly.
-bh.load_kernel("moon_pa_de440")
+bh.load_spice_kernel("moon_pa_de440")
 
 epc = bh.Epoch.from_date(2025, 1, 1, bh.TimeSystem.UTC)
 

--- a/examples/spice/spice_pck_orientation.rs
+++ b/examples/spice/spice_pck_orientation.rs
@@ -13,7 +13,7 @@ fn main() {
     bh::initialize_eop().unwrap();
 
     // PCKs are never auto-initialized; they must be loaded explicitly.
-    bh::spice::load_kernel("moon_pa_de440").unwrap();
+    bh::spice::load_spice_kernel("moon_pa_de440").unwrap();
 
     let epc = bh::Epoch::from_date(2025, 1, 1, bh::TimeSystem::UTC);
 

--- a/justfile
+++ b/justfile
@@ -50,8 +50,8 @@ download-resources: _setup
     @{{python}} -c "from brahe.plots.texture_utils import download_natural_earth_texture; download_natural_earth_texture('50m')"
     @{{python}} -c "from brahe.plots.basemap import get_natural_earth_land_shapefile; get_natural_earth_land_shapefile()"
     @{{python}} {{scripts_dir}}/warm_cartopy.py
-    @{{python}} -c "import brahe as bh; bh.load_common_kernels()"
-    @{{python}} -c "import brahe as bh; bh.load_kernel('mar099s')"
+    @{{python}} -c "import brahe as bh; bh.load_common_spice_kernels()"
+    @{{python}} -c "import brahe as bh; bh.load_spice_kernel('mar099s')"
 
 # Test all documentation examples (delegates to scripts/test_examples.py)
 test-examples *args: _setup
@@ -363,8 +363,8 @@ setup:
     uv sync --group dev
     uv pip install -e . --quiet
     .venv/bin/pre-commit install
-    @{{python}} -c "import brahe as bh; bh.load_common_kernels()"
-    @{{python}} -c "import brahe as bh; bh.load_kernel('mar099s')"
+    @{{python}} -c "import brahe as bh; bh.load_common_spice_kernels()"
+    @{{python}} -c "import brahe as bh; bh.load_spice_kernel('mar099s')"
     @echo "✓ Setup complete (.venv ready, pre-commit hooks installed, kernels cached)"
 
 # Set up the full dev environment (Python dev deps + Rust dev tools).

--- a/plots/fig_perturbation_magnitudes.py
+++ b/plots/fig_perturbation_magnitudes.py
@@ -30,7 +30,7 @@ os.makedirs(OUTDIR, exist_ok=True)
 bh.initialize_eop()
 
 # Initialize DE440s ephemeris for high-accuracy planetary positions
-bh.initialize_ephemeris()
+bh.load_common_spice_kernels()
 
 # Reference epoch for calculations (J2000)
 epoch = bh.Epoch.from_datetime(2000, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)

--- a/scripts/warm_data_cache.py
+++ b/scripts/warm_data_cache.py
@@ -6,7 +6,7 @@ each entry via brahe's own caching downloaders, so a warm run is idempotent:
 already-cached artifacts fast-path without hitting the network.
 
 Two manifest line forms are supported:
-    <kernel-name>              -> brahe.load_kernel(name), which downloads and
+    <kernel-name>              -> brahe.load_spice_kernel(name), which downloads and
                                    caches known DE/PCK/satellite kernel names
                                    via `download_spice_kernel`'s name
                                    resolution.
@@ -40,9 +40,9 @@ def _warm_entry(entry: str) -> str:
         path = datasets.icgem.download_model(body, model_name)
         return path
 
-    bh.load_kernel(entry)
-    assert entry in bh.loaded_kernels(), (
-        f"{entry!r} not in loaded_kernels() after load_kernel()"
+    bh.load_spice_kernel(entry)
+    assert entry in bh.loaded_spice_kernels(), (
+        f"{entry!r} not in loaded_spice_kernels() after load_spice_kernel()"
     )
     return "loaded"
 

--- a/src/datasets/naif.rs
+++ b/src/datasets/naif.rs
@@ -13,7 +13,6 @@ use crate::utils::BraheError;
 use crate::utils::atomic_write;
 use crate::utils::cache::get_naif_cache_dir;
 use std::fs;
-use std::io::Read;
 use std::path::PathBuf;
 
 /// Download a kernel's bytes from an explicit base URL.
@@ -57,20 +56,12 @@ fn fetch_kernel(kernel: SPICEKernel) -> Result<Vec<u8>, BraheError> {
 /// # Returns
 /// * `Result<Vec<u8>, BraheError>` - Binary kernel data
 fn fetch_kernel_from_url(url: &str, label: &str) -> Result<Vec<u8>, BraheError> {
-    let response = ureq::get(url).call().map_err(|e| {
+    // Retries transient network/server failures with exponential backoff so a
+    // single dropped connection to NAIF (e.g. "Connection refused") doesn't fail
+    // an otherwise-recoverable download.
+    let buffer = crate::utils::download::download_bytes(url).map_err(|e| {
         BraheError::Error(format!(
             "Failed to download kernel {} from NAIF: {}",
-            label, e
-        ))
-    })?;
-
-    // Read response body manually to avoid default size limits.
-    let mut buffer = Vec::new();
-    let mut reader = response.into_body().into_reader();
-
-    reader.read_to_end(&mut buffer).map_err(|e| {
-        BraheError::Error(format!(
-            "Failed to read kernel {} from NAIF response: {}",
             label, e
         ))
     })?;

--- a/src/frames/lunar.rs
+++ b/src/frames/lunar.rs
@@ -94,12 +94,12 @@ pub(crate) fn ensure_lunar_pck_loaded() {
         if crate::spice::kernel_is_loaded("moon_pa_de440") {
             return;
         }
-        crate::spice::load_kernel("moon_pa_de440").unwrap_or_else(|e| {
+        crate::spice::load_spice_kernel("moon_pa_de440").unwrap_or_else(|e| {
             panic!(
                 "Failed to auto-load lunar PCK 'moon_pa_de440': {}. \
                  Download it with brahe::datasets::naif::download_spice_kernel\
                  (SPICEKernel::MoonPaDe440, None) and call \
-                 brahe::spice::load_kernel(<path>).",
+                 brahe::spice::load_spice_kernel(<path>).",
                 e
             )
         });
@@ -659,7 +659,7 @@ mod tests {
     use super::*;
     use crate::constants::R_MOON;
     use crate::math::vector6_from_array;
-    use crate::spice::{load_kernel, unload_kernel};
+    use crate::spice::{load_spice_kernel, unload_spice_kernel};
     use crate::time::TimeSystem;
     use crate::utils::testing::{
         CacheRedirect, setup_global_test_spice, synthetic_pck_kernel_bytes,
@@ -871,7 +871,7 @@ mod tests {
         // lunar PCK required. Exercises state_eci_to_lci/state_lci_to_eci and
         // position_eci_to_lci/position_lci_to_eci offline.
         setup_global_test_spice();
-        load_kernel("de440s").unwrap();
+        load_spice_kernel("de440s").unwrap();
         let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
         let x_eci = vector6_from_array([1e8, 2e8, 3e8, 1.0, 2.0, 3.0]);
 
@@ -903,8 +903,8 @@ mod tests {
         // de440s stays resident throughout (never cleared); only the lunar PCK
         // is unloaded/reloaded so a prior panicked run cannot poison us.
         setup_global_test_spice();
-        load_kernel("de440s").unwrap();
-        let _ = unload_kernel("moon_pa_de440");
+        load_spice_kernel("de440s").unwrap();
+        let _ = unload_spice_kernel("moon_pa_de440");
         {
             let cache = CacheRedirect::new();
             cache.seed_real_de440s();
@@ -922,7 +922,7 @@ mod tests {
             assert!(!crate::spice::kernel_is_loaded("moon_pa_de440"));
             ensure_lunar_pck_loaded();
             if !crate::spice::kernel_is_loaded("moon_pa_de440") {
-                load_kernel("moon_pa_de440").unwrap();
+                load_spice_kernel("moon_pa_de440").unwrap();
             }
             let r_lci_lfpa = rotation_lci_to_lfpa(epc);
             assert!(crate::spice::kernel_is_loaded("moon_pa_de440"));
@@ -981,12 +981,12 @@ mod tests {
             // is a no-op (does not error).
             ensure_lunar_pck_loaded();
 
-            unload_kernel("moon_pa_de440").unwrap();
+            unload_spice_kernel("moon_pa_de440").unwrap();
         }
         // The latch is now set but the kernel was just unloaded, so later
         // latch-relying tests would see it missing. Best-effort restore of
         // the real PCK (real cache; tolerated failure keeps this test
         // offline-safe when nothing later needs the kernel).
-        let _ = load_kernel("moon_pa_de440");
+        let _ = load_spice_kernel("moon_pa_de440");
     }
 }

--- a/src/frames/mars.rs
+++ b/src/frames/mars.rs
@@ -63,7 +63,7 @@ pub(crate) fn ensure_mars_spk_loaded() {
                 "Failed to auto-load Mars ephemeris kernels (de440s/mar099s): {}. \
                  Download them with brahe::datasets::naif::download_spice_kernel \
                  (SPICEKernel::DE440s / SPICEKernel::Mar099s, None) and call \
-                 brahe::spice::load_kernel(<path>).",
+                 brahe::spice::load_spice_kernel(<path>).",
                 e
             )
         });
@@ -72,7 +72,7 @@ pub(crate) fn ensure_mars_spk_loaded() {
                 "Failed to auto-load Mars satellite ephemeris 'mar099s'. \
                  Download it with brahe::datasets::naif::download_spice_kernel\
                  (SPICEKernel::Mar099s, None) and call \
-                 brahe::spice::load_kernel(<path>)."
+                 brahe::spice::load_spice_kernel(<path>)."
             );
         }
     });
@@ -413,7 +413,7 @@ mod tests {
     use super::*;
     use crate::constants::R_MARS;
     use crate::math::vector6_from_array;
-    use crate::spice::{load_kernel, unload_kernel};
+    use crate::spice::{load_spice_kernel, unload_spice_kernel};
     use crate::time::TimeSystem;
     use crate::utils::testing::{
         CacheRedirect, setup_global_test_spice, synthetic_spk_kernel_bytes,
@@ -530,8 +530,8 @@ mod tests {
         // cache; the real de440s stays resident (never cleared) for the
         // barycenter chain. Only mar099s is unloaded/reloaded here.
         setup_global_test_spice();
-        load_kernel("de440s").unwrap();
-        let _ = unload_kernel("mar099s");
+        load_spice_kernel("de440s").unwrap();
+        let _ = unload_spice_kernel("mar099s");
         {
             let cache = CacheRedirect::new();
             cache.seed_real_de440s();
@@ -547,7 +547,7 @@ mod tests {
             assert!(!crate::spice::kernel_is_loaded("mar099s"));
             ensure_mars_spk_loaded();
             if !crate::spice::kernel_is_loaded("mar099s") {
-                load_kernel("mar099s").unwrap();
+                load_spice_kernel("mar099s").unwrap();
             }
             let x_mci = state_eci_to_mci(epc, x_eci);
             assert!(crate::spice::kernel_is_loaded("mar099s"));
@@ -573,12 +573,12 @@ mod tests {
             // ensure_mars_spk_loaded is idempotent while loaded.
             ensure_mars_spk_loaded();
 
-            unload_kernel("mar099s").unwrap();
+            unload_spice_kernel("mar099s").unwrap();
         }
         // The latch is now set but the kernel was just unloaded, so later
         // latch-relying tests would see it missing. Best-effort restore of
         // the real mar099s (real cache; tolerated failure keeps this test
         // offline-safe when nothing later needs the kernel).
-        let _ = load_kernel("mar099s");
+        let _ = load_spice_kernel("mar099s");
     }
 }

--- a/src/frames/transform.rs
+++ b/src/frames/transform.rs
@@ -1058,7 +1058,7 @@ mod tests {
         let path = dir.path().join("synthetic_bfpck.bpc");
         std::fs::write(&path, synthetic_pck_kernel_bytes(frame_id)).unwrap();
         let path = path.to_str().unwrap();
-        crate::spice::load_kernel(path).unwrap();
+        crate::spice::load_spice_kernel(path).unwrap();
 
         let epc = Epoch::from_jd(
             crate::constants::JD_J2000 + 500.0 / crate::constants::SECONDS_PER_DAY,
@@ -1084,7 +1084,7 @@ mod tests {
             }
         }
 
-        crate::spice::unload_kernel(path).unwrap();
+        crate::spice::unload_spice_kernel(path).unwrap();
     }
 
     #[test]

--- a/src/orbit_dynamics/ephemerides.rs
+++ b/src/orbit_dynamics/ephemerides.rs
@@ -11,12 +11,12 @@ use crate::attitude::RotationMatrix;
 use crate::constants::{AS2RAD, MJD_J2000, RADIANS};
 use crate::frames::rotation_eme2000_to_gcrf;
 pub use crate::spice::{
-    initialize_ephemeris, initialize_ephemeris_with_kernel, jupiter_barycenter_position_spice,
-    jupiter_position_spice, mars_barycenter_position_spice, mars_position_spice,
-    mercury_position_spice, moon_position_spice, neptune_barycenter_position_spice,
-    neptune_position_spice, saturn_barycenter_position_spice, saturn_position_spice,
-    solar_system_barycenter_position_spice, ssb_position_spice, sun_position_spice,
-    uranus_barycenter_position_spice, uranus_position_spice, venus_position_spice,
+    jupiter_barycenter_position_spice, jupiter_position_spice, mars_barycenter_position_spice,
+    mars_position_spice, mercury_position_spice, moon_position_spice,
+    neptune_barycenter_position_spice, neptune_position_spice, saturn_barycenter_position_spice,
+    saturn_position_spice, solar_system_barycenter_position_spice, ssb_position_spice,
+    sun_position_spice, uranus_barycenter_position_spice, uranus_position_spice,
+    venus_position_spice,
 };
 use crate::time::{Epoch, TimeSystem};
 

--- a/src/orbit_dynamics/third_body.rs
+++ b/src/orbit_dynamics/third_body.rs
@@ -12,10 +12,10 @@ use crate::propagators::CentralBody;
 use crate::propagators::force_model_config::{EphemerisSource, ThirdBody};
 use crate::spice::positions::{spk_pair_position_from_kernels, spk_strictly_resolvable};
 use crate::spice::{
-    SPICEKernel, jupiter_barycenter_position_spice, load_kernel, mars_barycenter_position_spice,
-    mercury_position_spice, moon_position_spice, neptune_barycenter_position_spice,
-    saturn_barycenter_position_spice, spk_position, sun_position_spice,
-    uranus_barycenter_position_spice, venus_position_spice,
+    SPICEKernel, jupiter_barycenter_position_spice, load_spice_kernel,
+    mars_barycenter_position_spice, mercury_position_spice, moon_position_spice,
+    neptune_barycenter_position_spice, saturn_barycenter_position_spice, spk_position,
+    sun_position_spice, uranus_barycenter_position_spice, venus_position_spice,
 };
 use crate::time::Epoch;
 use crate::utils::BraheError;
@@ -346,7 +346,7 @@ pub fn accel_third_body_for_body<P: IntoPosition>(
                 // all loaded kernels with the registry's last-loaded-wins
                 // precedence.
                 None => {
-                    load_kernel(kernel)?;
+                    load_spice_kernel(kernel)?;
                     spk_position(target, center, epc)?
                 }
             }
@@ -484,12 +484,12 @@ pub fn accel_third_body_moon<P: IntoPosition>(epc: Epoch, r_object: P) -> Vector
 /// use brahe::third_body::accel_third_body_sun_spice;
 /// use brahe::propagators::force_model_config::EphemerisSource;
 /// use brahe::constants::R_EARTH;
-/// use brahe::ephemerides::initialize_ephemeris;
+/// use brahe::spice::load_common_spice_kernels;
 /// use nalgebra::Vector3;
 ///
 /// let eop = FileEOPProvider::from_default_standard(true, EOPExtrapolation::Hold).unwrap();
 /// set_global_eop_provider(eop);
-/// initialize_ephemeris().unwrap();
+/// load_common_spice_kernels().unwrap();
 ///
 /// let epc = Epoch::from_date(2024, 2, 25, brahe::TimeSystem::UTC);
 /// let r_object = Vector3::new(R_EARTH + 500e3, 0.0, 0.0);
@@ -531,12 +531,12 @@ pub fn accel_third_body_sun_spice<P: IntoPosition>(
 /// use brahe::third_body::accel_third_body_moon_spice;
 /// use brahe::propagators::force_model_config::EphemerisSource;
 /// use brahe::constants::R_EARTH;
-/// use brahe::ephemerides::initialize_ephemeris;
+/// use brahe::spice::load_common_spice_kernels;
 /// use nalgebra::Vector3;
 ///
 /// let eop = FileEOPProvider::from_default_standard(true, EOPExtrapolation::Hold).unwrap();
 /// set_global_eop_provider(eop);
-/// initialize_ephemeris().unwrap();
+/// load_common_spice_kernels().unwrap();
 ///
 /// let epc = Epoch::from_date(2024, 2, 25, brahe::TimeSystem::UTC);
 /// let r_object = Vector3::new(R_EARTH + 500e3, 0.0, 0.0);
@@ -1041,7 +1041,7 @@ mod tests {
     #[serial]
     fn test_phobos_third_body_about_mars() {
         setup_global_test_spice();
-        crate::spice::load_kernel("mar099s").unwrap();
+        crate::spice::load_spice_kernel("mar099s").unwrap();
 
         let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
         let r = Vector3::new(R_MARS + 400e3, 0.0, 0.0);
@@ -1142,7 +1142,7 @@ mod tests {
     // triggers a fresh kernel *cache load* while it is active; that is an
     // accepted limitation shared with the registry's offline tests.)
 
-    use crate::spice::{load_kernel, unload_kernel};
+    use crate::spice::{load_spice_kernel, unload_spice_kernel};
     use crate::utils::testing::{CacheRedirect, synthetic_spk_kernel_bytes};
 
     /// Third-body acceleration formula replicated for expected values.
@@ -1199,10 +1199,10 @@ mod tests {
             );
 
             for order in [["de430", "de432s"], ["de432s", "de430"]] {
-                let _ = unload_kernel("de430");
-                let _ = unload_kernel("de432s");
+                let _ = unload_spice_kernel("de430");
+                let _ = unload_spice_kernel("de432s");
                 for name in order {
-                    load_kernel(name).unwrap();
+                    load_spice_kernel(name).unwrap();
                 }
 
                 let a = accel_third_body_for_body(
@@ -1225,8 +1225,8 @@ mod tests {
                 .unwrap();
                 assert_abs_diff_eq!(a, a_de432s, epsilon = a_de432s.norm() * 1e-12);
             }
-            let _ = unload_kernel("de430");
-            let _ = unload_kernel("de432s");
+            let _ = unload_spice_kernel("de430");
+            let _ = unload_spice_kernel("de432s");
         }
     }
 
@@ -1264,11 +1264,11 @@ mod tests {
                 "de432s.bsp",
                 &synthetic_spk_kernel_bytes(&[(4, 0, 800.0), (3, 0, 80.0)]),
             );
-            let _ = unload_kernel("mar099s");
-            let _ = unload_kernel("de430");
-            let _ = unload_kernel("de432s");
-            load_kernel("de430").unwrap();
-            load_kernel("de432s").unwrap();
+            let _ = unload_spice_kernel("mar099s");
+            let _ = unload_spice_kernel("de430");
+            let _ = unload_spice_kernel("de432s");
+            load_spice_kernel("de430").unwrap();
+            load_spice_kernel("de432s").unwrap();
 
             let a = accel_third_body_for_body(
                 &CentralBody::EMB,
@@ -1300,9 +1300,9 @@ mod tests {
             .unwrap();
             assert_abs_diff_eq!(a, a_mars, epsilon = a_mars.norm() * 1e-12);
 
-            let _ = unload_kernel("mar099s");
-            let _ = unload_kernel("de430");
-            let _ = unload_kernel("de432s");
+            let _ = unload_spice_kernel("mar099s");
+            let _ = unload_spice_kernel("de430");
+            let _ = unload_spice_kernel("de432s");
         }
     }
 
@@ -1329,15 +1329,15 @@ mod tests {
         std::fs::write(&path, synthetic_spk_kernel_bytes(&[(2000001, 0, 77.0)])).unwrap();
         let path = path.to_str().unwrap();
 
-        load_kernel("de440s").unwrap();
-        load_kernel(path).unwrap();
+        load_spice_kernel("de440s").unwrap();
+        load_spice_kernel(path).unwrap();
 
         let a =
             accel_third_body_for_body(&CentralBody::SSB, &body, EphemerisSource::DE440s, epc, r)
                 .unwrap();
         assert_abs_diff_eq!(a, a_expected, epsilon = a_expected.norm() * 1e-12);
 
-        let _ = unload_kernel(path);
+        let _ = unload_spice_kernel(path);
     }
 
     #[test]
@@ -1369,9 +1369,9 @@ mod tests {
             std::fs::write(&path, synthetic_spk_kernel_bytes(&[(950, 0, 33.0)])).unwrap();
             let path = path.to_str().unwrap();
 
-            let _ = unload_kernel("plu060");
-            load_kernel("de440s").unwrap();
-            load_kernel(path).unwrap();
+            let _ = unload_spice_kernel("plu060");
+            load_spice_kernel("de440s").unwrap();
+            load_spice_kernel(path).unwrap();
 
             let a = accel_third_body_for_body(
                 &CentralBody::SSB,
@@ -1383,8 +1383,8 @@ mod tests {
             .unwrap();
             assert_abs_diff_eq!(a, a_expected, epsilon = a_expected.norm() * 1e-12);
 
-            let _ = unload_kernel(path);
-            let _ = unload_kernel("plu060");
+            let _ = unload_spice_kernel(path);
+            let _ = unload_spice_kernel("plu060");
         }
     }
 

--- a/src/propagators/dnumerical_orbit_propagator.rs
+++ b/src/propagators/dnumerical_orbit_propagator.rs
@@ -9648,7 +9648,7 @@ mod tests {
 
         setup_global_test_eop();
         crate::utils::testing::setup_global_test_spice();
-        crate::spice::load_kernel("mar099s").unwrap();
+        crate::spice::load_spice_kernel("mar099s").unwrap();
 
         let epoch = Epoch::from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![R_EARTH + 500e3, 0.0, 0.0, 0.0, 7612.6, 0.0]);

--- a/src/spice/kernels.rs
+++ b/src/spice/kernels.rs
@@ -181,7 +181,7 @@ impl SPICEKernel {
     /// Every known kernel variant, for iterating over all downloadable
     /// kernels or documentation.
     ///
-    /// Not used by `load_all_kernels`, which loads a curated subset
+    /// Not used by `load_all_spice_kernels`, which loads a curated subset
     /// (one DE ephemeris, not every DE version) rather than every variant
     /// here.
     ///
@@ -214,8 +214,8 @@ impl SPICEKernel {
 ///
 /// [`From<&str>`](KernelSource::from) resolves the string to a
 /// [`SPICEKernel`] if it matches a known kernel name and otherwise treats it
-/// as a file path, so `load_kernel("de440s")` and
-/// `load_kernel("/path/to/custom.bsp")` both work.
+/// as a file path, so `load_spice_kernel("de440s")` and
+/// `load_spice_kernel("/path/to/custom.bsp")` both work.
 #[derive(Debug, Clone)]
 pub enum KernelSource {
     /// A known NAIF kernel, downloaded and cached on demand.

--- a/src/spice/positions.rs
+++ b/src/spice/positions.rs
@@ -845,16 +845,16 @@ mod tests {
         // body center rel its barycenter. Positions are constant on the
         // x-axis, so each result is the exact two-leg sum and velocity is
         // zero. This also covers all `system_kernel` match arms.
-        use crate::spice::{clear_kernels, load_kernel};
+        use crate::spice::{clear_spice_kernels, load_spice_kernel};
         use crate::utils::testing::{CacheRedirect, synthetic_spk_kernel_bytes};
 
         setup_global_test_spice();
         // Keep the real de440s resident so any concurrent cache-reading test
-        // still finds it (via load_kernel's idempotent short-circuit) while
+        // still finds it (via load_spice_kernel's idempotent short-circuit) while
         // BRAHE_CACHE is redirected below. The barycenter leg uses the DE440
         // (de440.bsp) slot, which no other default-suite test loads, so
         // seeding a synthetic version there cannot corrupt a concurrent read.
-        load_kernel("de440s").unwrap();
+        load_spice_kernel("de440s").unwrap();
 
         let epc = Epoch::from_date(2025, 1, 1, crate::time::TimeSystem::UTC);
         {
@@ -925,8 +925,8 @@ mod tests {
         }
         // Redirect dropped (real cache restored): drop the synthetic kernels
         // and reload the real de440s.
-        clear_kernels();
-        load_kernel("de440s").unwrap();
+        clear_spice_kernels();
+        load_spice_kernel("de440s").unwrap();
     }
 
     #[test]
@@ -966,11 +966,11 @@ mod tests {
     fn test_ssb_position_spice_alias_offline() {
         // `ssb_position_spice` forwards to `solar_system_barycenter_position_spice`.
         // A synthetic DE kernel provides SSB (0) rel Earth as a constant.
-        use crate::spice::{clear_kernels, load_kernel};
+        use crate::spice::{clear_spice_kernels, load_spice_kernel};
         use crate::utils::testing::{CacheRedirect, synthetic_spk_kernel_bytes};
 
         setup_global_test_spice();
-        load_kernel("de440s").unwrap(); // keep real de440s resident (see above)
+        load_spice_kernel("de440s").unwrap(); // keep real de440s resident (see above)
 
         let epc = Epoch::from_date(2025, 1, 1, crate::time::TimeSystem::UTC);
         {
@@ -981,8 +981,8 @@ mod tests {
             let r = ssb_position_spice(epc, SPICEKernel::DE440).unwrap();
             assert_abs_diff_eq!(r[0], 3000.0, epsilon = 1e-6);
         }
-        clear_kernels();
-        load_kernel("de440s").unwrap();
+        clear_spice_kernels();
+        load_spice_kernel("de440s").unwrap();
     }
 
     #[test]
@@ -990,11 +990,11 @@ mod tests {
     fn test_solar_system_barycenter_position_spice_error_offline() {
         // Error branch: a cached-but-unparseable DE kernel makes the load
         // fail, and the error propagates out of the generated position fn.
-        use crate::spice::{clear_kernels, load_kernel};
+        use crate::spice::{clear_spice_kernels, load_spice_kernel};
         use crate::utils::testing::CacheRedirect;
 
         setup_global_test_spice();
-        load_kernel("de440s").unwrap(); // keep real de440s resident (see above)
+        load_spice_kernel("de440s").unwrap(); // keep real de440s resident (see above)
 
         let epc = Epoch::from_date(2025, 1, 1, crate::time::TimeSystem::UTC);
         {
@@ -1006,8 +1006,8 @@ mod tests {
             let err = solar_system_barycenter_position_spice(epc, SPICEKernel::DE440).unwrap_err();
             assert!(!format!("{}", err).is_empty());
         }
-        clear_kernels();
-        load_kernel("de440s").unwrap();
+        clear_spice_kernels();
+        load_spice_kernel("de440s").unwrap();
     }
 
     #[test]

--- a/src/spice/registry.rs
+++ b/src/spice/registry.rs
@@ -112,11 +112,11 @@ fn resolve_kernel_path(source: &KernelSource) -> Result<std::path::PathBuf, Brah
 ///
 /// # Examples
 /// ```no_run
-/// use brahe::spice::load_kernel;
+/// use brahe::spice::load_spice_kernel;
 ///
-/// load_kernel("de440s").expect("Failed to load DE440s");
+/// load_spice_kernel("de440s").expect("Failed to load DE440s");
 /// ```
-pub fn load_kernel(kernel: impl Into<KernelSource>) -> Result<(), BraheError> {
+pub fn load_spice_kernel(kernel: impl Into<KernelSource>) -> Result<(), BraheError> {
     let source = kernel.into();
     let key = source.key().to_string();
 
@@ -153,23 +153,23 @@ pub fn load_kernel(kernel: impl Into<KernelSource>) -> Result<(), BraheError> {
     Ok(())
 }
 
-/// Unload a kernel previously loaded via [`load_kernel`].
+/// Unload a kernel previously loaded via [`load_spice_kernel`].
 ///
 /// # Arguments
 /// - `kernel`: The same kernel name/[`SPICEKernel`]/path originally passed to
-///   [`load_kernel`]
+///   [`load_spice_kernel`]
 ///
 /// # Returns
 /// - `Ok(())` on success, or `BraheError` if the kernel is not loaded
 ///
 /// # Examples
 /// ```no_run
-/// use brahe::spice::{load_kernel, unload_kernel};
+/// use brahe::spice::{load_spice_kernel, unload_spice_kernel};
 ///
-/// load_kernel("de440s").unwrap();
-/// unload_kernel("de440s").expect("Failed to unload DE440s");
+/// load_spice_kernel("de440s").unwrap();
+/// unload_spice_kernel("de440s").expect("Failed to unload DE440s");
 /// ```
-pub fn unload_kernel(kernel: impl Into<KernelSource>) -> Result<(), BraheError> {
+pub fn unload_spice_kernel(kernel: impl Into<KernelSource>) -> Result<(), BraheError> {
     let key = kernel.into().key().to_string();
     let mut reg = GLOBAL_SPICE.write().unwrap();
     if reg.kernels.remove(&key).is_none() {
@@ -187,12 +187,12 @@ pub fn unload_kernel(kernel: impl Into<KernelSource>) -> Result<(), BraheError> 
 ///
 /// # Examples
 /// ```no_run
-/// use brahe::spice::{load_kernel, clear_kernels};
+/// use brahe::spice::{load_spice_kernel, clear_spice_kernels};
 ///
-/// load_kernel("de440s").unwrap();
-/// clear_kernels();
+/// load_spice_kernel("de440s").unwrap();
+/// clear_spice_kernels();
 /// ```
-pub fn clear_kernels() {
+pub fn clear_spice_kernels() {
     let mut reg = GLOBAL_SPICE.write().unwrap();
     reg.kernels.clear();
     reg.load_order.clear();
@@ -202,16 +202,16 @@ pub fn clear_kernels() {
 /// Names/paths of currently loaded kernels, in load order.
 ///
 /// # Returns
-/// - Kernel names/paths in the order they were passed to [`load_kernel`]
+/// - Kernel names/paths in the order they were passed to [`load_spice_kernel`]
 ///
 /// # Examples
 /// ```no_run
-/// use brahe::spice::{load_kernel, loaded_kernels};
+/// use brahe::spice::{load_spice_kernel, loaded_spice_kernels};
 ///
-/// load_kernel("de440s").unwrap();
-/// assert_eq!(loaded_kernels(), vec!["de440s".to_string()]);
+/// load_spice_kernel("de440s").unwrap();
+/// assert_eq!(loaded_spice_kernels(), vec!["de440s".to_string()]);
 /// ```
-pub fn loaded_kernels() -> Vec<String> {
+pub fn loaded_spice_kernels() -> Vec<String> {
     GLOBAL_SPICE.read().unwrap().load_order.clone()
 }
 
@@ -222,8 +222,8 @@ pub fn loaded_kernels() -> Vec<String> {
 /// from — so a fragment like `"moon_pa_de440"` matches both a name-loaded
 /// kernel and a path-loaded copy of the same file. Allocation-free
 /// read-lock check, cheap enough for per-call guards (unlike cloning
-/// [`loaded_kernels`]); unlike a `OnceLock` latch it stays correct across
-/// [`clear_kernels`]/[`unload_kernel`].
+/// [`loaded_spice_kernels`]); unlike a `OnceLock` latch it stays correct across
+/// [`clear_spice_kernels`]/[`unload_spice_kernel`].
 ///
 /// # Arguments
 /// - `fragment`: Substring to search for in each loaded kernel's key
@@ -233,9 +233,9 @@ pub fn loaded_kernels() -> Vec<String> {
 ///
 /// # Examples
 /// ```no_run
-/// use brahe::spice::{kernel_is_loaded, load_kernel};
+/// use brahe::spice::{kernel_is_loaded, load_spice_kernel};
 ///
-/// load_kernel("de440s").unwrap();
+/// load_spice_kernel("de440s").unwrap();
 /// assert!(kernel_is_loaded("de440s"));
 /// assert!(!kernel_is_loaded("de440x"));
 /// ```
@@ -248,51 +248,14 @@ pub fn kernel_is_loaded(fragment: &str) -> bool {
         .any(|k| k.contains(fragment))
 }
 
-/// Initialize the global ephemeris with the default DE440s kernel.
-///
-/// Equivalent to `load_kernel("de440s")`. Optional: `spk_position` and
-/// related queries lazily auto-initialize DE440s if no kernels are loaded.
-///
-/// # Returns
-/// - `Ok(())` on success, or `BraheError` on download/parse failure
-///
-/// # Examples
-/// ```no_run
-/// use brahe::spice::initialize_ephemeris;
-///
-/// initialize_ephemeris().expect("Failed to initialize ephemeris");
-/// ```
-pub fn initialize_ephemeris() -> Result<(), BraheError> {
-    load_kernel("de440s")
-}
-
-/// Initialize the global ephemeris with a specific DE kernel.
-///
-/// Equivalent to `load_kernel(kernel)`.
-///
-/// # Arguments
-/// - `kernel`: A known DE kernel name/[`SPICEKernel`] (e.g. `"de440s"`, `"de440"`)
-///
-/// # Returns
-/// - `Ok(())` on success, or `BraheError` on download/parse failure
-///
-/// # Examples
-/// ```no_run
-/// use brahe::spice::initialize_ephemeris_with_kernel;
-///
-/// initialize_ephemeris_with_kernel("de440").expect("Failed to initialize DE440");
-/// ```
-pub fn initialize_ephemeris_with_kernel(kernel: impl Into<KernelSource>) -> Result<(), BraheError> {
-    load_kernel(kernel)
-}
-
-/// Kernels loaded by [`load_common_kernels`]: `de440s` (planetary ephemeris)
+/// Kernels loaded by [`load_common_spice_kernels`]: `de440s` (planetary ephemeris)
 /// and `moon_pa_de440` (lunar principal-axes orientation).
-pub(crate) const COMMON_KERNELS: &[SPICEKernel] = &[SPICEKernel::DE440s, SPICEKernel::MoonPaDe440];
+pub(crate) const COMMON_SPICE_KERNELS: &[SPICEKernel] =
+    &[SPICEKernel::DE440s, SPICEKernel::MoonPaDe440];
 
-/// Kernels loaded by [`load_all_kernels`]: [`COMMON_KERNELS`] plus every
+/// Kernels loaded by [`load_all_spice_kernels`]: [`COMMON_SPICE_KERNELS`] plus every
 /// satellite ephemeris kernel brahe knows how to download.
-pub(crate) const ALL_KERNELS: &[SPICEKernel] = &[
+pub(crate) const ALL_SPICE_KERNELS: &[SPICEKernel] = &[
     SPICEKernel::DE440s,
     SPICEKernel::MoonPaDe440,
     SPICEKernel::Mar099s,
@@ -307,7 +270,7 @@ pub(crate) const ALL_KERNELS: &[SPICEKernel] = &[
 /// and `moon_pa_de440` (lunar principal-axes orientation).
 ///
 /// ~46 MB total on first download; cached thereafter. Each kernel load is
-/// idempotent, so calling this alongside other [`load_kernel`] calls is
+/// idempotent, so calling this alongside other [`load_spice_kernel`] calls is
 /// safe.
 ///
 /// Loading is not atomic: on error, kernels already loaded before the
@@ -319,13 +282,13 @@ pub(crate) const ALL_KERNELS: &[SPICEKernel] = &[
 ///
 /// # Examples
 /// ```no_run
-/// use brahe::spice::load_common_kernels;
+/// use brahe::spice::load_common_spice_kernels;
 ///
-/// load_common_kernels().expect("Failed to load common kernels");
+/// load_common_spice_kernels().expect("Failed to load common kernels");
 /// ```
-pub fn load_common_kernels() -> Result<(), BraheError> {
-    for kernel in COMMON_KERNELS {
-        load_kernel(*kernel)?;
+pub fn load_common_spice_kernels() -> Result<(), BraheError> {
+    for kernel in COMMON_SPICE_KERNELS {
+        load_spice_kernel(*kernel)?;
     }
     Ok(())
 }
@@ -335,7 +298,7 @@ pub fn load_common_kernels() -> Result<(), BraheError> {
 /// `nep097`, `plu060`.
 ///
 /// ~2.5 GB total on first download; cached thereafter. Prefer
-/// [`load_common_kernels`] unless outer-planet body centers or moons are
+/// [`load_common_spice_kernels`] unless outer-planet body centers or moons are
 /// needed.
 ///
 /// Loading is not atomic: on error, kernels already loaded before the
@@ -347,13 +310,13 @@ pub fn load_common_kernels() -> Result<(), BraheError> {
 ///
 /// # Examples
 /// ```no_run
-/// use brahe::spice::load_all_kernels;
+/// use brahe::spice::load_all_spice_kernels;
 ///
-/// load_all_kernels().expect("Failed to load all kernels");
+/// load_all_spice_kernels().expect("Failed to load all kernels");
 /// ```
-pub fn load_all_kernels() -> Result<(), BraheError> {
-    for kernel in ALL_KERNELS {
-        load_kernel(*kernel)?;
+pub fn load_all_spice_kernels() -> Result<(), BraheError> {
+    for kernel in ALL_SPICE_KERNELS {
+        load_spice_kernel(*kernel)?;
     }
     Ok(())
 }
@@ -396,7 +359,7 @@ fn global_chain(target: i32, center: i32) -> Result<Arc<Vec<ChainLink>>, BraheEr
     let segments = collect_spk_segments(&reg);
     if segments.is_empty() {
         return Err(BraheError::InitializationError(
-            "No SPK kernels loaded; call load_kernel(...) or initialize_ephemeris() first"
+            "No SPK kernels loaded; call load_spice_kernel(...) or load_common_spice_kernels() first"
                 .to_string(),
         ));
     }
@@ -433,7 +396,7 @@ fn global_eval<T>(
 /// library's historical lazy-initialization behavior for `spk_*` queries.
 ///
 /// Checks for an SPK specifically (not just any loaded kernel) so that a
-/// registry holding only PCK kernels (e.g. after `load_kernel("moon_pa_de440")`)
+/// registry holding only PCK kernels (e.g. after `load_spice_kernel("moon_pa_de440")`)
 /// still auto-initializes the default ephemeris.
 fn ensure_default_ephemeris_loaded() -> Result<(), BraheError> {
     let has_spk = GLOBAL_SPICE
@@ -443,7 +406,7 @@ fn ensure_default_ephemeris_loaded() -> Result<(), BraheError> {
         .values()
         .any(|k| matches!(k, Kernel::Spk(_)));
     if !has_spk {
-        load_kernel("de440s")?;
+        load_spice_kernel("de440s")?;
     }
     Ok(())
 }
@@ -477,7 +440,7 @@ pub(crate) fn ensure_bodies_loadable(ids: &[i32]) -> Result<(), BraheError> {
             && (400..=999).contains(&id)
             && let Some(kernel) = satellite_system_kernel(id / 100)
         {
-            let _ = load_kernel(kernel);
+            let _ = load_spice_kernel(kernel);
         }
     }
     Ok(())
@@ -508,10 +471,10 @@ pub(crate) fn ensure_bodies_loadable(ids: &[i32]) -> Result<(), BraheError> {
 ///
 /// # Examples
 /// ```
-/// use brahe::spice::{NAIFId, spk_position, initialize_ephemeris};
+/// use brahe::spice::{NAIFId, spk_position, load_common_spice_kernels};
 /// use brahe::time::{Epoch, TimeSystem};
 ///
-/// initialize_ephemeris().unwrap();
+/// load_common_spice_kernels().unwrap();
 /// let epc = Epoch::from_date(2025, 1, 1, TimeSystem::UTC);
 /// let r_moon = spk_position(NAIFId::Moon, NAIFId::Earth, epc).unwrap();
 /// ```
@@ -549,10 +512,10 @@ pub fn spk_position(
 ///
 /// # Examples
 /// ```
-/// use brahe::spice::{NAIFId, spk_velocity, initialize_ephemeris};
+/// use brahe::spice::{NAIFId, spk_velocity, load_common_spice_kernels};
 /// use brahe::time::{Epoch, TimeSystem};
 ///
-/// initialize_ephemeris().unwrap();
+/// load_common_spice_kernels().unwrap();
 /// let epc = Epoch::from_date(2025, 1, 1, TimeSystem::UTC);
 /// let v_moon = spk_velocity(NAIFId::Moon, NAIFId::Earth, epc).unwrap();
 /// ```
@@ -590,10 +553,10 @@ pub fn spk_velocity(
 ///
 /// # Examples
 /// ```
-/// use brahe::spice::{NAIFId, spk_state, initialize_ephemeris};
+/// use brahe::spice::{NAIFId, spk_state, load_common_spice_kernels};
 /// use brahe::time::{Epoch, TimeSystem};
 ///
-/// initialize_ephemeris().unwrap();
+/// load_common_spice_kernels().unwrap();
 /// let epc = Epoch::from_date(2025, 1, 1, TimeSystem::UTC);
 /// let x_moon = spk_state(NAIFId::Moon, NAIFId::Earth, epc).unwrap();
 /// ```
@@ -622,7 +585,7 @@ pub fn spk_state(
 /// absent.
 fn spk_kernel_for_query(kernel: KernelSource) -> Result<Arc<SPK>, BraheError> {
     let key = kernel.key().to_string();
-    load_kernel(kernel)?;
+    load_spice_kernel(kernel)?;
     let reg = GLOBAL_SPICE.read().unwrap();
     match reg.kernels.get(&key) {
         Some(Kernel::Spk(spk)) => Ok(Arc::clone(spk)),
@@ -631,7 +594,7 @@ fn spk_kernel_for_query(kernel: KernelSource) -> Result<Arc<SPK>, BraheError> {
             key
         ))),
         // Reachable if another thread unloads the kernel between the
-        // load_kernel call above and this lookup.
+        // load_spice_kernel call above and this lookup.
         None => Err(BraheError::Error(format!(
             "Kernel '{}' was unloaded concurrently during query",
             key
@@ -800,7 +763,7 @@ fn pck_query<T>(
 /// searching loaded PCK kernels newest-first.
 ///
 /// PCKs are never auto-initialized; a PCK kernel must be explicitly loaded
-/// via [`load_kernel`] first.
+/// via [`load_spice_kernel`] first.
 ///
 /// # Arguments
 /// - `frame_id`: Body-frame class ID (e.g. 31008 for MOON_PA_DE440)
@@ -812,10 +775,10 @@ fn pck_query<T>(
 ///
 /// # Examples
 /// ```no_run
-/// use brahe::spice::{FrameId, load_kernel, pck_euler_angles};
+/// use brahe::spice::{FrameId, load_spice_kernel, pck_euler_angles};
 /// use brahe::time::{Epoch, TimeSystem};
 ///
-/// load_kernel("/path/to/moon_pa_de440_200625.bpc").unwrap();
+/// load_spice_kernel("/path/to/moon_pa_de440_200625.bpc").unwrap();
 /// let epc = Epoch::from_date(2025, 1, 1, TimeSystem::UTC);
 /// let (angles, rates) = pck_euler_angles(FrameId::MoonPaDe440, epc).unwrap();
 /// ```
@@ -832,7 +795,7 @@ pub fn pck_euler_angles(
 /// PCK kernels newest-first.
 ///
 /// PCKs are never auto-initialized; a PCK kernel must be explicitly loaded
-/// via [`load_kernel`] first.
+/// via [`load_spice_kernel`] first.
 ///
 /// # Arguments
 /// - `frame_id`: Body-frame class ID (e.g. 31008 for MOON_PA_DE440)
@@ -843,10 +806,10 @@ pub fn pck_euler_angles(
 ///
 /// # Examples
 /// ```no_run
-/// use brahe::spice::{FrameId, load_kernel, pck_euler_angle};
+/// use brahe::spice::{FrameId, load_spice_kernel, pck_euler_angle};
 /// use brahe::time::{Epoch, TimeSystem};
 ///
-/// load_kernel("/path/to/moon_pa_de440_200625.bpc").unwrap();
+/// load_spice_kernel("/path/to/moon_pa_de440_200625.bpc").unwrap();
 /// let epc = Epoch::from_date(2025, 1, 1, TimeSystem::UTC);
 /// let e = pck_euler_angle(FrameId::MoonPaDe440, epc).unwrap();
 /// ```
@@ -859,7 +822,7 @@ pub fn pck_euler_angle(frame_id: impl Into<FrameId>, epc: Epoch) -> Result<Euler
 /// `frame_id`, searching loaded PCK kernels newest-first.
 ///
 /// PCKs are never auto-initialized; a PCK kernel must be explicitly loaded
-/// via [`load_kernel`] first.
+/// via [`load_spice_kernel`] first.
 ///
 /// # Arguments
 /// - `frame_id`: Body-frame class ID (e.g. 31008 for MOON_PA_DE440)
@@ -870,10 +833,10 @@ pub fn pck_euler_angle(frame_id: impl Into<FrameId>, epc: Epoch) -> Result<Euler
 ///
 /// # Examples
 /// ```no_run
-/// use brahe::spice::{FrameId, load_kernel, pck_euler_rates};
+/// use brahe::spice::{FrameId, load_spice_kernel, pck_euler_rates};
 /// use brahe::time::{Epoch, TimeSystem};
 ///
-/// load_kernel("/path/to/moon_pa_de440_200625.bpc").unwrap();
+/// load_spice_kernel("/path/to/moon_pa_de440_200625.bpc").unwrap();
 /// let epc = Epoch::from_date(2025, 1, 1, TimeSystem::UTC);
 /// let rates = pck_euler_rates(FrameId::MoonPaDe440, epc).unwrap();
 /// ```
@@ -890,7 +853,7 @@ pub fn pck_euler_rates(
 /// newest-first.
 ///
 /// PCKs are never auto-initialized; a PCK kernel must be explicitly loaded
-/// via [`load_kernel`] first.
+/// via [`load_spice_kernel`] first.
 ///
 /// # Arguments
 /// - `frame_id`: Body-frame class ID (e.g. 31008 for MOON_PA_DE440)
@@ -902,10 +865,10 @@ pub fn pck_euler_rates(
 ///
 /// # Examples
 /// ```no_run
-/// use brahe::spice::{FrameId, load_kernel, pck_euler_angle_and_rates};
+/// use brahe::spice::{FrameId, load_spice_kernel, pck_euler_angle_and_rates};
 /// use brahe::time::{Epoch, TimeSystem};
 ///
-/// load_kernel("/path/to/moon_pa_de440_200625.bpc").unwrap();
+/// load_spice_kernel("/path/to/moon_pa_de440_200625.bpc").unwrap();
 /// let epc = Epoch::from_date(2025, 1, 1, TimeSystem::UTC);
 /// let (angle, rates) = pck_euler_angle_and_rates(FrameId::MoonPaDe440, epc).unwrap();
 /// ```
@@ -922,7 +885,7 @@ pub fn pck_euler_angle_and_rates(
 /// searching loaded PCK kernels newest-first.
 ///
 /// PCKs are never auto-initialized; a PCK kernel must be explicitly loaded
-/// via [`load_kernel`] first.
+/// via [`load_spice_kernel`] first.
 ///
 /// # Arguments
 /// - `frame_id`: Body-frame class ID (e.g. 31008 for MOON_PA_DE440)
@@ -933,10 +896,10 @@ pub fn pck_euler_angle_and_rates(
 ///
 /// # Examples
 /// ```no_run
-/// use brahe::spice::{FrameId, load_kernel, pck_quaternion};
+/// use brahe::spice::{FrameId, load_spice_kernel, pck_quaternion};
 /// use brahe::time::{Epoch, TimeSystem};
 ///
-/// load_kernel("/path/to/moon_pa_de440_200625.bpc").unwrap();
+/// load_spice_kernel("/path/to/moon_pa_de440_200625.bpc").unwrap();
 /// let epc = Epoch::from_date(2025, 1, 1, TimeSystem::UTC);
 /// let q = pck_quaternion(FrameId::MoonPaDe440, epc).unwrap();
 /// ```
@@ -949,7 +912,7 @@ pub fn pck_quaternion(frame_id: impl Into<FrameId>, epc: Epoch) -> Result<Quater
 /// body-fixed frame `frame_id`, searching loaded PCK kernels newest-first.
 ///
 /// PCKs are never auto-initialized; a PCK kernel must be explicitly loaded
-/// via [`load_kernel`] first.
+/// via [`load_spice_kernel`] first.
 ///
 /// # Arguments
 /// - `frame_id`: Body-frame class ID (e.g. 31008 for MOON_PA_DE440)
@@ -960,10 +923,10 @@ pub fn pck_quaternion(frame_id: impl Into<FrameId>, epc: Epoch) -> Result<Quater
 ///
 /// # Examples
 /// ```no_run
-/// use brahe::spice::{FrameId, load_kernel, pck_rotation_matrix};
+/// use brahe::spice::{FrameId, load_spice_kernel, pck_rotation_matrix};
 /// use brahe::time::{Epoch, TimeSystem};
 ///
-/// load_kernel("/path/to/moon_pa_de440_200625.bpc").unwrap();
+/// load_spice_kernel("/path/to/moon_pa_de440_200625.bpc").unwrap();
 /// let epc = Epoch::from_date(2025, 1, 1, TimeSystem::UTC);
 /// let r = pck_rotation_matrix(FrameId::MoonPaDe440, epc).unwrap();
 /// ```
@@ -1251,7 +1214,7 @@ mod tests {
         // falling through to an older kernel that doesn't have the frame
         // at all.
         setup_global_test_spice();
-        clear_kernels();
+        clear_spice_kernels();
 
         let dir = tempfile::tempdir().unwrap();
         let path_old = dir.path().join("old.bpc");
@@ -1259,8 +1222,8 @@ mod tests {
         std::fs::write(&path_old, synthetic_bpck_bytes()).unwrap(); // frame 31006 only
         std::fs::write(&path_new, synthetic_bpck_bytes_corrupt(31099)).unwrap();
 
-        load_kernel(path_old.to_str().unwrap()).unwrap();
-        load_kernel(path_new.to_str().unwrap()).unwrap();
+        load_spice_kernel(path_old.to_str().unwrap()).unwrap();
+        load_spice_kernel(path_new.to_str().unwrap()).unwrap();
 
         let err = pck_euler_angles(31099, epc_from_et(500.0)).unwrap_err();
         let msg = format!("{}", err);
@@ -1272,27 +1235,27 @@ mod tests {
         assert!(!msg.contains("not covered"), "error was masked: {}", msg);
 
         // Restore global state for other tests.
-        clear_kernels();
-        load_kernel("de440s").unwrap();
+        clear_spice_kernels();
+        load_spice_kernel("de440s").unwrap();
     }
 
     #[test]
     #[serial]
     fn test_registry_load_unload_idempotent() {
         setup_global_test_spice();
-        clear_kernels();
-        assert!(loaded_kernels().is_empty());
+        clear_spice_kernels();
+        assert!(loaded_spice_kernels().is_empty());
 
-        load_kernel("de440s").unwrap();
-        load_kernel("de440s").unwrap(); // idempotent
-        assert_eq!(loaded_kernels(), vec!["de440s".to_string()]);
+        load_spice_kernel("de440s").unwrap();
+        load_spice_kernel("de440s").unwrap(); // idempotent
+        assert_eq!(loaded_spice_kernels(), vec!["de440s".to_string()]);
 
-        unload_kernel("de440s").unwrap();
-        assert!(loaded_kernels().is_empty());
-        assert!(unload_kernel("de440s").is_err()); // not loaded
+        unload_spice_kernel("de440s").unwrap();
+        assert!(loaded_spice_kernels().is_empty());
+        assert!(unload_spice_kernel("de440s").is_err()); // not loaded
 
         // Restore for other tests
-        load_kernel("de440s").unwrap();
+        load_spice_kernel("de440s").unwrap();
     }
 
     #[test]
@@ -1320,11 +1283,11 @@ mod tests {
     #[serial]
     fn test_query_with_no_kernels_auto_initializes() {
         setup_global_test_spice(); // ensures de440s is in the local cache
-        clear_kernels();
-        // Auto-init loads de440s from cache without an explicit load_kernel
+        clear_spice_kernels();
+        // Auto-init loads de440s from cache without an explicit load_spice_kernel
         let r = spk_position(NAIFId::Sun, NAIFId::Earth, epc_2025()).unwrap();
         assert!(r.norm() > 1.4e11);
-        assert_eq!(loaded_kernels(), vec!["de440s".to_string()]);
+        assert_eq!(loaded_spice_kernels(), vec!["de440s".to_string()]);
     }
 
     #[test]
@@ -1333,27 +1296,27 @@ mod tests {
         // Regression test: `ensure_default_ephemeris_loaded` must check for
         // an *SPK* kernel specifically, not just any loaded kernel, so that
         // a registry holding only a PCK (e.g. after
-        // `load_kernel("moon_pa_de440")`) still auto-loads de440s for
+        // `load_spice_kernel("moon_pa_de440")`) still auto-loads de440s for
         // `spk_*` queries instead of erroring with "No SPK kernels loaded".
         setup_global_test_spice(); // ensures de440s is in the local cache
-        clear_kernels();
+        clear_spice_kernels();
 
         let dir = tempfile::tempdir().unwrap();
         let pck_path = dir.path().join("synthetic.bpc");
         std::fs::write(&pck_path, synthetic_bpck_bytes()).unwrap();
-        load_kernel(pck_path.to_str().unwrap()).unwrap();
+        load_spice_kernel(pck_path.to_str().unwrap()).unwrap();
         assert_eq!(
-            loaded_kernels(),
+            loaded_spice_kernels(),
             vec![pck_path.to_str().unwrap().to_string()]
         );
 
         let r = spk_position(NAIFId::Sun, NAIFId::Earth, epc_2025()).unwrap();
         assert!(r.norm() > 1.4e11);
-        assert!(loaded_kernels().contains(&"de440s".to_string()));
+        assert!(loaded_spice_kernels().contains(&"de440s".to_string()));
 
         // Restore global state for other tests.
-        clear_kernels();
-        load_kernel("de440s").unwrap();
+        clear_spice_kernels();
+        load_spice_kernel("de440s").unwrap();
     }
 
     #[test]
@@ -1363,7 +1326,7 @@ mod tests {
         // overlapping body pairs. Regression test for the cross-kernel
         // segment ordering in `global_chain`.
         setup_global_test_spice();
-        clear_kernels();
+        clear_spice_kernels();
 
         let dir = tempfile::tempdir().unwrap();
         let path_a = dir.path().join("a.bsp");
@@ -1371,21 +1334,21 @@ mod tests {
         std::fs::write(&path_a, synthetic_spk_bytes(1.0)).unwrap();
         std::fs::write(&path_b, synthetic_spk_bytes(2.0)).unwrap();
 
-        load_kernel(path_a.to_str().unwrap()).unwrap();
-        load_kernel(path_b.to_str().unwrap()).unwrap();
+        load_spice_kernel(path_a.to_str().unwrap()).unwrap();
+        load_spice_kernel(path_b.to_str().unwrap()).unwrap();
 
         // Later-loaded kernel B takes precedence (2.0 km = 2.0e3 m).
         let r = spk_position(10, NAIFId::SolarSystemBarycenter, epc_2025()).unwrap();
         assert_abs_diff_eq!(r[0], 2.0e3, epsilon = 1e-9);
 
         // Unloading B invalidates the chain cache and falls back to A.
-        unload_kernel(path_b.to_str().unwrap()).unwrap();
+        unload_spice_kernel(path_b.to_str().unwrap()).unwrap();
         let r = spk_position(10, NAIFId::SolarSystemBarycenter, epc_2025()).unwrap();
         assert_abs_diff_eq!(r[0], 1.0e3, epsilon = 1e-9);
 
         // Restore global state for other tests.
-        clear_kernels();
-        load_kernel("de440s").unwrap();
+        clear_spice_kernels();
+        load_spice_kernel("de440s").unwrap();
     }
 
     #[test]
@@ -1398,7 +1361,7 @@ mod tests {
         // the 1-hop direct link; querying an epoch only the two-hop path
         // covers must transparently fall back instead of erroring.
         setup_global_test_spice();
-        clear_kernels();
+        clear_spice_kernels();
 
         let dir = tempfile::tempdir().unwrap();
         let path_direct = dir.path().join("direct.bsp");
@@ -1412,9 +1375,9 @@ mod tests {
         std::fs::write(&path_ac, synthetic_spk_bytes_for(10, 3, 0.0, 200.0, 2.0)).unwrap();
         std::fs::write(&path_cb, synthetic_spk_bytes_for(3, 0, 0.0, 200.0, 3.0)).unwrap();
 
-        load_kernel(path_direct.to_str().unwrap()).unwrap();
-        load_kernel(path_ac.to_str().unwrap()).unwrap();
-        load_kernel(path_cb.to_str().unwrap()).unwrap();
+        load_spice_kernel(path_direct.to_str().unwrap()).unwrap();
+        load_spice_kernel(path_ac.to_str().unwrap()).unwrap();
+        load_spice_kernel(path_cb.to_str().unwrap()).unwrap();
 
         // et=50: covered by the (cached) direct link -> direct value.
         let r = spk_position(10, 0, epc_from_et(50.0)).unwrap();
@@ -1432,8 +1395,8 @@ mod tests {
         assert!(msg.contains("10") && msg.contains("coverage"));
 
         // Restore global state for other tests.
-        clear_kernels();
-        load_kernel("de440s").unwrap();
+        clear_spice_kernels();
+        load_spice_kernel("de440s").unwrap();
     }
 
     #[test]
@@ -1464,7 +1427,7 @@ mod tests {
     #[serial]
     fn test_concurrent_queries() {
         setup_global_test_spice();
-        load_kernel("de440s").unwrap();
+        load_spice_kernel("de440s").unwrap();
         let handles: Vec<_> = (0..8)
             .map(|i| {
                 std::thread::spawn(move || {
@@ -1494,10 +1457,10 @@ mod tests {
     #[serial]
     fn test_load_kernel_resolves_moon_pa_de440_network() {
         setup_global_test_spice();
-        clear_kernels();
+        clear_spice_kernels();
 
-        load_kernel("moon_pa_de440").unwrap();
-        assert_eq!(loaded_kernels(), vec!["moon_pa_de440".to_string()]);
+        load_spice_kernel("moon_pa_de440").unwrap();
+        assert_eq!(loaded_spice_kernels(), vec!["moon_pa_de440".to_string()]);
 
         // Frame class 31008 (MOON_PA_DE440) has coverage at 2025-01-01.
         let r = pck_rotation_matrix(31008, epc_2025()).unwrap().to_matrix();
@@ -1511,8 +1474,8 @@ mod tests {
         assert_abs_diff_eq!(q.to_rotation_matrix().to_matrix(), r, epsilon = 1e-9);
 
         // Restore global state for other tests.
-        clear_kernels();
-        load_kernel("de440s").unwrap();
+        clear_spice_kernels();
+        load_spice_kernel("de440s").unwrap();
     }
 
     #[test]
@@ -1520,10 +1483,10 @@ mod tests {
     #[serial]
     fn test_load_mar099s_and_query_phobos_deimos_network() {
         setup_global_test_spice();
-        clear_kernels();
+        clear_spice_kernels();
 
-        load_kernel("mar099s").unwrap();
-        assert_eq!(loaded_kernels(), vec!["mar099s".to_string()]);
+        load_spice_kernel("mar099s").unwrap();
+        assert_eq!(loaded_spice_kernels(), vec!["mar099s".to_string()]);
 
         let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
         // Phobos (401) relative to Mars barycenter (4): |r| ~ 9376 km
@@ -1534,8 +1497,8 @@ mod tests {
         assert!((r.norm() - 2.3463e7).abs() < 0.5e6);
 
         // Restore global state for other tests.
-        clear_kernels();
-        load_kernel("de440s").unwrap();
+        clear_spice_kernels();
+        load_spice_kernel("de440s").unwrap();
     }
 
     #[test]
@@ -1550,11 +1513,11 @@ mod tests {
     #[test]
     fn test_common_and_all_kernel_lists() {
         assert_eq!(
-            COMMON_KERNELS,
+            COMMON_SPICE_KERNELS,
             &[SPICEKernel::DE440s, SPICEKernel::MoonPaDe440]
         );
         assert_eq!(
-            ALL_KERNELS,
+            ALL_SPICE_KERNELS,
             &[
                 SPICEKernel::DE440s,
                 SPICEKernel::MoonPaDe440,
@@ -1573,16 +1536,16 @@ mod tests {
     #[serial]
     fn test_load_common_kernels() {
         setup_global_test_spice();
-        clear_kernels();
+        clear_spice_kernels();
 
-        load_common_kernels().unwrap();
-        let loaded = loaded_kernels();
+        load_common_spice_kernels().unwrap();
+        let loaded = loaded_spice_kernels();
         assert!(loaded.contains(&"de440s".to_string()));
         assert!(loaded.contains(&"moon_pa_de440".to_string()));
 
         // Restore global state for other tests.
-        clear_kernels();
-        load_kernel("de440s").unwrap();
+        clear_spice_kernels();
+        load_spice_kernel("de440s").unwrap();
     }
 
     #[test]
@@ -1591,7 +1554,7 @@ mod tests {
         // A path source that is neither a known kernel name nor an existing
         // file surfaces `resolve_kernel_path`'s IoError.
         setup_global_test_spice();
-        let err = load_kernel("/nonexistent/path/to/kernel.bsp").unwrap_err();
+        let err = load_spice_kernel("/nonexistent/path/to/kernel.bsp").unwrap_err();
         assert!(format!("{}", err).contains("neither a known kernel name"));
     }
 
@@ -1603,7 +1566,7 @@ mod tests {
         // suppress the DE auto-initialization and leave e.g. the Earth leg
         // of a 499<->399 query unresolvable.
         setup_global_test_spice();
-        load_kernel("de440s").unwrap();
+        load_spice_kernel("de440s").unwrap();
         {
             let cache = CacheRedirect::new();
             cache.seed_real_de440s();
@@ -1612,32 +1575,32 @@ mod tests {
                 &crate::utils::testing::synthetic_spk_kernel_bytes(&[(499, 4, 2.0)]),
             );
 
-            clear_kernels();
+            clear_spice_kernels();
             ensure_bodies_loadable(&[499]).unwrap();
             assert_eq!(
-                loaded_kernels(),
+                loaded_spice_kernels(),
                 vec!["de440s".to_string(), "mar099s".to_string()]
             );
 
             // Idempotent: a second call adds nothing.
             ensure_bodies_loadable(&[499]).unwrap();
-            assert_eq!(loaded_kernels().len(), 2);
+            assert_eq!(loaded_spice_kernels().len(), 2);
 
             // DE-covered IDs load no satellite kernel.
-            clear_kernels();
+            clear_spice_kernels();
             ensure_bodies_loadable(&[301, 399]).unwrap();
-            assert_eq!(loaded_kernels(), vec!["de440s".to_string()]);
+            assert_eq!(loaded_spice_kernels(), vec!["de440s".to_string()]);
         }
         // Restore global state for other tests.
-        clear_kernels();
-        load_kernel("de440s").unwrap();
+        clear_spice_kernels();
+        load_spice_kernel("de440s").unwrap();
     }
 
     #[test]
     #[serial]
     fn test_kernel_is_loaded() {
         setup_global_test_spice();
-        load_kernel("de440s").unwrap();
+        load_spice_kernel("de440s").unwrap();
         assert!(kernel_is_loaded("de440s"));
         // Substring of a loaded key matches; an unknown fragment does not.
         assert!(kernel_is_loaded("de440"));
@@ -1648,9 +1611,9 @@ mod tests {
     #[serial]
     fn test_load_kernel_rejects_unrecognized_daf_id_word() {
         // A structurally valid DAF whose ID word is neither DAF/SPK nor
-        // DAF/PCK hits `load_kernel`'s `other` arm.
+        // DAF/PCK hits `load_spice_kernel`'s `other` arm.
         setup_global_test_spice();
-        clear_kernels();
+        clear_spice_kernels();
 
         let mut bytes = crate::utils::testing::synthetic_spk_kernel_bytes(&[(10, 0, 1.0)]);
         bytes[..8].copy_from_slice(b"DAF/CK  ");
@@ -1658,68 +1621,46 @@ mod tests {
         let path = dir.path().join("mystery.bin");
         std::fs::write(&path, &bytes).unwrap();
 
-        let err = load_kernel(path.to_str().unwrap()).unwrap_err();
+        let err = load_spice_kernel(path.to_str().unwrap()).unwrap_err();
         assert!(format!("{}", err).contains("Unrecognized DAF ID word"));
 
         // Restore global state for other tests.
-        clear_kernels();
-        load_kernel("de440s").unwrap();
-    }
-
-    #[test]
-    #[serial]
-    fn test_initialize_ephemeris_variants() {
-        // `initialize_ephemeris` loads de440s; `initialize_ephemeris_with_kernel`
-        // loads a bring-your-own path (a valid synthetic SPK) without network.
-        setup_global_test_spice();
-        clear_kernels();
-
-        initialize_ephemeris().unwrap();
-        assert!(loaded_kernels().contains(&"de440s".to_string()));
-
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("byo.bsp");
-        std::fs::write(&path, synthetic_spk_bytes(1.0)).unwrap();
-        initialize_ephemeris_with_kernel(path.to_str().unwrap()).unwrap();
-        assert!(loaded_kernels().contains(&path.to_str().unwrap().to_string()));
-
-        // Restore global state for other tests.
-        clear_kernels();
-        load_kernel("de440s").unwrap();
+        clear_spice_kernels();
+        load_spice_kernel("de440s").unwrap();
     }
 
     #[test]
     #[serial]
     fn test_load_common_kernels_offline() {
         // Offline counterpart of `test_load_common_kernels`. The real de440s
-        // is kept resident so `load_common_kernels`' de440s load hits the
+        // is kept resident so `load_common_spice_kernels`' de440s load hits the
         // idempotent short-circuit (and any concurrent cache read stays
         // valid); only the synthetic moon_pa_de440 PCK is fetched, from the
         // redirected cache, so no download occurs.
         setup_global_test_spice();
-        load_kernel("de440s").unwrap();
+        load_spice_kernel("de440s").unwrap();
         {
             let cache = CacheRedirect::new();
             cache.seed_real_de440s();
             cache.seed("moon_pa_de440_200625.bpc", &synthetic_bpck_bytes());
 
-            load_common_kernels().unwrap();
-            let loaded = loaded_kernels();
+            load_common_spice_kernels().unwrap();
+            let loaded = loaded_spice_kernels();
             assert!(loaded.contains(&"de440s".to_string()));
             assert!(loaded.contains(&"moon_pa_de440".to_string()));
         }
-        clear_kernels();
-        load_kernel("de440s").unwrap();
+        clear_spice_kernels();
+        load_spice_kernel("de440s").unwrap();
     }
 
     #[test]
     #[serial]
     fn test_load_all_kernels_offline() {
-        // Every kernel `load_all_kernels` pulls beyond de440s (the lunar PCK
+        // Every kernel `load_all_spice_kernels` pulls beyond de440s (the lunar PCK
         // and one satellite ephemeris kernel per outer planet) is seeded as a
         // synthetic file; de440s stays resident and short-circuits.
         setup_global_test_spice();
-        load_kernel("de440s").unwrap();
+        load_spice_kernel("de440s").unwrap();
         {
             let cache = CacheRedirect::new();
             cache.seed_real_de440s();
@@ -1731,8 +1672,8 @@ mod tests {
             cache.seed("nep097.bsp", &synthetic_spk_bytes(1.0));
             cache.seed("plu060.bsp", &synthetic_spk_bytes(1.0));
 
-            load_all_kernels().unwrap();
-            let loaded = loaded_kernels();
+            load_all_spice_kernels().unwrap();
+            let loaded = loaded_spice_kernels();
             for name in [
                 "de440s",
                 "moon_pa_de440",
@@ -1746,8 +1687,8 @@ mod tests {
                 assert!(loaded.contains(&name.to_string()), "missing {}", name);
             }
         }
-        clear_kernels();
-        load_kernel("de440s").unwrap();
+        clear_spice_kernels();
+        load_spice_kernel("de440s").unwrap();
     }
 
     #[test]
@@ -1756,13 +1697,13 @@ mod tests {
         // `global_chain`'s `return Err` branch: with no SPK kernel loaded the
         // collected segment set is empty.
         setup_global_test_spice();
-        clear_kernels();
+        clear_spice_kernels();
 
         let err = global_chain(1, 0).unwrap_err();
         assert!(format!("{}", err).contains("No SPK kernels loaded"));
 
         // Restore global state for other tests.
-        load_kernel("de440s").unwrap();
+        load_spice_kernel("de440s").unwrap();
     }
 
     #[test]
@@ -1771,8 +1712,8 @@ mod tests {
         // First resolution is a cache miss (resolve + insert -> final `Ok`);
         // the second identical query is a cache hit (early `return Ok`).
         setup_global_test_spice();
-        clear_kernels();
-        load_kernel("de440s").unwrap();
+        clear_spice_kernels();
+        load_spice_kernel("de440s").unwrap();
 
         let c1 = global_chain(10, 0).unwrap();
         let c2 = global_chain(10, 0).unwrap();
@@ -1785,7 +1726,7 @@ mod tests {
         // Scoped SPK query against a loaded PCK hits `spk_kernel_for_query`'s
         // PCK error arm.
         setup_global_test_spice();
-        clear_kernels();
+        clear_spice_kernels();
 
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("orient.bpc");
@@ -1801,8 +1742,8 @@ mod tests {
         assert!(format!("{}", err).contains("binary PCK"));
 
         // Restore global state for other tests.
-        clear_kernels();
-        load_kernel("de440s").unwrap();
+        clear_spice_kernels();
+        load_spice_kernel("de440s").unwrap();
     }
 
     #[test]
@@ -1812,12 +1753,12 @@ mod tests {
         // accessor against a path-loaded synthetic PCK (frame 31006 covering
         // ET [0, 1000]).
         setup_global_test_spice();
-        clear_kernels();
+        clear_spice_kernels();
 
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("synthetic.bpc");
         std::fs::write(&path, synthetic_bpck_bytes()).unwrap();
-        load_kernel(path.to_str().unwrap()).unwrap();
+        load_spice_kernel(path.to_str().unwrap()).unwrap();
 
         let epc = epc_from_et(500.0);
         let angle = pck_euler_angle(31006, epc).unwrap();
@@ -1841,7 +1782,7 @@ mod tests {
         );
 
         // Restore global state for other tests.
-        clear_kernels();
-        load_kernel("de440s").unwrap();
+        clear_spice_kernels();
+        load_spice_kernel("de440s").unwrap();
     }
 }

--- a/src/trajectories/dorbit_trajectory.rs
+++ b/src/trajectories/dorbit_trajectory.rs
@@ -6065,7 +6065,7 @@ mod tests {
         // Load the lunar PCK explicitly: this module's tests run after the
         // spice registry-clearing tests in the serial order, and the lunar
         // auto-load latch (OnceLock) does not re-detect the clear.
-        crate::spice::load_kernel("moon_pa_de440").unwrap();
+        crate::spice::load_spice_kernel("moon_pa_de440").unwrap();
 
         let mut traj = DOrbitTrajectory::new(
             6,

--- a/src/trajectories/sorbit_trajectory.rs
+++ b/src/trajectories/sorbit_trajectory.rs
@@ -3016,7 +3016,7 @@ mod tests {
         // Load the lunar PCK explicitly: this module's tests run after the
         // spice registry-clearing tests in the serial order, and the lunar
         // auto-load latch (OnceLock) does not re-detect the clear.
-        crate::spice::load_kernel("moon_pa_de440").unwrap();
+        crate::spice::load_spice_kernel("moon_pa_de440").unwrap();
 
         let mut traj = SOrbitTrajectory::new(
             OrbitFrame::BodyCenteredInertial(301),

--- a/src/utils/download.rs
+++ b/src/utils/download.rs
@@ -116,11 +116,13 @@ pub(crate) fn download_to_file(
 pub(crate) fn download_bytes(url: &str) -> Result<Vec<u8>, BraheError> {
     let mut attempt: u32 = 0;
 
-    let response = loop {
+    loop {
         attempt += 1;
 
-        match ureq::get(url).call() {
-            Ok(response) => break response,
+        // Connection/status phase. ureq surfaces 4xx/5xx as `Err(StatusCode)`,
+        // so this covers both transport failures and retryable server statuses.
+        let response = match ureq::get(url).call() {
+            Ok(response) => response,
             Err(e) => {
                 if attempt < MAX_DOWNLOAD_ATTEMPTS && is_retryable_error(&e) {
                     sleep(backoff_delay(attempt));
@@ -131,19 +133,27 @@ pub(crate) fn download_bytes(url: &str) -> Result<Vec<u8>, BraheError> {
                     url, attempt, e
                 )));
             }
+        };
+
+        // Body phase, read through a streaming reader to bypass ureq's default
+        // in-memory size limit. A failure here (connection reset, truncated
+        // transfer, unexpected EOF) is a transport error too, so retry the whole
+        // request rather than surfacing a partial download.
+        let mut buffer = Vec::new();
+        match response.into_body().into_reader().read_to_end(&mut buffer) {
+            Ok(_) => return Ok(buffer),
+            Err(e) => {
+                if attempt < MAX_DOWNLOAD_ATTEMPTS {
+                    sleep(backoff_delay(attempt));
+                    continue;
+                }
+                return Err(BraheError::Error(format!(
+                    "reading response body from {} failed after {} attempt(s): {}",
+                    url, attempt, e
+                )));
+            }
         }
-    };
-
-    let mut buffer = Vec::new();
-    response
-        .into_body()
-        .into_reader()
-        .read_to_end(&mut buffer)
-        .map_err(|e| {
-            BraheError::Error(format!("failed reading response body from {}: {}", url, e))
-        })?;
-
-    Ok(buffer)
+    }
 }
 
 #[cfg(test)]

--- a/src/utils/download.rs
+++ b/src/utils/download.rs
@@ -5,6 +5,7 @@
  * files resiliently and write them to disk atomically.
  */
 
+use std::io::Read;
 use std::path::Path;
 use std::thread::sleep;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -104,10 +105,95 @@ pub(crate) fn download_to_file(
     Ok(())
 }
 
+/// Fetch the raw bytes of `url`, retrying transient failures with exponential
+/// backoff and jitter, and return them in memory.
+///
+/// Unlike [`download_to_file`], the response body is read through a streaming
+/// reader rather than ureq's convenience string method, so large binary payloads
+/// (e.g. multi-MB SPICE kernels) are not subject to ureq's default in-memory
+/// response size limit. The returned error carries the URL and attempt count;
+/// callers are expected to wrap it with product-specific context.
+pub(crate) fn download_bytes(url: &str) -> Result<Vec<u8>, BraheError> {
+    let mut attempt: u32 = 0;
+
+    let response = loop {
+        attempt += 1;
+
+        match ureq::get(url).call() {
+            Ok(response) => break response,
+            Err(e) => {
+                if attempt < MAX_DOWNLOAD_ATTEMPTS && is_retryable_error(&e) {
+                    sleep(backoff_delay(attempt));
+                    continue;
+                }
+                return Err(BraheError::Error(format!(
+                    "request to {} failed after {} attempt(s): {}",
+                    url, attempt, e
+                )));
+            }
+        }
+    };
+
+    let mut buffer = Vec::new();
+    response
+        .into_body()
+        .into_reader()
+        .read_to_end(&mut buffer)
+        .map_err(|e| {
+            BraheError::Error(format!("failed reading response body from {}: {}", url, e))
+        })?;
+
+    Ok(buffer)
+}
+
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
+    use httpmock::prelude::*;
+
     use super::*;
+
+    #[test]
+    fn test_download_bytes_returns_body_on_success() {
+        let server = MockServer::start();
+        let _mock = server.mock(|when, then| {
+            when.method(GET).path("/kernel.bsp");
+            then.status(200).body("kernel-bytes");
+        });
+
+        let bytes = download_bytes(&server.url("/kernel.bsp")).unwrap();
+        assert_eq!(bytes, b"kernel-bytes");
+    }
+
+    #[test]
+    fn test_download_bytes_retries_transient_failure() {
+        // A persistently transient (503) endpoint is retried up to the attempt
+        // cap before failing, so the mock records exactly MAX_DOWNLOAD_ATTEMPTS
+        // requests — proving the retry loop is wired into download_bytes.
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(GET).path("/kernel.bsp");
+            then.status(503);
+        });
+
+        let result = download_bytes(&server.url("/kernel.bsp"));
+        assert!(result.is_err());
+        assert_eq!(mock.calls(), MAX_DOWNLOAD_ATTEMPTS as usize);
+    }
+
+    #[test]
+    fn test_download_bytes_does_not_retry_client_error() {
+        // A 404 is not transient: download_bytes must fail after a single request.
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(GET).path("/kernel.bsp");
+            then.status(404);
+        });
+
+        let result = download_bytes(&server.url("/kernel.bsp"));
+        assert!(result.is_err());
+        assert_eq!(mock.calls(), 1);
+    }
 
     #[test]
     fn test_is_retryable_error() {

--- a/src/utils/testing.rs
+++ b/src/utils/testing.rs
@@ -350,7 +350,7 @@ pub(crate) fn setup_global_test_spice() {
         let cache_path = Path::new(&cache_dir).join("de440s.bsp");
         fs::copy(&test_asset_path, &cache_path).expect("Failed to copy test asset to cache");
 
-        crate::spice::load_kernel("de440s").expect("Failed to load DE440s test kernel");
+        crate::spice::load_spice_kernel("de440s").expect("Failed to load DE440s test kernel");
     });
 }
 

--- a/tests/orbit_dynamics/test_ephemerides.py
+++ b/tests/orbit_dynamics/test_ephemerides.py
@@ -101,14 +101,9 @@ class TestDEEphemerides:
                     shutil.copy(test_asset, cache_path)
 
             # Initialize ephemeris
-            bh.initialize_ephemeris()
+            bh.load_spice_kernel("de440s")
         except Exception as e:
             pytest.skip(f"Could not initialize ephemeris: {e}")
-
-    def test_initialize_ephemeris(self):
-        """Test that initialize_ephemeris completes without error"""
-        # Re-initialization should be safe
-        bh.initialize_ephemeris()
 
     def test_sun_position_spice_returns_vector(self):
         """Test that sun_position_spice returns a 3-element position vector"""

--- a/tests/orbit_dynamics/test_third_body.py
+++ b/tests/orbit_dynamics/test_third_body.py
@@ -10,9 +10,9 @@ import brahe as bh
 
 
 @pytest.fixture(scope="module", autouse=True)
-def initialize_ephemeris():
+def ensure_ephemeris():
     """Initialize DE ephemeris for all tests."""
-    bh.initialize_ephemeris()
+    bh.load_spice_kernel("de440s")
 
 
 class TestAnalyticalThirdBody:
@@ -657,7 +657,7 @@ class TestThirdBodyForBody:
     @pytest.mark.integration
     def test_phobos_third_body_about_mars(self):
         """Phobos as a third body about a Mars-centered object is small but nonzero."""
-        bh.load_kernel("mar099s")
+        bh.load_spice_kernel("mar099s")
         epc = bh.Epoch.from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, bh.TimeSystem.UTC)
         r = np.array([bh.R_MARS + 400e3, 0.0, 0.0])
 
@@ -677,8 +677,8 @@ class TestThirdBodyForBody:
         load-order-independence of the selection itself is pinned by the Rust
         offline tests with synthetic kernels, which Python cannot construct.
         """
-        bh.load_kernel("de440s")
-        bh.load_kernel("mar099s")
+        bh.load_spice_kernel("de440s")
+        bh.load_spice_kernel("mar099s")
         epc = bh.Epoch.from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, bh.TimeSystem.UTC)
         r = np.array([1e6, -2e6, 5e5])
 

--- a/tests/spice/test_positions.py
+++ b/tests/spice/test_positions.py
@@ -10,7 +10,7 @@ import brahe as bh
 @pytest.fixture(autouse=True)
 def ensure_kernel():
     try:
-        bh.initialize_ephemeris()
+        bh.load_spice_kernel("de440s")
     except Exception as e:
         pytest.skip(f"Could not initialize ephemeris: {e}")
 

--- a/tests/spice/test_registry.py
+++ b/tests/spice/test_registry.py
@@ -10,7 +10,7 @@ import brahe as bh
 def ensure_kernel():
     """Load the default kernel once per test module (cached on disk)."""
     try:
-        bh.initialize_ephemeris()
+        bh.load_spice_kernel("de440s")
     except Exception as e:
         pytest.skip(f"Could not initialize ephemeris: {e}")
 
@@ -20,32 +20,32 @@ def restore_baseline_kernels():
 
     The lunar/Mars frame auto-load guards (ensure_lunar_pck_loaded /
     ensure_mars_spk_loaded) are one-shot OnceLock latches: once they have
-    fired, a later clear_kernels() is not re-detected, so any kernel they
+    fired, a later clear_spice_kernels() is not re-detected, so any kernel they
     already loaded must be restored here — not just de440s.
     """
-    bh.clear_kernels()
-    bh.initialize_ephemeris()
+    bh.clear_spice_kernels()
+    bh.load_spice_kernel("de440s")
     for kernel in ("moon_pa_de440", "mar099s"):
         try:
-            bh.load_kernel(kernel)
+            bh.load_spice_kernel(kernel)
         except Exception:
             # Not cached and offline: nothing later can query it either.
             pass
 
 
 def test_loaded_kernels():
-    assert "de440s" in bh.loaded_kernels()
+    assert "de440s" in bh.loaded_spice_kernels()
 
 
 def test_load_kernel_idempotent():
-    bh.load_kernel("de440s")
-    bh.load_kernel("de440s")
-    assert bh.loaded_kernels().count("de440s") == 1
+    bh.load_spice_kernel("de440s")
+    bh.load_spice_kernel("de440s")
+    assert bh.loaded_spice_kernels().count("de440s") == 1
 
 
 def test_kernel_is_loaded():
     """Mirrors registry::tests::test_kernel_is_loaded."""
-    bh.load_kernel("de440s")
+    bh.load_spice_kernel("de440s")
     assert bh.kernel_is_loaded("de440s")
     assert bh.kernel_is_loaded("de440")
     assert not bh.kernel_is_loaded("nonexistent_kernel")
@@ -96,7 +96,7 @@ def test_naif_id_enum():
 
 
 def test_spk_position_accepts_enum_and_int(eop):
-    bh.load_kernel("test_assets/de440s.bsp")
+    bh.load_spice_kernel("test_assets/de440s.bsp")
     epc = bh.Epoch.from_date(2025, 1, 1, bh.TimeSystem.UTC)
     r_enum = bh.spk_position(bh.NAIFId.MOON, bh.NAIFId.EARTH, epc)
     r_int = bh.spk_position(301, 399, epc)
@@ -154,9 +154,9 @@ def test_spk_state_from_kernel_agrees_with_pooled():
 
 @pytest.mark.integration
 def test_load_common_kernels():
-    bh.clear_kernels()
-    bh.load_common_kernels()
-    loaded = bh.loaded_kernels()
+    bh.clear_spice_kernels()
+    bh.load_common_spice_kernels()
+    loaded = bh.loaded_spice_kernels()
     assert "de440s" in loaded
     assert "moon_pa_de440" in loaded
 
@@ -167,11 +167,11 @@ def test_load_common_kernels():
 def test_spk_position_from_kernel_auto_loads():
     """The _from_kernel query auto-loads the named kernel if not already
     present in the registry."""
-    bh.clear_kernels()
+    bh.clear_spice_kernels()
     epc = bh.Epoch.from_date(2025, 1, 1, bh.TimeSystem.UTC)
     r = bh.spk_position_from_kernel("de440s", bh.NAIFId.MOON, bh.NAIFId.EARTH, epc)
     assert r.shape == (3,)
-    assert "de440s" in bh.loaded_kernels()
+    assert "de440s" in bh.loaded_spice_kernels()
 
     # Restore baseline registry state for other tests.
     restore_baseline_kernels()
@@ -179,7 +179,7 @@ def test_spk_position_from_kernel_auto_loads():
 
 @pytest.mark.integration
 def test_pck_typed_returns(eop):
-    bh.load_kernel("moon_pa_de440")
+    bh.load_spice_kernel("moon_pa_de440")
     epc = bh.Epoch.from_date(2025, 1, 1, bh.TimeSystem.UTC)
     e = bh.pck_euler_angle(31008, epc)
     assert isinstance(e, bh.EulerAngle)

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -524,8 +524,10 @@ def test_state_eci_to_mci_matches_spk():
     # DE kernel first (Moon/Earth legs for the rest of this module), then the
     # satellite kernel: loading mar099s alone would suppress the de440s
     # auto-initialization, which only fires on an empty registry.
-    brahe.load_kernel("de440s")
-    brahe.load_kernel("mar099s")  # 499 reference leg (transform auto-loads it too)
+    brahe.load_spice_kernel("de440s")
+    brahe.load_spice_kernel(
+        "mar099s"
+    )  # 499 reference leg (transform auto-loads it too)
     offset = brahe.spk_state(brahe.NAIFId.MARS, brahe.NAIFId.EARTH, epc)
     expected = x - offset
     got = brahe.state_eci_to_mci(epc, x)


### PR DESCRIPTION
Prefixes the generic SPICE kernel registry API with `spice` so the function
names are unambiguous at call sites and under wildcard imports, removes the
redundant ephemeris-initialization helpers, and hardens NAIF kernel
downloads against transient network failures.

The renamed symbols were introduced in the native SPICE work and have not yet
appeared in a tagged release, so those parts are a pre-release API cleanup.

### Changed

- Renamed the SPICE kernel registry functions (Rust core and Python bindings) for specificity: `load_kernel` → `load_spice_kernel`, `unload_kernel` → `unload_spice_kernel`, `load_common_kernels` → `load_common_spice_kernels`, `load_all_kernels` → `load_all_spice_kernels`, `loaded_kernels` → `loaded_spice_kernels`, and `clear_kernels` → `clear_spice_kernels`. The internal kernel-set constants `COMMON_KERNELS` and `ALL_KERNELS` were likewise renamed to `COMMON_SPICE_KERNELS` and `ALL_SPICE_KERNELS`.
- NAIF SPICE kernel downloads now retry transient failures (connection errors, timeouts, truncated transfers, HTTP 429/5xx) with exponential backoff and jitter, matching the EOP/space-weather download behavior, so a brief NAIF outage no longer hard-fails a kernel fetch.

### Removed

- Removed `initialize_ephemeris` (Rust and Python) and the now-redundant `initialize_ephemeris_with_kernel` (Rust). Load the default kernel set with `load_common_spice_kernels()`, or `load_spice_kernel("de440s")` for the planetary ephemeris alone.

---

**Notes**

- Documentation and standalone examples that only need the ephemeris available now call `load_common_spice_kernels()`; test fixtures use `load_spice_kernel("de440s")` to preserve their offline, de440s-only behavior.
- `kernel_is_loaded` and the `spk_*_from_kernel` query functions were intentionally left unchanged.
- CI: `test_rust.yml` (unit + doctest jobs) and `docs_only.yml` now restore the manifest-keyed `~/.cache/brahe` kernel cache like `test_python.yml`/`integration_tests.yml`, so their example/frame/plot runs use cached kernels instead of downloading live from NAIF each run. This addresses a pre-existing flake surfaced by a transient "Connection refused" during those downloads.
- `just check` passes (test + lint + format-check + stubs + docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZto87JadZvLFzN5w5nLxL