### PR TITLE
Housekeeping: cache guard, CLI transforms, dev-build docs, example notes

### DIFF
--- a/brahe/cli/transform.py
+++ b/brahe/cli/transform.py
@@ -10,11 +10,41 @@ from brahe.cli.utils import set_cli_eop, parse_numeric_expression
 app = typer.Typer()
 
 
-class OrbitFrame(str, Enum):
-    """Reference frame for orbital states (matches brahe.OrbitFrame)"""
+class Frame(str, Enum):
+    """Named reference frames accepted by the transform commands.
+
+    Values mirror the strings understood by
+    [`ReferenceFrame.from_string`](../library_api/frames/router.md#brahe.ReferenceFrame.from_string).
+    """
 
     ECI = "ECI"
     ECEF = "ECEF"
+    GCRF = "GCRF"
+    ITRF = "ITRF"
+    EME2000 = "EME2000"
+    LCI = "LCI"
+    LFPA = "LFPA"
+    LFME = "LFME"
+    MCI = "MCI"
+    MCMF = "MCMF"
+    EMBI = "EMBI"
+    SSBI = "SSBI"
+    EMR = "EMR"
+    SER = "SER"
+    GSE = "GSE"
+
+
+def _resolve_frame(frame: Frame) -> "brahe.ReferenceFrame":
+    """Convert a CLI `Frame` value into a core `ReferenceFrame`.
+
+    Raises a Typer error with a clean message if the frame string is not
+    recognized by the core router.
+    """
+    try:
+        return brahe.ReferenceFrame.from_string(frame.value)
+    except Exception as e:  # noqa: BLE001 - surface as CLI error
+        typer.echo(f"ERROR: unknown reference frame '{frame.value}': {e}")
+        raise typer.Exit(code=1)
 
 
 class StateRepresentation(str, Enum):
@@ -26,71 +56,129 @@ class StateRepresentation(str, Enum):
     geocentric = "geocentric"  # Geocentric coordinates [lat, lon, radius, 0, 0, 0]
 
 
-class AttitudeRepresentation(str, Enum):
-    quaternion = "quaternion"
-    euler_angles = "euler_angles"
-    euler_axis = "euler_axis"
-    rotation_matrix = "rotation_matrix"
+def _parse_vector(values, n: int):
+    """Parse `n` state components, each allowing constant expressions."""
+    try:
+        return np.array([parse_numeric_expression(values[i]) for i in range(n)])
+    except ValueError as e:
+        typer.echo(f"Error parsing state values: {e}")
+        raise typer.Exit(code=1)
+
+
+def _echo_vector(x, format_string: str):
+    typer.echo("[" + ", ".join(f"{v:{format_string}}" for v in x) + "]")
 
 
 @app.command()
 def frame(
     from_frame: Annotated[
-        OrbitFrame, typer.Argument(help="The reference frame to convert from")
+        Frame, typer.Argument(help="The reference frame to convert from")
     ],
     to_frame: Annotated[
-        OrbitFrame, typer.Argument(help="The reference frame to convert to")
+        Frame, typer.Argument(help="The reference frame to convert to")
     ],
-    epoch: Annotated[
-        str, typer.Argument(help="Epoch to perform the conversion at if required")
-    ],
+    epoch: Annotated[str, typer.Argument(help="Epoch to perform the conversion at")],
     state: Annotated[
         Tuple[float, float, float, float, float, float],
-        typer.Argument(..., help="The state to convert"),
+        typer.Argument(..., help="The state to convert [x, y, z, vx, vy, vz]"),
     ],
     format_string: Annotated[
         str, typer.Option("--format", help="The format of the output")
     ] = "f",
 ):
+    """Transform a Cartesian state vector between reference frames."""
     logger.info(
         f"Converting state between frames: {from_frame.value} -> {to_frame.value}"
     )
     logger.debug(f"Epoch: {epoch}, State: {state}")
     set_cli_eop()
     epc = brahe.Epoch(epoch)
-
-    # Parse state values (may contain constant expressions)
-    try:
-        x = np.array(
-            [
-                parse_numeric_expression(state[0]),
-                parse_numeric_expression(state[1]),
-                parse_numeric_expression(state[2]),
-                parse_numeric_expression(state[3]),
-                parse_numeric_expression(state[4]),
-                parse_numeric_expression(state[5]),
-            ]
-        )
-    except ValueError as e:
-        typer.echo(f"Error parsing state values: {e}")
-        raise typer.Exit(code=1)
+    x = _parse_vector(state, 6)
 
     if from_frame == to_frame:
-        typer.echo(
-            f"[{x[0]:{format_string}}, {x[1]:{format_string}}, {x[2]:{format_string}}, {x[3]:{format_string}}, {x[4]:{format_string}}, {x[5]:{format_string}}]"
-        )
+        _echo_vector(x, format_string)
+        return
 
-    if from_frame == OrbitFrame.ECI and to_frame == OrbitFrame.ECEF:
-        x = brahe.state_eci_to_ecef(epc, x)
-        typer.echo(
-            f"[{x[0]:{format_string}}, {x[1]:{format_string}}, {x[2]:{format_string}}, {x[3]:{format_string}}, {x[4]:{format_string}}, {x[5]:{format_string}}]"
-        )
+    src = _resolve_frame(from_frame)
+    dst = _resolve_frame(to_frame)
+    try:
+        y = brahe.state_frame_to_frame(src, dst, epc, x)
+    except Exception as e:  # noqa: BLE001 - surface as CLI error
+        typer.echo(f"ERROR: frame transform failed: {e}")
+        raise typer.Exit(code=1)
+    _echo_vector(y, format_string)
 
-    if from_frame == OrbitFrame.ECEF and to_frame == OrbitFrame.ECI:
-        x = brahe.state_ecef_to_eci(epc, x)
-        typer.echo(
-            f"[{x[0]:{format_string}}, {x[1]:{format_string}}, {x[2]:{format_string}}, {x[3]:{format_string}}, {x[4]:{format_string}}, {x[5]:{format_string}}]"
-        )
+
+@app.command()
+def position(
+    from_frame: Annotated[
+        Frame, typer.Argument(help="The reference frame to convert from")
+    ],
+    to_frame: Annotated[
+        Frame, typer.Argument(help="The reference frame to convert to")
+    ],
+    epoch: Annotated[str, typer.Argument(help="Epoch to perform the conversion at")],
+    pos: Annotated[
+        Tuple[float, float, float],
+        typer.Argument(..., help="The position to convert [x, y, z]"),
+    ],
+    format_string: Annotated[
+        str, typer.Option("--format", help="The format of the output")
+    ] = "f",
+):
+    """Transform a position vector between reference frames."""
+    logger.info(
+        f"Converting position between frames: {from_frame.value} -> {to_frame.value}"
+    )
+    logger.debug(f"Epoch: {epoch}, Position: {pos}")
+    set_cli_eop()
+    epc = brahe.Epoch(epoch)
+    x = _parse_vector(pos, 3)
+
+    if from_frame == to_frame:
+        _echo_vector(x, format_string)
+        return
+
+    src = _resolve_frame(from_frame)
+    dst = _resolve_frame(to_frame)
+    try:
+        y = brahe.position_frame_to_frame(src, dst, epc, x)
+    except Exception as e:  # noqa: BLE001 - surface as CLI error
+        typer.echo(f"ERROR: position transform failed: {e}")
+        raise typer.Exit(code=1)
+    _echo_vector(y, format_string)
+
+
+@app.command()
+def rotation(
+    from_frame: Annotated[
+        Frame, typer.Argument(help="The reference frame to convert from")
+    ],
+    to_frame: Annotated[
+        Frame, typer.Argument(help="The reference frame to convert to")
+    ],
+    epoch: Annotated[str, typer.Argument(help="Epoch to perform the conversion at")],
+    format_string: Annotated[
+        str, typer.Option("--format", help="The format of the output")
+    ] = "f",
+):
+    """Emit the 3x3 rotation matrix between two reference frames."""
+    logger.info(
+        f"Computing rotation between frames: {from_frame.value} -> {to_frame.value}"
+    )
+    logger.debug(f"Epoch: {epoch}")
+    set_cli_eop()
+    epc = brahe.Epoch(epoch)
+
+    src = _resolve_frame(from_frame)
+    dst = _resolve_frame(to_frame)
+    try:
+        r = brahe.rotation_frame_to_frame(src, dst, epc)
+    except Exception as e:  # noqa: BLE001 - surface as CLI error
+        typer.echo(f"ERROR: rotation transform failed: {e}")
+        raise typer.Exit(code=1)
+    for row in np.asarray(r):
+        _echo_vector(row, format_string)
 
 
 @app.command()
@@ -114,13 +202,13 @@ def coordinates(
         typer.Argument(..., help="The state to convert"),
     ],
     from_frame: Annotated[
-        OrbitFrame,
+        Frame,
         typer.Option(help="Reference frame for cartesian input (ECI or ECEF)"),
-    ] = OrbitFrame.ECI,
+    ] = Frame.ECI,
     to_frame: Annotated[
-        OrbitFrame,
+        Frame,
         typer.Option(help="Reference frame for cartesian output (ECI or ECEF)"),
-    ] = OrbitFrame.ECI,
+    ] = Frame.ECI,
     as_degrees: Annotated[
         bool, typer.Option(help="Output format in degrees if applicable")
     ] = True,
@@ -167,7 +255,7 @@ def coordinates(
         x_eci = brahe.state_koe_to_eci(x, angle_format)
 
         if to_system == StateRepresentation.cartesian:
-            if to_frame == OrbitFrame.ECEF:
+            if to_frame == Frame.ECEF:
                 if not epoch:
                     typer.echo("ERROR: --epoch required for frame conversion to ECEF")
                     raise typer.Exit(code=1)
@@ -193,16 +281,16 @@ def coordinates(
             # Need ECI for Keplerian
             x_eci = (
                 x
-                if from_frame == OrbitFrame.ECI
+                if from_frame == Frame.ECI
                 else brahe.state_ecef_to_eci(brahe.Epoch(epoch), x)
             )
             x = brahe.state_eci_to_koe(x_eci, angle_format)
         elif to_system == StateRepresentation.cartesian:
             # Frame conversion
             epc = brahe.Epoch(epoch)
-            if from_frame == OrbitFrame.ECI and to_frame == OrbitFrame.ECEF:
+            if from_frame == Frame.ECI and to_frame == Frame.ECEF:
                 x = brahe.state_eci_to_ecef(epc, x)
-            elif from_frame == OrbitFrame.ECEF and to_frame == OrbitFrame.ECI:
+            elif from_frame == Frame.ECEF and to_frame == Frame.ECI:
                 x = brahe.state_ecef_to_eci(epc, x)
         elif to_system in (
             StateRepresentation.geodetic,
@@ -211,7 +299,7 @@ def coordinates(
             # Need ECEF for geodetic/geocentric
             x_ecef = (
                 brahe.state_eci_to_ecef(brahe.Epoch(epoch), x)
-                if from_frame == OrbitFrame.ECI
+                if from_frame == Frame.ECI
                 else x
             )
             if to_system == StateRepresentation.geodetic:
@@ -229,7 +317,7 @@ def coordinates(
             # Geodetic->ECEF gives position only
             x = (
                 brahe.position_ecef_to_eci(brahe.Epoch(epoch), x_ecef)
-                if to_frame == OrbitFrame.ECI
+                if to_frame == Frame.ECI
                 else x_ecef
             )
         elif to_system == StateRepresentation.keplerian:
@@ -248,7 +336,7 @@ def coordinates(
             # Geodetic->ECEF gives position only
             x = (
                 brahe.position_ecef_to_eci(brahe.Epoch(epoch), x_ecef)
-                if to_frame == OrbitFrame.ECI
+                if to_frame == Frame.ECI
                 else x_ecef
             )
         elif to_system == StateRepresentation.keplerian:

--- a/brahe/cli/transform.py
+++ b/brahe/cli/transform.py
@@ -44,14 +44,11 @@ class CartesianFrame(str, Enum):
 def _resolve_frame(frame: Frame) -> "brahe.ReferenceFrame":
     """Convert a CLI `Frame` value into a core `ReferenceFrame`.
 
-    Raises a Typer error with a clean message if the frame string is not
-    recognized by the core router.
+    Every `Frame` member mirrors a string accepted by
+    `ReferenceFrame.from_string`; Typer rejects any other value before this
+    is reached.
     """
-    try:
-        return brahe.ReferenceFrame.from_string(frame.value)
-    except Exception as e:  # noqa: BLE001 - surface as CLI error
-        typer.echo(f"ERROR: unknown reference frame '{frame.value}': {e}")
-        raise typer.Exit(code=1)
+    return brahe.ReferenceFrame.from_string(frame.value)
 
 
 class StateRepresentation(str, Enum):

--- a/brahe/cli/transform.py
+++ b/brahe/cli/transform.py
@@ -34,6 +34,13 @@ class Frame(str, Enum):
     GSE = "GSE"
 
 
+class CartesianFrame(str, Enum):
+    """Reference frame for cartesian coordinate input/output (ECI or ECEF)."""
+
+    ECI = "ECI"
+    ECEF = "ECEF"
+
+
 def _resolve_frame(frame: Frame) -> "brahe.ReferenceFrame":
     """Convert a CLI `Frame` value into a core `ReferenceFrame`.
 
@@ -202,13 +209,13 @@ def coordinates(
         typer.Argument(..., help="The state to convert"),
     ],
     from_frame: Annotated[
-        Frame,
+        CartesianFrame,
         typer.Option(help="Reference frame for cartesian input (ECI or ECEF)"),
-    ] = Frame.ECI,
+    ] = CartesianFrame.ECI,
     to_frame: Annotated[
-        Frame,
+        CartesianFrame,
         typer.Option(help="Reference frame for cartesian output (ECI or ECEF)"),
-    ] = Frame.ECI,
+    ] = CartesianFrame.ECI,
     as_degrees: Annotated[
         bool, typer.Option(help="Output format in degrees if applicable")
     ] = True,
@@ -255,7 +262,7 @@ def coordinates(
         x_eci = brahe.state_koe_to_eci(x, angle_format)
 
         if to_system == StateRepresentation.cartesian:
-            if to_frame == Frame.ECEF:
+            if to_frame == CartesianFrame.ECEF:
                 if not epoch:
                     typer.echo("ERROR: --epoch required for frame conversion to ECEF")
                     raise typer.Exit(code=1)
@@ -281,16 +288,16 @@ def coordinates(
             # Need ECI for Keplerian
             x_eci = (
                 x
-                if from_frame == Frame.ECI
+                if from_frame == CartesianFrame.ECI
                 else brahe.state_ecef_to_eci(brahe.Epoch(epoch), x)
             )
             x = brahe.state_eci_to_koe(x_eci, angle_format)
         elif to_system == StateRepresentation.cartesian:
             # Frame conversion
             epc = brahe.Epoch(epoch)
-            if from_frame == Frame.ECI and to_frame == Frame.ECEF:
+            if from_frame == CartesianFrame.ECI and to_frame == CartesianFrame.ECEF:
                 x = brahe.state_eci_to_ecef(epc, x)
-            elif from_frame == Frame.ECEF and to_frame == Frame.ECI:
+            elif from_frame == CartesianFrame.ECEF and to_frame == CartesianFrame.ECI:
                 x = brahe.state_ecef_to_eci(epc, x)
         elif to_system in (
             StateRepresentation.geodetic,
@@ -299,7 +306,7 @@ def coordinates(
             # Need ECEF for geodetic/geocentric
             x_ecef = (
                 brahe.state_eci_to_ecef(brahe.Epoch(epoch), x)
-                if from_frame == Frame.ECI
+                if from_frame == CartesianFrame.ECI
                 else x
             )
             if to_system == StateRepresentation.geodetic:
@@ -317,7 +324,7 @@ def coordinates(
             # Geodetic->ECEF gives position only
             x = (
                 brahe.position_ecef_to_eci(brahe.Epoch(epoch), x_ecef)
-                if to_frame == Frame.ECI
+                if to_frame == CartesianFrame.ECI
                 else x_ecef
             )
         elif to_system == StateRepresentation.keplerian:
@@ -336,7 +343,7 @@ def coordinates(
             # Geodetic->ECEF gives position only
             x = (
                 brahe.position_ecef_to_eci(brahe.Epoch(epoch), x_ecef)
-                if to_frame == Frame.ECI
+                if to_frame == CartesianFrame.ECI
                 else x_ecef
             )
         elif to_system == StateRepresentation.keplerian:

--- a/docs/examples/dawn_ceres_orbit.md
+++ b/docs/examples/dawn_ceres_orbit.md
@@ -60,6 +60,17 @@ anywhere a [`ReferenceFrame`](../library_api/frames/router.md#referenceframe) is
 --8<-- "./examples/examples/dawn_ceres_orbit.py:body_fixed_frame"
 ```
 
+!!! note "The angular-velocity callback drives the velocity transport term"
+    `register_custom_frame` accepts an optional `omega(epoch)` callback
+    returning the body-fixed angular velocity. When it is omitted, the rate is
+    recovered by central-differencing `rotation(epoch)`, which costs extra
+    rotation evaluations per query and is only as accurate as the
+    finite-difference step. Supplying `omega` analytically - as this example
+    does from the constant IAU spin rate - makes the velocity transport term
+    exact and avoids that overhead. See
+    [Reference Frame Router](../learn/frames/frame_transformations.md) and
+    [Propagation Around Other Central Bodies](../learn/orbit_propagation/numerical_propagation/other_central_bodies.md).
+
 ## Force Model
 
 `CentralBody.Custom` bundles the body's GM, radius, spin vector, and
@@ -80,6 +91,15 @@ keeps gravity-only for self-containment:
 ``` python
 --8<-- "./examples/examples/dawn_ceres_orbit.py:force_model"
 ```
+
+!!! note "A custom body has no ephemeris until you supply one"
+    Third-body perturbations require the perturbing body's position from a
+    loaded SPK kernel. The DE kernels brahe ships carry no Ceres ephemeris, so
+    a `CentralBody.Custom` defined this way can be neither perturbed by nor
+    perturb other bodies until a Ceres SPK is loaded. Point-mass, gravity-only
+    propagation is therefore the self-contained starting point for a
+    user-defined body; adding third-body forces means first generating and
+    loading a Ceres SPK.
 
 ## Propagation
 

--- a/docs/examples/doppler_compensation.md
+++ b/docs/examples/doppler_compensation.md
@@ -138,6 +138,9 @@ $$
 !!! note "Frequency Scaling"
     The magnitude of Doppler compensation scales with carrier frequency. X-band (8.4 GHz) experiences about $8.4/2.2 \approx 3.8\times$ the frequency shift of S-band (2.2 GHz) for the same line-of-sight velocity.
 
+!!! note "Uplink and downlink compensation are not symmetric"
+    Downlink compensation is a single first-order shift ($\Delta f_r = -f_x^d\, v_{los}/c$), but uplink carries the extra $(c - v_{los})$ denominator. The asymmetry is not rounding: the ground station must pre-distort its transmit frequency so that, after the Doppler shift the signal accrues in flight, it arrives at the spacecraft's fixed design frequency. Solving that inverse condition introduces the denominator, so uplink and downlink compensations differ in both sign and magnitude for the same $v_{los}$.
+
 ### Implementation
 
 We create a custom property computer that calculates the line-of-sight velocity from the satellite state and computes Doppler compensation for both S-band uplink (2.2 GHz) and X-band downlink (8.4 GHz):

--- a/docs/examples/earth_moon_free_return.md
+++ b/docs/examples/earth_moon_free_return.md
@@ -57,6 +57,17 @@ We fly the tuned design as it would be flown. The propagator starts in the parki
 --8<-- "./examples/examples/earth_moon_free_return.py:final_run"
 ```
 
+!!! note "Event geometry follows the integration center, not Earth"
+    Because the state is integrated about the Earth-Moon barycenter, any
+    detector or maneuver that assumes an Earth-centered state is wrong by the
+    Earth-barycenter offset (thousands of kilometers). A plain
+    [`AltitudeEvent`](../library_api/events/premade.md#brahe.AltitudeEvent)
+    measures altitude above the barycenter, and an impulsive burn added to the
+    raw integration velocity would be along the barycentric velocity - so both
+    must translate to ECI first. This example's terminal entry cutoff uses a
+    custom [`ValueEvent`](../library_api/events/detectors.md#brahe.ValueEvent)
+    that re-centers on Earth before computing geodetic altitude.
+
 ## Distance History
 
 Sampling the recorded trajectory gives the distance from Earth and from the Moon over the whole flight. The Earth distance climbs to nearly lunar distance and returns to the entry interface; the Moon distance dips sharply at the flyby. The final epoch is appended to the sample times so the re-entry point itself is captured.

--- a/docs/examples/geo_hohmann_transfer.md
+++ b/docs/examples/geo_hohmann_transfer.md
@@ -59,6 +59,14 @@ $$T_{transfer} = \pi \sqrt{\frac{a_{transfer}^3}{\mu}}$$
 
 The total delta-v of approximately 3.85 km/s is substantial - this is why geostationary satellites require large launch vehicles or are launched into geostationary transfer orbits (GTO) where the rocket provides the first burn and the satellite provides the circularization burn.
 
+!!! note "Hohmann is optimal only up to a radius ratio near 11.9"
+    The two-impulse Hohmann transfer is the minimum-delta-v maneuver between
+    coplanar circular orbits only when the ratio of final to initial radius
+    stays below about 11.94. Above that, a three-burn bi-elliptic transfer -
+    coasting out past the target and back - costs less total delta-v despite
+    the extra burn and a much longer flight time. The LEO-to-GEO radius ratio
+    here is about 6.6, comfortably inside the regime where Hohmann wins.
+
 ## Implementation
 
 ### Initial State

--- a/docs/examples/ground_contacts.md
+++ b/docs/examples/ground_contacts.md
@@ -87,6 +87,15 @@ The duration histogram shows the distribution of contact lengths, with statistic
   <iframe class="only-dark"  src="../figures/ground_contacts_duration_dist_dark.html"  loading="lazy"></iframe>
 </div>
 
+!!! note "Station latitude drives contact frequency for polar orbits"
+    NISAR flies a near-polar orbit, so its orbital planes converge near the
+    poles. A high-latitude station falls under many more passes per day than a
+    low-latitude one, which the satellite overflies only on the fraction of
+    revolutions whose ground track happens to cross it. Most of the spread in
+    the daily-contacts bar chart is this latitude geometry rather than
+    differences in station capability, and it is why polar and high-latitude
+    ground sites dominate networks that support sun-synchronous missions.
+
 ## Full Code Example
 
 ??? "Full Code"

--- a/docs/examples/imaging_data_latency.md
+++ b/docs/examples/imaging_data_latency.md
@@ -68,6 +68,15 @@ For each AOI exit event, we find the next ground contact for that satellite and 
 --8<-- "./examples/examples/imaging_data_latency.py:compute_latencies"
 ```
 
+!!! note "This latency is a lower bound on delivery time"
+    The metric measures from AOI exit to the start of the next ground contact.
+    It excludes the time to actually downlink the collected data during that
+    contact, onboard processing and buffering before downlink, and
+    ground-segment processing after receipt. Treat it as the orbital-geometry
+    floor on data-delivery latency, not an end-to-end delivery time - the
+    excluded terms can dominate for large collections or contended downlink
+    schedules.
+
 ## Results
 
 ### Top 5 Worst Latencies

--- a/docs/examples/imaging_opportunities.md
+++ b/docs/examples/imaging_opportunities.md
@@ -55,6 +55,21 @@ This creates a composite constraint that requires **all three conditions** to be
 - `LookDirectionConstraint`: Requires right-looking geometry
 - `OffNadirConstraint`: Limits imaging angle to 35-45° off-nadir
 
+!!! note "Look direction and pass direction jointly fix the imaged geometry"
+    A side-looking SAR images to one side of its ground track, so the
+    right-looking [`LookDirectionConstraint`](../learn/access_computation/constraints.md)
+    ([API](../library_api/access/constraints.md#brahe.LookDirectionConstraint))
+    combined with a descending
+    [`AscDscConstraint`](../learn/access_computation/constraints.md)
+    ([API](../library_api/access/constraints.md#brahe.AscDscConstraint))
+    selects a specific illumination geometry: which side of the track, and
+    from which heading, the target is viewed. Composed with an
+    [`OffNadirConstraint`](../learn/access_computation/constraints.md)
+    ([API](../library_api/access/constraints.md#brahe.OffNadirConstraint))
+    into an all-of constraint, a pass is reported only when it satisfies every
+    condition at once - relaxing any one changes which opportunities survive,
+    not merely how many.
+
 ## Compute Collection Opportunities
 
 Now we'll compute all imaging opportunities between the constellation and San Francisco over a 7-day period:

--- a/docs/examples/low_thrust_orbit_raising.md
+++ b/docs/examples/low_thrust_orbit_raising.md
@@ -89,6 +89,16 @@ The Tsiolkovsky rocket equation provides a theoretical check on our mass trackin
 
 $$\Delta v = I_{sp} \cdot g_0 \cdot \ln\left(\frac{m_0}{m_f}\right)$$
 
+!!! note "Low-thrust transfers cost more delta-v but far less propellant"
+    Spreading thrust continuously around the orbit is less delta-v-efficient
+    than the two impulses of a Hohmann transfer: the burn is never confined to
+    the optimal points, so a spiral raise accumulates steering and gravity
+    losses and its total delta-v exceeds the impulsive value for the same
+    altitude change. Electric propulsion still wins on mass because its
+    specific impulse is several times higher - the Tsiolkovsky equation turns
+    that into an exponentially smaller propellant fraction, which is the
+    quantity the extended mass state tracks here.
+
 ## Performance Comparison
 
 The following plots compare the 100W and 300W configurations over 24 hours of continuous thrust:

--- a/docs/examples/lro_lunar_orbit.md
+++ b/docs/examples/lro_lunar_orbit.md
@@ -68,9 +68,11 @@ Moon-Centered Inertial (LCI) frame:
 
 !!! note "state_bci vs. state_eci"
     [`state_bci`](../learn/orbit_propagation/numerical_propagation/cislunar_lunar_propagation.md)
+    ([API](../library_api/propagators/numerical_orbit_propagator.md#brahe.NumericalOrbitPropagator.state_bci))
     returns the propagator's native state in the central body's
     body-centered inertial frame (LCI for a Moon-centered propagator).
     [`state_eci`](../learn/orbit_propagation/numerical_propagation/numerical_orbit_propagator.md#state-at-arbitrary-epochs)
+    ([API](../library_api/propagators/numerical_orbit_propagator.md#brahe.NumericalOrbitPropagator.state_eci))
     instead always returns an Earth-centered state - for a
     Moon-centered propagator it adds the Moon's Earth-relative position,
     which would report altitudes near the Earth-Moon distance rather than

--- a/docs/examples/max_communications_gap.md
+++ b/docs/examples/max_communications_gap.md
@@ -87,6 +87,15 @@ To better understand what percentage of gaps fall below a certain duration, we c
 
 The cumulative distribution plot includes reference lines at the 25th, 50th, 75th, and 90th percentiles, making it easy to determine what fraction of gaps are below a specific value.
 
+!!! note "The maximum gap grows with the observation window"
+    Maximum contact gap is an extreme-value statistic, not an average: the
+    longest gap observed tends to increase the longer the simulation runs,
+    because rare unfavorable geometries only surface given enough time. A
+    seven-day maximum is therefore a floor on the true worst case, not a
+    converged value. The median and percentile gaps from the cumulative
+    distribution are far more stable and are the better basis for sizing
+    routine reactivity and latency budgets.
+
 ## Contact Gap Visualization
 
 Finally, we'll visualize the 3 longest gaps on a ground track plot to see where they occur. For each gap, we extract the satellite's ground track during that time period and plot it as a colored segment. We also interpolate to the ±180° edges to avoid visual gaps at the antimeridian. This type of visualization can be helpful in understanding ground network design and where additional ground stations might help:

--- a/docs/examples/mro_mars_orbit.md
+++ b/docs/examples/mro_mars_orbit.md
@@ -77,6 +77,16 @@ frame:
 --8<-- "./examples/examples/mro_mars_orbit.py:propagation"
 ```
 
+!!! note "state_bci vs. state_eci for Mars orbits"
+    A Mars-centered propagator's [`state_bci`](../learn/orbit_propagation/numerical_propagation/cislunar_lunar_propagation.md)
+    returns the state in the Mars body-centered inertial frame (MCI), while
+    [`state_eci`](../library_api/propagators/numerical_orbit_propagator.md#brahe.NumericalOrbitPropagator.state_eci)
+    always returns an Earth-centered state - for a Mars-centered propagator it
+    adds Mars's Earth-relative position, reporting distances near the
+    Earth-Mars range rather than above the Martian surface. Use
+    [`state_bci`](../library_api/propagators/numerical_orbit_propagator.md#brahe.NumericalOrbitPropagator.state_bci)
+    whenever you need the distance from the body being orbited.
+
 ## Element Evolution
 
 Sampling the trajectory over the 2-day propagation and converting each

--- a/docs/examples/oem_access_prediction.md
+++ b/docs/examples/oem_access_prediction.md
@@ -68,6 +68,17 @@ Compare each OEM-based access window against the corresponding direct propagator
 --8<-- "./examples/examples/oem_access_prediction.py:compare_results"
 ```
 
+!!! note "Ephemeris-file access accuracy is set by sampling, not the algorithm"
+    Access windows from an
+    [`OrbitTrajectory`](../library_api/trajectories/orbit_trajectory.md#brahe.OrbitTrajectory)
+    built from a [CCSDS OEM](../learn/ccsds/oem.md) are only as accurate as
+    that ephemeris. Between samples the state is interpolated, so rise and set
+    edge timing is bounded by the sample spacing (60 s here) and the
+    interpolation order, not by the access search itself. The sub-5-second,
+    sub-0.5-degree agreement with the direct propagator measures interpolation
+    fidelity; coarser OEM spacing widens that gap while the algorithm is
+    unchanged.
+
 ## Display Results
 
 Print all OEM-based access windows grouped by station with summary statistics.

--- a/docs/examples/tessellation_visualization.md
+++ b/docs/examples/tessellation_visualization.md
@@ -54,6 +54,17 @@ descending passes:
     ![Ireland tessellation](../figures/tessellation_ireland_tiles_dark.png#only-dark)
 </figure>
 
+!!! note "Ascending and descending passes need separate tiles"
+    [`AscDsc.EITHER`](../library_api/access/enums.md#brahe.AscDsc) doubles the
+    tile set because a SAR tile is pass-direction-specific. The look side and
+    ground-track heading differ between ascending and descending passes, so the
+    same patch of ground is covered by one tile shaped for the ascending
+    geometry and a separate tile for the descending geometry. Restricting to
+    `AscDsc.ASCENDING` or `AscDsc.DESCENDING` collects a single geometry and
+    halves the tiles. See the
+    [tessellation guide](../learn/access_computation/tessellation.md) and
+    [`OrbitGeometryTessellatorConfig`](../library_api/access/tessellation.md#brahe.OrbitGeometryTessellatorConfig).
+
 ## Compute Collection Opportunities
 
 Use an off-nadir constraint (10°–45°) to find all collection windows over a

--- a/docs/examples/using_different_integrators.md
+++ b/docs/examples/using_different_integrators.md
@@ -112,6 +112,19 @@ Key observations:
 
 The energy and angular momentum errors reveal an important pattern: adaptive lower-order methods (RKF45, DP54) can accumulate more error over long integrations despite taking fewer steps, while higher-order methods such as RKF78 and RKN1210 are useful when tight tolerances justify the additional stage evaluations.
 
+!!! note "RKN1210 exploits the second-order structure of orbital motion"
+    Orbital dynamics is a second-order system - acceleration as a function of
+    position, $\ddot{\mathbf{r}} = -\mu\,\mathbf{r}/r^3$ plus perturbations.
+    [RKN1210](../learn/integrators/index.md)
+    ([API](../library_api/integrators/rkn1210.md#brahe.RKN1210Integrator)) is a
+    Runge-Kutta-Nyström method that integrates position and velocity directly
+    from acceleration instead of first flattening the problem into a
+    first-order system, and its high order holds tight tolerances across large
+    steps. That structural match is why it needs far fewer steps than RK4 here.
+    The comparison also shows step count is no measure of accuracy on its own:
+    adaptive control bounds the local error per step, not the global error
+    accumulated over 106 orbits.
+
 ## Angular Momentum Conservation
 
 To visualize how each integrator performs over time, we plot the angular momentum magnitude error:

--- a/docs/examples/visualizing_gps.md
+++ b/docs/examples/visualizing_gps.md
@@ -38,6 +38,15 @@ computes the or orbital period of the satellite by converting the semi-major axi
 
 It then propagates the satellite to one full orbit past its epoch using the `propagate_to` method to ensure that the trajectory contains position data for one complete orbit.
 
+!!! note "GPS satellites are semi-synchronous, not geosynchronous"
+    The orbital period computed from each satellite's semi-major axis comes out
+    near 11 hours 58 minutes - half a sidereal day - not 24 hours. GPS flies a
+    semi-synchronous medium Earth orbit at about 20,200 km altitude, so each
+    satellite completes two revolutions per sidereal day and repeats its ground
+    track once daily. Propagating for "one orbit" here therefore covers roughly
+    twelve hours, which is why the constellation arcs are much larger than in a
+    LEO example.
+
 ## Visualize in 3D
 
 We'll create an interactive 3D visualization of the entire GPS constellation using Plotly. We'll use the Natural Earth 50m texture for a realistic Earth representation:

--- a/docs/examples/visualizing_starlink.md
+++ b/docs/examples/visualizing_starlink.md
@@ -53,6 +53,14 @@ The resulting plot shows the complete Starlink constellation orbiting Earth. The
   <iframe class="only-dark"  src="../figures/visualizing_starlink_dark.html"  loading="lazy"></iframe>
 </div>
 
+!!! note "The snapshot shows orbital shells, not random scatter"
+    Most Starlink satellites operate near 550 km altitude, with the largest
+    group at about 53 degrees inclination and further groups at higher
+    inclinations. The banded structure in the single-epoch snapshot is the
+    superposition of these discrete orbital shells' planes, each populated with
+    many evenly phased satellites. The markers are drawn at one common epoch, so
+    the view is an instantaneous geometry rather than swept orbit paths.
+
 ## Full Code Example
 
 ??? "Full Code"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -50,6 +50,25 @@ uv pip install brahe
 uv pip install "brahe[plots]"
 ```
 
+### Installing Development Builds
+
+Every push to `main` publishes rolling `latest` wheels and an sdist to a
+[PEP 503](https://peps.python.org/pep-0503/) package index served from
+`docs.brahe.space`. These are automatically-built development snapshots — use
+them to test unreleased features without building from source. They may be
+unstable; prefer the PyPI release for production use.
+
+```bash
+# pip
+pip install brahe --extra-index-url https://docs.brahe.space/simple/
+
+# uv
+uv pip install brahe --extra-index-url https://docs.brahe.space/simple/
+```
+
+The `--extra-index-url` flag keeps PyPI as the primary index and adds the
+development index as a fallback, so dependencies still resolve from PyPI.
+
 ### Verifying Installation
 
 After installation, verify that Brahe is working correctly:

--- a/docs/learn/cli/transform.md
+++ b/docs/learn/cli/transform.md
@@ -5,9 +5,8 @@ Convert between coordinate systems and reference frames.
 ## Overview
 
 The `transform` command group provides conversions between:
-- **Reference frames**: ECI (Earth-Centered Inertial) ↔ ECEF (Earth-Centered Earth-Fixed)
+- **Reference frames**: full frame-to-frame transforms across all named frames (`ECI`/`GCRF`, `ECEF`/`ITRF`, `EME2000`, lunar `LCI`/`LFPA`/`LFME`, Mars `MCI`/`MCMF`, `EMBI`, `SSBI`, and synodic `EMR`/`SER`/`GSE`)
 - **Coordinate systems**: Keplerian, Cartesian, Geodetic, Geocentric
-- **Attitude representations**: Quaternions, Euler angles, rotation matrices (planned)
 
 ## Commands
 
@@ -21,8 +20,8 @@ brahe transform frame <FROM_FRAME> <TO_FRAME> <EPOCH> <x> <y> <z> <vx> <vy> <vz>
 ```
 
 **Arguments:**
-- `FROM_FRAME` - Source reference frame: `ECI` or `ECEF`
-- `TO_FRAME` - Target reference frame: `ECI` or `ECEF`
+- `FROM_FRAME` - Source reference frame (any named frame: `ECI`, `ECEF`, `GCRF`, `ITRF`, `EME2000`, `LCI`, `LFPA`, `LFME`, `MCI`, `MCMF`, `EMBI`, `SSBI`, `EMR`, `SER`, `GSE`)
+- `TO_FRAME` - Target reference frame (same set as `FROM_FRAME`)
 - `EPOCH` - Epoch for the transformation (ISO-8601 format with timezone)
 - `x y z vx vy vz` - State vector [m, m, m, m/s, m/s, m/s]
 
@@ -57,6 +56,64 @@ Output:
 ```bash
 # [1234308.01, 6766461.20, 15974.24, -6884.83, 1255.90, 0.25]
 ```
+
+---
+
+### `position`
+
+Transform a position vector between reference frames.
+
+**Syntax:**
+```bash
+brahe transform position <FROM_FRAME> <TO_FRAME> <EPOCH> <x> <y> <z> [OPTIONS]
+```
+
+**Arguments:**
+- `FROM_FRAME` / `TO_FRAME` - Any named frame (see `frame`)
+- `EPOCH` - Epoch (ISO-8601 format with timezone)
+- `x y z` - Position vector [m, m, m]
+
+**Options:**
+- `--format <fmt>` - Output format string (default: `f`)
+
+**Example:**
+```bash
+brahe transform position GCRF ITRF "2024-01-01T00:00:00Z" 6878137 0 0
+```
+
+---
+
+### `rotation`
+
+Emit the 3x3 rotation matrix between two reference frames at an epoch.
+
+**Syntax:**
+```bash
+brahe transform rotation <FROM_FRAME> <TO_FRAME> <EPOCH> [OPTIONS]
+```
+
+**Arguments:**
+- `FROM_FRAME` / `TO_FRAME` - Any named frame (see `frame`)
+- `EPOCH` - Epoch (ISO-8601 format with timezone)
+
+**Options:**
+- `--format <fmt>` - Output format string (default: `f`)
+
+**Example:**
+```bash
+brahe transform rotation GCRF ITRF "2024-01-01T00:00:00Z"
+```
+Output (three matrix rows):
+```bash
+# [-0.170986, 0.985273, 0.000365]
+# [-0.985271, -0.170986, 0.002292]
+# [0.002321, 0.000032, 0.999997]
+```
+
+!!! note "Non-Earth frames need SPK kernels"
+    Transforms involving lunar, Mars, barycentric, or synodic frames require
+    SPICE ephemeris kernels, which are downloaded to the cache on first use.
+    See [`state_frame_to_frame`](../../library_api/frames/router.md#brahe.state_frame_to_frame).
 
 ---
 

--- a/docs/learn/cli/transform.md
+++ b/docs/learn/cli/transform.md
@@ -12,7 +12,7 @@ The `transform` command group provides conversions between:
 
 ### `frame`
 
-Transform state vectors between ECI and ECEF reference frames.
+Transform a Cartesian state vector between reference frames.
 
 **Syntax:**
 ```bash

--- a/src/datasets/icgem/download.rs
+++ b/src/datasets/icgem/download.rs
@@ -234,6 +234,7 @@ pub(crate) fn download_icgem_model_with_url(
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
+    use crate::utils::testing::CacheRedirect;
 
     fn entry(body: ICGEMBody, name: &str, degree: u32) -> IndexEntry {
         IndexEntry {
@@ -319,10 +320,7 @@ mod tests {
     fn test_download_end_to_end_with_mock_server() {
         use httpmock::prelude::*;
 
-        let dir = tempfile::tempdir().unwrap();
-        unsafe {
-            std::env::set_var("BRAHE_CACHE", dir.path());
-        }
+        let _cache = CacheRedirect::new();
 
         let html = std::fs::read_to_string("test_assets/icgem/tom_longtime_sample.html").unwrap();
         let gfc = std::fs::read_to_string("data/gravity_models/JGM3.gfc").unwrap();
@@ -351,10 +349,6 @@ mod tests {
         assert!(path.exists());
         assert!(path.to_string_lossy().contains("models"));
         assert!(path.to_string_lossy().contains("earth"));
-
-        unsafe {
-            std::env::remove_var("BRAHE_CACHE");
-        }
     }
 
     #[test]
@@ -362,10 +356,7 @@ mod tests {
     fn test_download_uses_cache_on_second_call() {
         use httpmock::prelude::*;
 
-        let dir = tempfile::tempdir().unwrap();
-        unsafe {
-            std::env::set_var("BRAHE_CACHE", dir.path());
-        }
+        let _cache = CacheRedirect::new();
 
         let html = std::fs::read_to_string("test_assets/icgem/tom_longtime_sample.html").unwrap();
         let gfc = std::fs::read_to_string("data/gravity_models/JGM3.gfc").unwrap();
@@ -394,10 +385,6 @@ mod tests {
         // disk with fetched_at = now, so the second call finds a fresh cache
         // and skips the network entirely.
         list_mock.assert_calls(1);
-
-        unsafe {
-            std::env::remove_var("BRAHE_CACHE");
-        }
     }
 
     // TODO: This test is super flakey because it depends on the live ICGEM service

--- a/src/datasets/icgem/index.rs
+++ b/src/datasets/icgem/index.rs
@@ -222,6 +222,7 @@ pub fn refresh_all_icgem_indexes() -> Result<(), BraheError> {
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
+    use crate::utils::testing::CacheRedirect;
 
     #[test]
     fn test_index_entry_round_trip_json() {
@@ -316,10 +317,7 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn test_list_models_uses_fresh_cache() {
-        let dir = tempfile::tempdir().unwrap();
-        unsafe {
-            std::env::set_var("BRAHE_CACHE", dir.path());
-        }
+        let _cache = CacheRedirect::new();
 
         let path = index_path_for(&ICGEMBody::Earth).unwrap();
         let file = IndexFile {
@@ -338,20 +336,13 @@ mod tests {
         let entries = list_icgem_models_with_url(&ICGEMBody::Earth, "http://127.0.0.1:1").unwrap();
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].name, "JGM3");
-
-        unsafe {
-            std::env::remove_var("BRAHE_CACHE");
-        }
     }
 
     #[test]
     #[serial_test::serial]
     fn test_list_models_refreshes_stale_cache() {
         use httpmock::prelude::*;
-        let dir = tempfile::tempdir().unwrap();
-        unsafe {
-            std::env::set_var("BRAHE_CACHE", dir.path());
-        }
+        let _cache = CacheRedirect::new();
 
         let path = index_path_for(&ICGEMBody::Earth).unwrap();
         let stale = IndexFile {
@@ -370,19 +361,12 @@ mod tests {
 
         let entries = list_icgem_models_with_url(&ICGEMBody::Earth, &server.base_url()).unwrap();
         assert!(!entries.is_empty());
-
-        unsafe {
-            std::env::remove_var("BRAHE_CACHE");
-        }
     }
 
     #[test]
     #[serial_test::serial]
     fn test_list_models_stale_fallback_on_network_failure() {
-        let dir = tempfile::tempdir().unwrap();
-        unsafe {
-            std::env::set_var("BRAHE_CACHE", dir.path());
-        }
+        let _cache = CacheRedirect::new();
 
         let path = index_path_for(&ICGEMBody::Earth).unwrap();
         let stale = IndexFile {
@@ -401,10 +385,6 @@ mod tests {
         let entries = list_icgem_models_with_url(&ICGEMBody::Earth, "http://127.0.0.1:1").unwrap();
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].name, "STALE");
-
-        unsafe {
-            std::env::remove_var("BRAHE_CACHE");
-        }
     }
 
     #[test]
@@ -413,10 +393,7 @@ mod tests {
         // The celestial cache file holds entries for ALL non-Earth bodies.
         // list_icgem_models(Mars) must return only Mars entries — not Moon,
         // Venus, or Ceres ones that share the same file.
-        let dir = tempfile::tempdir().unwrap();
-        unsafe {
-            std::env::set_var("BRAHE_CACHE", dir.path());
-        }
+        let _cache = CacheRedirect::new();
 
         let path = index_path_for(&ICGEMBody::Moon).unwrap(); // celestial index file
         let file = IndexFile {
@@ -468,9 +445,5 @@ mod tests {
         let ceres_entries =
             list_icgem_models_with_url(&ICGEMBody::Ceres, "http://127.0.0.1:1").unwrap();
         assert!(ceres_entries.is_empty());
-
-        unsafe {
-            std::env::remove_var("BRAHE_CACHE");
-        }
     }
 }

--- a/src/orbit_dynamics/gravity.rs
+++ b/src/orbit_dynamics/gravity.rs
@@ -2837,7 +2837,7 @@ mod tests {
 
     use crate::constants::{GM_EARTH, R_EARTH};
     use crate::traits::DStatePropagator;
-    use crate::utils::testing::setup_global_test_eop;
+    use crate::utils::testing::{CacheRedirect, setup_global_test_eop};
     use crate::{
         AngleFormat, CentralBody, DNumericalOrbitPropagator, EOPExtrapolation, Epoch,
         FileEOPProvider, FileSpaceWeatherProvider, ForceModelConfig, FrameTransformationModel,
@@ -3929,10 +3929,7 @@ mod tests {
     fn test_gravity_model_type_icgem_variant_loads_jgm3() {
         use crate::datasets::icgem::ICGEMBody;
 
-        let dir = tempfile::tempdir().unwrap();
-        unsafe {
-            std::env::set_var("BRAHE_CACHE", dir.path());
-        }
+        let _cache = CacheRedirect::new();
 
         // Seed the icgem cache with a manually-placed gfc file so no network
         // fetch is required.
@@ -3966,10 +3963,6 @@ mod tests {
         };
         let model = GravityModel::from_model_type(&mt).unwrap();
         assert_eq!(model.n_max, 70);
-
-        unsafe {
-            std::env::remove_var("BRAHE_CACHE");
-        }
     }
 
     #[test]
@@ -3987,10 +3980,7 @@ mod tests {
         let eop = FileEOPProvider::from_default_standard(true, EOPExtrapolation::Hold).unwrap();
         set_global_eop_provider(eop);
 
-        let dir = tempfile::tempdir().unwrap();
-        unsafe {
-            std::env::set_var("BRAHE_CACHE", dir.path());
-        }
+        let _cache = CacheRedirect::new();
 
         // Seed the ICGEM cache with JGM3 so no network fetch is required.
         let cache_dir =
@@ -4083,10 +4073,6 @@ mod tests {
         let dz = final_state[2] - dstate[2];
         let drift = (dx * dx + dy * dy + dz * dz).sqrt();
         assert!(drift > 100e3, "state barely moved: drift = {} m", drift);
-
-        unsafe {
-            std::env::remove_var("BRAHE_CACHE");
-        }
     }
 
     #[test]

--- a/src/orbit_dynamics/ocean_tides.rs
+++ b/src/orbit_dynamics/ocean_tides.rs
@@ -927,8 +927,8 @@ mod tests {
     fn test_new_rejects_and_removes_truncated_cache() {
         // A pre-existing cache file missing main constituents must be rejected
         // and deleted so the next call re-downloads.
-        let dir = tempfile::tempdir().unwrap();
-        let tides = dir.path().join("tides");
+        let cache = crate::utils::testing::CacheRedirect::new();
+        let tides = cache.cache_path().join("tides");
         std::fs::create_dir_all(&tides).unwrap();
         let cached = tides.join("fes2004_Cnm-Snm.dat");
         let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -939,19 +939,9 @@ mod tests {
         let truncated: String = content.lines().take(400).collect::<Vec<_>>().join("\n");
         std::fs::write(&cached, &truncated).unwrap();
 
-        let prev = std::env::var("BRAHE_CACHE").ok();
-        unsafe {
-            std::env::set_var("BRAHE_CACHE", dir.path());
-        }
         let result = OceanTideModel::new(20, 20, false);
         assert!(result.is_err(), "truncated cache must error");
         assert!(!cached.exists(), "corrupt cache file must be removed");
-        unsafe {
-            match prev {
-                Some(v) => std::env::set_var("BRAHE_CACHE", v),
-                None => std::env::remove_var("BRAHE_CACHE"),
-            }
-        }
     }
 
     #[test]

--- a/src/orbit_dynamics/ocean_tides.rs
+++ b/src/orbit_dynamics/ocean_tides.rs
@@ -863,20 +863,10 @@ mod tests {
     #[cfg_attr(not(feature = "integration"), ignore)]
     fn test_fes2004_download() {
         // Network-gated: clean cache, real download, file is complete.
-        let dir = tempfile::tempdir().unwrap();
-        let prev = std::env::var("BRAHE_CACHE").ok();
-        unsafe {
-            std::env::set_var("BRAHE_CACHE", dir.path());
-        }
+        let _cache = crate::utils::testing::CacheRedirect::new();
         let path = fes2004_coefficients_path().unwrap();
         let len = std::fs::metadata(&path).unwrap().len();
         assert!(len > 3_500_000, "downloaded file too small: {len}");
-        unsafe {
-            match prev {
-                Some(v) => std::env::set_var("BRAHE_CACHE", v),
-                None => std::env::remove_var("BRAHE_CACHE"),
-            }
-        }
     }
 
     #[test]

--- a/src/utils/testing.rs
+++ b/src/utils/testing.rs
@@ -535,6 +535,15 @@ impl CacheRedirect {
             fs::copy(&src, self.naif_dir.join("de440s.bsp")).unwrap();
         }
     }
+
+    /// Root of the redirected cache (the tempdir `BRAHE_CACHE` points at).
+    /// Tests seed synthetic files under the model-specific subdirectories
+    /// (e.g. `icgem/models/earth/`) resolved from this root via the
+    /// `crate::utils::cache::get_*_cache_dir` helpers while the redirect is
+    /// active.
+    pub(crate) fn cache_path(&self) -> &std::path::Path {
+        self._dir.path()
+    }
 }
 
 impl Drop for CacheRedirect {
@@ -549,44 +558,18 @@ impl Drop for CacheRedirect {
     }
 }
 
-/// Guard returned by [`setup_test_fes2004_cache`]. Holds the tempdir alive and
-/// restores the previous `BRAHE_CACHE` value on drop, mirroring
-/// [`CacheRedirect`]'s restoration semantics.
-pub(crate) struct Fes2004CacheGuard {
-    _dir: tempfile::TempDir,
-    prev: Option<String>,
-}
-
-impl Drop for Fes2004CacheGuard {
-    fn drop(&mut self) {
-        // SAFETY: single-threaded within a #[serial] test.
-        unsafe {
-            match &self.prev {
-                Some(v) => env::set_var("BRAHE_CACHE", v),
-                None => env::remove_var("BRAHE_CACHE"),
-            }
-        }
-    }
-}
-
 /// Point `BRAHE_CACHE` at a fresh temp dir pre-seeded with the packaged
 /// FES2004 test fixture (degree/order <= 30), so ocean-tide code paths run
-/// offline. The returned guard must be held for the test's duration and
-/// restores the previous `BRAHE_CACHE` value on drop; callers mutate
-/// process-global env and must be `#[serial]`.
-pub(crate) fn setup_test_fes2004_cache() -> Fes2004CacheGuard {
-    let prev = env::var("BRAHE_CACHE").ok();
-    let dir = tempfile::tempdir().expect("tempdir");
-    let tides = dir.path().join("tides");
+/// offline. Returns a [`CacheRedirect`]; hold it for the test's duration. The
+/// prior `BRAHE_CACHE` value is restored on drop. Callers mutate process-global
+/// env and MUST be `#[serial]`.
+pub(crate) fn setup_test_fes2004_cache() -> CacheRedirect {
+    let redirect = CacheRedirect::new();
+    let tides = redirect.cache_path().join("tides");
     fs::create_dir_all(&tides).expect("tides cache subdir");
     let fixture = Path::new(env!("CARGO_MANIFEST_DIR")).join("test_data/fes2004_Cnm-Snm_n30.dat");
     fs::copy(&fixture, tides.join("fes2004_Cnm-Snm.dat")).expect("copy FES2004 fixture");
-    // SAFETY: single-threaded within a #[serial] test; no other thread reads
-    // the environment concurrently.
-    unsafe {
-        env::set_var("BRAHE_CACHE", dir.path());
-    }
-    Fes2004CacheGuard { _dir: dir, prev }
+    redirect
 }
 
 /// Initialize global space weather provider with test data for unit testing.

--- a/tests/cli/test_transform.py
+++ b/tests/cli/test_transform.py
@@ -586,6 +586,52 @@ class TestCoordinatesCommand:
         assert "ERROR" in result.stdout
 
 
+class TestCoordinatesFrameValidation:
+    def test_coordinates_rejects_non_eci_ecef_frame(self):
+        result = runner.invoke(
+            app,
+            [
+                "transform",
+                "coordinates",
+                "keplerian",
+                "cartesian",
+                "2024-01-01T00:00:00Z",
+                "6878137",
+                "0.01",
+                "45",
+                "0",
+                "0",
+                "0",
+                "--to-frame",
+                "GCRF",
+            ],
+        )
+        # A non-ECI/ECEF frame must be rejected by CLI validation, not silently mis-routed.
+        assert result.exit_code != 0
+
+    def test_coordinates_accepts_ecef_frame(self):
+        result = runner.invoke(
+            app,
+            [
+                "transform",
+                "coordinates",
+                "keplerian",
+                "cartesian",
+                "2024-01-01T00:00:00Z",
+                "6878137",
+                "0.01",
+                "45",
+                "0",
+                "0",
+                "0",
+                "--to-frame",
+                "ECEF",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "[" in result.stdout
+
+
 class TestFrameNamedFrames:
     """Frame transforms across the full named-frame set."""
 

--- a/tests/cli/test_transform.py
+++ b/tests/cli/test_transform.py
@@ -694,6 +694,13 @@ class TestRotationCommand:
         assert result.exit_code == 0
         rows = [ln for ln in result.stdout.splitlines() if ln.strip().startswith("[")]
         assert len(rows) == 3
+        matrix = [
+            [float(v) for v in row.strip().strip("[]").split(",")] for row in rows
+        ]
+        for i in range(3):
+            for j in range(3):
+                expected = 1.0 if i == j else 0.0
+                assert matrix[i][j] == pytest.approx(expected, abs=1e-9)
 
 
 if __name__ == "__main__":

--- a/tests/cli/test_transform.py
+++ b/tests/cli/test_transform.py
@@ -586,5 +586,115 @@ class TestCoordinatesCommand:
         assert "ERROR" in result.stdout
 
 
+class TestFrameNamedFrames:
+    """Frame transforms across the full named-frame set."""
+
+    def test_gcrf_itrf_matches_eci_ecef(self):
+        """GCRF->ITRF is the ECI->ECEF alias and must agree numerically."""
+        args_tail = ["2024-01-01T00:00:00Z", "6878137", "0", "0", "0", "7500", "0"]
+        r_named = runner.invoke(app, ["transform", "frame", "GCRF", "ITRF", *args_tail])
+        r_alias = runner.invoke(app, ["transform", "frame", "ECI", "ECEF", *args_tail])
+        assert r_named.exit_code == 0
+        assert r_alias.exit_code == 0
+        assert r_named.stdout.strip() == r_alias.stdout.strip()
+
+    def test_same_frame_returns_input(self):
+        result = runner.invoke(
+            app,
+            [
+                "transform",
+                "frame",
+                "GCRF",
+                "GCRF",
+                "2024-01-01T00:00:00Z",
+                "6878137",
+                "0",
+                "0",
+                "0",
+                "7500",
+                "0",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "6878137" in result.stdout
+
+    def test_unknown_frame_errors_cleanly(self):
+        result = runner.invoke(
+            app,
+            [
+                "transform",
+                "frame",
+                "NOPE",
+                "ECEF",
+                "2024-01-01T00:00:00Z",
+                "1",
+                "0",
+                "0",
+                "0",
+                "0",
+                "0",
+            ],
+        )
+        assert result.exit_code != 0
+
+
+class TestPositionCommand:
+    def test_position_gcrf_itrf(self):
+        result = runner.invoke(
+            app,
+            [
+                "transform",
+                "position",
+                "GCRF",
+                "ITRF",
+                "2024-01-01T00:00:00Z",
+                "6878137",
+                "0",
+                "0",
+            ],
+        )
+        assert result.exit_code == 0
+        assert result.stdout.count(",") == 2  # three components -> two commas
+
+    def test_position_same_frame_returns_input(self):
+        result = runner.invoke(
+            app,
+            [
+                "transform",
+                "position",
+                "ITRF",
+                "ITRF",
+                "2024-01-01T00:00:00Z",
+                "6878137",
+                "0",
+                "0",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "6878137" in result.stdout
+
+
+class TestRotationCommand:
+    def test_rotation_emits_three_rows(self):
+        result = runner.invoke(
+            app,
+            ["transform", "rotation", "GCRF", "ITRF", "2024-01-01T00:00:00Z"],
+        )
+        assert result.exit_code == 0
+        rows = [ln for ln in result.stdout.splitlines() if ln.strip().startswith("[")]
+        assert len(rows) == 3
+        for row in rows:
+            assert row.count(",") == 2
+
+    def test_rotation_same_frame_is_identity(self):
+        result = runner.invoke(
+            app,
+            ["transform", "rotation", "GCRF", "GCRF", "2024-01-01T00:00:00Z"],
+        )
+        assert result.exit_code == 0
+        rows = [ln for ln in result.stdout.splitlines() if ln.strip().startswith("[")]
+        assert len(rows) == 3
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/cli/test_transform.py
+++ b/tests/cli/test_transform.py
@@ -5,8 +5,11 @@ Tests all conversion paths for coordinates and frame conversions.
 """
 
 import pytest
+import typer
+import brahe
 from typer.testing import CliRunner
 from brahe.cli.__main__ import app
+from brahe.cli.transform import _parse_vector
 
 runner = CliRunner()
 
@@ -747,6 +750,101 @@ class TestRotationCommand:
             for j in range(3):
                 expected = 1.0 if i == j else 0.0
                 assert matrix[i][j] == pytest.approx(expected, abs=1e-9)
+
+
+class TestTransformErrorPaths:
+    """Error-surfacing paths must produce a clean CLI error, not a traceback."""
+
+    def test_parse_vector_rejects_invalid_expression(self):
+        # A component that is neither a number nor a known constant expression
+        # must raise a clean typer.Exit(1), not propagate the ValueError.
+        with pytest.raises(typer.Exit) as exc:
+            _parse_vector(["notanumber", "0", "0"], 3)
+        assert exc.value.exit_code == 1
+
+    def test_frame_transform_error_surfaces_cleanly(self, monkeypatch):
+        def boom(*args, **kwargs):
+            raise RuntimeError("kernel unavailable")
+
+        monkeypatch.setattr(brahe, "state_frame_to_frame", boom)
+        result = runner.invoke(
+            app,
+            [
+                "transform",
+                "frame",
+                "GCRF",
+                "ITRF",
+                "2024-01-01T00:00:00Z",
+                "6878137",
+                "0",
+                "0",
+                "0",
+                "7500",
+                "0",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "ERROR: frame transform failed" in result.stdout
+
+    def test_position_transform_error_surfaces_cleanly(self, monkeypatch):
+        def boom(*args, **kwargs):
+            raise RuntimeError("kernel unavailable")
+
+        monkeypatch.setattr(brahe, "position_frame_to_frame", boom)
+        result = runner.invoke(
+            app,
+            [
+                "transform",
+                "position",
+                "GCRF",
+                "ITRF",
+                "2024-01-01T00:00:00Z",
+                "6878137",
+                "0",
+                "0",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "ERROR: position transform failed" in result.stdout
+
+    def test_rotation_transform_error_surfaces_cleanly(self, monkeypatch):
+        def boom(*args, **kwargs):
+            raise RuntimeError("kernel unavailable")
+
+        monkeypatch.setattr(brahe, "rotation_frame_to_frame", boom)
+        result = runner.invoke(
+            app,
+            ["transform", "rotation", "GCRF", "ITRF", "2024-01-01T00:00:00Z"],
+        )
+        assert result.exit_code == 1
+        assert "ERROR: rotation transform failed" in result.stdout
+
+
+class TestCoordinatesCartesianFrameConversion:
+    def test_cartesian_ecef_to_eci(self):
+        # Exercises the ECEF->ECI cartesian frame-conversion branch.
+        result = runner.invoke(
+            app,
+            [
+                "transform",
+                "coordinates",
+                "cartesian",
+                "cartesian",
+                "2024-01-01T00:00:00Z",
+                "6878137",
+                "0",
+                "0",
+                "0",
+                "7500",
+                "0",
+                "--from-frame",
+                "ECEF",
+                "--to-frame",
+                "ECI",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "[" in result.stdout
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Pull Request

## Description

Resolves four independent housekeeping backlog items:

1. **`BRAHE_CACHE` test-redirect consolidation.** All raw `std::env::set_var`/`remove_var("BRAHE_CACHE")` test redirects (in `icgem/index.rs`, `icgem/download.rs`, `gravity.rs`, `ocean_tides.rs`) now route through the panic-safe RAII guard `CacheRedirect`, which restores the prior value on drop instead of unconditionally clearing it. The redundant `Fes2004CacheGuard` is removed — `setup_test_fes2004_cache()` now returns a pre-seeded `CacheRedirect`. No user-facing behavior change; this is test-support hygiene.

2. **CLI arbitrary frame transforms.** `brahe transform` now exposes the full frame router. `transform frame` accepts all named reference frames (previously ECI/ECEF only), and new `transform position` and `transform rotation` subcommands cover position-only transforms and the 3×3 rotation matrix. All three dispatch through the core `state_frame_to_frame` / `position_frame_to_frame` / `rotation_frame_to_frame` routers, with clean error messages for kernel/transform failures.

3. **Development-build install docs.** New "Installing Development Builds" section in `docs/installation.md` documenting the rolling `latest` package index at `https://docs.brahe.space/simple/`.

4. **Consistent example notes.** Every `docs/examples/*` page now carries 1–3 deconflicted `!!! note` admonitions in the style of the LRO `state_bci` note — each teaching one non-obvious correctness hazard or modeling insight, with links to both the conceptual `learn/` page and the `library_api/` reference.

## Changelog

### Added
- `brahe transform position` and `brahe transform rotation` CLI subcommands for position-vector and rotation-matrix transforms between reference frames.
- `brahe transform frame` now accepts all named reference frames (GCRF, ITRF, EME2000, lunar LCI/LFPA/LFME, Mars MCI/MCMF, EMBI, SSBI, synodic EMR/SER/GSE) in addition to the ECI/ECEF aliases.

### Changed
- `brahe transform frame` dispatches through the core frame router (`state_frame_to_frame`) instead of a hardcoded ECI↔ECEF path.

### Fixed
- `brahe transform frame` no longer emits duplicate output when the source and target frames are identical (missing early return).
- `brahe transform coordinates` now rejects non-ECI/ECEF values for `--from-frame`/`--to-frame` at validation instead of silently mis-routing them.

## Note to Reviewers

- Item 1 touches only test code; the full Rust suite passes and no raw `BRAHE_CACHE` mutation remains outside `src/utils/cache.rs` (which legitimately tests the env-var override) and the guard itself.
- CLI coverage is in `tests/cli/test_transform.py` (33 tests). `just check` passes end to end. Docs build warnings about missing `comparing_propagators_keplerian_*` figure SVGs are pre-existing (generated at CI time) and unrelated to this PR.