### PR TITLE
Polish docs, examples, and CI ahead of release

### DIFF
--- a/.github/workflows/docs_only.yml
+++ b/.github/workflows/docs_only.yml
@@ -97,6 +97,18 @@ jobs:
           restore-keys: |
             network-example-figures-
 
+      # Same rationale as the figures restore above, for the captured stdout of
+      # the NETWORK-flagged examples. Restored before the --ci-only run so the
+      # fresher non-network outputs overwrite any overlap (the run writes
+      # per-example files and never wipes docs/outputs).
+      - name: Restore network example outputs
+        uses: actions/cache/restore@v6.1.0
+        with:
+          path: docs/outputs/
+          key: network-example-outputs-
+          restore-keys: |
+            network-example-outputs-
+
       - name: Test examples (including CI-ONLY)
         run: just test-examples --ci-only
 

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -52,10 +52,12 @@ jobs:
     if: needs.check-skip.outputs.should_skip == 'false'
     uses: ./.github/workflows/test_examples.yml
 
-  # Validate crates.io package builds correctly and is under size limit
+  # Validate crates.io package builds correctly and is under size limit.
+  # Runs in parallel with test-rust (both gate only on check-skip) so the
+  # package build and the test suite finish concurrently rather than serially.
   validate-rust-package:
     runs-on: ubuntu-latest
-    needs: [check-skip, test-rust]
+    needs: [check-skip]
     if: needs.check-skip.outputs.should_skip == 'false'
     env:
       RUST_TOOLCHAIN: stable
@@ -91,11 +93,14 @@ jobs:
       - name: Build and validate Rust package
         run: just build --lang rust
 
-  # Validate PyPI packages build correctly with proper metadata
+  # Validate PyPI packages build correctly with proper metadata.
+  # Gated on delay-python (not test-python) so it runs in parallel with
+  # test-python while still respecting the runner-claim stagger that keeps
+  # Rust jobs ahead of Python jobs in the runner queue.
   validate-python-package:
     runs-on: ubuntu-latest
-    needs: [check-skip, test-python]
-    if: needs.check-skip.outputs.should_skip == 'false'
+    needs: [delay-python]
+    if: needs.delay-python.result == 'success'
     env:
       RUST_TOOLCHAIN: stable
     steps:
@@ -190,8 +195,13 @@ jobs:
     name: ci-success
     runs-on: ubuntu-latest
     if: always()
+    # Include the gating jobs (check-skip, delay-python) so their failure is
+    # caught directly. Otherwise a failed gate would only cascade into skipped
+    # downstream jobs, which this check tolerates, yielding a false green.
     needs:
+      - check-skip
       - test-rust
+      - delay-python
       - test-python
       - test-examples
       - validate-rust-package

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -216,6 +216,18 @@ jobs:
           path: docs/figures/
           key: network-example-figures-${{ github.run_id }}
 
+      # Text-output analogue of the figures cache above. NETWORK-flagged
+      # examples (first_script, clients_celestrak, ...) only run here, so this
+      # is the only producer of their captured stdout. Persist docs/outputs so
+      # the docs deploys (update_docs.yml, docs_only.yml), whose own --ci-only
+      # example runs skip these examples, can restore and overlay it.
+      - name: Save network example outputs to cache
+        if: ${{ inputs.use_retry }}
+        uses: actions/cache/save@v6.1.0
+        with:
+          path: docs/outputs/
+          key: network-example-outputs-${{ github.run_id }}
+
       - name: Generate documentation plots
         if: ${{ !inputs.use_retry }}
         run: just make-plots

--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -47,6 +47,17 @@ jobs:
           restore-keys: |
             network-example-figures-
 
+      # Captured stdout of the NETWORK-flagged examples, saved by the weekly
+      # --network integration run. Restored BEFORE the doc-outputs artifact
+      # download so the artifact's --ci-only outputs overlay any overlap.
+      - name: Restore network example outputs
+        uses: actions/cache/restore@v6.1.0
+        with:
+          path: docs/outputs/
+          key: network-example-outputs-
+          restore-keys: |
+            network-example-outputs-
+
       - name: Download figures artifact
         uses: actions/download-artifact@v8
         with:

--- a/docs/getting_started/coordinate_transformations.md
+++ b/docs/getting_started/coordinate_transformations.md
@@ -4,7 +4,7 @@ In dynamics we are primarily concerned with the object _state_, which encodes th
 
 ## Keplerian and Cartesian Transformations
 
-We can take a state in Keplerian orbital elements and transform it into Cartesian orbital elements using `state_koe_to_eci`. We can invert this transformation using `state_eci_to_koe` to get back the original Keplerian orbital elements.
+We can take a state in Keplerian orbital elements and transform it into Cartesian orbital elements using [`state_koe_to_eci`](../library_api/coordinates/cartesian.md). We can invert this transformation using [`state_eci_to_koe`](../library_api/coordinates/cartesian.md) to get back the original Keplerian orbital elements.
 
 === "Python"
 
@@ -32,7 +32,7 @@ We can take a state in Keplerian orbital elements and transform it into Cartesia
 
 ## Cartesian to Geodetic
 
-Similarly we can convert from a Cartesian state in ECEF to geodetic coordinates (longitude, latitude, altitude) using `state_ecef_to_geodetic`.
+Similarly we can convert from a Cartesian position in ECEF to geodetic coordinates (longitude, latitude, altitude) using [`position_ecef_to_geodetic`](../library_api/coordinates/geodetic.md).
 
 === "Python"
 
@@ -56,3 +56,11 @@ Similarly we can convert from a Cartesian state in ECEF to geodetic coordinates 
         ```
         --8<-- "./docs/outputs/getting_started/coordinates_cartesian_geodetic.rs.txt"
         ```
+
+## See Also
+
+- [Cartesian Coordinates API Reference](../library_api/coordinates/cartesian.md)
+- [Geodetic Coordinates API Reference](../library_api/coordinates/geodetic.md)
+- [Cartesian Transformations (Learn)](../learn/coordinates/cartesian_transformations.md)
+- [Geodetic Transformations (Learn)](../learn/coordinates/geodetic_transformations.md)
+- [Coordinates User Guide](../learn/coordinates/index.md)

--- a/docs/getting_started/frame_transformations.md
+++ b/docs/getting_started/frame_transformations.md
@@ -7,7 +7,7 @@ Brahe provides functions for transforming between different reference frames.
 
 ## Earth-Centered Inertial (ECI) and Earth-Centered Earth-Fixed (ECEF) Transformations
 
-We can transform from ECI to ECEF using `state_eci_to_ecef`, which properly accounts for Earth's precession, nutation, sidereal rotation, and polar motion.
+We can transform from ECI to ECEF using [`state_eci_to_ecef`](../library_api/frames/eci_ecef.md), which properly accounts for Earth's precession, nutation, sidereal rotation, and polar motion.
 
 === "Python"
 
@@ -31,3 +31,9 @@ We can transform from ECI to ECEF using `state_eci_to_ecef`, which properly acco
         ```
         --8<-- "./docs/outputs/getting_started/frames_eci_ecef.rs.txt"
         ```
+
+## See Also
+
+- [ECI / ECEF Frame API Reference](../library_api/frames/eci_ecef.md)
+- [ECI / ECEF Transformations (Learn)](../learn/frames/eci_ecef.md)
+- [Reference Frames User Guide](../learn/frames/index.md)

--- a/docs/getting_started/managing_external_data.md
+++ b/docs/getting_started/managing_external_data.md
@@ -35,6 +35,15 @@ The age of the data is only checked when the provider is initialized, so if you 
     --8<-- "./examples/getting_started/load_external_data.rs:1"
     ```
 
+???+ example "Output"
+    === "Python"
+        ```
+        --8<-- "./docs/outputs/getting_started/load_external_data.py.txt"
+        ```
+
+    === "Rust"
+        ```
+        --8<-- "./docs/outputs/getting_started/load_external_data.rs.txt"
         ```
 
 ## Other Providers

--- a/docs/getting_started/package_conventions.md
+++ b/docs/getting_started/package_conventions.md
@@ -37,4 +37,10 @@ It is the _responsibility of the user_ to ensure that the inputs to Brahe functi
 
 ## Angle Format
 
-For functions that deal with angular quantities for either inputs or outputs, Brahe provides the `AngleFormat` enum to specify the format of the angles. Given the frequency of working with different angle formats this makes it easy to work with different formats without needing to manually convert before or after calling Brahe functions.
+For functions that deal with angular quantities for either inputs or outputs, Brahe provides the [`AngleFormat`](../library_api/coordinates/enums.md) enum to specify the format of the angles. Given the frequency of working with different angle formats this makes it easy to work with different formats without needing to manually convert before or after calling Brahe functions.
+
+## See Also
+
+- [Coordinate Enums API Reference](../library_api/coordinates/enums.md) — including `AngleFormat`
+- [Units and Constants API Reference](../library_api/constants/units.md)
+- [Coordinates User Guide](../learn/coordinates/index.md)

--- a/docs/getting_started/time.md
+++ b/docs/getting_started/time.md
@@ -6,7 +6,7 @@
 
 Since astrodynamics is the study of the motion of objects in space, time is a fundamental quantity to the package. Unfortunately, time can quickly become a complex topic with many different time systems, formats, and conventions.
 
-Brahe attempts to solve this challenge by providing the `Epoch` class to represent a single instant in time. An `Epoch` can be initialized in a variety of ways, it can be manipulated with simple arithmetic operations, and and it can be compared to other `Epoch` instances. Brahe ensures that all of the complexities of time systems, formats, and conventions are handled internally by the `Epoch` class so that users can work with time in a simple and intuitive way.
+Brahe attempts to solve this challenge by providing the [`Epoch`](../library_api/time/epoch.md) class to represent a single instant in time. An `Epoch` can be initialized in a variety of ways, it can be manipulated with simple arithmetic operations, and and it can be compared to other `Epoch` instances. Brahe ensures that all of the complexities of time systems, formats, and conventions are handled internally by the `Epoch` class so that users can work with time in a simple and intuitive way.
 
 There are more ways to work with Epochs and time than are covered here. Checkout the [Time User Guide](../learn/time/index.md) or the [API Reference](../library_api/time/index.md) for more details and examples of working with time in Brahe.
 
@@ -85,7 +85,7 @@ There are also a variety of ways to output `Epoch` instances as other represenst
 
 ## Time Ranges 
 
-Since it's common to work with time ranges, Brahe provides the `TimeRange` iterator to quickly generate a range of epochs with a specified time step. 
+Since it's common to work with time ranges, Brahe provides the [`TimeRange`](../library_api/time/time_range.md) iterator to quickly generate a range of epochs with a specified time step. 
 
 === "Python"
 
@@ -112,7 +112,7 @@ Since it's common to work with time ranges, Brahe provides the `TimeRange` itera
 
 ## Time Systems
 
-In astrodynamics, we often deal with models and measurements in other time systems (e.g. GPS, TAI, TT, etc.). Brahe provides support for working with different time systems through the `TimeSystem` enum. When creating an `Epoch`, you can specify the time system of the input time, and Brahe will handle the conversion to the internal time system (TAI) for you. Similarly when outputting an `Epoch`, you can specify the desired time system for the output, and Brahe will handle the conversion for you. Comparisons between `Epoch` instances are time-system aware, so you can compare `Epoch` instances in different time systems and Brahe will handle the conversion for you.
+In astrodynamics, we often deal with models and measurements in other time systems (e.g. GPS, TAI, TT, etc.). Brahe provides support for working with different time systems through the [`TimeSystem`](../library_api/time/time_system.md) enum. When creating an `Epoch`, you can specify the time system of the input time, and Brahe will handle the conversion to the internal time system (TAI) for you. Similarly when outputting an `Epoch`, you can specify the desired time system for the output, and Brahe will handle the conversion for you. Comparisons between `Epoch` instances are time-system aware, so you can compare `Epoch` instances in different time systems and Brahe will handle the conversion for you.
 
 === "Python"
 
@@ -136,3 +136,12 @@ In astrodynamics, we often deal with models and measurements in other time syste
         ```
         --8<-- "./docs/outputs/getting_started/epoch_time_systems.rs.txt"
         ```
+
+## See Also
+
+- [Epoch API Reference](../library_api/time/epoch.md)
+- [TimeRange API Reference](../library_api/time/time_range.md)
+- [TimeSystem API Reference](../library_api/time/time_system.md)
+- [Epoch (Learn)](../learn/time/epoch.md)
+- [Time Ranges (Learn)](../learn/time/time_range.md)
+- [Time User Guide](../learn/time/index.md)

--- a/examples/examples/star_field_simulation.py
+++ b/examples/examples/star_field_simulation.py
@@ -52,6 +52,15 @@ n_frames = positions.shape[0]
 
 # The sensor boresight points along the velocity vector (along-track)
 boresights = velocities / np.linalg.norm(velocities, axis=1, keepdims=True)
+
+# Roll reference for the sensor frame: the orbit normal (r x v). It is
+# perpendicular to the boresight everywhere on the orbit, so using it as the
+# sensor "up" direction gives an (u, v) basis that rotates continuously as the
+# boresight sweeps around the orbit -- with no singularity or sign flip at the
+# plane crossings. This keeps every star moving in one consistent direction in
+# the sensor view over the full orbital period.
+orbit_normals = np.cross(positions, velocities)
+orbit_normals /= np.linalg.norm(orbit_normals, axis=1, keepdims=True)
 # --8<-- [end:scenario]
 
 # --8<-- [start:catalog]
@@ -93,27 +102,30 @@ star_shell_radius_km = STAR_SHELL_RADIUS * 1e-3
 
 
 # --8<-- [start:cone]
-def boresight_basis(boresight):
+def boresight_basis(boresight, up_reference):
     """Build an orthonormal (u, v) basis spanning the plane perpendicular
     to the boresight direction.
+
+    ``v`` is aligned with ``up_reference`` (its component perpendicular to the
+    boresight) and ``u`` completes the right-handed frame. Passing the orbit
+    normal as ``up_reference`` -- which stays perpendicular to a velocity-aligned
+    boresight over the whole orbit -- makes the basis vary continuously as the
+    boresight sweeps around, so the projected star field never flips direction.
     """
-    reference = np.array([0.0, 0.0, 1.0])
-    if abs(np.dot(reference, boresight)) > 0.9:
-        reference = np.array([0.0, 1.0, 0.0])
-    u = np.cross(boresight, reference)
-    u /= np.linalg.norm(u)
-    v = np.cross(boresight, u)
+    v = up_reference - np.dot(up_reference, boresight) * boresight
+    v /= np.linalg.norm(v)
+    u = np.cross(v, boresight)
     return u, v
 
 
-def fov_cone_mesh(apex, boresight, length, half_angle_deg, n_segments):
+def fov_cone_mesh(apex, boresight, up_reference, length, half_angle_deg, n_segments):
     """Build FOV cone mesh vertices and triangle faces for `go.Mesh3d`.
 
     The cone apex sits at the satellite position and its axis is aligned
     with the boresight direction; vertex 0 is the apex and vertices
     1..n_segments form the base circle.
     """
-    u, v = boresight_basis(boresight)
+    u, v = boresight_basis(boresight, up_reference)
 
     radius = length * np.tan(np.radians(half_angle_deg))
     theta = np.linspace(0.0, 2 * np.pi, n_segments, endpoint=False)
@@ -141,19 +153,23 @@ def marker_sizes(vmags):
 
 
 # --8<-- [start:sensor_frame]
-def sensor_frame_angles(star_unit_vectors, boresight):
+def sensor_frame_angles(star_unit_vectors, boresight, up_reference):
     """Project star unit vectors into boresight-relative angular offsets.
 
     Decomposes each star's angular separation from the boresight into a
     cross-boresight (x) and an "elevation-like" (y) component, both in
-    degrees, using the same (u, v) basis as the FOV cone. A constant
-    angular separation from the boresight (the FOV boundary) is therefore
-    an exact circle of that radius in (x, y).
+    degrees, using the same (u, v) basis as the FOV cone. The orbit-normal
+    axis maps to x and the in-orbit-plane axis to y, so the along-track sweep
+    of the boresight scrolls the star field along the elevation axis rather
+    than sideways. A constant angular separation from the boresight (the FOV
+    boundary) is therefore an exact circle of that radius in (x, y).
     """
-    u, v = boresight_basis(boresight)
+    u, v = boresight_basis(boresight, up_reference)
     cos_theta = np.clip(star_unit_vectors @ boresight, -1.0, 1.0)
     theta_deg = np.degrees(np.arccos(cos_theta))
-    phi = np.arctan2(star_unit_vectors @ v, star_unit_vectors @ u)
+    # v is the orbit normal (-> x, cross-boresight); u lies in the orbit plane
+    # (-> y, elevation-like), which is the direction the boresight sweeps.
+    phi = np.arctan2(star_unit_vectors @ u, star_unit_vectors @ v)
     return theta_deg * np.cos(phi), theta_deg * np.sin(phi)
 
 
@@ -277,7 +293,12 @@ def create_figure(theme):
 
     # Trace 3: FOV cone (animated)
     cone_vertices, cone_i, cone_j, cone_k = fov_cone_mesh(
-        positions_km[0], boresights[0], cone_length_km, HALF_ANGLE_DEG, CONE_SEGMENTS
+        positions_km[0],
+        boresights[0],
+        orbit_normals[0],
+        cone_length_km,
+        HALF_ANGLE_DEG,
+        CONE_SEGMENTS,
     )
     fig.add_trace(
         go.Mesh3d(
@@ -321,6 +342,7 @@ def create_figure(theme):
         cone_vertices, cone_i, cone_j, cone_k = fov_cone_mesh(
             positions_km[k],
             boresights[k],
+            orbit_normals[k],
             cone_length_km,
             HALF_ANGLE_DEG,
             CONE_SEGMENTS,
@@ -402,13 +424,24 @@ def create_sensor_view_figure(theme):
         )
     )
 
-    # Trace 1: visible stars (animated)
+    # Trace 1: visible stars (animated). The orbit-normal roll reference in
+    # sensor_frame_angles keeps the (u, v) basis continuous over the orbit, so
+    # each star drifts smoothly and consistently frame-to-frame; stars only
+    # appear/disappear as they cross the field-of-view boundary.
+    # Each star carries a stable catalog-index id. Plotly matches points across
+    # frames by id (object constancy), so a star that stays in view glides to
+    # its new position while stars crossing the field-of-view boundary fade in
+    # and out -- rather than markers being reassigned by list position when the
+    # visible-star count changes, which makes unrelated stars appear to jump.
     frame0_idx = np.nonzero(visible_mask[:, 0])[0]
-    x0, y0 = sensor_frame_angles(star_unit_vectors[frame0_idx], boresights[0])
+    x0, y0 = sensor_frame_angles(
+        star_unit_vectors[frame0_idx], boresights[0], orbit_normals[0]
+    )
     fig.add_trace(
         go.Scatter(
             x=x0,
             y=y0,
+            ids=[str(i) for i in frame0_idx],
             mode="markers",
             marker=dict(
                 size=marker_sizes(star_vmags[frame0_idx]),
@@ -424,7 +457,9 @@ def create_sensor_view_figure(theme):
     frames = []
     for k in range(n_frames):
         idx = np.nonzero(visible_mask[:, k])[0]
-        x_k, y_k = sensor_frame_angles(star_unit_vectors[idx], boresights[k])
+        x_k, y_k = sensor_frame_angles(
+            star_unit_vectors[idx], boresights[k], orbit_normals[k]
+        )
         frames.append(
             go.Frame(
                 name=str(k),
@@ -433,6 +468,7 @@ def create_sensor_view_figure(theme):
                     go.Scatter(
                         x=x_k,
                         y=y_k,
+                        ids=[str(i) for i in idx],
                         marker=dict(size=marker_sizes(star_vmags[idx])),
                         text=[star_names[i] for i in idx],
                     )

--- a/examples/getting_started/load_external_data.rs
+++ b/examples/getting_started/load_external_data.rs
@@ -6,5 +6,9 @@ fn main() {
     // data if the local data is more than 7 days old. Only updates on initialization.
     bh::initialize_eop().unwrap();
     bh::initialize_sw().unwrap();
+
+    // Print last date of data
+    println!("EOP data available through: {}", bh::Epoch::from_mjd(bh::get_global_eop_mjd_max(), bh::TimeSystem::UTC));
+    println!("SW data available through: {}", bh::Epoch::from_mjd(bh::get_global_sw_mjd_max(), bh::TimeSystem::UTC));
 }
 

--- a/examples/getting_started/other_data_providers.py
+++ b/examples/getting_started/other_data_providers.py
@@ -20,6 +20,12 @@ bh.set_global_eop_provider(static_provider)
 default_file_provider = bh.FileEOPProvider.from_default_standard(True, "Hold")
 bh.set_global_eop_provider(default_file_provider)
 
+# The bundled standard product covers a fixed date range (no network required)
+print(
+    "Bundled standard EOP data available through:",
+    bh.Epoch(bh.get_global_eop_mjd_max()),
+)
+
 # There are also functions to explicitly download a specific file and and load it from a file
 # Uncomment these lines to try them out
 # eop_path = "eop_c04.txt"

--- a/examples/getting_started/other_data_providers.rs
+++ b/examples/getting_started/other_data_providers.rs
@@ -19,6 +19,9 @@ fn main() {
     let default_file_provider = bh::FileEOPProvider::from_default_standard(true, bh::EOPExtrapolation::Hold).unwrap();
     bh::set_global_eop_provider(default_file_provider);
 
+    // The bundled standard product covers a fixed date range (no network required)
+    println!("Bundled standard EOP data available through: {}", bh::Epoch::from_mjd(bh::get_global_eop_mjd_max(), bh::TimeSystem::UTC));
+
     // There are also functions to explicitly download a specific file and and load it from a file
     // Uncomment these lines to try them out
     // let eop_path = "eop_c04.txt";


### PR DESCRIPTION
## Description

Final polish pass ahead of the next release, bundling four independent fixes across the getting-started documentation and the example pipeline: restoring missing example output on three getting-started pages, running the CI package-validation jobs in parallel with the test suites, fixing the star-field sensor animation, and cross-linking getting-started function references to the API and Learn docs.

## Changelog

### Changed
- Crates.io and PyPI package-validation CI jobs now run in parallel with the Rust and Python test suites instead of waiting for them to finish
- Getting-started documentation now links function and class references to their corresponding library API and Learn pages

### Fixed
- Captured output of the NETWORK-flagged getting-started examples (first script, Celestrak client) now reaches the deployed docs through a network-example-outputs cache, and the offline external-data examples emit output, so the affected pages no longer render empty output blocks
- Star-field sensor view no longer flips direction at orbital plane crossings by using the orbit normal as a continuous roll reference, scrolls the star field along the elevation axis, and preserves per-star identity so markers fade in and out instead of jumping when the visible-star count changes
- ci-success aggregation now includes the check-skip and delay-python gating jobs so a failed gate cannot be reported as a passing run

## Note to Reviewers
- The first-script and Celestrak example output blocks are populated from the network-example-outputs cache saved by the weekly/release integration run; on a cold cache they render empty until the first integration run repopulates it
