### PR TITLE
Fix missing docs figures for network examples

### DIFF
--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -250,6 +250,32 @@ jobs:
           path: docs/outputs/
           key: network-example-outputs-${{ github.run_id }}
 
+      # Same-run hand-off of the NETWORK-flagged examples' figures/outputs to
+      # the docs deploy. release.yml runs this --network job (via
+      # integration_tests.yml) and update_docs.yml in the SAME run, so
+      # update_docs can download these artifacts directly - more reliable than
+      # the caches above, whose per-run reservation collides when release.yml
+      # invokes test_examples.yml twice concurrently (--ci-only and --network),
+      # leaving the release deploy with no network figures. The caches remain
+      # the cross-run fallback for docs deploys (docs_only.yml, main pushes)
+      # that do not run this job in the same run. Distinct artifact names from
+      # the --ci-only path's doc-figures/doc-outputs so the two never collide.
+      - name: Upload network example figures as artifact
+        if: ${{ inputs.use_retry }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: network-doc-figures
+          path: docs/figures/
+          retention-days: 7
+
+      - name: Upload network example outputs as artifact
+        if: ${{ inputs.use_retry }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: network-doc-outputs
+          path: docs/outputs/
+          retention-days: 7
+
       - name: Generate documentation plots
         if: ${{ !inputs.use_retry }}
         run: just make-plots

--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -58,6 +58,31 @@ jobs:
           restore-keys: |
             network-example-outputs-
 
+      # Same-run artifact hand-off from the --network integration-examples job,
+      # which release.yml runs in THIS run. More reliable than the caches above,
+      # whose per-run reservation the release run cannot dependably populate.
+      # Downloaded AFTER the cache restore so the fresher in-run figures win.
+      #
+      # Tolerated ONLY on non-release deploys (version == ''): main-push deploys
+      # from unit_tests.yml have no network producer in-run and must fall back
+      # to the restored caches. On a versioned release the producer job is
+      # guaranteed to have run in this same run, so a missing/failed download is
+      # a real hand-off failure - fail loud rather than silently publishing docs
+      # with the NETWORK examples' figures missing (the original v1.7.0 bug).
+      - name: Download network example figures artifact
+        continue-on-error: ${{ inputs.version == '' }}
+        uses: actions/download-artifact@v8
+        with:
+          name: network-doc-figures
+          path: docs/figures/
+
+      - name: Download network example outputs artifact
+        continue-on-error: ${{ inputs.version == '' }}
+        uses: actions/download-artifact@v8
+        with:
+          name: network-doc-outputs
+          path: docs/outputs/
+
       - name: Download figures artifact
         uses: actions/download-artifact@v8
         with:

--- a/docs/getting_started/first_script.md
+++ b/docs/getting_started/first_script.md
@@ -64,7 +64,7 @@ To do this, add the following code to your script after the preamble:
 === "Rust"
 
     ``` rust
-    --8<-- "./examples/getting_started/first_script.rs:1"
+    --8<-- "./examples/getting_started/first_script.rs:4"
     ```
 
     Save this file as `first_script.rs` and you can run it with:

--- a/docs/getting_started/first_script.md
+++ b/docs/getting_started/first_script.md
@@ -64,7 +64,7 @@ To do this, add the following code to your script after the preamble:
 === "Rust"
 
     ``` rust
-    --8<-- "./examples/getting_started/first_script.rs:4"
+    --8<-- "./examples/getting_started/first_script.rs:3"
     ```
 
     Save this file as `first_script.rs` and you can run it with:

--- a/docs/getting_started/satellite_data_sources.md
+++ b/docs/getting_started/satellite_data_sources.md
@@ -20,7 +20,7 @@ The celestrack client
 === "Rust"
 
     ``` rust
-    --8<-- "./examples/getting_started/clients_celestrak.rs:1"
+    --8<-- "./examples/getting_started/clients_celestrak.rs:3"
     ```
 
 ???+ example "Output"

--- a/examples/getting_started/clients_celestrak.rs
+++ b/examples/getting_started/clients_celestrak.rs
@@ -1,5 +1,6 @@
 //! FLAGS = ["NETWORK"]
 
+#![allow(unused_imports)]
 use brahe as bh;
 use brahe::traits::SStatePropagator;
 

--- a/examples/getting_started/clients_spacetrack.rs
+++ b/examples/getting_started/clients_spacetrack.rs
@@ -1,4 +1,5 @@
 // FLAGS = ["MANUAL"]
+#![allow(unused_imports)]
 use brahe as bh;
 use bh::spacetrack::{RequestClass, SortOrder, SpaceTrackClient, SpaceTrackQuery};
 use brahe::traits::SStatePropagator;

--- a/examples/getting_started/coordinates_cartesian_geodetic.rs
+++ b/examples/getting_started/coordinates_cartesian_geodetic.rs
@@ -1,3 +1,4 @@
+#![allow(unused_imports)]
 use brahe as bh;
 use nalgebra as na;
 

--- a/examples/getting_started/coordinates_keplerian_cartesian.rs
+++ b/examples/getting_started/coordinates_keplerian_cartesian.rs
@@ -1,3 +1,4 @@
+#![allow(unused_imports)]
 use brahe as bh;
 use nalgebra as na;
 

--- a/examples/getting_started/epoch_initialization.rs
+++ b/examples/getting_started/epoch_initialization.rs
@@ -1,4 +1,4 @@
-#[allow(unused_imports)]
+#![allow(unused_imports)]
 use brahe as bh;
 
 fn main() {

--- a/examples/getting_started/epoch_operations.rs
+++ b/examples/getting_started/epoch_operations.rs
@@ -1,4 +1,4 @@
-#[allow(unused_imports)]
+#![allow(unused_imports)]
 use brahe as bh;
 
 fn main() {

--- a/examples/getting_started/epoch_output.rs
+++ b/examples/getting_started/epoch_output.rs
@@ -1,4 +1,4 @@
-#[allow(unused_imports)]
+#![allow(unused_imports)]
 use brahe as bh;
 
 fn main() {

--- a/examples/getting_started/epoch_range.rs
+++ b/examples/getting_started/epoch_range.rs
@@ -1,4 +1,4 @@
-#[allow(unused_imports)]
+#![allow(unused_imports)]
 use brahe as bh;
 
 fn main() {

--- a/examples/getting_started/epoch_time_systems.rs
+++ b/examples/getting_started/epoch_time_systems.rs
@@ -1,4 +1,4 @@
-#[allow(unused_imports)]
+#![allow(unused_imports)]
 use brahe as bh;
 
 fn main() {

--- a/examples/getting_started/first_script.rs
+++ b/examples/getting_started/first_script.rs
@@ -1,6 +1,6 @@
 //! FLAGS = ["NETWORK"]
 
-#[allow(unused_imports)]
+#![allow(unused_imports)]
 use brahe as bh;
 use brahe::utils::Identifiable;
 

--- a/examples/getting_started/frames_eci_ecef.rs
+++ b/examples/getting_started/frames_eci_ecef.rs
@@ -1,3 +1,4 @@
+#![allow(unused_imports)]
 use brahe as bh;
 use nalgebra as na;
 

--- a/examples/getting_started/load_external_data.rs
+++ b/examples/getting_started/load_external_data.rs
@@ -1,4 +1,4 @@
-#[allow(unused_imports)]
+#![allow(unused_imports)]
 use brahe as bh;
 
 fn main() {

--- a/examples/getting_started/orbits_apogee_perigee.rs
+++ b/examples/getting_started/orbits_apogee_perigee.rs
@@ -1,3 +1,4 @@
+#![allow(unused_imports)]
 use brahe as bh;
 use nalgebra as na;
 

--- a/examples/getting_started/orbits_period.rs
+++ b/examples/getting_started/orbits_period.rs
@@ -1,3 +1,4 @@
+#![allow(unused_imports)]
 use brahe as bh;
 use nalgebra as na;
 

--- a/examples/getting_started/orbits_ssi.rs
+++ b/examples/getting_started/orbits_ssi.rs
@@ -1,3 +1,4 @@
+#![allow(unused_imports)]
 use brahe as bh;
 
 fn main() {

--- a/examples/getting_started/other_data_providers.rs
+++ b/examples/getting_started/other_data_providers.rs
@@ -1,4 +1,4 @@
-#[allow(unused_imports)]
+#![allow(unused_imports)]
 use brahe as bh;
 
 fn main() {

--- a/examples/getting_started/propagation_numerical.rs
+++ b/examples/getting_started/propagation_numerical.rs
@@ -1,3 +1,4 @@
+#![allow(unused_imports)]
 use brahe as bh;
 use bh::traits::DStatePropagator;
 use nalgebra as na;

--- a/examples/getting_started/vector_types.rs
+++ b/examples/getting_started/vector_types.rs
@@ -1,4 +1,4 @@
-#[allow(unused_imports)]
+#![allow(unused_imports)]
 use brahe as bh;
 use nalgebra as na;
 


### PR DESCRIPTION
## Description

This PR groups three v1.7.0 documentation fixes.

Missing figures/tables/output: the 7 `NETWORK`-flagged doc examples (`max_communications_gap`, `ground_contacts`, `imaging_data_latency`, `starlink_propagation`, `doppler_compensation`, `imaging_opportunities`, `tessellation_visualization`) plus the `first_script` getting-started example had their figures, CSV tables, and captured text output 404 on the deployed v1.7.0 site. Their `docs/figures/*` and `docs/outputs/*` are gitignored, and the docs deploy's own `--ci-only` example run skips them, so their outputs must be carried in from the `--network` run. That transport relied solely on an actions cache keyed by `github.run_id`, which `release.yml` cannot reliably populate because it invokes `test_examples.yml` twice concurrently in one run (`--ci-only` and `--network`): the `--network` cache save lost its key reservation, no prior weekly main-scoped cache existed, and `update-docs` restored nothing. Both cache save and restore are non-fatal, so the release published incomplete docs with no failed step. This adds a same-run artifact hand-off (`network-doc-figures` / `network-doc-outputs`) uploaded by the `--network` job and downloaded by `update-docs`, layered over the retained cache fallback; the download is tolerated only on non-release deploys so a versioned release fails loud rather than silently shipping missing figures.

Rust example snippets: the getting-started Rust snippets either hid the `#[allow(unused_imports)]` attribute or lacked it entirely, so a reader copying a block could hit an unused-import error (the example runner compiles with `-D warnings`). Every getting-started Rust example is normalized to a crate-level `#![allow(unused_imports)]` placed after any `FLAGS` directive, with each snippet include offset set to render that attribute as the first line while still hiding the internal `FLAGS` comment. All non-network getting-started Rust examples were verified to run under `rust-script` with `-D warnings`.

## Changelog

### Fixed
- Fixed missing figures, CSV tables, and text output on the deployed documentation site for the `NETWORK`-flagged examples by adding a same-run artifact hand-off from the `--network` example run to the docs deploy, with releases now failing loud if the hand-off is absent instead of publishing incomplete docs.
- Fixed getting-started Rust example snippets that exposed the internal `FLAGS` directive or omitted the `#![allow(unused_imports)]` attribute needed to compile a copied block, normalizing all of them to show a crate-level allow attribute and hide the runner directive.

## Note to Reviewers
The CI change was reviewed with Codex (structural checks all passed). The Rust-snippet change was verified by rebuilding the docs (0 griffe warnings) and running all non-network getting-started Rust examples through `rust-script` with `-D warnings`. This repairs future deploys only; the live v1.7.0 site remains broken until a redeploy runs with the network outputs present (dispatch `integration_tests.yml` on `main` to populate the cache/artifacts, then re-trigger a docs deploy).