### PR TITLE
Fix warm-cache job and isolate step failures

### DIFF
--- a/.github/brahe-data-manifest.txt
+++ b/.github/brahe-data-manifest.txt
@@ -10,5 +10,8 @@ mar099s
 # ICGEM gravity models (icgem:<body>:<model name>):
 icgem:moon:GRGM660PRIM
 icgem:mars:ggm2bc80
-# Horizons SPK (Ceres, for the dawn_ceres_orbit example):
-horizons:ceres:2015-12-01:2016-03-01
+# Horizons SPK (Ceres, for the dawn_ceres_orbit example). The body name is the
+# SBDB search string and is hashed verbatim into the SBDB cache key, so it must
+# match the example's lookup exactly ("Ceres", not "ceres") or the example
+# repeats the lookup against a different cache entry:
+horizons:Ceres:2015-12-01:2016-03-01

--- a/.github/workflows/warm_data_cache.yml
+++ b/.github/workflows/warm_data_cache.yml
@@ -131,16 +131,19 @@ jobs:
                         exit 1
                     fi
 
-            # Both saves run only on a key miss and only after their warm step
-            # succeeded, because a cache entry cannot be rewritten under a key
-            # that already exists. Saving a partial warm would make that key an
-            # exact hit on every later run, skipping this save and stranding
-            # the missing artifact indefinitely - the failure mode already
-            # documented for naif-kernels-v1 in test_examples.yml. Skipping the
-            # save instead leaves a plain miss that the next run retries in
-            # full, and costs consumers nothing meanwhile: every workflow that
-            # reads these caches falls back through `restore-keys:
-            # brahe-data-v1-` to the previous entry.
+            # Both saves run only on a key miss and only after their own warm
+            # step succeeded, because a cache entry cannot be rewritten under a
+            # key that already exists: saving a partial warm would make that
+            # key an exact hit on every later run, skipping this save and
+            # stranding the missing artifact indefinitely - the failure mode
+            # already documented for naif-kernels-v1 in test_examples.yml.
+            # Skipping the save leaves a plain miss the next run retries in
+            # full. For the manifest cache that costs consumers nothing
+            # meanwhile, since every workflow reading it falls back through
+            # `restore-keys: brahe-data-v1-` to the previous entry; the fixed
+            # star-catalogs-v1 key has no such fallback, so a skipped save
+            # there does mean a week of live downloads - still cheaper than
+            # stranding a catalog on a key that can never be rewritten.
             -   name: Save brahe data cache
                 if: ${{ !cancelled() && steps.brahe-data-cache.outputs.cache-hit != 'true' && steps.warm-data-cache.outcome == 'success' }}
                 uses: actions/cache/save@v6.1.0

--- a/.github/workflows/warm_data_cache.yml
+++ b/.github/workflows/warm_data_cache.yml
@@ -13,8 +13,8 @@ name: Warm Brahe Data Cache
 # separately (star-catalogs-v1, fixed) since it isn't manifest-driven.
 #
 # Every step is guarded so that a single failure — an unreachable mirror, a
-# flaky cache action — neither skips the remaining warming work nor discards
-# what already succeeded. See the comments on the steps themselves.
+# flaky cache action — does not skip the remaining warming work. See the
+# comments on the steps themselves.
 on:
     schedule:
         - cron: "0 6 * * 1"
@@ -51,11 +51,12 @@ jobs:
                 run: uv python install 3.14
 
             # Split into restore + explicit save (rather than actions/cache)
-            # because actions/cache declares `post-if: success()`: on a job
-            # that ends in failure its save post-step is skipped entirely and
-            # nothing is persisted, discarding every artifact the surviving
-            # steps did warm. The paired save steps at the end of the job are
-            # guarded with `!cancelled()` instead, so a partial warm persists.
+            # because actions/cache declares `post-if: success()`, which ties
+            # both saves to the whole job succeeding: a star catalog that
+            # failed to download would also block the unrelated manifest cache
+            # from being written. The paired save steps at the end of the job
+            # are gated on their own warm step instead, so the two caches
+            # persist independently.
             -   name: Restore brahe data cache (kernels, gravity models)
                 id: brahe-data-cache
                 if: ${{ !cancelled() }}
@@ -88,6 +89,7 @@ jobs:
                 run: uv pip install -e ".[all]"
 
             -   name: Warm data cache (re-download anything evicted)
+                id: warm-data-cache
                 if: ${{ !cancelled() }}
                 run: uv run --frozen python scripts/warm_data_cache.py
 
@@ -129,28 +131,23 @@ jobs:
                         exit 1
                     fi
 
-            # Both saves run only on a key miss, mirroring what actions/cache's
-            # own post-step would do. They differ in how much failure they
-            # tolerate, because their keys behave differently.
-            #
-            # The manifest-hash key rotates whenever the manifest changes, so
-            # saving a partial warm here is worth it: the artifacts that did
-            # download persist, and consumers re-download only the rest. The
-            # partial cache is an exact hit next week (so the gap is not
-            # re-saved) until the next manifest change moves the key.
+            # Both saves run only on a key miss and only after their warm step
+            # succeeded, because a cache entry cannot be rewritten under a key
+            # that already exists. Saving a partial warm would make that key an
+            # exact hit on every later run, skipping this save and stranding
+            # the missing artifact indefinitely - the failure mode already
+            # documented for naif-kernels-v1 in test_examples.yml. Skipping the
+            # save instead leaves a plain miss that the next run retries in
+            # full, and costs consumers nothing meanwhile: every workflow that
+            # reads these caches falls back through `restore-keys:
+            # brahe-data-v1-` to the previous entry.
             -   name: Save brahe data cache
-                if: ${{ !cancelled() && steps.brahe-data-cache.outputs.cache-hit != 'true' }}
+                if: ${{ !cancelled() && steps.brahe-data-cache.outputs.cache-hit != 'true' && steps.warm-data-cache.outcome == 'success' }}
                 uses: actions/cache/save@v6.1.0
                 with:
                     path: ~/.cache/brahe
                     key: brahe-data-v1-${{ hashFiles('.github/brahe-data-manifest.txt') }}
 
-            # star-catalogs-v1 is a fixed key that never rotates, so a partial
-            # save here would be permanent: the incomplete set would be an
-            # exact hit on every later run, skipping this save forever and
-            # leaving the missing catalog to be re-downloaded by every
-            # consumer. Saving only a complete pair keeps a failed week a
-            # plain miss, which the next run retries in full.
             -   name: Save star catalog downloads
                 if: ${{ !cancelled() && steps.star-catalogs-cache.outputs.cache-hit != 'true' && steps.warm-star-catalogs.outcome == 'success' }}
                 uses: actions/cache/save@v6.1.0

--- a/.github/workflows/warm_data_cache.yml
+++ b/.github/workflows/warm_data_cache.yml
@@ -4,13 +4,17 @@ name: Warm Brahe Data Cache
 # star catalogs) from being evicted by GitHub's 7-day "not accessed" cache
 # eviction policy. The manifest only changes when new artifacts are added to
 # the brahe-data-manifest.txt (which is rare), so most weeks this run
-# restores an exact cache-key hit and does nothing else: actions/cache only
-# *saves* on a cache-key miss, but a restore still counts as an access and
+# restores an exact cache-key hit and does nothing else: the save steps run
+# only on a cache-key miss, but a restore still counts as an access and
 # resets the 7-day idle-eviction clock — so a restore-only run is sufficient
 # to keep the cache alive for test_python.yml and integration_tests.yml. If
 # the manifest ever changes, this run also downloads the new/changed
 # artifacts and saves them under the new key. The star catalog cache is keyed
 # separately (star-catalogs-v1, fixed) since it isn't manifest-driven.
+#
+# Every step is guarded so that a single failure — an unreachable mirror, a
+# flaky cache action — neither skips the remaining warming work nor discards
+# what already succeeded. See the comments on the steps themselves.
 on:
     schedule:
         - cron: "0 6 * * 1"
@@ -22,21 +26,40 @@ jobs:
         steps:
             -   uses: actions/checkout@v7.0.1
 
+            # Every step below carries `if: ${{ !cancelled() }}` so one failure
+            # never skips the remaining warming work. A step's default
+            # condition is `success()`, which GitHub defines as "none of the
+            # *previous* steps have failed" - job-wide and sticky, so a single
+            # failed step (a flaky cache action, an unreachable mirror) would
+            # otherwise skip every step after it and the run would warm and
+            # save nothing. The job still reports failure - each step either
+            # does its work or fails on its own.
             -   name: Set up Rust toolchain
+                if: ${{ !cancelled() }}
                 uses: actions-rust-lang/setup-rust-toolchain@v1.17.0
                 with:
                     toolchain: stable
 
             -   name: Install the latest version of uv
+                if: ${{ !cancelled() }}
                 uses: astral-sh/setup-uv@v8.3.2
                 with:
                     enable-cache: true
 
             -   name: Install Python 3.14
+                if: ${{ !cancelled() }}
                 run: uv python install 3.14
 
-            -   name: Cache brahe data (kernels, gravity models)
-                uses: actions/cache@v6.1.0
+            # Split into restore + explicit save (rather than actions/cache)
+            # because actions/cache declares `post-if: success()`: on a job
+            # that ends in failure its save post-step is skipped entirely and
+            # nothing is persisted, discarding every artifact the surviving
+            # steps did warm. The paired save steps at the end of the job are
+            # guarded with `!cancelled()` instead, so a partial warm persists.
+            -   name: Restore brahe data cache (kernels, gravity models)
+                id: brahe-data-cache
+                if: ${{ !cancelled() }}
+                uses: actions/cache/restore@v6.1.0
                 with:
                     path: ~/.cache/brahe
                     key: brahe-data-v1-${{ hashFiles('.github/brahe-data-manifest.txt') }}
@@ -46,8 +69,10 @@ jobs:
             # FK5 + Hipparcos only. Explicit file paths (not the whole
             # star_catalogs/ dir) so the 526 MB Tycho-2 catalog is never
             # warmed or cached here.
-            -   name: Cache star catalog downloads
-                uses: actions/cache@v6.1.0
+            -   name: Restore star catalog downloads
+                id: star-catalogs-cache
+                if: ${{ !cancelled() }}
+                uses: actions/cache/restore@v6.1.0
                 with:
                     path: |
                         ~/.cache/brahe/star_catalogs/FK5_Catalog.txt
@@ -55,29 +80,85 @@ jobs:
                     key: star-catalogs-v1
 
             -   name: Install dependencies
+                if: ${{ !cancelled() }}
                 run: uv sync --all-extras --frozen
 
             -   name: Build Python extension
+                if: ${{ !cancelled() }}
                 run: uv pip install -e ".[all]"
 
             -   name: Warm data cache (re-download anything evicted)
+                if: ${{ !cancelled() }}
                 run: uv run --frozen python scripts/warm_data_cache.py
 
             # The mirror 403s default curl user agents, hence -A. Skips the
             # download when the file is already cached (restore-only weeks).
+            # This step shares no dependency with the brahe build, so an
+            # evicted catalog is still re-downloaded when the build or the
+            # manifest warm failed. Each catalog is downloaded independently
+            # and failures are reported together at the end, so one
+            # unreachable file does not skip the other.
             -   name: Warm star catalog cache (re-download anything evicted)
+                id: warm-star-catalogs
+                if: ${{ !cancelled() }}
                 run: |
-                    mkdir -p ~/.cache/brahe/star_catalogs
-                    [ -s ~/.cache/brahe/star_catalogs/FK5_Catalog.txt ] || { \
-                        curl -fsSL -A "Mozilla/5.0" \
-                            -o ~/.cache/brahe/star_catalogs/FK5_Catalog.txt.tmp \
-                            https://www.simplespacedata.org/star_catalog/cds/fk5/latest/FK5_Catalog.txt \
-                        && mv ~/.cache/brahe/star_catalogs/FK5_Catalog.txt.tmp ~/.cache/brahe/star_catalogs/FK5_Catalog.txt; }
-                    [ -s ~/.cache/brahe/star_catalogs/Hipparcos_Catalog.txt ] || { \
-                        curl -fsSL -A "Mozilla/5.0" \
-                            -o ~/.cache/brahe/star_catalogs/Hipparcos_Catalog.txt.tmp \
-                            https://www.simplespacedata.org/star_catalog/cds/hipparcos/latest/Hipparcos_Catalog.txt \
-                        && mv ~/.cache/brahe/star_catalogs/Hipparcos_Catalog.txt.tmp ~/.cache/brahe/star_catalogs/Hipparcos_Catalog.txt; }
+                    dir=~/.cache/brahe/star_catalogs
+                    mkdir -p "$dir"
+                    failed=""
+                    warm_catalog() {
+                        name=$1
+                        url=$2
+                        if [ -s "$dir/$name" ]; then
+                            echo "  $name -> cached"
+                        elif curl -fsSL --retry 3 --retry-delay 5 \
+                            -A "Mozilla/5.0" -o "$dir/$name.tmp" "$url" \
+                            && mv "$dir/$name.tmp" "$dir/$name"; then
+                            echo "  $name -> downloaded"
+                        else
+                            rm -f "$dir/$name.tmp"
+                            echo "  $name -> FAILED"
+                            failed="$failed $name"
+                        fi
+                    }
+                    warm_catalog FK5_Catalog.txt \
+                        https://www.simplespacedata.org/star_catalog/cds/fk5/latest/FK5_Catalog.txt
+                    warm_catalog Hipparcos_Catalog.txt \
+                        https://www.simplespacedata.org/star_catalog/cds/hipparcos/latest/Hipparcos_Catalog.txt
+                    if [ -n "$failed" ]; then
+                        echo "Star catalog downloads failed:$failed" >&2
+                        exit 1
+                    fi
+
+            # Both saves run only on a key miss, mirroring what actions/cache's
+            # own post-step would do. They differ in how much failure they
+            # tolerate, because their keys behave differently.
+            #
+            # The manifest-hash key rotates whenever the manifest changes, so
+            # saving a partial warm here is worth it: the artifacts that did
+            # download persist, and consumers re-download only the rest. The
+            # partial cache is an exact hit next week (so the gap is not
+            # re-saved) until the next manifest change moves the key.
+            -   name: Save brahe data cache
+                if: ${{ !cancelled() && steps.brahe-data-cache.outputs.cache-hit != 'true' }}
+                uses: actions/cache/save@v6.1.0
+                with:
+                    path: ~/.cache/brahe
+                    key: brahe-data-v1-${{ hashFiles('.github/brahe-data-manifest.txt') }}
+
+            # star-catalogs-v1 is a fixed key that never rotates, so a partial
+            # save here would be permanent: the incomplete set would be an
+            # exact hit on every later run, skipping this save forever and
+            # leaving the missing catalog to be re-downloaded by every
+            # consumer. Saving only a complete pair keeps a failed week a
+            # plain miss, which the next run retries in full.
+            -   name: Save star catalog downloads
+                if: ${{ !cancelled() && steps.star-catalogs-cache.outputs.cache-hit != 'true' && steps.warm-star-catalogs.outcome == 'success' }}
+                uses: actions/cache/save@v6.1.0
+                with:
+                    path: |
+                        ~/.cache/brahe/star_catalogs/FK5_Catalog.txt
+                        ~/.cache/brahe/star_catalogs/Hipparcos_Catalog.txt
+                    key: star-catalogs-v1
 
     # pr_tests.yml's "validate-rust-package" and "validate-python-package" jobs
     # only ever run on pull requests, so with cache-save-if gated to main (see

--- a/scripts/warm_data_cache.py
+++ b/scripts/warm_data_cache.py
@@ -5,12 +5,28 @@ Reads `.github/brahe-data-manifest.txt` (one artifact per line) and downloads
 each entry via brahe's own caching downloaders, so a warm run is idempotent:
 already-cached artifacts fast-path without hitting the network.
 
-Two manifest line forms are supported:
+Three manifest line forms are supported:
     <kernel-name>              -> brahe.load_spice_kernel(name), which downloads and
                                    caches known DE/PCK/satellite kernel names
                                    via `download_spice_kernel`'s name
                                    resolution.
     icgem:<body>:<model-name>  -> brahe.datasets.icgem.download_model(body, model-name)
+    horizons:<body>:<start>:<stop>
+                               -> brahe.datasets.sbdb resolves <body> to its SPK ID,
+                                   then brahe.datasets.horizons generates and caches
+                                   an SPK spanning the two `YYYY-MM-DD` TDB dates.
+                                   Warms both the SBDB and Horizons caches.
+
+An entry carrying a prefix this script does not recognize is a hard error
+rather than being passed to `load_spice_kernel` as a kernel name, so a new
+manifest form added without a matching handler here fails with a message
+naming the prefix.
+
+Every entry is attempted even when an earlier one fails, so a single evicted
+or unreachable artifact does not prevent the rest of the cache from being
+refreshed. Downloads are retried with a linear backoff, since the upstream
+mirrors (NAIF, ICGEM, SBDB, Horizons) fail transiently more often than they
+fail permanently. The script still exits non-zero when anything failed.
 
 This is the download-only counterpart to `scripts/warm_cartopy.py`: CI
 workflows restore/save `~/.cache/brahe` via `actions/cache`, keyed on the
@@ -19,6 +35,8 @@ workflow) or rely on the test suite's own fixtures to populate the same
 cache (regular test/integration runs).
 """
 
+import sys
+import time
 from pathlib import Path
 
 import brahe as bh
@@ -27,19 +45,31 @@ import brahe.datasets as datasets
 REPO_ROOT = Path(__file__).resolve().parent.parent
 MANIFEST_PATH = REPO_ROOT / ".github" / "brahe-data-manifest.txt"
 
+# Download attempts per entry, and the base delay between them (seconds). The
+# delay scales with the attempt number, matching the `curl --retry 3
+# --retry-delay 5` used for the star catalogs in warm_data_cache.yml.
+ATTEMPTS = 3
+RETRY_DELAY = 5.0
+
 
 def _read_manifest() -> list[str]:
-    lines = MANIFEST_PATH.read_text().splitlines()
-    return [line.strip() for line in lines if line.strip() and not line.startswith("#")]
+    """Read non-blank, non-comment manifest entries.
+
+    Lines are stripped before the comment test so an indented `#` comment is
+    ignored rather than being read as a kernel name.
+    """
+    lines = (line.strip() for line in MANIFEST_PATH.read_text().splitlines())
+    return [line for line in lines if line and not line.startswith("#")]
 
 
-def _warm_entry(entry: str) -> str:
-    """Download one manifest entry, returning a description of what was cached."""
-    if entry.startswith("icgem:"):
-        _, body, model_name = entry.split(":", 2)
-        path = datasets.icgem.download_model(body, model_name)
-        return path
+def _tdb_midnight(date: str) -> bh.Epoch:
+    """Parse a `YYYY-MM-DD` manifest date as midnight TDB."""
+    year, month, day = (int(part) for part in date.split("-"))
+    return bh.Epoch.from_datetime(year, month, day, 0, 0, 0.0, 0.0, bh.TimeSystem.TDB)
 
+
+def _warm_kernel(entry: str) -> str:
+    """Warm a NAIF kernel referenced by name."""
     bh.load_spice_kernel(entry)
     assert entry in bh.loaded_spice_kernels(), (
         f"{entry!r} not in loaded_spice_kernels() after load_spice_kernel()"
@@ -47,13 +77,99 @@ def _warm_entry(entry: str) -> str:
     return "loaded"
 
 
+def _warm_icgem(spec: str) -> str:
+    """Warm an ICGEM gravity model from a `<body>:<model-name>` spec."""
+    body, model_name = spec.split(":", 1)
+    return datasets.icgem.download_model(body, model_name)
+
+
+def _warm_horizons(spec: str) -> str:
+    """Warm an SBDB lookup and Horizons SPK from a `<body>:<start>:<stop>` spec.
+
+    The request is built exactly as `examples/examples/dawn_ceres_orbit.py`
+    builds it - SPK ID from SBDB, midnight-TDB bounds - because the Horizons
+    cache key hashes the command, span, and center, so any difference here
+    would cache a second kernel the example never reads. The SBDB cache key
+    hashes the search string verbatim, so `<body>` must also match the
+    example's spelling for the lookup itself to be warmed.
+    """
+    body, start, stop = spec.split(":", 2)
+    spkid = datasets.sbdb.SBDBClient().lookup(body).naif_id()
+    request = datasets.horizons.HorizonsSPKRequest.for_spkid(
+        spkid, _tdb_midnight(start), _tdb_midnight(stop)
+    )
+    return datasets.horizons.HorizonsClient().get_spk(request).path
+
+
+_PREFIX_HANDLERS = {
+    "icgem": _warm_icgem,
+    "horizons": _warm_horizons,
+}
+
+
+def _warm_entry(entry: str) -> str:
+    """Download one manifest entry, returning a description of what was cached."""
+    prefix, separator, spec = entry.partition(":")
+    if not separator:
+        return _warm_kernel(entry)
+
+    if prefix not in _PREFIX_HANDLERS:
+        raise ValueError(
+            f"Manifest entry {entry!r} uses unknown prefix {prefix + ':'!r}; "
+            f"known prefixes are {sorted(p + ':' for p in _PREFIX_HANDLERS)}. "
+            f"Add a handler in {Path(__file__).name} for new manifest forms."
+        )
+
+    return _PREFIX_HANDLERS[prefix](spec)
+
+
+def _warm_with_retries(entry: str) -> str:
+    """Warm one entry, retrying transient download failures.
+
+    A `ValueError` is a manifest-format error raised by `_warm_entry` itself,
+    so it is reported immediately rather than retried.
+    """
+    for attempt in range(1, ATTEMPTS + 1):
+        try:
+            return _warm_entry(entry)
+        except ValueError:
+            raise
+        except Exception as exc:  # retry any download-side failure
+            if attempt == ATTEMPTS:
+                raise
+            print(
+                f"  {entry:<28} -> attempt {attempt}/{ATTEMPTS} failed ({exc}); retrying",
+                flush=True,
+            )
+            time.sleep(RETRY_DELAY * attempt)
+
+    raise AssertionError("unreachable: loop either returns or raises")
+
+
 def main() -> None:
     entries = _read_manifest()
     print(f"Warming brahe data cache from {MANIFEST_PATH.relative_to(REPO_ROOT)}...")
 
+    failures: list[tuple[str, Exception]] = []
     for entry in entries:
-        result = _warm_entry(entry)
-        print(f"  {entry:<28} -> {result}")
+        try:
+            result = _warm_with_retries(entry)
+        except Exception as exc:  # noqa: BLE001 - one bad artifact must not stop the rest
+            failures.append((entry, exc))
+            print(f"  {entry:<28} -> FAILED: {exc}", flush=True)
+            continue
+        print(f"  {entry:<28} -> {result}", flush=True)
+
+    if failures:
+        print(
+            f"\nBrahe data cache partially warm: "
+            f"{len(entries) - len(failures)} of {len(entries)} artifact(s) verified, "
+            f"{len(failures)} failed:",
+            file=sys.stderr,
+        )
+        for entry, exc in failures:
+            print(f"  {entry}: {type(exc).__name__}: {exc}", file=sys.stderr)
+        raise SystemExit(1)
 
     print(f"Brahe data cache warm: {len(entries)} artifact(s) verified.")
 


### PR DESCRIPTION
# Pull Request

## Description

The weekly `Warm Brahe Data Cache` workflow has failed since #416 added a `horizons:` entry to `.github/brahe-data-manifest.txt` without a matching handler in `scripts/warm_data_cache.py`. The entry fell through to `load_spice_kernel()`, which raised and aborted the job before the star catalogs were warmed or either cache was saved. This adds the missing handler and makes the warm process tolerate any single step failure, so the remaining artifacts are still fetched and persisted.

## Changelog

### Changed
- `scripts/warm_data_cache.py` now warms each manifest entry independently with retries, aggregates failures into one report, and rejects an unrecognized manifest prefix with a named error rather than passing it to `load_spice_kernel`.

### Fixed
- Fixed the weekly `Warm Brahe Data Cache` workflow aborting on the `horizons:` manifest entry, which had no handler in `scripts/warm_data_cache.py`.
