### PR TITLE
Vectorize Earth frame transformations

### DIFF
--- a/crates/brahe-py/src/batch.rs
+++ b/crates/brahe-py/src/batch.rs
@@ -1,0 +1,268 @@
+// Batch argument parsing and dispatch helpers for vectorized transformation
+// bindings.
+//
+// Vectorized Python functions accept either a single vector (1-D input, the
+// scalar path) or an array of vectors whose component axis is selected by
+// `axis` (numpy convention, default `-1`). Epoch arguments accept a single
+// `Epoch` or a sequence of `Epoch`. Batch evaluation calls the plural core
+// function with the GIL released and restores the input layout on output.
+
+/// Shape bookkeeping for a batched vector argument: the original array shape
+/// and the (normalized) component axis.
+struct BatchLayout {
+    shape: Vec<usize>,
+    axis: usize,
+}
+
+impl BatchLayout {
+    /// Layout describing a batch of `n` vectors laid out along a fresh batch
+    /// dimension, with the component axis placed according to `axis` (`-1`
+    /// or `1` puts components last, giving `(n, N)`; `0` gives `(N, n)`).
+    fn for_broadcast<const N: usize>(n: usize, axis: isize) -> PyResult<Self> {
+        let axis = normalize_axis(axis, 2)?;
+        let shape = if axis == 1 { vec![n, N] } else { vec![N, n] };
+        Ok(BatchLayout { shape, axis })
+    }
+
+    /// Number of vectors described by this layout.
+    fn batch_len(&self) -> usize {
+        self.shape
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| *i != self.axis)
+            .map(|(_, d)| d)
+            .product()
+    }
+}
+
+/// A vector argument parsed from Python: a single vector or a batch.
+enum VecArg<const N: usize> {
+    Single(SVector<f64, N>),
+    Batch {
+        vecs: Vec<SVector<f64, N>>,
+        layout: BatchLayout,
+    },
+}
+
+/// An epoch argument parsed from Python: a single epoch or a sequence.
+enum EpochArg {
+    Single(time::Epoch),
+    Many(Vec<time::Epoch>),
+}
+
+/// Resolve a possibly negative axis against `ndim`.
+fn normalize_axis(axis: isize, ndim: usize) -> PyResult<usize> {
+    let n = ndim as isize;
+    if axis < -n || axis >= n {
+        return Err(exceptions::PyValueError::new_err(format!(
+            "axis {} is out of bounds for array of dimension {}",
+            axis, ndim
+        )));
+    }
+    Ok(if axis < 0 { (axis + n) as usize } else { axis as usize })
+}
+
+/// Parse a Python object into a single vector or a batch of vectors with the
+/// component axis at `axis`.
+fn parse_vec_arg<const N: usize>(obj: &Bound<'_, PyAny>, axis: isize) -> PyResult<VecArg<N>> {
+    let py = obj.py();
+    let np = py
+        .import("numpy")
+        .map_err(|_| exceptions::PyImportError::new_err("Failed to import numpy"))?;
+    let float64 = np.getattr("float64")?;
+    let arr = np
+        .call_method1("asarray", (obj, float64))
+        .map_err(|_| {
+            exceptions::PyTypeError::new_err("Expected a numpy array or Python list of floats")
+        })?;
+    let arr = arr
+        .cast::<PyArrayDyn<f64>>()
+        .map_err(|_| exceptions::PyTypeError::new_err("Expected a numpy array or Python list"))?;
+    let readonly = arr.readonly();
+    let view = readonly.as_array();
+    let ndim = view.ndim();
+
+    if ndim == 0 {
+        return Err(exceptions::PyValueError::new_err(
+            "Expected an array or list of vectors, got a scalar",
+        ));
+    }
+
+    if ndim == 1 {
+        let len = view.len();
+        if len != N {
+            return Err(exceptions::PyValueError::new_err(format!(
+                "Expected array or list of length {}, got {}",
+                N, len
+            )));
+        }
+        return Ok(VecArg::Single(SVector::<f64, N>::from_iterator(
+            view.iter().copied(),
+        )));
+    }
+
+    let axis_norm = normalize_axis(axis, ndim)?;
+    let shape = view.shape().to_vec();
+    if shape[axis_norm] != N {
+        return Err(exceptions::PyValueError::new_err(format!(
+            "Expected axis {} to have length {}, got shape {:?}",
+            axis, N, shape
+        )));
+    }
+
+    // Move the component axis last so each lane along it is one vector.
+    let mut perm: Vec<usize> = (0..ndim).filter(|&i| i != axis_norm).collect();
+    perm.push(axis_norm);
+    let moved = view.permuted_axes(perm);
+    let vecs: Vec<SVector<f64, N>> = moved
+        .lanes(ndarray::Axis(ndim - 1))
+        .into_iter()
+        .map(|lane| SVector::<f64, N>::from_iterator(lane.iter().copied()))
+        .collect();
+
+    Ok(VecArg::Batch {
+        vecs,
+        layout: BatchLayout {
+            shape,
+            axis: axis_norm,
+        },
+    })
+}
+
+/// Parse a Python object into a single epoch or a sequence of epochs.
+fn parse_epoch_arg(obj: &Bound<'_, PyAny>) -> PyResult<EpochArg> {
+    if let Ok(epc) = obj.extract::<PyRef<'_, PyEpoch>>() {
+        return Ok(EpochArg::Single(epc.obj));
+    }
+    if let Ok(epochs) = obj.extract::<Vec<PyRef<'_, PyEpoch>>>() {
+        return Ok(EpochArg::Many(epochs.iter().map(|e| e.obj).collect()));
+    }
+    Err(exceptions::PyTypeError::new_err(
+        "Expected an Epoch or a sequence of Epoch",
+    ))
+}
+
+/// Validate the epoch/batch broadcast rule before calling the core.
+fn check_batch_lengths(n_epochs: usize, n_vecs: usize) -> PyResult<()> {
+    if n_epochs == 1 || n_vecs == 1 || n_epochs == n_vecs {
+        Ok(())
+    } else {
+        Err(exceptions::PyValueError::new_err(format!(
+            "Epoch count {} does not match batch length {}; expected 1 or equal lengths",
+            n_epochs, n_vecs
+        )))
+    }
+}
+
+/// Convert a batch result back to a numpy array in the layout of the input.
+///
+/// When the core broadcast a length-1 batch across `n` epochs, the output is
+/// laid out along a fresh batch dimension instead.
+fn vecs_to_numpy<'py, const N: usize>(
+    py: Python<'py>,
+    layout: &BatchLayout,
+    axis: isize,
+    vecs: Vec<SVector<f64, N>>,
+) -> PyResult<Bound<'py, PyAny>> {
+    let n = vecs.len();
+    let layout_owned;
+    let layout = if layout.batch_len() == n {
+        layout
+    } else {
+        layout_owned = BatchLayout::for_broadcast::<N>(n, axis)?;
+        &layout_owned
+    };
+    let ndim = layout.shape.len();
+
+    // Build (batch dims..., N) then move the component axis back into place.
+    let mut moved_shape: Vec<usize> = layout
+        .shape
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| *i != layout.axis)
+        .map(|(_, d)| *d)
+        .collect();
+    moved_shape.push(N);
+    let flat: Vec<f64> = vecs.iter().flat_map(|v| v.iter().copied()).collect();
+    let arr = ndarray::ArrayD::from_shape_vec(ndarray::IxDyn(&moved_shape), flat)
+        .map_err(|e| exceptions::PyValueError::new_err(e.to_string()))?;
+
+    let mut inv: Vec<usize> = (0..ndim - 1).collect();
+    inv.insert(layout.axis, ndim - 1);
+    let restored = arr.view().permuted_axes(inv);
+    Ok(restored.to_pyarray(py).into_any())
+}
+
+/// Convert a batch of 3x3 matrices to an `(n, 3, 3)` numpy array.
+fn matrices_to_numpy<'py>(py: Python<'py>, mats: Vec<SMatrix3>) -> Bound<'py, PyAny> {
+    let n = mats.len();
+    let flat: Vec<f64> = mats
+        .iter()
+        .flat_map(|m| (0..3).flat_map(move |i| (0..3).map(move |j| m[(i, j)])))
+        .collect();
+    flat.into_pyarray(py).reshape([n, 3, 3]).unwrap().into_any()
+}
+
+/// Dispatch an epoch-dependent vector transform on a single vector or a batch.
+fn dispatch_epoch_vec<'py, const N: usize>(
+    py: Python<'py>,
+    epc: &Bound<'py, PyAny>,
+    x: &Bound<'py, PyAny>,
+    axis: isize,
+    scalar: impl Fn(time::Epoch, SVector<f64, N>) -> SVector<f64, N>,
+    batch: impl Fn(&[time::Epoch], &[SVector<f64, N>]) -> Result<Vec<SVector<f64, N>>, RustBraheError>
+    + Sync,
+) -> PyResult<Bound<'py, PyAny>> {
+    let epochs = parse_epoch_arg(epc)?;
+    let vecs = parse_vec_arg::<N>(x, axis)?;
+    let (epochs, vecs, layout) = match (epochs, vecs) {
+        (EpochArg::Single(e), VecArg::Single(v)) => {
+            return Ok(vector_to_numpy!(py, scalar(e, v), N, f64).into_any());
+        }
+        (EpochArg::Single(e), VecArg::Batch { vecs, layout }) => (vec![e], vecs, layout),
+        (EpochArg::Many(epochs), VecArg::Single(v)) => {
+            let layout = BatchLayout::for_broadcast::<N>(1, axis)?;
+            (epochs, vec![v], layout)
+        }
+        (EpochArg::Many(epochs), VecArg::Batch { vecs, layout }) => (epochs, vecs, layout),
+    };
+    check_batch_lengths(epochs.len(), vecs.len())?;
+    let out = py.detach(|| batch(&epochs, &vecs))?;
+    vecs_to_numpy(py, &layout, axis, out)
+}
+
+/// Dispatch an epoch-free vector transform on a single vector or a batch.
+fn dispatch_vec<'py, const N: usize>(
+    py: Python<'py>,
+    x: &Bound<'py, PyAny>,
+    axis: isize,
+    scalar: impl Fn(SVector<f64, N>) -> SVector<f64, N>,
+    batch: impl Fn(&[SVector<f64, N>]) -> Vec<SVector<f64, N>> + Sync,
+) -> PyResult<Bound<'py, PyAny>> {
+    match parse_vec_arg::<N>(x, axis)? {
+        VecArg::Single(v) => Ok(vector_to_numpy!(py, scalar(v), N, f64).into_any()),
+        VecArg::Batch { vecs, layout } => {
+            let out = py.detach(|| batch(&vecs));
+            vecs_to_numpy(py, &layout, axis, out)
+        }
+    }
+}
+
+/// Dispatch an epoch-dependent rotation on a single epoch or a sequence.
+fn dispatch_epoch_rotation<'py>(
+    py: Python<'py>,
+    epc: &Bound<'py, PyAny>,
+    scalar: impl Fn(time::Epoch) -> SMatrix3,
+    batch: impl Fn(&[time::Epoch]) -> Vec<SMatrix3> + Sync,
+) -> PyResult<Bound<'py, PyAny>> {
+    match parse_epoch_arg(epc)? {
+        EpochArg::Single(e) => {
+            let mat = scalar(e);
+            Ok(matrix_to_numpy!(py, mat, 3, 3, f64).into_any())
+        }
+        EpochArg::Many(epochs) => {
+            let out = py.detach(|| batch(&epochs));
+            Ok(matrices_to_numpy(py, out))
+        }
+    }
+}

--- a/crates/brahe-py/src/frames.rs
+++ b/crates/brahe-py/src/frames.rs
@@ -226,8 +226,10 @@ fn py_rotation_ecef_to_eci<'py>(py: Python<'py>, epc: &Bound<'py, PyAny>) -> PyR
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x (numpy.ndarray or list): Position vector in `GCRF` frame (m), shape `(3,)`, or a batch
 ///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
-///     axis (int, optional): Axis of `x` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x` along which the 3 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 3)` the components lie along the last axis, so the default `-1`
+///         applies; a `(3, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Position vector in `ITRF` frame (m), shape `(3,)` for a single
@@ -248,6 +250,14 @@ fn py_rotation_ecef_to_eci<'py>(py: Python<'py>, epc: &Bound<'py, PyAny>) -> PyR
 ///     # Transform to ITRF
 ///     r_itrf = bh.position_gcrf_to_itrf(epc, r_gcrf)
 ///     print(f"ITRF position: {r_itrf}")
+///
+///     # Batch: one row per position, one shared epoch
+///     positions = np.tile(r_gcrf, (10, 1))                     # shape (10, 3)
+///     positions_itrf = bh.position_gcrf_to_itrf(epc, positions)  # shape (10, 3)
+///
+///     # One position at a sequence of epochs
+///     epochs = [epc + 60.0 * i for i in range(5)]
+///     track = bh.position_gcrf_to_itrf(epochs, r_gcrf)         # shape (5, 3)
 ///     ```
 #[pyfunction]
 #[pyo3(signature = (epc, x, axis=-1))]
@@ -274,8 +284,10 @@ fn py_position_gcrf_to_itrf<'py>(
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x (numpy.ndarray or list): Position vector in `ECI` frame (m), shape `(3,)`, or a batch
 ///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
-///     axis (int, optional): Axis of `x` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x` along which the 3 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 3)` the components lie along the last axis, so the default `-1`
+///         applies; a `(3, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Position vector in `ECEF` frame (m), shape `(3,)` for a single
@@ -322,8 +334,10 @@ fn py_position_eci_to_ecef<'py>(
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x (numpy.ndarray or list): Position vector in `ITRF` frame (m), shape `(3,)`, or a batch
 ///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
-///     axis (int, optional): Axis of `x` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x` along which the 3 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 3)` the components lie along the last axis, so the default `-1`
+///         applies; a `(3, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Position vector in `GCRF` frame (m), shape `(3,)` for a single
@@ -370,8 +384,10 @@ fn py_position_itrf_to_gcrf<'py>(
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x (numpy.ndarray or list): Position vector in `ECEF` frame (m), shape `(3,)`, or a batch
 ///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
-///     axis (int, optional): Axis of `x` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x` along which the 3 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 3)` the components lie along the last axis, so the default `-1`
+///         applies; a `(3, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Position vector in `ECI` frame (m), shape `(3,)` for a single
@@ -419,8 +435,10 @@ fn py_position_ecef_to_eci<'py>(
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x_gcrf (numpy.ndarray or list): State vector in `GCRF` frame `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
 ///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
-///     axis (int, optional): Axis of `x_gcrf` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_gcrf` along which the 6 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 6)` the components lie along the last axis, so the default `-1`
+///         applies; a `(6, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: State vector in `ITRF` frame `[position (m), velocity (m/s)]`, shape `(6,)` for a single
@@ -468,8 +486,10 @@ fn py_state_gcrf_to_itrf<'py>(
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x_eci (numpy.ndarray or list): State vector in `ECI` frame `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
 ///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
-///     axis (int, optional): Axis of `x_eci` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_eci` along which the 6 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 6)` the components lie along the last axis, so the default `-1`
+///         applies; a `(6, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: State vector in `ECEF` frame `[position (m), velocity (m/s)]`, shape `(6,)` for a single
@@ -490,6 +510,13 @@ fn py_state_gcrf_to_itrf<'py>(
 ///     # Transform to ECEF
 ///     state_ecef = bh.state_eci_to_ecef(epc, state_eci)
 ///     print(f"ECEF state: {state_ecef}")
+///
+///     # Batch: one row per state, one shared epoch
+///     states_eci = np.tile(state_eci, (10, 1))              # shape (10, 6)
+///     states_ecef = bh.state_eci_to_ecef(epc, states_eci)   # shape (10, 6)
+///
+///     # Column layout: components along axis 0
+///     cols_ecef = bh.state_eci_to_ecef(epc, states_eci.T, axis=0)  # shape (6, 10)
 ///     ```
 #[pyfunction]
 #[pyo3(signature = (epc, x_eci, axis=-1))]
@@ -517,8 +544,10 @@ fn py_state_eci_to_ecef<'py>(
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x_itrf (numpy.ndarray or list): State vector in `ITRF` frame `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
 ///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
-///     axis (int, optional): Axis of `x_itrf` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_itrf` along which the 6 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 6)` the components lie along the last axis, so the default `-1`
+///         applies; a `(6, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: State vector in `GCRF` frame `[position (m), velocity (m/s)]`, shape `(6,)` for a single
@@ -566,8 +595,10 @@ fn py_state_itrf_to_gcrf<'py>(
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x_ecef (numpy.ndarray or list): State vector in `ECEF` frame `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
 ///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
-///     axis (int, optional): Axis of `x_ecef` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_ecef` along which the 6 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 6)` the components lie along the last axis, so the default `-1`
+///         applies; a `(6, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: State vector in `ECI` frame `[position (m), velocity (m/s)]`, shape `(6,)` for a single
@@ -694,8 +725,10 @@ unsafe fn py_rotation_eme2000_to_gcrf<'py>(py: Python<'py>) -> Bound<'py, PyArra
 /// Args:
 ///     x (numpy.ndarray or list): Position vector in `GCRF` frame (m), shape `(3,)`, or a batch
 ///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
-///     axis (int, optional): Axis of `x` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x` along which the 3 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 3)` the components lie along the last axis, so the default `-1`
+///         applies; a `(3, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Position vector in `EME2000` frame (m), shape `(3,)` for a single
@@ -736,8 +769,10 @@ fn py_position_gcrf_to_eme2000<'py>(
 /// Args:
 ///     x (numpy.ndarray or list): Position vector in `EME2000` frame (m), shape `(3,)`, or a batch
 ///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
-///     axis (int, optional): Axis of `x` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x` along which the 3 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 3)` the components lie along the last axis, so the default `-1`
+///         applies; a `(3, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Position vector in `GCRF` frame (m), shape `(3,)` for a single
@@ -778,8 +813,10 @@ fn py_position_eme2000_to_gcrf<'py>(
 /// Args:
 ///     x_gcrf (numpy.ndarray or list): State vector in `GCRF` frame `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
 ///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
-///     axis (int, optional): Axis of `x_gcrf` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_gcrf` along which the 6 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 6)` the components lie along the last axis, so the default `-1`
+///         applies; a `(6, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: State vector in `EME2000` frame `[position (m), velocity (m/s)]`, shape `(6,)` for a single
@@ -820,8 +857,10 @@ fn py_state_gcrf_to_eme2000<'py>(
 /// Args:
 ///     x_eme2000 (numpy.ndarray or list): State vector in `EME2000` frame `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
 ///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
-///     axis (int, optional): Axis of `x_eme2000` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_eme2000` along which the 6 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 6)` the components lie along the last axis, so the default `-1`
+///         applies; a `(6, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: State vector in `GCRF` frame `[position (m), velocity (m/s)]`, shape `(6,)` for a single

--- a/crates/brahe-py/src/frames.rs
+++ b/crates/brahe-py/src/frames.rs
@@ -79,10 +79,12 @@ unsafe fn py_polar_motion<'py>(py: Python<'py>, epc: &PyEpoch) -> Bound<'py, PyA
 /// derived from empirical observations.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of transformation matrix
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of transformation matrix. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///
 /// Returns:
-///     numpy.ndarray: 3x3 rotation matrix transforming `GCRF` -> `ITRF`
+///     numpy.ndarray: 3x3 rotation matrix transforming `GCRF` -> `ITRF`, shape `(3, 3)` for a single epoch or `(n, 3, 3)`
+///         for a sequence of `n` epochs.
 ///
 /// Example:
 ///     ```python
@@ -100,9 +102,8 @@ unsafe fn py_polar_motion<'py>(py: Python<'py>, epc: &PyEpoch) -> Bound<'py, PyA
 #[pyfunction]
 #[pyo3(text_signature = "(epc)")]
 #[pyo3(name = "rotation_gcrf_to_itrf")]
-unsafe fn py_rotation_gcrf_to_itrf<'py>(py: Python<'py>, epc: &PyEpoch) -> Bound<'py, PyArray<f64, Ix2>> {
-    let mat = frames::rotation_gcrf_to_itrf(epc.obj);
-    matrix_to_numpy!(py, mat, 3, 3, f64)
+fn py_rotation_gcrf_to_itrf<'py>(py: Python<'py>, epc: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_epoch_rotation(py, epc, frames::rotation_gcrf_to_itrf, frames::rotations_gcrf_to_itrf)
 }
 
 /// Computes the combined rotation matrix from the inertial to the Earth-fixed
@@ -114,10 +115,12 @@ unsafe fn py_rotation_gcrf_to_itrf<'py>(py: Python<'py>, epc: &PyEpoch) -> Bound
 /// to the `ITRF` (International Terrestrial Reference Frame) implementation.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of transformation matrix
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of transformation matrix. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///
 /// Returns:
-///     numpy.ndarray: 3x3 rotation matrix transforming `ECI` (`GCRF`) -> `ECEF` (`ITRF`)
+///     numpy.ndarray: 3x3 rotation matrix transforming `ECI` (`GCRF`) -> `ECEF` (`ITRF`), shape `(3, 3)` for a single epoch or `(n, 3, 3)`
+///         for a sequence of `n` epochs.
 ///
 /// Example:
 ///     ```python
@@ -135,9 +138,8 @@ unsafe fn py_rotation_gcrf_to_itrf<'py>(py: Python<'py>, epc: &PyEpoch) -> Bound
 #[pyfunction]
 #[pyo3(text_signature = "(epc)")]
 #[pyo3(name = "rotation_eci_to_ecef")]
-unsafe fn py_rotation_eci_to_ecef<'py>(py: Python<'py>, epc: &PyEpoch) -> Bound<'py, PyArray<f64, Ix2>> {
-    let mat = frames::rotation_eci_to_ecef(epc.obj);
-    matrix_to_numpy!(py, mat, 3, 3, f64)
+fn py_rotation_eci_to_ecef<'py>(py: Python<'py>, epc: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_epoch_rotation(py, epc, frames::rotation_eci_to_ecef, frames::rotations_eci_to_ecef)
 }
 
 /// Computes the combined rotation matrix from ITRF (International Terrestrial Reference Frame)
@@ -153,10 +155,12 @@ unsafe fn py_rotation_eci_to_ecef<'py>(py: Python<'py>, epc: &PyEpoch) -> Bound<
 /// derived from empirical observations.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of transformation matrix
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of transformation matrix. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///
 /// Returns:
-///     numpy.ndarray: 3x3 rotation matrix transforming `ITRF` -> `GCRF`
+///     numpy.ndarray: 3x3 rotation matrix transforming `ITRF` -> `GCRF`, shape `(3, 3)` for a single epoch or `(n, 3, 3)`
+///         for a sequence of `n` epochs.
 ///
 /// Example:
 ///     ```python
@@ -172,9 +176,8 @@ unsafe fn py_rotation_eci_to_ecef<'py>(py: Python<'py>, epc: &PyEpoch) -> Bound<
 #[pyfunction]
 #[pyo3(text_signature = "(epc)")]
 #[pyo3(name = "rotation_itrf_to_gcrf")]
-unsafe fn py_rotation_itrf_to_gcrf<'py>(py: Python<'py>, epc: &PyEpoch) -> Bound<'py, PyArray<f64, Ix2>> {
-    let mat = frames::rotation_itrf_to_gcrf(epc.obj);
-    matrix_to_numpy!(py, mat, 3, 3, f64)
+fn py_rotation_itrf_to_gcrf<'py>(py: Python<'py>, epc: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_epoch_rotation(py, epc, frames::rotation_itrf_to_gcrf, frames::rotations_itrf_to_gcrf)
 }
 
 /// Computes the combined rotation matrix from the Earth-fixed to the inertial
@@ -186,10 +189,12 @@ unsafe fn py_rotation_itrf_to_gcrf<'py>(py: Python<'py>, epc: &PyEpoch) -> Bound
 /// to the `GCRF` (Geocentric Celestial Reference Frame) implementation.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of transformation matrix
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of transformation matrix. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///
 /// Returns:
-///     numpy.ndarray: 3x3 rotation matrix transforming `ECEF` (`ITRF`) -> `ECI` (`GCRF`)
+///     numpy.ndarray: 3x3 rotation matrix transforming `ECEF` (`ITRF`) -> `ECI` (`GCRF`), shape `(3, 3)` for a single epoch or `(n, 3, 3)`
+///         for a sequence of `n` epochs.
 ///
 /// Example:
 ///     ```python
@@ -205,9 +210,8 @@ unsafe fn py_rotation_itrf_to_gcrf<'py>(py: Python<'py>, epc: &PyEpoch) -> Bound
 #[pyfunction]
 #[pyo3(text_signature = "(epc)")]
 #[pyo3(name = "rotation_ecef_to_eci")]
-unsafe fn py_rotation_ecef_to_eci<'py>(py: Python<'py>, epc: &PyEpoch) -> Bound<'py, PyArray<f64, Ix2>> {
-    let mat = frames::rotation_ecef_to_eci(epc.obj);
-    matrix_to_numpy!(py, mat, 3, 3, f64)
+fn py_rotation_ecef_to_eci<'py>(py: Python<'py>, epc: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_epoch_rotation(py, epc, frames::rotation_ecef_to_eci, frames::rotations_ecef_to_eci)
 }
 
 /// Transforms a position vector from GCRF (Geocentric Celestial Reference Frame)
@@ -218,11 +222,17 @@ unsafe fn py_rotation_ecef_to_eci<'py>(py: Python<'py>, epc: &PyEpoch) -> Bound<
 /// orientation parameters.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for the transformation
-///     x (numpy.ndarray or list): Position vector in `GCRF` frame (m), shape `(3,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x (numpy.ndarray or list): Position vector in `GCRF` frame (m), shape `(3,)`, or a batch
+///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
+///     axis (int, optional): Axis of `x` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: Position vector in `ITRF` frame (m), shape `(3,)`
+///     numpy.ndarray: Position vector in `ITRF` frame (m), shape `(3,)` for a single
+///         input, or the batch layout of `x` (shape `(n, 3)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Example:
 ///     ```python
@@ -240,16 +250,16 @@ unsafe fn py_rotation_ecef_to_eci<'py>(py: Python<'py>, epc: &PyEpoch) -> Bound<
 ///     print(f"ITRF position: {r_itrf}")
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(epc, x)")]
+#[pyo3(signature = (epc, x, axis=-1))]
+#[pyo3(text_signature = "(epc, x, axis=-1)")]
 #[pyo3(name = "position_gcrf_to_itrf")]
 fn py_position_gcrf_to_itrf<'py>(
     py: Python<'py>,
-    epc: &PyEpoch,
-    x: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::position_gcrf_to_itrf(epc.obj, pyany_to_svector::<3>(&x)?);
-
-    Ok(vector_to_numpy!(py, vec, 3, f64))
+    epc: &Bound<'py, PyAny>,
+    x: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_epoch_vec::<3>(py, epc, x, axis, frames::position_gcrf_to_itrf, frames::positions_gcrf_to_itrf)
 }
 
 /// Transforms a position vector from the Earth Centered Inertial (`ECI`/`GCRF`) frame
@@ -260,11 +270,17 @@ fn py_position_gcrf_to_itrf<'py>(
 /// rotation, and polar motion corrections using global Earth orientation parameters.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for the transformation
-///     x (numpy.ndarray or list): Position vector in `ECI` frame (m), shape `(3,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x (numpy.ndarray or list): Position vector in `ECI` frame (m), shape `(3,)`, or a batch
+///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
+///     axis (int, optional): Axis of `x` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: Position vector in `ECEF` frame (m), shape `(3,)`
+///     numpy.ndarray: Position vector in `ECEF` frame (m), shape `(3,)` for a single
+///         input, or the batch layout of `x` (shape `(n, 3)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Example:
 ///     ```python
@@ -282,16 +298,16 @@ fn py_position_gcrf_to_itrf<'py>(
 ///     print(f"ECEF position: {r_ecef}")
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(epc, x)")]
+#[pyo3(signature = (epc, x, axis=-1))]
+#[pyo3(text_signature = "(epc, x, axis=-1)")]
 #[pyo3(name = "position_eci_to_ecef")]
 fn py_position_eci_to_ecef<'py>(
     py: Python<'py>,
-    epc: &PyEpoch,
-    x: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::position_eci_to_ecef(epc.obj, pyany_to_svector::<3>(&x)?);
-
-    Ok(vector_to_numpy!(py, vec, 3, f64))
+    epc: &Bound<'py, PyAny>,
+    x: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_epoch_vec::<3>(py, epc, x, axis, frames::position_eci_to_ecef, frames::positions_eci_to_ecef)
 }
 
 /// Transforms a position vector from ITRF (International Terrestrial Reference Frame)
@@ -302,11 +318,17 @@ fn py_position_eci_to_ecef<'py>(
 /// orientation parameters.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for the transformation
-///     x (numpy.ndarray or list): Position vector in `ITRF` frame (m), shape `(3,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x (numpy.ndarray or list): Position vector in `ITRF` frame (m), shape `(3,)`, or a batch
+///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
+///     axis (int, optional): Axis of `x` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: Position vector in `GCRF` frame (m), shape `(3,)`
+///     numpy.ndarray: Position vector in `GCRF` frame (m), shape `(3,)` for a single
+///         input, or the batch layout of `x` (shape `(n, 3)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Example:
 ///     ```python
@@ -324,16 +346,16 @@ fn py_position_eci_to_ecef<'py>(
 ///     print(f"GCRF position: {r_gcrf}")
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(epc, x)")]
+#[pyo3(signature = (epc, x, axis=-1))]
+#[pyo3(text_signature = "(epc, x, axis=-1)")]
 #[pyo3(name = "position_itrf_to_gcrf")]
 fn py_position_itrf_to_gcrf<'py>(
     py: Python<'py>,
-    epc: &PyEpoch,
-    x: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::position_itrf_to_gcrf(epc.obj, pyany_to_svector::<3>(&x)?);
-
-    Ok(vector_to_numpy!(py, vec, 3, f64))
+    epc: &Bound<'py, PyAny>,
+    x: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_epoch_vec::<3>(py, epc, x, axis, frames::position_itrf_to_gcrf, frames::positions_itrf_to_gcrf)
 }
 
 /// Transforms a position vector from the Earth Centered Earth Fixed (`ECEF`/`ITRF`)
@@ -344,11 +366,17 @@ fn py_position_itrf_to_gcrf<'py>(
 /// rotation, and polar motion corrections using global Earth orientation parameters.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for the transformation
-///     x (numpy.ndarray or list): Position vector in `ECEF` frame (m), shape `(3,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x (numpy.ndarray or list): Position vector in `ECEF` frame (m), shape `(3,)`, or a batch
+///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
+///     axis (int, optional): Axis of `x` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: Position vector in `ECI` frame (m), shape `(3,)`
+///     numpy.ndarray: Position vector in `ECI` frame (m), shape `(3,)` for a single
+///         input, or the batch layout of `x` (shape `(n, 3)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Example:
 ///     ```python
@@ -366,16 +394,16 @@ fn py_position_itrf_to_gcrf<'py>(
 ///     print(f"ECI position: {r_eci}")
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(epc, x)")]
+#[pyo3(signature = (epc, x, axis=-1))]
+#[pyo3(text_signature = "(epc, x, axis=-1)")]
 #[pyo3(name = "position_ecef_to_eci")]
 fn py_position_ecef_to_eci<'py>(
     py: Python<'py>,
-    epc: &PyEpoch,
-    x: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::position_ecef_to_eci(epc.obj, pyany_to_svector::<3>(&x)?);
-
-    Ok(vector_to_numpy!(py, vec, 3, f64))
+    epc: &Bound<'py, PyAny>,
+    x: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_epoch_vec::<3>(py, epc, x, axis, frames::position_ecef_to_eci, frames::positions_ecef_to_eci)
 }
 
 /// Transforms a state vector (position and velocity) from GCRF (Geocentric Celestial
@@ -387,11 +415,17 @@ fn py_position_ecef_to_eci<'py>(
 /// rotation rate.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for the transformation
-///     x_gcrf (numpy.ndarray or list): State vector in `GCRF` frame `[position (m), velocity (m/s)]`, shape `(6,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x_gcrf (numpy.ndarray or list): State vector in `GCRF` frame `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
+///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
+///     axis (int, optional): Axis of `x_gcrf` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: State vector in `ITRF` frame `[position (m), velocity (m/s)]`, shape `(6,)`
+///     numpy.ndarray: State vector in `ITRF` frame `[position (m), velocity (m/s)]`, shape `(6,)` for a single
+///         input, or the batch layout of `x_gcrf` (shape `(n, 6)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Example:
 ///     ```python
@@ -409,16 +443,16 @@ fn py_position_ecef_to_eci<'py>(
 ///     print(f"ITRF state: {state_itrf}")
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(epc, x_gcrf)")]
+#[pyo3(signature = (epc, x_gcrf, axis=-1))]
+#[pyo3(text_signature = "(epc, x_gcrf, axis=-1)")]
 #[pyo3(name = "state_gcrf_to_itrf")]
 fn py_state_gcrf_to_itrf<'py>(
     py: Python<'py>,
-    epc: &PyEpoch,
-    x_gcrf: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::state_gcrf_to_itrf(epc.obj, pyany_to_svector::<6>(&x_gcrf)?);
-
-    Ok(vector_to_numpy!(py, vec, 6, f64))
+    epc: &Bound<'py, PyAny>,
+    x_gcrf: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_epoch_vec::<6>(py, epc, x_gcrf, axis, frames::state_gcrf_to_itrf, frames::states_gcrf_to_itrf)
 }
 
 /// Transforms a state vector (position and velocity) from the Earth Centered
@@ -430,11 +464,17 @@ fn py_state_gcrf_to_itrf<'py>(
 /// The velocity transformation accounts for the Earth's rotation rate.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for the transformation
-///     x_eci (numpy.ndarray or list): State vector in `ECI` frame `[position (m), velocity (m/s)]`, shape `(6,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x_eci (numpy.ndarray or list): State vector in `ECI` frame `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
+///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
+///     axis (int, optional): Axis of `x_eci` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: State vector in `ECEF` frame `[position (m), velocity (m/s)]`, shape `(6,)`
+///     numpy.ndarray: State vector in `ECEF` frame `[position (m), velocity (m/s)]`, shape `(6,)` for a single
+///         input, or the batch layout of `x_eci` (shape `(n, 6)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Example:
 ///     ```python
@@ -452,16 +492,16 @@ fn py_state_gcrf_to_itrf<'py>(
 ///     print(f"ECEF state: {state_ecef}")
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(epc, x_eci)")]
+#[pyo3(signature = (epc, x_eci, axis=-1))]
+#[pyo3(text_signature = "(epc, x_eci, axis=-1)")]
 #[pyo3(name = "state_eci_to_ecef")]
 fn py_state_eci_to_ecef<'py>(
     py: Python<'py>,
-    epc: &PyEpoch,
-    x_eci: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::state_eci_to_ecef(epc.obj, pyany_to_svector::<6>(&x_eci)?);
-
-    Ok(vector_to_numpy!(py, vec, 6, f64))
+    epc: &Bound<'py, PyAny>,
+    x_eci: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_epoch_vec::<6>(py, epc, x_eci, axis, frames::state_eci_to_ecef, frames::states_eci_to_ecef)
 }
 
 /// Transforms a state vector (position and velocity) from ITRF (International Terrestrial
@@ -473,11 +513,17 @@ fn py_state_eci_to_ecef<'py>(
 /// rotation rate.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for the transformation
-///     x_itrf (numpy.ndarray or list): State vector in `ITRF` frame `[position (m), velocity (m/s)]`, shape `(6,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x_itrf (numpy.ndarray or list): State vector in `ITRF` frame `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
+///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
+///     axis (int, optional): Axis of `x_itrf` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: State vector in `GCRF` frame `[position (m), velocity (m/s)]`, shape `(6,)`
+///     numpy.ndarray: State vector in `GCRF` frame `[position (m), velocity (m/s)]`, shape `(6,)` for a single
+///         input, or the batch layout of `x_itrf` (shape `(n, 6)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Example:
 ///     ```python
@@ -495,16 +541,16 @@ fn py_state_eci_to_ecef<'py>(
 ///     print(f"GCRF state: {state_gcrf}")
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(epc, x_itrf)")]
+#[pyo3(signature = (epc, x_itrf, axis=-1))]
+#[pyo3(text_signature = "(epc, x_itrf, axis=-1)")]
 #[pyo3(name = "state_itrf_to_gcrf")]
 fn py_state_itrf_to_gcrf<'py>(
     py: Python<'py>,
-    epc: &PyEpoch,
-    x_itrf: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::state_itrf_to_gcrf(epc.obj, pyany_to_svector::<6>(&x_itrf)?);
-
-    Ok(vector_to_numpy!(py, vec, 6, f64))
+    epc: &Bound<'py, PyAny>,
+    x_itrf: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_epoch_vec::<6>(py, epc, x_itrf, axis, frames::state_itrf_to_gcrf, frames::states_itrf_to_gcrf)
 }
 
 /// Transforms a state vector (position and velocity) from the Earth Centered
@@ -516,11 +562,17 @@ fn py_state_itrf_to_gcrf<'py>(
 /// The velocity transformation accounts for the Earth's rotation rate.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for the transformation
-///     x_ecef (numpy.ndarray or list): State vector in `ECEF` frame `[position (m), velocity (m/s)]`, shape `(6,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x_ecef (numpy.ndarray or list): State vector in `ECEF` frame `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
+///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
+///     axis (int, optional): Axis of `x_ecef` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: State vector in `ECI` frame `[position (m), velocity (m/s)]`, shape `(6,)`
+///     numpy.ndarray: State vector in `ECI` frame `[position (m), velocity (m/s)]`, shape `(6,)` for a single
+///         input, or the batch layout of `x_ecef` (shape `(n, 6)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Example:
 ///     ```python
@@ -538,16 +590,16 @@ fn py_state_itrf_to_gcrf<'py>(
 ///     print(f"ECI state: {state_eci}")
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(epc, x_ecef)")]
+#[pyo3(signature = (epc, x_ecef, axis=-1))]
+#[pyo3(text_signature = "(epc, x_ecef, axis=-1)")]
 #[pyo3(name = "state_ecef_to_eci")]
 fn py_state_ecef_to_eci<'py>(
     py: Python<'py>,
-    epc: &PyEpoch,
-    x_ecef: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::state_ecef_to_eci(epc.obj, pyany_to_svector::<6>(&x_ecef)?);
-
-    Ok(vector_to_numpy!(py, vec, 6, f64))
+    epc: &Bound<'py, PyAny>,
+    x_ecef: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_epoch_vec::<6>(py, epc, x_ecef, axis, frames::state_ecef_to_eci, frames::states_ecef_to_eci)
 }
 
 /// Computes the frame bias matrix transforming GCRF (Geocentric Celestial Reference Frame)
@@ -640,10 +692,15 @@ unsafe fn py_rotation_eme2000_to_gcrf<'py>(py: Python<'py>) -> Bound<'py, PyArra
 /// that does not vary with time.
 ///
 /// Args:
-///     x (numpy.ndarray or list): Position vector in `GCRF` frame (m), shape `(3,)`
+///     x (numpy.ndarray or list): Position vector in `GCRF` frame (m), shape `(3,)`, or a batch
+///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
+///     axis (int, optional): Axis of `x` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: Position vector in `EME2000` frame (m), shape `(3,)`
+///     numpy.ndarray: Position vector in `EME2000` frame (m), shape `(3,)` for a single
+///         input, or the batch layout of `x` (shape `(n, 3)` for a single vector
+///         for batched input.
 ///
 /// Example:
 ///     ```python
@@ -658,15 +715,15 @@ unsafe fn py_rotation_eme2000_to_gcrf<'py>(py: Python<'py>) -> Bound<'py, PyArra
 ///     print(f"EME2000 position: {r_eme2000}")
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(x)")]
+#[pyo3(signature = (x, axis=-1))]
+#[pyo3(text_signature = "(x, axis=-1)")]
 #[pyo3(name = "position_gcrf_to_eme2000")]
 fn py_position_gcrf_to_eme2000<'py>(
     py: Python<'py>,
-    x: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::position_gcrf_to_eme2000(pyany_to_svector::<3>(&x)?);
-
-    Ok(vector_to_numpy!(py, vec, 3, f64))
+    x: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_vec::<3>(py, x, axis, frames::position_gcrf_to_eme2000, frames::positions_gcrf_to_eme2000)
 }
 
 /// Transforms a position vector from EME2000 (Earth Mean Equator and Equinox of J2000.0)
@@ -677,10 +734,15 @@ fn py_position_gcrf_to_eme2000<'py>(
 /// that does not vary with time.
 ///
 /// Args:
-///     x (numpy.ndarray or list): Position vector in `EME2000` frame (m), shape `(3,)`
+///     x (numpy.ndarray or list): Position vector in `EME2000` frame (m), shape `(3,)`, or a batch
+///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
+///     axis (int, optional): Axis of `x` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: Position vector in `GCRF` frame (m), shape `(3,)`
+///     numpy.ndarray: Position vector in `GCRF` frame (m), shape `(3,)` for a single
+///         input, or the batch layout of `x` (shape `(n, 3)` for a single vector
+///         for batched input.
 ///
 /// Example:
 ///     ```python
@@ -695,15 +757,15 @@ fn py_position_gcrf_to_eme2000<'py>(
 ///     print(f"GCRF position: {r_gcrf}")
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(x)")]
+#[pyo3(signature = (x, axis=-1))]
+#[pyo3(text_signature = "(x, axis=-1)")]
 #[pyo3(name = "position_eme2000_to_gcrf")]
 fn py_position_eme2000_to_gcrf<'py>(
     py: Python<'py>,
-    x: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::position_eme2000_to_gcrf(pyany_to_svector::<3>(&x)?);
-
-    Ok(vector_to_numpy!(py, vec, 3, f64))
+    x: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_vec::<3>(py, x, axis, frames::position_eme2000_to_gcrf, frames::positions_eme2000_to_gcrf)
 }
 
 /// Transforms a state vector (position and velocity) from GCRF (Geocentric Celestial
@@ -714,10 +776,15 @@ fn py_position_eme2000_to_gcrf<'py>(
 /// additional correction terms.
 ///
 /// Args:
-///     x_gcrf (numpy.ndarray or list): State vector in `GCRF` frame `[position (m), velocity (m/s)]`, shape `(6,)`
+///     x_gcrf (numpy.ndarray or list): State vector in `GCRF` frame `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
+///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
+///     axis (int, optional): Axis of `x_gcrf` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: State vector in `EME2000` frame `[position (m), velocity (m/s)]`, shape `(6,)`
+///     numpy.ndarray: State vector in `EME2000` frame `[position (m), velocity (m/s)]`, shape `(6,)` for a single
+///         input, or the batch layout of `x_gcrf` (shape `(n, 6)` for a single vector
+///         for batched input.
 ///
 /// Example:
 ///     ```python
@@ -732,15 +799,15 @@ fn py_position_eme2000_to_gcrf<'py>(
 ///     print(f"EME2000 state: {state_eme2000}")
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(x_gcrf)")]
+#[pyo3(signature = (x_gcrf, axis=-1))]
+#[pyo3(text_signature = "(x_gcrf, axis=-1)")]
 #[pyo3(name = "state_gcrf_to_eme2000")]
 fn py_state_gcrf_to_eme2000<'py>(
     py: Python<'py>,
-    x_gcrf: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::state_gcrf_to_eme2000(pyany_to_svector::<6>(&x_gcrf)?);
-
-    Ok(vector_to_numpy!(py, vec, 6, f64))
+    x_gcrf: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_vec::<6>(py, x_gcrf, axis, frames::state_gcrf_to_eme2000, frames::states_gcrf_to_eme2000)
 }
 
 /// Transforms a state vector (position and velocity) from EME2000 (Earth Mean Equator
@@ -751,10 +818,15 @@ fn py_state_gcrf_to_eme2000<'py>(
 /// additional correction terms.
 ///
 /// Args:
-///     x_eme2000 (numpy.ndarray or list): State vector in `EME2000` frame `[position (m), velocity (m/s)]`, shape `(6,)`
+///     x_eme2000 (numpy.ndarray or list): State vector in `EME2000` frame `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
+///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
+///     axis (int, optional): Axis of `x_eme2000` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: State vector in `GCRF` frame `[position (m), velocity (m/s)]`, shape `(6,)`
+///     numpy.ndarray: State vector in `GCRF` frame `[position (m), velocity (m/s)]`, shape `(6,)` for a single
+///         input, or the batch layout of `x_eme2000` (shape `(n, 6)` for a single vector
+///         for batched input.
 ///
 /// Example:
 ///     ```python
@@ -769,15 +841,15 @@ fn py_state_gcrf_to_eme2000<'py>(
 ///     print(f"GCRF state: {state_gcrf}")
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(x_eme2000)")]
+#[pyo3(signature = (x_eme2000, axis=-1))]
+#[pyo3(text_signature = "(x_eme2000, axis=-1)")]
 #[pyo3(name = "state_eme2000_to_gcrf")]
 fn py_state_eme2000_to_gcrf<'py>(
     py: Python<'py>,
-    x_eme2000: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::state_eme2000_to_gcrf(pyany_to_svector::<6>(&x_eme2000)?);
-
-    Ok(vector_to_numpy!(py, vec, 6, f64))
+    x_eme2000: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_vec::<6>(py, x_eme2000, axis, frames::state_eme2000_to_gcrf, frames::states_eme2000_to_gcrf)
 }
 
 // ============================================================================

--- a/crates/brahe-py/src/lib.rs
+++ b/crates/brahe-py/src/lib.rs
@@ -19,7 +19,7 @@ use std::sync::{Arc, Mutex};
 use nalgebra as na;
 use nalgebra::{DMatrix, DVector, SVector, Vector3, Vector6};
 use numpy::{
-    IntoPyArray, Ix1, Ix2, PyArray, PyArrayMethods, PyReadonlyArray1, PyReadonlyArray2,
+    IntoPyArray, Ix1, Ix2, PyArray, PyArrayDyn, PyArrayMethods, PyReadonlyArray1, PyReadonlyArray2,
     PyReadonlyArray3, PyUntypedArrayMethods, ToPyArray, ndarray,
 };
 
@@ -585,6 +585,7 @@ include!("horizons.rs");
 include!("eop.rs");
 include!("space_weather.rs");
 include!("time.rs");
+include!("batch.rs");
 include!("frames.rs");
 include!("coordinates.rs");
 include!("orbits.rs");

--- a/docs/learn/frames/vectorized.md
+++ b/docs/learn/frames/vectorized.md
@@ -41,19 +41,3 @@ Rotation-matrix functions such as `rotation_eci_to_ecef` accept a sequence of ep
         ```
         --8<-- "./docs/outputs/frames/vectorized_transforms.rs.txt"
         ```
-
-## Rust API
-
-The Rust core exposes each batch operation as a plural function alongside its scalar counterpart: `rotation_eci_to_ecef` and `rotations_eci_to_ecef`, `position_eci_to_ecef` and `positions_eci_to_ecef`, `state_eci_to_ecef` and `states_eci_to_ecef`. Plural functions take slices and return a `Vec`. Epoch-dependent functions take `&[Epoch]` as their first argument and follow one broadcast rule: every slice argument has length `1` or the common batch length, and the output has the common length. A length mismatch returns `Err(BraheError::Error)`.
-
-Batches evaluate sequentially for small inputs and on the global thread pool for large ones. The pool size is controlled with `set_num_threads`; see [Threading](../utilities/threading.md).
-
-## Two Regimes
-
-The batch speed-up comes from two different sources, and which one applies depends on the epochs.
-
-When all vectors share one epoch, the transformation context (for ECI/ECEF, the bias-precession-nutation, Earth-rotation, and polar-motion matrices) is computed once and applied to every vector. The per-vector work is a handful of matrix products, so the cost of the batch is dominated by the single context evaluation.
-
-When each vector has its own epoch, the context must be evaluated per vector and the batch runs those evaluations across the thread pool. The speed-up over a Python loop is then the sum of avoiding per-call overhead and using multiple cores.
-
-Results are identical to calling the scalar function in a loop in both regimes; the plural functions apply the same expressions in the same order.

--- a/docs/learn/frames/vectorized.md
+++ b/docs/learn/frames/vectorized.md
@@ -1,0 +1,59 @@
+# Vectorized Transformations
+
+Frame transformation functions accept a batch of vectors in a single call. Passing a two-dimensional array such as `(n, 6)` to `state_eci_to_ecef` transforms every row and returns an array of the same shape; the loop, the Earth-orientation lookups, and the thread scheduling all happen inside the Rust core. A batch that shares one epoch runs hundreds of times faster than a Python loop over the scalar function because the IAU 2006/2000A rotation matrices are computed once and applied to every vector.
+
+## Batch Input
+
+A vectorized function is the same function as the scalar one. It decides how to evaluate based on the shape of its inputs:
+
+| Input | Behavior |
+|---|---|
+| 1-D vector, single `Epoch` | Scalar transformation, unchanged output shape `(3,)` or `(6,)` |
+| Array with the components along `axis` (default `-1`), single `Epoch` | Every vector is transformed with one shared epoch; the output keeps the input layout |
+| 1-D vector, sequence of `n` epochs | The vector is transformed at each epoch; the output has shape `(n, k)` (or `(k, n)` with `axis=0`) |
+| Array of `n` vectors, sequence of `n` epochs | Vector `i` is transformed at epoch `i`; the output keeps the input layout |
+
+`axis` names the array dimension that holds the vector components, following the numpy convention used by functions such as `np.linalg.norm`. The default `-1` matches the common `(n, 6)` layout where each row is a state; `axis=0` selects a `(6, n)` layout where each column is a state. Any number of leading batch dimensions is accepted, so a `(2, 3, 6)` array is transformed element by element and returned as `(2, 3, 6)`.
+
+Epoch arguments accept an `Epoch` or any sequence of `Epoch` objects (list, tuple, or object array). The epoch count must be `1` or equal to the number of vectors; other combinations raise `ValueError`.
+
+Rotation-matrix functions such as `rotation_eci_to_ecef` accept a sequence of epochs and return an `(n, 3, 3)` array.
+
+=== "Python"
+
+    ``` python
+    --8<-- "./examples/frames/vectorized_transforms.py:8"
+    ```
+
+=== "Rust"
+
+    ``` rust
+    --8<-- "./examples/frames/vectorized_transforms.rs:4"
+    ```
+
+??? example "Output"
+    === "Python"
+        ```
+        --8<-- "./docs/outputs/frames/vectorized_transforms.py.txt"
+        ```
+
+    === "Rust"
+        ```
+        --8<-- "./docs/outputs/frames/vectorized_transforms.rs.txt"
+        ```
+
+## Rust API
+
+The Rust core exposes each batch operation as a plural function alongside its scalar counterpart: `rotation_eci_to_ecef` and `rotations_eci_to_ecef`, `position_eci_to_ecef` and `positions_eci_to_ecef`, `state_eci_to_ecef` and `states_eci_to_ecef`. Plural functions take slices and return a `Vec`. Epoch-dependent functions take `&[Epoch]` as their first argument and follow one broadcast rule: every slice argument has length `1` or the common batch length, and the output has the common length. A length mismatch returns `Err(BraheError::Error)`.
+
+Batches evaluate sequentially for small inputs and on the global thread pool for large ones. The pool size is controlled with `set_num_threads`; see [Threading](../utilities/threading.md).
+
+## Two Regimes
+
+The batch speed-up comes from two different sources, and which one applies depends on the epochs.
+
+When all vectors share one epoch, the transformation context (for ECI/ECEF, the bias-precession-nutation, Earth-rotation, and polar-motion matrices) is computed once and applied to every vector. The per-vector work is a handful of matrix products, so the cost of the batch is dominated by the single context evaluation.
+
+When each vector has its own epoch, the context must be evaluated per vector and the batch runs those evaluations across the thread pool. The speed-up over a Python loop is then the sum of avoiding per-call overhead and using multiple cores.
+
+Results are identical to calling the scalar function in a loop in both regimes; the plural functions apply the same expressions in the same order.

--- a/examples/frames/vectorized_transforms.py
+++ b/examples/frames/vectorized_transforms.py
@@ -14,7 +14,7 @@ bh.initialize_eop()
 epc = bh.Epoch(2024, 1, 1, 12, 0, 0.0, time_system=bh.UTC)
 
 # Build a batch of ECI states: one row per satellite, columns [x, y, z, vx, vy, vz]
-raan = np.linspace(0.0, 360.0, 8, endpoint=False)
+raan = np.linspace(0.0, 360.0, 6, endpoint=False)
 states_eci = np.array(
     [
         bh.state_koe_to_eci(
@@ -48,7 +48,7 @@ for e, r in zip(epochs, station_eci):
     print(f"  {e}: [{r[0]:.1f}, {r[1]:.1f}, {r[2]:.1f}] m")
 
 # Many epochs, many states: one epoch per row
-states_ecef_series = bh.state_eci_to_ecef(epochs, states_eci[:6])
+states_ecef_series = bh.state_eci_to_ecef(epochs, states_eci)
 print(f"Per-epoch ECEF states shape: {states_ecef_series.shape}")
 
 # A sequence of epochs also vectorizes the rotation matrices

--- a/examples/frames/vectorized_transforms.py
+++ b/examples/frames/vectorized_transforms.py
@@ -1,0 +1,55 @@
+# /// script
+# dependencies = ["brahe"]
+# ///
+"""
+Transform batches of states and positions between ECI and ECEF in one call
+"""
+
+import brahe as bh
+import numpy as np
+
+bh.initialize_eop()
+
+epc = bh.Epoch(2024, 1, 1, 12, 0, 0.0, time_system=bh.UTC)
+
+# Build a batch of ECI states: one row per satellite, columns [x, y, z, vx, vy, vz]
+raan = np.linspace(0.0, 360.0, 8, endpoint=False)
+states_eci = np.array(
+    [
+        bh.state_koe_to_eci(
+            np.array([bh.R_EARTH + 500e3, 0.001, 97.8, r, 0.0, 0.0]),
+            bh.AngleFormat.DEGREES,
+        )
+        for r in raan
+    ]
+)
+print(f"ECI states shape: {states_eci.shape}")
+
+# One epoch, many states: the rotation matrices are computed once
+states_ecef = bh.state_eci_to_ecef(epc, states_eci)
+print(f"ECEF states shape: {states_ecef.shape}")
+print(
+    f"First ECEF state: {np.array2string(states_ecef[0], precision=3, suppress_small=True, max_line_width=120)}"
+)
+
+# The same call with the components along the first axis
+states_ecef_t = bh.state_eci_to_ecef(epc, states_eci.T, axis=0)
+print(f"Transposed layout shape: {states_ecef_t.shape}")
+
+# Many epochs, one position: a ground station tracked through inertial space
+epochs = [epc + 600.0 * i for i in range(6)]
+station_ecef = bh.position_geodetic_to_ecef(
+    np.array([-122.4, 37.8, 0.0]), bh.AngleFormat.DEGREES
+)
+station_eci = bh.position_ecef_to_eci(epochs, station_ecef)
+print(f"Station ECI positions shape: {station_eci.shape}")
+for e, r in zip(epochs, station_eci):
+    print(f"  {e}: [{r[0]:.1f}, {r[1]:.1f}, {r[2]:.1f}] m")
+
+# Many epochs, many states: one epoch per row
+states_ecef_series = bh.state_eci_to_ecef(epochs, states_eci[:6])
+print(f"Per-epoch ECEF states shape: {states_ecef_series.shape}")
+
+# A sequence of epochs also vectorizes the rotation matrices
+rotations = bh.rotation_eci_to_ecef(epochs)
+print(f"Rotation matrices shape: {rotations.shape}")

--- a/examples/frames/vectorized_transforms.py
+++ b/examples/frames/vectorized_transforms.py
@@ -5,8 +5,9 @@
 Transform batches of states and positions between ECI and ECEF in one call
 """
 
-import brahe as bh
 import numpy as np
+
+import brahe as bh
 
 bh.initialize_eop()
 

--- a/examples/frames/vectorized_transforms.rs
+++ b/examples/frames/vectorized_transforms.rs
@@ -10,9 +10,9 @@ fn main() {
     let epc = bh::Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh::TimeSystem::UTC);
 
     // Build a batch of ECI states, one per satellite
-    let states_eci: Vec<na::SVector<f64, 6>> = (0..8)
+    let states_eci: Vec<na::SVector<f64, 6>> = (0..6)
         .map(|i| {
-            let raan = 45.0 * i as f64;
+            let raan = 60.0 * i as f64;
             let oe = na::SVector::<f64, 6>::new(bh::R_EARTH + 500e3, 0.001, 97.8, raan, 0.0, 0.0);
             bh::state_koe_to_eci(oe, bh::AngleFormat::Degrees)
         })
@@ -42,7 +42,7 @@ fn main() {
     }
 
     // Many epochs, many states: one epoch per state
-    let states_ecef_series = bh::states_eci_to_ecef(&epochs, &states_eci[..6]).unwrap();
+    let states_ecef_series = bh::states_eci_to_ecef(&epochs, &states_eci).unwrap();
     println!("Per-epoch ECEF states: {}", states_ecef_series.len());
 
     // A sequence of epochs also vectorizes the rotation matrices

--- a/examples/frames/vectorized_transforms.rs
+++ b/examples/frames/vectorized_transforms.rs
@@ -1,0 +1,51 @@
+//! Transform batches of states and positions between ECI and ECEF in one call
+
+#[allow(unused_imports)]
+use brahe as bh;
+use nalgebra as na;
+
+fn main() {
+    bh::initialize_eop().unwrap();
+
+    let epc = bh::Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh::TimeSystem::UTC);
+
+    // Build a batch of ECI states, one per satellite
+    let states_eci: Vec<na::SVector<f64, 6>> = (0..8)
+        .map(|i| {
+            let raan = 45.0 * i as f64;
+            let oe = na::SVector::<f64, 6>::new(bh::R_EARTH + 500e3, 0.001, 97.8, raan, 0.0, 0.0);
+            bh::state_koe_to_eci(oe, bh::AngleFormat::Degrees)
+        })
+        .collect();
+    println!("ECI states: {}", states_eci.len());
+
+    // One epoch, many states: the rotation matrices are computed once
+    let states_ecef = bh::states_eci_to_ecef(&[epc], &states_eci).unwrap();
+    println!("ECEF states: {}", states_ecef.len());
+    let s = states_ecef[0];
+    println!(
+        "First ECEF state: [{:.3}, {:.3}, {:.3}, {:.3}, {:.3}, {:.3}]",
+        s[0], s[1], s[2], s[3], s[4], s[5]
+    );
+
+    // Many epochs, one position: a ground station tracked through inertial space
+    let epochs: Vec<bh::Epoch> = (0..6).map(|i| epc + 600.0 * i as f64).collect();
+    let station_ecef = bh::position_geodetic_to_ecef(
+        na::Vector3::new(-122.4, 37.8, 0.0),
+        bh::AngleFormat::Degrees,
+    )
+    .unwrap();
+    let station_eci = bh::positions_ecef_to_eci(&epochs, &[station_ecef]).unwrap();
+    println!("Station ECI positions: {}", station_eci.len());
+    for (e, r) in epochs.iter().zip(&station_eci) {
+        println!("  {}: [{:.1}, {:.1}, {:.1}] m", e, r[0], r[1], r[2]);
+    }
+
+    // Many epochs, many states: one epoch per state
+    let states_ecef_series = bh::states_eci_to_ecef(&epochs, &states_eci[..6]).unwrap();
+    println!("Per-epoch ECEF states: {}", states_ecef_series.len());
+
+    // A sequence of epochs also vectorizes the rotation matrices
+    let rotations = bh::rotations_eci_to_ecef(&epochs);
+    println!("Rotation matrices: {}", rotations.len());
+}

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -204,6 +204,7 @@ nav:
           - learn/frames/eci_ecef.md
           - learn/frames/gcrf_itrf.md
           - learn/frames/eme2000_gcrf.md
+          - Vectorized Transformations: learn/frames/vectorized.md
           - Lunar Frames: learn/frames/lunar_frames.md
           - Mars Frames: learn/frames/mars_frames.md
           - Synodic Frames: learn/frames/synodic_frames.md

--- a/src/frames/eci_ecef.rs
+++ b/src/frames/eci_ecef.rs
@@ -6,10 +6,12 @@ use nalgebra::Vector3;
 
 use crate::math::{SMatrix3, SVector6};
 use crate::time::Epoch;
+use crate::utils::BraheError;
 
 use super::gcrf_itrf::{
-    position_gcrf_to_itrf, position_itrf_to_gcrf, rotation_gcrf_to_itrf, rotation_itrf_to_gcrf,
-    state_gcrf_to_itrf, state_itrf_to_gcrf,
+    position_gcrf_to_itrf, position_itrf_to_gcrf, positions_gcrf_to_itrf, positions_itrf_to_gcrf,
+    rotation_gcrf_to_itrf, rotation_itrf_to_gcrf, rotations_gcrf_to_itrf, rotations_itrf_to_gcrf,
+    state_gcrf_to_itrf, state_itrf_to_gcrf, states_gcrf_to_itrf, states_itrf_to_gcrf,
 };
 
 /// Computes the combined rotation matrix from the inertial to the Earth-fixed
@@ -247,6 +249,245 @@ pub fn state_ecef_to_eci(epc: Epoch, x_ecef: SVector6) -> SVector6 {
     state_itrf_to_gcrf(epc, x_ecef)
 }
 
+/// Computes the ECI-to-ECEF rotation matrix for each epoch in `epochs`.
+///
+/// Batch form of [`rotation_gcrf_to_itrf`]; alias for [`rotations_gcrf_to_itrf`]. `ECI` refers to the
+/// `GCRF` (Geocentric Celestial Reference Frame) implementation, and `ECEF` refers
+/// to the `ITRF` (International Terrestrial Reference Frame) implementation.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants for computation of the transformation matrices
+///
+/// # Returns
+/// - Rotation matrices transforming `ECI` (`GCRF`) -> `ECEF` (`ITRF`), one per epoch, in input order
+///
+/// # Examples:
+/// ```
+/// use brahe::eop::*;
+/// use brahe::constants::R_EARTH;
+/// use brahe::{vector3_from_array, vector6_from_array};
+/// use brahe::orbits::perigee_velocity;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use brahe::frames::*;
+///
+/// // Quick EOP initialization
+/// let eop = FileEOPProvider::from_default_file(EOPType::StandardBulletinA, true, EOPExtrapolation::Zero).unwrap();
+/// set_global_eop_provider(eop);
+///
+/// let epc = Epoch::from_datetime(2007, 4, 5, 12, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let epochs = vec![epc, epc + 60.0, epc + 120.0];
+///
+/// let rotations = rotations_eci_to_ecef(&epochs);
+/// assert_eq!(rotations.len(), 3);
+/// ```
+pub fn rotations_eci_to_ecef(epochs: &[Epoch]) -> Vec<SMatrix3> {
+    rotations_gcrf_to_itrf(epochs)
+}
+
+/// Computes the ECEF-to-ECI rotation matrix for each epoch in `epochs`.
+///
+/// Batch form of [`rotation_itrf_to_gcrf`]; alias for [`rotations_itrf_to_gcrf`]. `ECI` refers to the
+/// `GCRF` (Geocentric Celestial Reference Frame) implementation, and `ECEF` refers
+/// to the `ITRF` (International Terrestrial Reference Frame) implementation.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants for computation of the transformation matrices
+///
+/// # Returns
+/// - Rotation matrices transforming `ECEF` (`ITRF`) -> `ECI` (`GCRF`), one per epoch, in input order
+///
+/// # Examples:
+/// ```
+/// use brahe::eop::*;
+/// use brahe::constants::R_EARTH;
+/// use brahe::{vector3_from_array, vector6_from_array};
+/// use brahe::orbits::perigee_velocity;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use brahe::frames::*;
+///
+/// // Quick EOP initialization
+/// let eop = FileEOPProvider::from_default_file(EOPType::StandardBulletinA, true, EOPExtrapolation::Zero).unwrap();
+/// set_global_eop_provider(eop);
+///
+/// let epc = Epoch::from_datetime(2007, 4, 5, 12, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let epochs = vec![epc, epc + 60.0, epc + 120.0];
+///
+/// let rotations = rotations_ecef_to_eci(&epochs);
+/// assert_eq!(rotations.len(), 3);
+/// ```
+pub fn rotations_ecef_to_eci(epochs: &[Epoch]) -> Vec<SMatrix3> {
+    rotations_itrf_to_gcrf(epochs)
+}
+
+/// Transforms a batch of Cartesian positions from ECI to ECEF. `epochs` and the vector argument follow the broadcast rule: each has length 1 or the common batch length. A single epoch computes the transformation once and applies it to every element.
+///
+/// Batch form of [`position_gcrf_to_itrf`]; alias for [`positions_gcrf_to_itrf`]. `ECI` refers to the
+/// `GCRF` (Geocentric Celestial Reference Frame) implementation, and `ECEF` refers
+/// to the `ITRF` (International Terrestrial Reference Frame) implementation.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x`: Cartesian `ECI` positions, length 1 or the batch length. Units: (*m*)
+///
+/// # Returns
+/// - Cartesian `ECEF` positions in input order. Units: (*m*)
+/// - Error if `epochs` and `x` do not satisfy the broadcast rule
+///
+/// # Examples:
+/// ```
+/// use brahe::eop::*;
+/// use brahe::constants::R_EARTH;
+/// use brahe::{vector3_from_array, vector6_from_array};
+/// use brahe::orbits::perigee_velocity;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use brahe::frames::*;
+///
+/// // Quick EOP initialization
+/// let eop = FileEOPProvider::from_default_file(EOPType::StandardBulletinA, true, EOPExtrapolation::Zero).unwrap();
+/// set_global_eop_provider(eop);
+///
+/// let epc = Epoch::from_datetime(2007, 4, 5, 12, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let epochs = vec![epc, epc + 60.0, epc + 120.0];
+///
+/// let positions = vec![vector3_from_array([R_EARTH, 0.0, 0.0]); 3];
+/// let x_ecef = positions_eci_to_ecef(&epochs, &positions).unwrap();
+/// assert_eq!(x_ecef.len(), 3);
+/// ```
+pub fn positions_eci_to_ecef(
+    epochs: &[Epoch],
+    x: &[Vector3<f64>],
+) -> Result<Vec<Vector3<f64>>, BraheError> {
+    positions_gcrf_to_itrf(epochs, x)
+}
+
+/// Transforms a batch of Cartesian positions from ECEF to ECI. `epochs` and the vector argument follow the broadcast rule: each has length 1 or the common batch length. A single epoch computes the transformation once and applies it to every element.
+///
+/// Batch form of [`position_itrf_to_gcrf`]; alias for [`positions_itrf_to_gcrf`]. `ECI` refers to the
+/// `GCRF` (Geocentric Celestial Reference Frame) implementation, and `ECEF` refers
+/// to the `ITRF` (International Terrestrial Reference Frame) implementation.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x`: Cartesian `ECEF` positions, length 1 or the batch length. Units: (*m*)
+///
+/// # Returns
+/// - Cartesian `ECI` positions in input order. Units: (*m*)
+/// - Error if `epochs` and `x` do not satisfy the broadcast rule
+///
+/// # Examples:
+/// ```
+/// use brahe::eop::*;
+/// use brahe::constants::R_EARTH;
+/// use brahe::{vector3_from_array, vector6_from_array};
+/// use brahe::orbits::perigee_velocity;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use brahe::frames::*;
+///
+/// // Quick EOP initialization
+/// let eop = FileEOPProvider::from_default_file(EOPType::StandardBulletinA, true, EOPExtrapolation::Zero).unwrap();
+/// set_global_eop_provider(eop);
+///
+/// let epc = Epoch::from_datetime(2007, 4, 5, 12, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let epochs = vec![epc, epc + 60.0, epc + 120.0];
+///
+/// // One ground station, many epochs
+/// let station = vector3_from_array([R_EARTH, 0.0, 0.0]);
+/// let x_eci = positions_ecef_to_eci(&epochs, &[station]).unwrap();
+/// assert_eq!(x_eci.len(), 3);
+/// ```
+pub fn positions_ecef_to_eci(
+    epochs: &[Epoch],
+    x: &[Vector3<f64>],
+) -> Result<Vec<Vector3<f64>>, BraheError> {
+    positions_itrf_to_gcrf(epochs, x)
+}
+
+/// Transforms a batch of Cartesian states from ECI to ECEF. `epochs` and the vector argument follow the broadcast rule: each has length 1 or the common batch length. A single epoch computes the transformation once and applies it to every element.
+///
+/// Batch form of [`state_gcrf_to_itrf`]; alias for [`states_gcrf_to_itrf`]. `ECI` refers to the
+/// `GCRF` (Geocentric Celestial Reference Frame) implementation, and `ECEF` refers
+/// to the `ITRF` (International Terrestrial Reference Frame) implementation.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x_eci`: Cartesian `ECI` states (position, velocity), length 1 or the batch length. Units: (*m*; *m/s*)
+///
+/// # Returns
+/// - Cartesian `ECEF` states (position, velocity) in input order. Units: (*m*; *m/s*)
+/// - Error if `epochs` and `x_eci` do not satisfy the broadcast rule
+///
+/// # Examples:
+/// ```
+/// use brahe::eop::*;
+/// use brahe::constants::R_EARTH;
+/// use brahe::{vector3_from_array, vector6_from_array};
+/// use brahe::orbits::perigee_velocity;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use brahe::frames::*;
+///
+/// // Quick EOP initialization
+/// let eop = FileEOPProvider::from_default_file(EOPType::StandardBulletinA, true, EOPExtrapolation::Zero).unwrap();
+/// set_global_eop_provider(eop);
+///
+/// let epc = Epoch::from_datetime(2007, 4, 5, 12, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let epochs = vec![epc, epc + 60.0, epc + 120.0];
+///
+/// let v = perigee_velocity(R_EARTH + 500e3, 0.0);
+/// let states = vec![vector6_from_array([R_EARTH + 500e3, 0.0, 0.0, 0.0, v, 0.0]); 3];
+/// // One epoch, many states
+/// let x_ecef = states_eci_to_ecef(&epochs[..1], &states).unwrap();
+/// assert_eq!(x_ecef.len(), 3);
+/// ```
+pub fn states_eci_to_ecef(
+    epochs: &[Epoch],
+    x_eci: &[SVector6],
+) -> Result<Vec<SVector6>, BraheError> {
+    states_gcrf_to_itrf(epochs, x_eci)
+}
+
+/// Transforms a batch of Cartesian states from ECEF to ECI. `epochs` and the vector argument follow the broadcast rule: each has length 1 or the common batch length. A single epoch computes the transformation once and applies it to every element.
+///
+/// Batch form of [`state_itrf_to_gcrf`]; alias for [`states_itrf_to_gcrf`]. `ECI` refers to the
+/// `GCRF` (Geocentric Celestial Reference Frame) implementation, and `ECEF` refers
+/// to the `ITRF` (International Terrestrial Reference Frame) implementation.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x_ecef`: Cartesian `ECEF` states (position, velocity), length 1 or the batch length. Units: (*m*; *m/s*)
+///
+/// # Returns
+/// - Cartesian `ECI` states (position, velocity) in input order. Units: (*m*; *m/s*)
+/// - Error if `epochs` and `x_ecef` do not satisfy the broadcast rule
+///
+/// # Examples:
+/// ```
+/// use brahe::eop::*;
+/// use brahe::constants::R_EARTH;
+/// use brahe::{vector3_from_array, vector6_from_array};
+/// use brahe::orbits::perigee_velocity;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use brahe::frames::*;
+///
+/// // Quick EOP initialization
+/// let eop = FileEOPProvider::from_default_file(EOPType::StandardBulletinA, true, EOPExtrapolation::Zero).unwrap();
+/// set_global_eop_provider(eop);
+///
+/// let epc = Epoch::from_datetime(2007, 4, 5, 12, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let epochs = vec![epc, epc + 60.0, epc + 120.0];
+///
+/// let v = perigee_velocity(R_EARTH + 500e3, 0.0);
+/// let states = vec![vector6_from_array([R_EARTH + 500e3, 0.0, 0.0, 0.0, v, 0.0]); 3];
+/// // Paired epochs and states
+/// let x_eci = states_ecef_to_eci(&epochs, &states).unwrap();
+/// assert_eq!(x_eci.len(), 3);
+/// ```
+pub fn states_ecef_to_eci(
+    epochs: &[Epoch],
+    x_ecef: &[SVector6],
+) -> Result<Vec<SVector6>, BraheError> {
+    states_itrf_to_gcrf(epochs, x_ecef)
+}
+
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
@@ -433,5 +674,59 @@ mod tests {
         assert_abs_diff_eq!(gcrf[3], eci2[3], epsilon = tol);
         assert_abs_diff_eq!(gcrf[4], eci2[4], epsilon = tol);
         assert_abs_diff_eq!(gcrf[5], eci2[5], epsilon = tol);
+    }
+
+    #[test]
+    #[serial]
+    fn test_batch_eci_ecef_matches_gcrf_itrf() {
+        setup_global_test_eop();
+        let epc0 = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
+        let epochs: Vec<Epoch> = (0..3).map(|i| epc0 + 60.0 * i as f64).collect();
+        let states: Vec<_> = (0..3)
+            .map(|i| {
+                let oe =
+                    vector6_from_array([R_EARTH + 500e3, 0.01, 97.8, 15.0 + i as f64, 30.0, 45.0]);
+                state_koe_to_eci(oe, DEGREES)
+            })
+            .collect();
+        let positions: Vec<Vector3<f64>> = states
+            .iter()
+            .map(|s| Vector3::new(s[0], s[1], s[2]))
+            .collect();
+
+        assert_eq!(
+            rotations_eci_to_ecef(&epochs),
+            rotations_gcrf_to_itrf(&epochs)
+        );
+        assert_eq!(
+            rotations_ecef_to_eci(&epochs),
+            rotations_itrf_to_gcrf(&epochs)
+        );
+        assert_eq!(
+            positions_eci_to_ecef(&epochs, &positions).unwrap(),
+            positions_gcrf_to_itrf(&epochs, &positions).unwrap()
+        );
+        assert_eq!(
+            positions_ecef_to_eci(&epochs, &positions).unwrap(),
+            positions_itrf_to_gcrf(&epochs, &positions).unwrap()
+        );
+        assert_eq!(
+            states_eci_to_ecef(&epochs, &states).unwrap(),
+            states_gcrf_to_itrf(&epochs, &states).unwrap()
+        );
+        assert_eq!(
+            states_ecef_to_eci(&epochs, &states).unwrap(),
+            states_itrf_to_gcrf(&epochs, &states).unwrap()
+        );
+        assert_eq!(
+            states_eci_to_ecef(&epochs[..1], &states).unwrap(),
+            states_gcrf_to_itrf(&epochs[..1], &states).unwrap()
+        );
+        for i in 0..3 {
+            assert_eq!(
+                states_eci_to_ecef(&epochs, &states).unwrap()[i],
+                state_eci_to_ecef(epochs[i], states[i])
+            );
+        }
     }
 }

--- a/src/frames/eme_2000.rs
+++ b/src/frames/eme_2000.rs
@@ -6,6 +6,7 @@ use nalgebra::{Vector3, matrix};
 
 use crate::constants::AS2RAD;
 use crate::math::{SMatrix3, SVector6};
+use crate::utils::batch::batch_map;
 
 /// Computes the bias matrix transforming the GCRF to the EME 2000
 /// reference frame.
@@ -233,11 +234,118 @@ pub fn state_eme2000_to_gcrf(x_eme2000: SVector6) -> SVector6 {
     SVector6::new(p[0], p[1], p[2], v[0], v[1], v[2])
 }
 
+/// Transforms a batch of Cartesian positions from GCRF to EME2000.
+///
+/// Batch form of [`position_gcrf_to_eme2000`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// # Arguments
+/// - `x_gcrf`: Cartesian GCRF positions. Units: (*m*)
+///
+/// # Returns
+/// - Cartesian EME2000 positions in input order. Units: (*m*)
+///
+/// # Example
+/// ```
+/// use brahe::constants::R_EARTH;
+/// use brahe::{vector3_from_array, vector6_from_array};
+/// use brahe::orbits::perigee_velocity;
+/// use brahe::frames::*;
+///
+/// let positions = vec![vector3_from_array([R_EARTH, 0.0, 0.0]); 3];
+/// let x_eme2000 = positions_gcrf_to_eme2000(&positions);
+/// assert_eq!(x_eme2000.len(), 3);
+/// ```
+pub fn positions_gcrf_to_eme2000(x_gcrf: &[Vector3<f64>]) -> Vec<Vector3<f64>> {
+    batch_map(x_gcrf, |x| position_gcrf_to_eme2000(*x))
+}
+
+/// Transforms a batch of Cartesian positions from EME2000 to GCRF.
+///
+/// Batch form of [`position_eme2000_to_gcrf`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// # Arguments
+/// - `x_eme2000`: Cartesian EME2000 positions. Units: (*m*)
+///
+/// # Returns
+/// - Cartesian GCRF positions in input order. Units: (*m*)
+///
+/// # Example
+/// ```
+/// use brahe::constants::R_EARTH;
+/// use brahe::{vector3_from_array, vector6_from_array};
+/// use brahe::orbits::perigee_velocity;
+/// use brahe::frames::*;
+///
+/// let positions = vec![vector3_from_array([R_EARTH, 0.0, 0.0]); 3];
+/// let x_gcrf = positions_eme2000_to_gcrf(&positions);
+/// assert_eq!(x_gcrf.len(), 3);
+/// ```
+pub fn positions_eme2000_to_gcrf(x_eme2000: &[Vector3<f64>]) -> Vec<Vector3<f64>> {
+    batch_map(x_eme2000, |x| position_eme2000_to_gcrf(*x))
+}
+
+/// Transforms a batch of Cartesian states from GCRF to EME2000.
+///
+/// Batch form of [`state_gcrf_to_eme2000`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// # Arguments
+/// - `x_gcrf`: Cartesian GCRF states (position, velocity). Units: (*m*; *m/s*)
+///
+/// # Returns
+/// - Cartesian EME2000 states (position, velocity) in input order. Units: (*m*; *m/s*)
+///
+/// # Example
+/// ```
+/// use brahe::constants::R_EARTH;
+/// use brahe::{vector3_from_array, vector6_from_array};
+/// use brahe::orbits::perigee_velocity;
+/// use brahe::frames::*;
+///
+/// let v = perigee_velocity(R_EARTH + 500e3, 0.0);
+/// let states = vec![vector6_from_array([R_EARTH + 500e3, 0.0, 0.0, 0.0, v, 0.0]); 3];
+/// let x_eme2000 = states_gcrf_to_eme2000(&states);
+/// assert_eq!(x_eme2000.len(), 3);
+/// ```
+pub fn states_gcrf_to_eme2000(x_gcrf: &[SVector6]) -> Vec<SVector6> {
+    batch_map(x_gcrf, |x| state_gcrf_to_eme2000(*x))
+}
+
+/// Transforms a batch of Cartesian states from EME2000 to GCRF.
+///
+/// Batch form of [`state_eme2000_to_gcrf`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// # Arguments
+/// - `x_eme2000`: Cartesian EME2000 states (position, velocity). Units: (*m*; *m/s*)
+///
+/// # Returns
+/// - Cartesian GCRF states (position, velocity) in input order. Units: (*m*; *m/s*)
+///
+/// # Example
+/// ```
+/// use brahe::constants::R_EARTH;
+/// use brahe::{vector3_from_array, vector6_from_array};
+/// use brahe::orbits::perigee_velocity;
+/// use brahe::frames::*;
+///
+/// let v = perigee_velocity(R_EARTH + 500e3, 0.0);
+/// let states = vec![vector6_from_array([R_EARTH + 500e3, 0.0, 0.0, 0.0, v, 0.0]); 3];
+/// let x_gcrf = states_eme2000_to_gcrf(&states);
+/// assert_eq!(x_gcrf.len(), 3);
+/// ```
+pub fn states_eme2000_to_gcrf(x_eme2000: &[SVector6]) -> Vec<SVector6> {
+    batch_map(x_eme2000, |x| state_eme2000_to_gcrf(*x))
+}
+
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use approx::assert_abs_diff_eq;
     use nalgebra::Vector3;
+    use serial_test::parallel;
 
     use crate::constants::{AS2RAD, DEGREES, R_EARTH};
     use crate::coordinates::state_koe_to_eci;
@@ -405,5 +513,34 @@ mod tests {
         assert_abs_diff_eq!(gcrf_2[3], gcrf[3], epsilon = tol);
         assert_abs_diff_eq!(gcrf_2[4], gcrf[4], epsilon = tol);
         assert_abs_diff_eq!(gcrf_2[5], gcrf[5], epsilon = tol);
+    }
+
+    #[test]
+    #[parallel]
+    fn test_batch_eme2000_gcrf_match_scalar() {
+        let states: Vec<_> = (0..3)
+            .map(|i| {
+                let oe =
+                    vector6_from_array([R_EARTH + 500e3, 0.01, 97.8, 15.0 + i as f64, 30.0, 45.0]);
+                state_koe_to_eci(oe, DEGREES)
+            })
+            .collect();
+        let positions: Vec<Vector3<f64>> = states
+            .iter()
+            .map(|s| Vector3::new(s[0], s[1], s[2]))
+            .collect();
+
+        let out = states_gcrf_to_eme2000(&states);
+        let back = states_eme2000_to_gcrf(&out);
+        let pos_out = positions_gcrf_to_eme2000(&positions);
+        let pos_back = positions_eme2000_to_gcrf(&pos_out);
+        for i in 0..3 {
+            assert_eq!(out[i], state_gcrf_to_eme2000(states[i]));
+            assert_eq!(back[i], state_eme2000_to_gcrf(out[i]));
+            assert_eq!(pos_out[i], position_gcrf_to_eme2000(positions[i]));
+            assert_eq!(pos_back[i], position_eme2000_to_gcrf(pos_out[i]));
+        }
+        assert!(states_gcrf_to_eme2000(&[]).is_empty());
+        assert!(positions_eme2000_to_gcrf(&[]).is_empty());
     }
 }

--- a/src/frames/eme_2000.rs
+++ b/src/frames/eme_2000.rs
@@ -257,7 +257,7 @@ pub fn state_eme2000_to_gcrf(x_eme2000: SVector6) -> SVector6 {
 /// assert_eq!(x_eme2000.len(), 3);
 /// ```
 pub fn positions_gcrf_to_eme2000(x_gcrf: &[Vector3<f64>]) -> Vec<Vector3<f64>> {
-    batch_map(x_gcrf, |x| position_gcrf_to_eme2000(*x))
+    batch_map(|x| position_gcrf_to_eme2000(*x), x_gcrf)
 }
 
 /// Transforms a batch of Cartesian positions from EME2000 to GCRF.
@@ -283,7 +283,7 @@ pub fn positions_gcrf_to_eme2000(x_gcrf: &[Vector3<f64>]) -> Vec<Vector3<f64>> {
 /// assert_eq!(x_gcrf.len(), 3);
 /// ```
 pub fn positions_eme2000_to_gcrf(x_eme2000: &[Vector3<f64>]) -> Vec<Vector3<f64>> {
-    batch_map(x_eme2000, |x| position_eme2000_to_gcrf(*x))
+    batch_map(|x| position_eme2000_to_gcrf(*x), x_eme2000)
 }
 
 /// Transforms a batch of Cartesian states from GCRF to EME2000.
@@ -310,7 +310,7 @@ pub fn positions_eme2000_to_gcrf(x_eme2000: &[Vector3<f64>]) -> Vec<Vector3<f64>
 /// assert_eq!(x_eme2000.len(), 3);
 /// ```
 pub fn states_gcrf_to_eme2000(x_gcrf: &[SVector6]) -> Vec<SVector6> {
-    batch_map(x_gcrf, |x| state_gcrf_to_eme2000(*x))
+    batch_map(|x| state_gcrf_to_eme2000(*x), x_gcrf)
 }
 
 /// Transforms a batch of Cartesian states from EME2000 to GCRF.
@@ -337,7 +337,7 @@ pub fn states_gcrf_to_eme2000(x_gcrf: &[SVector6]) -> Vec<SVector6> {
 /// assert_eq!(x_gcrf.len(), 3);
 /// ```
 pub fn states_eme2000_to_gcrf(x_eme2000: &[SVector6]) -> Vec<SVector6> {
-    batch_map(x_eme2000, |x| state_eme2000_to_gcrf(*x))
+    batch_map(|x| state_eme2000_to_gcrf(*x), x_eme2000)
 }
 
 #[cfg(test)]

--- a/src/frames/gcrf_itrf.rs
+++ b/src/frames/gcrf_itrf.rs
@@ -574,7 +574,7 @@ pub fn state_itrf_to_gcrf(epc: Epoch, x_itrf: SVector6) -> SVector6 {
 /// assert_eq!(rotations.len(), 3);
 /// ```
 pub fn rotations_gcrf_to_itrf(epochs: &[Epoch]) -> Vec<SMatrix3> {
-    batch_map(epochs, |epc| rotation_gcrf_to_itrf(*epc))
+    batch_map(|epc| rotation_gcrf_to_itrf(*epc), epochs)
 }
 
 /// Computes the ITRF-to-GCRF rotation matrix for each epoch in `epochs`.
@@ -605,7 +605,7 @@ pub fn rotations_gcrf_to_itrf(epochs: &[Epoch]) -> Vec<SMatrix3> {
 /// assert_eq!(rotations.len(), 3);
 /// ```
 pub fn rotations_itrf_to_gcrf(epochs: &[Epoch]) -> Vec<SMatrix3> {
-    batch_map(epochs, |epc| rotation_itrf_to_gcrf(*epc))
+    batch_map(|epc| rotation_itrf_to_gcrf(*epc), epochs)
 }
 
 /// Transforms a batch of Cartesian positions from GCRF to ITRF.
@@ -650,7 +650,7 @@ pub fn positions_gcrf_to_itrf(
     epochs: &[Epoch],
     x: &[Vector3<f64>],
 ) -> Result<Vec<Vector3<f64>>, BraheError> {
-    batch_map_epochs(epochs, x, rotation_gcrf_to_itrf, |r, x| r * x)
+    batch_map_epochs(rotation_gcrf_to_itrf, |r, x| r * x, epochs, x)
 }
 
 /// Transforms a batch of Cartesian positions from ITRF to GCRF.
@@ -693,7 +693,7 @@ pub fn positions_itrf_to_gcrf(
     epochs: &[Epoch],
     x: &[Vector3<f64>],
 ) -> Result<Vec<Vector3<f64>>, BraheError> {
-    batch_map_epochs(epochs, x, rotation_itrf_to_gcrf, |r, x| r * x)
+    batch_map_epochs(rotation_itrf_to_gcrf, |r, x| r * x, epochs, x)
 }
 
 /// Transforms a batch of Cartesian states from GCRF to ITRF.
@@ -741,7 +741,7 @@ pub fn states_gcrf_to_itrf(
     epochs: &[Epoch],
     x_gcrf: &[SVector6],
 ) -> Result<Vec<SVector6>, BraheError> {
-    batch_map_epochs(epochs, x_gcrf, gcrf_itrf_context, apply_state_gcrf_to_itrf)
+    batch_map_epochs(gcrf_itrf_context, apply_state_gcrf_to_itrf, epochs, x_gcrf)
 }
 
 /// Transforms a batch of Cartesian states from ITRF to GCRF.
@@ -790,7 +790,7 @@ pub fn states_itrf_to_gcrf(
     epochs: &[Epoch],
     x_itrf: &[SVector6],
 ) -> Result<Vec<SVector6>, BraheError> {
-    batch_map_epochs(epochs, x_itrf, gcrf_itrf_context, apply_state_itrf_to_gcrf)
+    batch_map_epochs(gcrf_itrf_context, apply_state_itrf_to_gcrf, epochs, x_itrf)
 }
 
 #[cfg(test)]

--- a/src/frames/gcrf_itrf.rs
+++ b/src/frames/gcrf_itrf.rs
@@ -374,6 +374,16 @@ struct GcrfItrfContext {
 /// # Returns
 /// - Context holding the bias-precession-nutation, Earth-rotation, and
 ///   polar-motion matrices
+///
+/// # Examples
+///
+/// ```ignore
+/// use brahe::time::{Epoch, TimeSystem};
+///
+/// let epc = Epoch::from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let c = gcrf_itrf_context(epc);
+/// let r_gcrf_to_itrf = c.pm * c.r * c.bpn;
+/// ```
 fn gcrf_itrf_context(epc: Epoch) -> GcrfItrfContext {
     GcrfItrfContext {
         bpn: bias_precession_nutation(epc),
@@ -390,6 +400,19 @@ fn gcrf_itrf_context(epc: Epoch) -> GcrfItrfContext {
 ///
 /// # Returns
 /// - Cartesian ITRF state (position, velocity). Units: (*m*; *m/s*)
+///
+/// # Examples
+///
+/// ```ignore
+/// use brahe::time::{Epoch, TimeSystem};
+/// use brahe::vector6_from_array;
+///
+/// let epc = Epoch::from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let c = gcrf_itrf_context(epc);
+/// let x_gcrf = vector6_from_array([7.0e6, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
+/// // The same context serves every state of a batch that shares the epoch
+/// let x_itrf = apply_state_gcrf_to_itrf(&c, &x_gcrf);
+/// ```
 fn apply_state_gcrf_to_itrf(c: &GcrfItrfContext, x_gcrf: &SVector6) -> SVector6 {
     let (bpn, r, pm) = (c.bpn, c.r, c.pm);
 
@@ -414,6 +437,18 @@ fn apply_state_gcrf_to_itrf(c: &GcrfItrfContext, x_gcrf: &SVector6) -> SVector6 
 ///
 /// # Returns
 /// - Cartesian GCRF state (position, velocity). Units: (*m*; *m/s*)
+///
+/// # Examples
+///
+/// ```ignore
+/// use brahe::time::{Epoch, TimeSystem};
+/// use brahe::vector6_from_array;
+///
+/// let epc = Epoch::from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let c = gcrf_itrf_context(epc);
+/// let x_itrf = vector6_from_array([7.0e6, 0.0, 0.0, 0.0, 7.0e3, 0.0]);
+/// let x_gcrf = apply_state_itrf_to_gcrf(&c, &x_itrf);
+/// ```
 fn apply_state_itrf_to_gcrf(c: &GcrfItrfContext, x_itrf: &SVector6) -> SVector6 {
     let (bpn, r, pm) = (c.bpn, c.r, c.pm);
 

--- a/src/frames/gcrf_itrf.rs
+++ b/src/frames/gcrf_itrf.rs
@@ -10,6 +10,8 @@ use crate::constants::MJD_ZERO;
 use crate::eop;
 use crate::math::matrix3_from_array;
 use crate::time::{Epoch, TimeSystem};
+use crate::utils::BraheError;
+use crate::utils::batch::{batch_map, batch_map_epochs};
 
 /// Computes the Bias-Precession-Nutation matrix transforming the GCRS to the
 /// CIRS intermediate reference frame. This transformation corrects for the
@@ -357,6 +359,77 @@ pub fn position_itrf_to_gcrf(epc: Epoch, x: Vector3<f64>) -> Vector3<f64> {
     rotation_itrf_to_gcrf(epc) * x
 }
 
+/// Bias-precession-nutation, Earth-rotation, and polar-motion matrices for one epoch.
+struct GcrfItrfContext {
+    bpn: SMatrix3,
+    r: SMatrix3,
+    pm: SMatrix3,
+}
+
+/// Compute the sequential GCRF-to-ITRF transformation matrices for `epc`.
+///
+/// # Arguments
+/// - `epc`: Epoch instant for computation of the transformation
+///
+/// # Returns
+/// - Context holding the bias-precession-nutation, Earth-rotation, and
+///   polar-motion matrices
+fn gcrf_itrf_context(epc: Epoch) -> GcrfItrfContext {
+    GcrfItrfContext {
+        bpn: bias_precession_nutation(epc),
+        r: earth_rotation(epc),
+        pm: polar_motion(epc),
+    }
+}
+
+/// Apply a precomputed GCRF-to-ITRF context to one Cartesian GCRF state.
+///
+/// # Arguments
+/// - `c`: Transformation matrices for the epoch
+/// - `x_gcrf`: Cartesian GCRF state (position, velocity). Units: (*m*; *m/s*)
+///
+/// # Returns
+/// - Cartesian ITRF state (position, velocity). Units: (*m*; *m/s*)
+fn apply_state_gcrf_to_itrf(c: &GcrfItrfContext, x_gcrf: &SVector6) -> SVector6 {
+    let (bpn, r, pm) = (c.bpn, c.r, c.pm);
+
+    // Create Earth's Angular Rotation Vector
+    let omega_vec = Vector3::new(0.0, 0.0, constants::OMEGA_EARTH);
+
+    let r_gcrf = x_gcrf.fixed_rows::<3>(0);
+    let v_gcrf = x_gcrf.fixed_rows::<3>(3);
+
+    let p: Vector3<f64> = Vector3::from(pm * r * bpn * r_gcrf);
+    let v: Vector3<f64> = pm * (r * bpn * v_gcrf - omega_vec.cross(&(r * bpn * r_gcrf)));
+
+    SVector6::new(p[0], p[1], p[2], v[0], v[1], v[2])
+}
+
+/// Apply a precomputed GCRF-to-ITRF context to one Cartesian ITRF state,
+/// producing the GCRF state.
+///
+/// # Arguments
+/// - `c`: Transformation matrices for the epoch
+/// - `x_itrf`: Cartesian ITRF state (position, velocity). Units: (*m*; *m/s*)
+///
+/// # Returns
+/// - Cartesian GCRF state (position, velocity). Units: (*m*; *m/s*)
+fn apply_state_itrf_to_gcrf(c: &GcrfItrfContext, x_itrf: &SVector6) -> SVector6 {
+    let (bpn, r, pm) = (c.bpn, c.r, c.pm);
+
+    // Create Earth's Angular Rotation Vector
+    let omega_vec = Vector3::new(0.0, 0.0, constants::OMEGA_EARTH);
+
+    let r_itrf = x_itrf.fixed_rows::<3>(0);
+    let v_itrf = x_itrf.fixed_rows::<3>(3);
+
+    let p: Vector3<f64> = Vector3::from((pm * r * bpn).transpose() * r_itrf);
+    let v: Vector3<f64> = (r * bpn).transpose()
+        * (pm.transpose() * v_itrf + omega_vec.cross(&(pm.transpose() * r_itrf)));
+
+    SVector6::new(p[0], p[1], p[2], v[0], v[1], v[2])
+}
+
 /// Transforms a Cartesian state in GCRF (Geocentric Celestial Reference Frame)
 /// to the equivalent state in ITRF (International Terrestrial Reference Frame).
 ///
@@ -393,21 +466,7 @@ pub fn position_itrf_to_gcrf(epc: Epoch, x: Vector3<f64>) -> Vector3<f64> {
 /// let x_itrf = state_gcrf_to_itrf(epc, x_gcrf);
 /// ```
 pub fn state_gcrf_to_itrf(epc: Epoch, x_gcrf: SVector6) -> SVector6 {
-    // Compute Sequential Transformation Matrices
-    let bpn = bias_precession_nutation(epc);
-    let r = earth_rotation(epc);
-    let pm = polar_motion(epc);
-
-    // Create Earth's Angular Rotation Vector
-    let omega_vec = Vector3::new(0.0, 0.0, constants::OMEGA_EARTH);
-
-    let r_gcrf = x_gcrf.fixed_rows::<3>(0);
-    let v_gcrf = x_gcrf.fixed_rows::<3>(3);
-
-    let p: Vector3<f64> = Vector3::from(pm * r * bpn * r_gcrf);
-    let v: Vector3<f64> = pm * (r * bpn * v_gcrf - omega_vec.cross(&(r * bpn * r_gcrf)));
-
-    SVector6::new(p[0], p[1], p[2], v[0], v[1], v[2])
+    apply_state_gcrf_to_itrf(&gcrf_itrf_context(epc), &x_gcrf)
 }
 
 /// Transforms a Cartesian state in ITRF (International Terrestrial Reference Frame)
@@ -449,22 +508,254 @@ pub fn state_gcrf_to_itrf(epc: Epoch, x_gcrf: SVector6) -> SVector6 {
 /// let x_gcrf2 = state_itrf_to_gcrf(epc, x_itrf);
 /// ```
 pub fn state_itrf_to_gcrf(epc: Epoch, x_itrf: SVector6) -> SVector6 {
-    // Compute Sequential Transformation Matrices
-    let bpn = bias_precession_nutation(epc);
-    let r = earth_rotation(epc);
-    let pm = polar_motion(epc);
+    apply_state_itrf_to_gcrf(&gcrf_itrf_context(epc), &x_itrf)
+}
 
-    // Create Earth's Angular Rotation Vector
-    let omega_vec = Vector3::new(0.0, 0.0, constants::OMEGA_EARTH);
+/// Computes the GCRF-to-ITRF rotation matrix for each epoch in `epochs`.
+///
+/// Batch form of [`rotation_gcrf_to_itrf`]. Evaluation runs on the global
+/// thread pool for large inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants for computation of the transformation matrices
+///
+/// # Returns
+/// - Rotation matrices transforming GCRF -> ITRF, one per epoch, in input order
+///
+/// # Example
+/// ```
+/// use brahe::eop::*;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use brahe::frames::*;
+///
+/// // Quick EOP initialization
+/// let eop = FileEOPProvider::from_default_file(EOPType::StandardBulletinA, true, EOPExtrapolation::Zero).unwrap();
+/// set_global_eop_provider(eop);
+///
+/// let epc = Epoch::from_datetime(2007, 4, 5, 12, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let epochs = vec![epc, epc + 60.0, epc + 120.0];
+///
+/// let rotations = rotations_gcrf_to_itrf(&epochs);
+/// assert_eq!(rotations.len(), 3);
+/// ```
+pub fn rotations_gcrf_to_itrf(epochs: &[Epoch]) -> Vec<SMatrix3> {
+    batch_map(epochs, |epc| rotation_gcrf_to_itrf(*epc))
+}
 
-    let r_itrf = x_itrf.fixed_rows::<3>(0);
-    let v_itrf = x_itrf.fixed_rows::<3>(3);
+/// Computes the ITRF-to-GCRF rotation matrix for each epoch in `epochs`.
+///
+/// Batch form of [`rotation_itrf_to_gcrf`]. Evaluation runs on the global
+/// thread pool for large inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants for computation of the transformation matrices
+///
+/// # Returns
+/// - Rotation matrices transforming ITRF -> GCRF, one per epoch, in input order
+///
+/// # Example
+/// ```
+/// use brahe::eop::*;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use brahe::frames::*;
+///
+/// // Quick EOP initialization
+/// let eop = FileEOPProvider::from_default_file(EOPType::StandardBulletinA, true, EOPExtrapolation::Zero).unwrap();
+/// set_global_eop_provider(eop);
+///
+/// let epc = Epoch::from_datetime(2007, 4, 5, 12, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let epochs = vec![epc, epc + 60.0, epc + 120.0];
+///
+/// let rotations = rotations_itrf_to_gcrf(&epochs);
+/// assert_eq!(rotations.len(), 3);
+/// ```
+pub fn rotations_itrf_to_gcrf(epochs: &[Epoch]) -> Vec<SMatrix3> {
+    batch_map(epochs, |epc| rotation_itrf_to_gcrf(*epc))
+}
 
-    let p: Vector3<f64> = Vector3::from((pm * r * bpn).transpose() * r_itrf);
-    let v: Vector3<f64> = (r * bpn).transpose()
-        * (pm.transpose() * v_itrf + omega_vec.cross(&(pm.transpose() * r_itrf)));
+/// Transforms a batch of Cartesian positions from GCRF to ITRF.
+///
+/// Batch form of [`position_gcrf_to_itrf`]. `epochs` and `x` follow the
+/// broadcast rule: each has length 1 or the common batch length. A single
+/// epoch computes the rotation matrix once and applies it to every position;
+/// per-element epochs compute it per position. Evaluation runs on the global
+/// thread pool for large inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x`: Cartesian GCRF positions, length 1 or the batch length. Units: (*m*)
+///
+/// # Returns
+/// - Cartesian ITRF positions in input order. Units: (*m*)
+/// - Error if `epochs` and `x` do not satisfy the broadcast rule
+///
+/// # Example
+/// ```
+/// use brahe::eop::*;
+/// use brahe::constants::R_EARTH;
+/// use brahe::vector3_from_array;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use brahe::frames::*;
+///
+/// // Quick EOP initialization
+/// let eop = FileEOPProvider::from_default_file(EOPType::StandardBulletinA, true, EOPExtrapolation::Zero).unwrap();
+/// set_global_eop_provider(eop);
+///
+/// let epc = Epoch::from_datetime(2007, 4, 5, 12, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let positions = vec![
+///     vector3_from_array([R_EARTH, 0.0, 0.0]),
+///     vector3_from_array([0.0, R_EARTH, 0.0]),
+/// ];
+///
+/// // One epoch, many positions
+/// let x_itrf = positions_gcrf_to_itrf(&[epc], &positions).unwrap();
+/// assert_eq!(x_itrf.len(), 2);
+/// ```
+pub fn positions_gcrf_to_itrf(
+    epochs: &[Epoch],
+    x: &[Vector3<f64>],
+) -> Result<Vec<Vector3<f64>>, BraheError> {
+    batch_map_epochs(epochs, x, rotation_gcrf_to_itrf, |r, x| r * x)
+}
 
-    SVector6::new(p[0], p[1], p[2], v[0], v[1], v[2])
+/// Transforms a batch of Cartesian positions from ITRF to GCRF.
+///
+/// Batch form of [`position_itrf_to_gcrf`]. `epochs` and `x` follow the
+/// broadcast rule: each has length 1 or the common batch length. A single
+/// epoch computes the rotation matrix once and applies it to every position;
+/// per-element epochs compute it per position. Evaluation runs on the global
+/// thread pool for large inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x`: Cartesian ITRF positions, length 1 or the batch length. Units: (*m*)
+///
+/// # Returns
+/// - Cartesian GCRF positions in input order. Units: (*m*)
+/// - Error if `epochs` and `x` do not satisfy the broadcast rule
+///
+/// # Example
+/// ```
+/// use brahe::eop::*;
+/// use brahe::constants::R_EARTH;
+/// use brahe::vector3_from_array;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use brahe::frames::*;
+///
+/// // Quick EOP initialization
+/// let eop = FileEOPProvider::from_default_file(EOPType::StandardBulletinA, true, EOPExtrapolation::Zero).unwrap();
+/// set_global_eop_provider(eop);
+///
+/// let epc = Epoch::from_datetime(2007, 4, 5, 12, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let epochs = vec![epc, epc + 60.0, epc + 120.0];
+/// let station = vector3_from_array([R_EARTH, 0.0, 0.0]);
+///
+/// // One ground station, many epochs
+/// let x_gcrf = positions_itrf_to_gcrf(&epochs, &[station]).unwrap();
+/// assert_eq!(x_gcrf.len(), 3);
+/// ```
+pub fn positions_itrf_to_gcrf(
+    epochs: &[Epoch],
+    x: &[Vector3<f64>],
+) -> Result<Vec<Vector3<f64>>, BraheError> {
+    batch_map_epochs(epochs, x, rotation_itrf_to_gcrf, |r, x| r * x)
+}
+
+/// Transforms a batch of Cartesian states from GCRF to ITRF.
+///
+/// Batch form of [`state_gcrf_to_itrf`]. `epochs` and `x_gcrf` follow the
+/// broadcast rule: each has length 1 or the common batch length. A single
+/// epoch computes the transformation matrices once and applies them to every
+/// state; per-element epochs compute them per state. Evaluation runs on the
+/// global thread pool for large inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x_gcrf`: Cartesian GCRF states (position, velocity), length 1 or the
+///   batch length. Units: (*m*; *m/s*)
+///
+/// # Returns
+/// - Cartesian ITRF states (position, velocity) in input order. Units: (*m*; *m/s*)
+/// - Error if `epochs` and `x_gcrf` do not satisfy the broadcast rule
+///
+/// # Example
+/// ```
+/// use brahe::eop::*;
+/// use brahe::vector6_from_array;
+/// use brahe::constants::R_EARTH;
+/// use brahe::orbits::perigee_velocity;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use brahe::frames::*;
+///
+/// // Quick EOP initialization
+/// let eop = FileEOPProvider::from_default_file(EOPType::StandardBulletinA, true, EOPExtrapolation::Zero).unwrap();
+/// set_global_eop_provider(eop);
+///
+/// let epc = Epoch::from_datetime(2007, 4, 5, 12, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let v = perigee_velocity(R_EARTH + 500e3, 0.0);
+/// let states = vec![
+///     vector6_from_array([R_EARTH + 500e3, 0.0, 0.0, 0.0, v, 0.0]),
+///     vector6_from_array([0.0, R_EARTH + 500e3, 0.0, -v, 0.0, 0.0]),
+/// ];
+///
+/// // One epoch, many states
+/// let x_itrf = states_gcrf_to_itrf(&[epc], &states).unwrap();
+/// assert_eq!(x_itrf.len(), 2);
+/// ```
+pub fn states_gcrf_to_itrf(
+    epochs: &[Epoch],
+    x_gcrf: &[SVector6],
+) -> Result<Vec<SVector6>, BraheError> {
+    batch_map_epochs(epochs, x_gcrf, gcrf_itrf_context, apply_state_gcrf_to_itrf)
+}
+
+/// Transforms a batch of Cartesian states from ITRF to GCRF.
+///
+/// Batch form of [`state_itrf_to_gcrf`]. `epochs` and `x_itrf` follow the
+/// broadcast rule: each has length 1 or the common batch length. A single
+/// epoch computes the transformation matrices once and applies them to every
+/// state; per-element epochs compute them per state. Evaluation runs on the
+/// global thread pool for large inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x_itrf`: Cartesian ITRF states (position, velocity), length 1 or the
+///   batch length. Units: (*m*; *m/s*)
+///
+/// # Returns
+/// - Cartesian GCRF states (position, velocity) in input order. Units: (*m*; *m/s*)
+/// - Error if `epochs` and `x_itrf` do not satisfy the broadcast rule
+///
+/// # Example
+/// ```
+/// use brahe::eop::*;
+/// use brahe::vector6_from_array;
+/// use brahe::constants::R_EARTH;
+/// use brahe::orbits::perigee_velocity;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use brahe::frames::*;
+///
+/// // Quick EOP initialization
+/// let eop = FileEOPProvider::from_default_file(EOPType::StandardBulletinA, true, EOPExtrapolation::Zero).unwrap();
+/// set_global_eop_provider(eop);
+///
+/// let epc = Epoch::from_datetime(2007, 4, 5, 12, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let epochs = vec![epc, epc + 60.0];
+/// let v = perigee_velocity(R_EARTH + 500e3, 0.0);
+/// let states = vec![
+///     vector6_from_array([R_EARTH + 500e3, 0.0, 0.0, 0.0, v, 0.0]),
+///     vector6_from_array([0.0, R_EARTH + 500e3, 0.0, -v, 0.0, 0.0]),
+/// ];
+///
+/// // Paired epochs and states
+/// let x_gcrf = states_itrf_to_gcrf(&epochs, &states).unwrap();
+/// assert_eq!(x_gcrf.len(), 2);
+/// ```
+pub fn states_itrf_to_gcrf(
+    epochs: &[Epoch],
+    x_itrf: &[SVector6],
+) -> Result<Vec<SVector6>, BraheError> {
+    batch_map_epochs(epochs, x_itrf, gcrf_itrf_context, apply_state_itrf_to_gcrf)
 }
 
 #[cfg(test)]
@@ -478,8 +769,9 @@ mod tests {
     use crate::coordinates::state_koe_to_eci;
     use crate::eop::{StaticEOPProvider, set_global_eop_provider};
     use crate::frames::*;
-    use crate::math::vector6_from_array;
+    use crate::math::{SVector6, vector6_from_array};
     use crate::time::{Epoch, TimeSystem};
+    use crate::utils::batch::PARALLEL_THRESHOLD;
     use crate::utils::testing::setup_global_test_eop;
 
     #[allow(non_snake_case)]
@@ -682,5 +974,144 @@ mod tests {
         assert_abs_diff_eq!(itrf2[3], itrf[3], epsilon = tol);
         assert_abs_diff_eq!(itrf2[4], itrf[4], epsilon = tol);
         assert_abs_diff_eq!(itrf2[5], itrf[5], epsilon = tol);
+    }
+
+    fn sample_states(n: usize) -> Vec<SVector6> {
+        (0..n)
+            .map(|i| {
+                let oe = vector6_from_array([
+                    R_EARTH + 500e3 + 1e3 * i as f64,
+                    0.01,
+                    97.8,
+                    15.0 + i as f64,
+                    30.0,
+                    45.0 + 2.0 * i as f64,
+                ]);
+                state_koe_to_eci(oe, DEGREES)
+            })
+            .collect()
+    }
+
+    fn sample_epochs(n: usize) -> Vec<Epoch> {
+        let epc0 = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
+        (0..n).map(|i| epc0 + 60.0 * i as f64).collect()
+    }
+
+    #[test]
+    #[serial]
+    fn test_states_gcrf_to_itrf_shared_epoch_matches_scalar() {
+        setup_global_test_eop();
+        let epc = sample_epochs(1);
+        let states = sample_states(5);
+        let out = states_gcrf_to_itrf(&epc, &states).unwrap();
+        for (s, o) in states.iter().zip(&out) {
+            assert_eq!(*o, state_gcrf_to_itrf(epc[0], *s));
+        }
+
+        let states = sample_states(PARALLEL_THRESHOLD + 1);
+        let out = states_gcrf_to_itrf(&epc, &states).unwrap();
+        for (s, o) in states.iter().zip(&out) {
+            assert_eq!(*o, state_gcrf_to_itrf(epc[0], *s));
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_states_gcrf_to_itrf_per_epoch_matches_scalar() {
+        setup_global_test_eop();
+        let epochs = sample_epochs(5);
+        let states = sample_states(5);
+        let out = states_gcrf_to_itrf(&epochs, &states).unwrap();
+        for i in 0..5 {
+            assert_eq!(out[i], state_gcrf_to_itrf(epochs[i], states[i]));
+        }
+
+        let out = states_gcrf_to_itrf(&epochs, &states[..1]).unwrap();
+        for i in 0..5 {
+            assert_eq!(out[i], state_gcrf_to_itrf(epochs[i], states[0]));
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_states_itrf_to_gcrf_matches_scalar_and_roundtrip() {
+        setup_global_test_eop();
+        let epochs = sample_epochs(4);
+        let states = sample_states(4);
+        let itrf = states_gcrf_to_itrf(&epochs, &states).unwrap();
+        let back = states_itrf_to_gcrf(&epochs, &itrf).unwrap();
+        for i in 0..4 {
+            assert_eq!(back[i], state_itrf_to_gcrf(epochs[i], itrf[i]));
+            for k in 0..3 {
+                assert_abs_diff_eq!(back[i][k], states[i][k], epsilon = 1e-6);
+            }
+            for k in 3..6 {
+                assert_abs_diff_eq!(back[i][k], states[i][k], epsilon = 1e-9);
+            }
+        }
+
+        let shared = states_itrf_to_gcrf(&epochs[..1], &itrf).unwrap();
+        for i in 0..4 {
+            assert_eq!(shared[i], state_itrf_to_gcrf(epochs[0], itrf[i]));
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_positions_gcrf_itrf_match_scalar() {
+        setup_global_test_eop();
+        let epochs = sample_epochs(3);
+        let pos: Vec<Vector3<f64>> = sample_states(3)
+            .iter()
+            .map(|s| Vector3::new(s[0], s[1], s[2]))
+            .collect();
+
+        let out = positions_gcrf_to_itrf(&epochs, &pos).unwrap();
+        for i in 0..3 {
+            assert_eq!(out[i], position_gcrf_to_itrf(epochs[i], pos[i]));
+        }
+
+        let out_shared = positions_gcrf_to_itrf(&epochs[..1], &pos).unwrap();
+        for i in 0..3 {
+            assert_eq!(out_shared[i], position_gcrf_to_itrf(epochs[0], pos[i]));
+        }
+
+        let back = positions_itrf_to_gcrf(&epochs, &out).unwrap();
+        for i in 0..3 {
+            assert_eq!(back[i], position_itrf_to_gcrf(epochs[i], out[i]));
+        }
+
+        let station = positions_itrf_to_gcrf(&epochs, &pos[..1]).unwrap();
+        for i in 0..3 {
+            assert_eq!(station[i], position_itrf_to_gcrf(epochs[i], pos[0]));
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_rotations_gcrf_itrf_match_scalar() {
+        setup_global_test_eop();
+        let epochs = sample_epochs(3);
+        let r = rotations_gcrf_to_itrf(&epochs);
+        let rt = rotations_itrf_to_gcrf(&epochs);
+        for i in 0..3 {
+            assert_eq!(r[i], rotation_gcrf_to_itrf(epochs[i]));
+            assert_eq!(rt[i], rotation_itrf_to_gcrf(epochs[i]));
+        }
+        assert!(rotations_gcrf_to_itrf(&[]).is_empty());
+    }
+
+    #[test]
+    #[serial]
+    fn test_states_gcrf_to_itrf_length_mismatch_and_empty() {
+        setup_global_test_eop();
+        assert!(states_gcrf_to_itrf(&sample_epochs(2), &sample_states(3)).is_err());
+        assert!(positions_gcrf_to_itrf(&sample_epochs(2), &[Vector3::zeros(); 3]).is_err());
+        assert!(
+            states_gcrf_to_itrf(&sample_epochs(1), &[])
+                .unwrap()
+                .is_empty()
+        );
+        assert!(states_gcrf_to_itrf(&[], &[]).unwrap().is_empty());
     }
 }

--- a/src/utils/batch.rs
+++ b/src/utils/batch.rs
@@ -7,8 +7,6 @@
  * composition of its scalar counterpart with one of these primitives.
  */
 
-#![allow(dead_code)]
-
 use rayon::prelude::*;
 
 use crate::time::Epoch;
@@ -155,6 +153,7 @@ pub(crate) fn batch_map<T: Sync, U: Send>(f: impl Fn(&T) -> U + Sync, inputs: &[
 /// let sums = batch_zip(|a, b| a + b, &[10.0], &[1.0, 2.0]).unwrap();
 /// assert_eq!(sums, vec![11.0, 12.0]);
 /// ```
+#[allow(dead_code)]
 pub(crate) fn batch_zip<A: Sync, B: Sync, U: Send>(
     f: impl Fn(&A, &B) -> U + Sync,
     a: &[A],

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -292,6 +292,194 @@ def test_gcrf_itrf_eci_ecef_equivalence(eop):
     assert np.allclose(state_gcrf_itrf, state_eci_ecef)
 
 
+# Batch (vectorized) transformation tests
+def _sample_states(n):
+    return np.array(
+        [
+            brahe.state_koe_to_eci(
+                np.array(
+                    [
+                        brahe.R_EARTH + 500e3 + 1e3 * i,
+                        0.01,
+                        97.8,
+                        15.0 + i,
+                        30.0,
+                        45.0 + 2 * i,
+                    ]
+                ),
+                brahe.AngleFormat.DEGREES,
+            )
+            for i in range(n)
+        ]
+    )
+
+
+def _sample_epochs(n):
+    epc0 = brahe.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, brahe.TimeSystem.UTC)
+    return [epc0 + 60.0 * i for i in range(n)]
+
+
+def test_state_eci_to_ecef_batch_shared_epoch(eop):
+    epc = _sample_epochs(1)[0]
+    states = _sample_states(5)
+    out = brahe.state_eci_to_ecef(epc, states)
+    assert out.shape == (5, 6)
+    for i in range(5):
+        np.testing.assert_array_equal(out[i], brahe.state_eci_to_ecef(epc, states[i]))
+    out_t = brahe.state_eci_to_ecef(epc, states.T, axis=0)
+    assert out_t.shape == (6, 5)
+    np.testing.assert_array_equal(out_t, out.T)
+
+
+def test_state_eci_to_ecef_batch_epoch_sequence(eop):
+    epochs = _sample_epochs(5)
+    states = _sample_states(5)
+    out = brahe.state_eci_to_ecef(epochs, states)
+    assert out.shape == (5, 6)
+    for i in range(5):
+        np.testing.assert_array_equal(
+            out[i], brahe.state_eci_to_ecef(epochs[i], states[i])
+        )
+    np.testing.assert_array_equal(brahe.state_eci_to_ecef(tuple(epochs), states), out)
+    np.testing.assert_array_equal(
+        brahe.state_eci_to_ecef(np.array(epochs, dtype=object), states), out
+    )
+
+
+def test_position_ecef_to_eci_single_position_many_epochs(eop):
+    epochs = _sample_epochs(4)
+    station = np.array([brahe.R_EARTH, 0.0, 0.0])
+    out = brahe.position_ecef_to_eci(epochs, station)
+    assert out.shape == (4, 3)
+    for i in range(4):
+        np.testing.assert_array_equal(
+            out[i], brahe.position_ecef_to_eci(epochs[i], station)
+        )
+    out0 = brahe.position_ecef_to_eci(epochs, station, axis=0)
+    assert out0.shape == (3, 4)
+    np.testing.assert_array_equal(out0, out.T)
+
+
+def test_state_gcrf_to_itrf_batch_nd_and_list_input(eop):
+    epc = _sample_epochs(1)[0]
+    states = _sample_states(6).reshape(2, 3, 6)
+    out = brahe.state_gcrf_to_itrf(epc, states)
+    assert out.shape == (2, 3, 6)
+    for i in range(2):
+        for j in range(3):
+            np.testing.assert_array_equal(
+                out[i, j], brahe.state_gcrf_to_itrf(epc, states[i, j])
+            )
+    states_mid = np.moveaxis(states, 2, 1)
+    out_mid = brahe.state_gcrf_to_itrf(epc, states_mid, axis=1)
+    assert out_mid.shape == (2, 6, 3)
+    np.testing.assert_array_equal(np.moveaxis(out_mid, 1, 2), out)
+    small = _sample_states(3)
+    np.testing.assert_array_equal(
+        brahe.state_gcrf_to_itrf(epc, small.tolist()),
+        brahe.state_gcrf_to_itrf(epc, small),
+    )
+
+
+def test_state_itrf_to_gcrf_batch_roundtrip(eop):
+    epochs = _sample_epochs(4)
+    states = _sample_states(4)
+    itrf = brahe.state_gcrf_to_itrf(epochs, states)
+    for i in range(4):
+        np.testing.assert_array_equal(
+            itrf[i], brahe.state_gcrf_to_itrf(epochs[i], states[i])
+        )
+    back = brahe.state_itrf_to_gcrf(epochs, itrf)
+    for i in range(4):
+        np.testing.assert_array_equal(
+            back[i], brahe.state_itrf_to_gcrf(epochs[i], itrf[i])
+        )
+    np.testing.assert_allclose(back[:, :3], states[:, :3], atol=1e-6)
+    np.testing.assert_allclose(back[:, 3:], states[:, 3:], atol=1e-9)
+
+
+def test_rotation_eci_to_ecef_batch(eop):
+    epochs = _sample_epochs(3)
+    R = brahe.rotation_eci_to_ecef(epochs)
+    assert R.shape == (3, 3, 3)
+    for i in range(3):
+        np.testing.assert_array_equal(R[i], brahe.rotation_eci_to_ecef(epochs[i]))
+    Rt = brahe.rotation_ecef_to_eci(epochs)
+    for i in range(3):
+        np.testing.assert_array_equal(Rt[i], brahe.rotation_ecef_to_eci(epochs[i]))
+    np.testing.assert_array_equal(brahe.rotation_gcrf_to_itrf(epochs), R)
+    np.testing.assert_array_equal(brahe.rotation_itrf_to_gcrf(epochs), Rt)
+    assert brahe.rotation_eci_to_ecef(epochs[0]).shape == (3, 3)
+
+
+def test_batch_positions_eci_ecef_gcrf_itrf(eop):
+    epochs = _sample_epochs(3)
+    pos = _sample_states(3)[:, :3]
+    for f in (
+        brahe.position_eci_to_ecef,
+        brahe.position_ecef_to_eci,
+        brahe.position_gcrf_to_itrf,
+        brahe.position_itrf_to_gcrf,
+    ):
+        out = f(epochs, pos)
+        assert out.shape == (3, 3)
+        for i in range(3):
+            np.testing.assert_array_equal(out[i], f(epochs[i], pos[i]))
+        out1 = f(epochs[0], pos)
+        for i in range(3):
+            np.testing.assert_array_equal(out1[i], f(epochs[0], pos[i]))
+
+
+def test_batch_states_eci_ecef_alias(eop):
+    epochs = _sample_epochs(3)
+    states = _sample_states(3)
+    np.testing.assert_array_equal(
+        brahe.state_eci_to_ecef(epochs, states),
+        brahe.state_gcrf_to_itrf(epochs, states),
+    )
+    np.testing.assert_array_equal(
+        brahe.state_ecef_to_eci(epochs, states),
+        brahe.state_itrf_to_gcrf(epochs, states),
+    )
+
+
+def test_batch_eme2000_gcrf():
+    states = _sample_states(3)
+    for f in (brahe.state_gcrf_to_eme2000, brahe.state_eme2000_to_gcrf):
+        out = f(states)
+        assert out.shape == (3, 6)
+        for i in range(3):
+            np.testing.assert_array_equal(out[i], f(states[i]))
+        out0 = f(states.T, axis=0)
+        np.testing.assert_array_equal(out0, out.T)
+    pos = states[:, :3]
+    for f in (brahe.position_gcrf_to_eme2000, brahe.position_eme2000_to_gcrf):
+        out = f(pos)
+        assert out.shape == (3, 3)
+        for i in range(3):
+            np.testing.assert_array_equal(out[i], f(pos[i]))
+
+
+def test_batch_input_errors(eop):
+    epochs = _sample_epochs(3)
+    states = _sample_states(3)
+    with pytest.raises(ValueError):
+        brahe.state_eci_to_ecef(epochs[0], states, axis=0)
+    with pytest.raises(ValueError):
+        brahe.state_eci_to_ecef(epochs[0], states, axis=2)
+    with pytest.raises(ValueError):
+        brahe.state_eci_to_ecef(epochs[:2], states)
+    with pytest.raises(ValueError):
+        brahe.state_eci_to_ecef(epochs[0], np.zeros((3, 5)))
+    with pytest.raises(TypeError):
+        brahe.state_eci_to_ecef([1.0, 2.0], states)
+    with pytest.raises(ValueError):
+        brahe.state_eci_to_ecef(epochs[0], 5.0)
+    assert brahe.state_eci_to_ecef(epochs[0], np.zeros((0, 6))).shape == (0, 6)
+    with pytest.raises(TypeError):
+        brahe.rotation_eci_to_ecef([1.0, 2.0])
+
+
 # EME2000 <> GCRF transformation tests
 def test_bias_eme2000():
     """Test the bias matrix computation for GCRF to EME2000"""


### PR DESCRIPTION
# Pull Request

## Description

Vectorizes the Earth frame transformations. Rust gains plural functions for ECI/ECEF, GCRF/ITRF, and EME2000 (`rotations_*`, `positions_*`, `states_*`; 16 functions) built on the batch primitives; the GCRF/ITRF scalar state transforms are split into a private `GcrfItrfContext` + `apply_*` pair so a batch sharing one epoch computes the IAU 2006/2000A matrices once, with results bit-identical to the scalar functions. In Python the existing functions dispatch on input shape: a 1-D vector behaves exactly as before, an array with the components along `axis` (default `-1`) is transformed as a batch keeping its layout, and epoch arguments accept an `Epoch` or a sequence of epochs (one per vector, or one vector broadcast across all epochs). Batches call the core with the GIL released. Adds the shared Python dispatch helpers (`crates/brahe-py/src/batch.rs`), a Learn page, and a standalone example.

## Changelog

### Added
- Batch Earth frame transformations `rotations_/positions_/states_{eci_to_ecef,ecef_to_eci,gcrf_to_itrf,itrf_to_gcrf}` and `positions_/states_{gcrf_to_eme2000,eme2000_to_gcrf}` in Rust; a shared epoch hoists the IAU 2006/2000A rotation matrices across the batch.
- Python `rotation_/position_/state_*` Earth frame functions accept batches of vectors with an `axis` keyword (default `-1`, numpy component-axis convention) and `Epoch | Sequence[Epoch]` epoch arguments; single-vector calls are unchanged.
- Learn page "Vectorized Transformations" and `examples/frames/vectorized_transforms.{py,rs}`.

## Note to Reviewers
The scalar `state_gcrf_to_itrf`/`state_itrf_to_gcrf` bodies move verbatim into `apply_state_*`; the scalar functions become `apply(&context(epc), &x)`. Rust tests assert exact equality of every plural against a loop of the scalar on the hoisted, per-epoch, and broadcast paths; Python tests mirror them and cover `axis`, N-D input, list input, epoch sequence forms, and error cases.
