### PR TITLE
Vectorize planetary, synodic, and generic frame transformations

### DIFF
--- a/crates/brahe-py/src/batch.rs
+++ b/crates/brahe-py/src/batch.rs
@@ -203,6 +203,45 @@ fn matrices_to_numpy<'py>(py: Python<'py>, mats: Vec<SMatrix3>) -> Bound<'py, Py
     flat.into_pyarray(py).reshape([n, 3, 3]).unwrap().into_any()
 }
 
+/// Inputs of a batched epoch-dependent transform: epochs, vectors, and the
+/// output layout.
+struct EpochVecBatch<const N: usize> {
+    epochs: Vec<time::Epoch>,
+    vecs: Vec<SVector<f64, N>>,
+    layout: BatchLayout,
+}
+
+/// Parsed epoch/vector arguments: either the scalar pair or a batch.
+enum EpochVecArgs<const N: usize> {
+    Single(time::Epoch, SVector<f64, N>),
+    Batch(EpochVecBatch<N>),
+}
+
+/// Parse and validate the epoch and vector arguments of a transform.
+fn parse_epoch_vec_args<const N: usize>(
+    epc: &Bound<'_, PyAny>,
+    x: &Bound<'_, PyAny>,
+    axis: isize,
+) -> PyResult<EpochVecArgs<N>> {
+    let epochs = parse_epoch_arg(epc)?;
+    let vecs = parse_vec_arg::<N>(x, axis)?;
+    let (epochs, vecs, layout) = match (epochs, vecs) {
+        (EpochArg::Single(e), VecArg::Single(v)) => return Ok(EpochVecArgs::Single(e, v)),
+        (EpochArg::Single(e), VecArg::Batch { vecs, layout }) => (vec![e], vecs, layout),
+        (EpochArg::Many(epochs), VecArg::Single(v)) => {
+            let layout = BatchLayout::for_broadcast::<N>(1, axis)?;
+            (epochs, vec![v], layout)
+        }
+        (EpochArg::Many(epochs), VecArg::Batch { vecs, layout }) => (epochs, vecs, layout),
+    };
+    check_batch_lengths(epochs.len(), vecs.len())?;
+    Ok(EpochVecArgs::Batch(EpochVecBatch {
+        epochs,
+        vecs,
+        layout,
+    }))
+}
+
 /// Dispatch an epoch-dependent vector transform on a single vector or a batch.
 fn dispatch_epoch_vec<'py, const N: usize>(
     py: Python<'py>,
@@ -213,22 +252,38 @@ fn dispatch_epoch_vec<'py, const N: usize>(
     batch: impl Fn(&[time::Epoch], &[SVector<f64, N>]) -> Result<Vec<SVector<f64, N>>, RustBraheError>
     + Sync,
 ) -> PyResult<Bound<'py, PyAny>> {
-    let epochs = parse_epoch_arg(epc)?;
-    let vecs = parse_vec_arg::<N>(x, axis)?;
-    let (epochs, vecs, layout) = match (epochs, vecs) {
-        (EpochArg::Single(e), VecArg::Single(v)) => {
-            return Ok(vector_to_numpy!(py, scalar(e, v), N, f64).into_any());
+    match parse_epoch_vec_args::<N>(epc, x, axis)? {
+        EpochVecArgs::Single(e, v) => Ok(vector_to_numpy!(py, scalar(e, v), N, f64).into_any()),
+        EpochVecArgs::Batch(b) => {
+            let out = py.detach(|| batch(&b.epochs, &b.vecs))?;
+            vecs_to_numpy(py, &b.layout, axis, out)
         }
-        (EpochArg::Single(e), VecArg::Batch { vecs, layout }) => (vec![e], vecs, layout),
-        (EpochArg::Many(epochs), VecArg::Single(v)) => {
-            let layout = BatchLayout::for_broadcast::<N>(1, axis)?;
-            (epochs, vec![v], layout)
+    }
+}
+
+/// Dispatch a fallible epoch-dependent vector transform on a single vector or
+/// a batch. Errors from the core are raised as `RuntimeError`.
+fn try_dispatch_epoch_vec<'py, const N: usize>(
+    py: Python<'py>,
+    epc: &Bound<'py, PyAny>,
+    x: &Bound<'py, PyAny>,
+    axis: isize,
+    scalar: impl Fn(time::Epoch, SVector<f64, N>) -> Result<SVector<f64, N>, RustBraheError>,
+    batch: impl Fn(&[time::Epoch], &[SVector<f64, N>]) -> Result<Vec<SVector<f64, N>>, RustBraheError>
+    + Sync,
+) -> PyResult<Bound<'py, PyAny>> {
+    match parse_epoch_vec_args::<N>(epc, x, axis)? {
+        EpochVecArgs::Single(e, v) => {
+            let out = scalar(e, v).map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))?;
+            Ok(vector_to_numpy!(py, out, N, f64).into_any())
         }
-        (EpochArg::Many(epochs), VecArg::Batch { vecs, layout }) => (epochs, vecs, layout),
-    };
-    check_batch_lengths(epochs.len(), vecs.len())?;
-    let out = py.detach(|| batch(&epochs, &vecs))?;
-    vecs_to_numpy(py, &layout, axis, out)
+        EpochVecArgs::Batch(b) => {
+            let out = py
+                .detach(|| batch(&b.epochs, &b.vecs))
+                .map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))?;
+            vecs_to_numpy(py, &b.layout, axis, out)
+        }
+    }
 }
 
 /// Dispatch an epoch-free vector transform on a single vector or a batch.
@@ -262,6 +317,28 @@ fn dispatch_epoch_rotation<'py>(
         }
         EpochArg::Many(epochs) => {
             let out = py.detach(|| batch(&epochs));
+            Ok(matrices_to_numpy(py, out))
+        }
+    }
+}
+
+/// Dispatch a fallible epoch-dependent rotation on a single epoch or a
+/// sequence. Errors from the core are raised as `RuntimeError`.
+fn try_dispatch_epoch_rotation<'py>(
+    py: Python<'py>,
+    epc: &Bound<'py, PyAny>,
+    scalar: impl Fn(time::Epoch) -> Result<SMatrix3, RustBraheError>,
+    batch: impl Fn(&[time::Epoch]) -> Result<Vec<SMatrix3>, RustBraheError> + Sync,
+) -> PyResult<Bound<'py, PyAny>> {
+    match parse_epoch_arg(epc)? {
+        EpochArg::Single(e) => {
+            let mat = scalar(e).map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))?;
+            Ok(matrix_to_numpy!(py, mat, 3, 3, f64).into_any())
+        }
+        EpochArg::Many(epochs) => {
+            let out = py
+                .detach(|| batch(&epochs))
+                .map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))?;
             Ok(matrices_to_numpy(py, out))
         }
     }

--- a/crates/brahe-py/src/frames.rs
+++ b/crates/brahe-py/src/frames.rs
@@ -1015,8 +1015,10 @@ fn py_rotation_mcmf_to_mci<'py>(py: Python<'py>, epc: &Bound<'py, PyAny>) -> PyR
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x_mci (numpy.ndarray or list): Cartesian MCI position (m), shape `(3,)`, or a batch
 ///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
-///     axis (int, optional): Axis of `x_mci` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_mci` along which the 3 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 3)` the components lie along the last axis, so the default `-1`
+///         applies; a `(3, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian MCMF position (m), shape `(3,)` for a single
@@ -1051,8 +1053,10 @@ fn py_position_mci_to_mcmf<'py>(
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x_mcmf (numpy.ndarray or list): Cartesian MCMF position (m), shape `(3,)`, or a batch
 ///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
-///     axis (int, optional): Axis of `x_mcmf` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_mcmf` along which the 3 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 3)` the components lie along the last axis, so the default `-1`
+///         applies; a `(3, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian MCI position (m), shape `(3,)` for a single
@@ -1090,8 +1094,10 @@ fn py_position_mcmf_to_mci<'py>(
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x_mci (numpy.ndarray or list): Cartesian MCI state `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
 ///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
-///     axis (int, optional): Axis of `x_mci` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_mci` along which the 6 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 6)` the components lie along the last axis, so the default `-1`
+///         applies; a `(6, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian MCMF state `[position (m), velocity (m/s)]`, shape `(6,)` for a single
@@ -1128,8 +1134,10 @@ fn py_state_mci_to_mcmf<'py>(
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x_mcmf (numpy.ndarray or list): Cartesian MCMF state `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
 ///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
-///     axis (int, optional): Axis of `x_mcmf` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_mcmf` along which the 6 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 6)` the components lie along the last axis, so the default `-1`
+///         applies; a `(6, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian MCI state `[position (m), velocity (m/s)]`, shape `(6,)` for a single
@@ -1171,8 +1179,10 @@ fn py_state_mcmf_to_mci<'py>(
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x_eci (numpy.ndarray or list): Cartesian ECI position (m), shape `(3,)`, or a batch
 ///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
-///     axis (int, optional): Axis of `x_eci` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_eci` along which the 3 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 3)` the components lie along the last axis, so the default `-1`
+///         applies; a `(3, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian EMBI position (m), shape `(3,)` for a single
@@ -1212,8 +1222,10 @@ fn py_position_eci_to_emb<'py>(
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x_emb (numpy.ndarray or list): Cartesian EMBI position (m), shape `(3,)`, or a batch
 ///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
-///     axis (int, optional): Axis of `x_emb` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_emb` along which the 3 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 3)` the components lie along the last axis, so the default `-1`
+///         applies; a `(3, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian ECI position (m), shape `(3,)` for a single
@@ -1254,8 +1266,10 @@ fn py_position_emb_to_eci<'py>(
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x_eci (numpy.ndarray or list): Cartesian ECI state (m; m/s), shape `(6,)`, or a batch
 ///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
-///     axis (int, optional): Axis of `x_eci` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_eci` along which the 6 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 6)` the components lie along the last axis, so the default `-1`
+///         applies; a `(6, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian EMBI state (m; m/s), shape `(6,)` for a single
@@ -1296,8 +1310,10 @@ fn py_state_eci_to_emb<'py>(
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x_emb (numpy.ndarray or list): Cartesian EMBI state (m; m/s), shape `(6,)`, or a batch
 ///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
-///     axis (int, optional): Axis of `x_emb` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_emb` along which the 6 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 6)` the components lie along the last axis, so the default `-1`
+///         applies; a `(6, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian ECI state (m; m/s), shape `(6,)` for a single
@@ -1337,8 +1353,10 @@ fn py_state_emb_to_eci<'py>(
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x_eci (numpy.ndarray or list): Cartesian ECI position (m), shape `(3,)`, or a batch
 ///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
-///     axis (int, optional): Axis of `x_eci` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_eci` along which the 3 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 3)` the components lie along the last axis, so the default `-1`
+///         applies; a `(3, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian MCI position (m), shape `(3,)` for a single
@@ -1377,8 +1395,10 @@ fn py_position_eci_to_mci<'py>(
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x_mci (numpy.ndarray or list): Cartesian MCI position (m), shape `(3,)`, or a batch
 ///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
-///     axis (int, optional): Axis of `x_mci` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_mci` along which the 3 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 3)` the components lie along the last axis, so the default `-1`
+///         applies; a `(3, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian ECI position (m), shape `(3,)` for a single
@@ -1417,8 +1437,10 @@ fn py_position_mci_to_eci<'py>(
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x_eci (numpy.ndarray or list): Cartesian ECI state `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
 ///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
-///     axis (int, optional): Axis of `x_eci` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_eci` along which the 6 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 6)` the components lie along the last axis, so the default `-1`
+///         applies; a `(6, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian MCI state `[position (m), velocity (m/s)]`, shape `(6,)` for a single
@@ -1457,8 +1479,10 @@ fn py_state_eci_to_mci<'py>(
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x_mci (numpy.ndarray or list): Cartesian MCI state `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
 ///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
-///     axis (int, optional): Axis of `x_mci` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_mci` along which the 6 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 6)` the components lie along the last axis, so the default `-1`
+///         applies; a `(6, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian ECI state `[position (m), velocity (m/s)]`, shape `(6,)` for a single
@@ -1645,8 +1669,10 @@ fn py_rotation_lfme_to_lci<'py>(py: Python<'py>, epc: &Bound<'py, PyAny>) -> PyR
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x_lci (numpy.ndarray or list): Cartesian LCI position (m), shape `(3,)`, or a batch
 ///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
-///     axis (int, optional): Axis of `x_lci` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_lci` along which the 3 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 3)` the components lie along the last axis, so the default `-1`
+///         applies; a `(3, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian LFPA position (m), shape `(3,)` for a single
@@ -1681,8 +1707,10 @@ fn py_position_lci_to_lfpa<'py>(
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x_lfpa (numpy.ndarray or list): Cartesian LFPA position (m), shape `(3,)`, or a batch
 ///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
-///     axis (int, optional): Axis of `x_lfpa` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_lfpa` along which the 3 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 3)` the components lie along the last axis, so the default `-1`
+///         applies; a `(3, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian LCI position (m), shape `(3,)` for a single
@@ -1717,8 +1745,10 @@ fn py_position_lfpa_to_lci<'py>(
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x_lci (numpy.ndarray or list): Cartesian LCI position (m), shape `(3,)`, or a batch
 ///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
-///     axis (int, optional): Axis of `x_lci` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_lci` along which the 3 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 3)` the components lie along the last axis, so the default `-1`
+///         applies; a `(3, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian LFME position (m), shape `(3,)` for a single
@@ -1753,8 +1783,10 @@ fn py_position_lci_to_lfme<'py>(
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x_lfme (numpy.ndarray or list): Cartesian LFME position (m), shape `(3,)`, or a batch
 ///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
-///     axis (int, optional): Axis of `x_lfme` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_lfme` along which the 3 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 3)` the components lie along the last axis, so the default `-1`
+///         applies; a `(3, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian LCI position (m), shape `(3,)` for a single
@@ -1792,8 +1824,10 @@ fn py_position_lfme_to_lci<'py>(
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x_lci (numpy.ndarray or list): Cartesian LCI state `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
 ///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
-///     axis (int, optional): Axis of `x_lci` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_lci` along which the 6 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 6)` the components lie along the last axis, so the default `-1`
+///         applies; a `(6, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian LFPA state `[position (m), velocity (m/s)]`, shape `(6,)` for a single
@@ -1830,8 +1864,10 @@ fn py_state_lci_to_lfpa<'py>(
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x_lfpa (numpy.ndarray or list): Cartesian LFPA state `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
 ///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
-///     axis (int, optional): Axis of `x_lfpa` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_lfpa` along which the 6 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 6)` the components lie along the last axis, so the default `-1`
+///         applies; a `(6, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian LCI state `[position (m), velocity (m/s)]`, shape `(6,)` for a single
@@ -1869,8 +1905,10 @@ fn py_state_lfpa_to_lci<'py>(
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x_lci (numpy.ndarray or list): Cartesian LCI state `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
 ///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
-///     axis (int, optional): Axis of `x_lci` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_lci` along which the 6 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 6)` the components lie along the last axis, so the default `-1`
+///         applies; a `(6, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian LFME state `[position (m), velocity (m/s)]`, shape `(6,)` for a single
@@ -1907,8 +1945,10 @@ fn py_state_lci_to_lfme<'py>(
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x_lfme (numpy.ndarray or list): Cartesian LFME state `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
 ///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
-///     axis (int, optional): Axis of `x_lfme` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_lfme` along which the 6 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 6)` the components lie along the last axis, so the default `-1`
+///         applies; a `(6, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian LCI state `[position (m), velocity (m/s)]`, shape `(6,)` for a single
@@ -1948,8 +1988,10 @@ fn py_state_lfme_to_lci<'py>(
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x_eci (numpy.ndarray or list): Cartesian ECI position (m), shape `(3,)`, or a batch
 ///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
-///     axis (int, optional): Axis of `x_eci` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_eci` along which the 3 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 3)` the components lie along the last axis, so the default `-1`
+///         applies; a `(3, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian LCI position (m), shape `(3,)` for a single
@@ -1986,8 +2028,10 @@ fn py_position_eci_to_lci<'py>(
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x_lci (numpy.ndarray or list): Cartesian LCI position (m), shape `(3,)`, or a batch
 ///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
-///     axis (int, optional): Axis of `x_lci` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_lci` along which the 3 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 3)` the components lie along the last axis, so the default `-1`
+///         applies; a `(3, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian ECI position (m), shape `(3,)` for a single
@@ -2025,8 +2069,10 @@ fn py_position_lci_to_eci<'py>(
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x_eci (numpy.ndarray or list): Cartesian ECI state `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
 ///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
-///     axis (int, optional): Axis of `x_eci` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_eci` along which the 6 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 6)` the components lie along the last axis, so the default `-1`
+///         applies; a `(6, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian LCI state `[position (m), velocity (m/s)]`, shape `(6,)` for a single
@@ -2063,8 +2109,10 @@ fn py_state_eci_to_lci<'py>(
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x_lci (numpy.ndarray or list): Cartesian LCI state `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
 ///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
-///     axis (int, optional): Axis of `x_lci` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_lci` along which the 6 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 6)` the components lie along the last axis, so the default `-1`
+///         applies; a `(6, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian ECI state `[position (m), velocity (m/s)]`, shape `(6,)` for a single
@@ -2170,8 +2218,10 @@ fn py_rotation_emr_to_gcrf<'py>(py: Python<'py>, epc: &Bound<'py, PyAny>) -> PyR
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x_gcrf (numpy.ndarray or list): Cartesian GCRF position (m), shape `(3,)`, or a batch
 ///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
-///     axis (int, optional): Axis of `x_gcrf` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_gcrf` along which the 3 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 3)` the components lie along the last axis, so the default `-1`
+///         applies; a `(3, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian EMR position (m), shape `(3,)` for a single
@@ -2212,8 +2262,10 @@ fn py_position_gcrf_to_emr<'py>(
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x_emr (numpy.ndarray or list): Cartesian EMR position (m), shape `(3,)`, or a batch
 ///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
-///     axis (int, optional): Axis of `x_emr` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_emr` along which the 3 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 3)` the components lie along the last axis, so the default `-1`
+///         applies; a `(3, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian GCRF position (m), shape `(3,)` for a single
@@ -2257,8 +2309,10 @@ fn py_position_emr_to_gcrf<'py>(
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x_gcrf (numpy.ndarray or list): Cartesian GCRF state `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
 ///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
-///     axis (int, optional): Axis of `x_gcrf` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_gcrf` along which the 6 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 6)` the components lie along the last axis, so the default `-1`
+///         applies; a `(6, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian EMR state `[position (m), velocity (m/s)]`, shape `(6,)` for a single
@@ -2300,8 +2354,10 @@ fn py_state_gcrf_to_emr<'py>(
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x_emr (numpy.ndarray or list): Cartesian EMR state `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
 ///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
-///     axis (int, optional): Axis of `x_emr` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_emr` along which the 6 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 6)` the components lie along the last axis, so the default `-1`
+///         applies; a `(6, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian GCRF state `[position (m), velocity (m/s)]`, shape `(6,)` for a single
@@ -2407,8 +2463,10 @@ fn py_rotation_ser_to_gcrf<'py>(py: Python<'py>, epc: &Bound<'py, PyAny>) -> PyR
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x_gcrf (numpy.ndarray or list): Cartesian GCRF position (m), shape `(3,)`, or a batch
 ///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
-///     axis (int, optional): Axis of `x_gcrf` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_gcrf` along which the 3 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 3)` the components lie along the last axis, so the default `-1`
+///         applies; a `(3, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian SER position (m), shape `(3,)` for a single
@@ -2449,8 +2507,10 @@ fn py_position_gcrf_to_ser<'py>(
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x_ser (numpy.ndarray or list): Cartesian SER position (m), shape `(3,)`, or a batch
 ///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
-///     axis (int, optional): Axis of `x_ser` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_ser` along which the 3 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 3)` the components lie along the last axis, so the default `-1`
+///         applies; a `(3, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian GCRF position (m), shape `(3,)` for a single
@@ -2494,8 +2554,10 @@ fn py_position_ser_to_gcrf<'py>(
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x_gcrf (numpy.ndarray or list): Cartesian GCRF state `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
 ///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
-///     axis (int, optional): Axis of `x_gcrf` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_gcrf` along which the 6 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 6)` the components lie along the last axis, so the default `-1`
+///         applies; a `(6, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian SER state `[position (m), velocity (m/s)]`, shape `(6,)` for a single
@@ -2537,8 +2599,10 @@ fn py_state_gcrf_to_ser<'py>(
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x_ser (numpy.ndarray or list): Cartesian SER state `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
 ///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
-///     axis (int, optional): Axis of `x_ser` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_ser` along which the 6 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 6)` the components lie along the last axis, so the default `-1`
+///         applies; a `(6, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian GCRF state `[position (m), velocity (m/s)]`, shape `(6,)` for a single
@@ -2643,8 +2707,10 @@ fn py_rotation_gse_to_gcrf<'py>(py: Python<'py>, epc: &Bound<'py, PyAny>) -> PyR
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x_gcrf (numpy.ndarray or list): Cartesian GCRF position (m), shape `(3,)`, or a batch
 ///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
-///     axis (int, optional): Axis of `x_gcrf` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_gcrf` along which the 3 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 3)` the components lie along the last axis, so the default `-1`
+///         applies; a `(3, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian GSE position (m), shape `(3,)` for a single
@@ -2686,8 +2752,10 @@ fn py_position_gcrf_to_gse<'py>(
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x_gse (numpy.ndarray or list): Cartesian GSE position (m), shape `(3,)`, or a batch
 ///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
-///     axis (int, optional): Axis of `x_gse` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_gse` along which the 3 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 3)` the components lie along the last axis, so the default `-1`
+///         applies; a `(3, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian GCRF position (m), shape `(3,)` for a single
@@ -2730,8 +2798,10 @@ fn py_position_gse_to_gcrf<'py>(
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x_gcrf (numpy.ndarray or list): Cartesian GCRF state `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
 ///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
-///     axis (int, optional): Axis of `x_gcrf` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_gcrf` along which the 6 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 6)` the components lie along the last axis, so the default `-1`
+///         applies; a `(6, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian GSE state `[position (m), velocity (m/s)]`, shape `(6,)` for a single
@@ -2773,8 +2843,10 @@ fn py_state_gcrf_to_gse<'py>(
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x_gse (numpy.ndarray or list): Cartesian GSE state `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
 ///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
-///     axis (int, optional): Axis of `x_gse` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_gse` along which the 6 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 6)` the components lie along the last axis, so the default `-1`
+///         applies; a `(6, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian GCRF state `[position (m), velocity (m/s)]`, shape `(6,)` for a single
@@ -3326,8 +3398,10 @@ fn py_unregister_custom_frame(key: u32) -> bool {
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x (numpy.ndarray or list): Cartesian position in `from_frame` axes/center (m), shape `(3,)`, or a batch
 ///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
-///     axis (int, optional): Axis of `x` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x` along which the 3 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 3)` the components lie along the last axis, so the default `-1`
+///         applies; a `(3, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian position in `to_frame` axes/center (m), shape `(3,)` for a single
@@ -3390,8 +3464,10 @@ fn py_position_frame_to_frame<'py>(
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x (numpy.ndarray or list): Cartesian state in `from_frame` axes/center `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
 ///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
-///     axis (int, optional): Axis of `x` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x` along which the 6 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 6)` the components lie along the last axis, so the default `-1`
+///         applies; a `(6, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian state in `to_frame` axes/center `[position (m), velocity (m/s)]`, shape `(6,)` for a single

--- a/crates/brahe-py/src/frames.rs
+++ b/crates/brahe-py/src/frames.rs
@@ -900,10 +900,12 @@ fn py_state_eme2000_to_gcrf<'py>(
 ///
 /// Args:
 ///     naif_id (int): NAIF ID of the body (see `iau_rotation_model_ids` for the supported set)
-///     epc (Epoch): Epoch instant for computation of the transformation matrix
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation matrix. A sequence evaluates
+///         one matrix per epoch.
 ///
 /// Returns:
-///     numpy.ndarray: 3x3 rotation matrix transforming ICRF -> body-fixed
+///     numpy.ndarray: 3x3 rotation matrix transforming ICRF -> body-fixed, shape `(3, 3)` for a single epoch or `(n, 3, 3)`
+///         for a sequence of `n` epochs.
 ///
 /// Raises:
 ///     RuntimeError: If no IAU/WGCCRE rotation model is embedded for `naif_id`
@@ -918,14 +920,17 @@ fn py_state_eme2000_to_gcrf<'py>(
 #[pyfunction]
 #[pyo3(text_signature = "(naif_id, epc)")]
 #[pyo3(name = "rotation_icrf_to_body_fixed_iau")]
-unsafe fn py_rotation_icrf_to_body_fixed_iau<'py>(
+fn py_rotation_icrf_to_body_fixed_iau<'py>(
     py: Python<'py>,
     naif_id: i32,
-    epc: &PyEpoch,
-) -> PyResult<Bound<'py, PyArray<f64, Ix2>>> {
-    let mat = frames::rotation_icrf_to_body_fixed_iau(naif_id, epc.obj)
-        .map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))?;
-    Ok(matrix_to_numpy!(py, mat, 3, 3, f64))
+    epc: &Bound<'py, PyAny>,
+) -> PyResult<Bound<'py, PyAny>> {
+    try_dispatch_epoch_rotation(
+        py,
+        epc,
+        |e| frames::rotation_icrf_to_body_fixed_iau(naif_id, e),
+        |es| frames::rotations_icrf_to_body_fixed_iau(naif_id, es),
+    )
 }
 
 /// Sorted list of NAIF IDs with an embedded IAU/WGCCRE rotation model.
@@ -956,10 +961,12 @@ fn py_iau_rotation_model_ids() -> Vec<i32> {
 /// prime-meridian model for Mars.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation matrix
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation matrix. A sequence evaluates
+///         one matrix per epoch.
 ///
 /// Returns:
-///     numpy.ndarray: 3x3 rotation matrix transforming MCI -> MCMF
+///     numpy.ndarray: 3x3 rotation matrix transforming MCI -> MCMF, shape `(3, 3)` for a single epoch or `(n, 3, 3)`
+///         for a sequence of `n` epochs.
 ///
 /// Example:
 ///     ```python
@@ -971,22 +978,20 @@ fn py_iau_rotation_model_ids() -> Vec<i32> {
 #[pyfunction]
 #[pyo3(text_signature = "(epc)")]
 #[pyo3(name = "rotation_mci_to_mcmf")]
-unsafe fn py_rotation_mci_to_mcmf<'py>(
-    py: Python<'py>,
-    epc: &PyEpoch,
-) -> Bound<'py, PyArray<f64, Ix2>> {
-    let mat = frames::rotation_mci_to_mcmf(epc.obj);
-    matrix_to_numpy!(py, mat, 3, 3, f64)
+fn py_rotation_mci_to_mcmf<'py>(py: Python<'py>, epc: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_epoch_rotation(py, epc, frames::rotation_mci_to_mcmf, frames::rotations_mci_to_mcmf)
 }
 
 /// Computes the rotation matrix from Mars-Centered Mars-Fixed (MCMF) to
 /// Mars-Centered Inertial (MCI). Inverse of `rotation_mci_to_mcmf`.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation matrix
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation matrix. A sequence evaluates
+///         one matrix per epoch.
 ///
 /// Returns:
-///     numpy.ndarray: 3x3 rotation matrix transforming MCMF -> MCI
+///     numpy.ndarray: 3x3 rotation matrix transforming MCMF -> MCI, shape `(3, 3)` for a single epoch or `(n, 3, 3)`
+///         for a sequence of `n` epochs.
 ///
 /// Example:
 ///     ```python
@@ -998,23 +1003,25 @@ unsafe fn py_rotation_mci_to_mcmf<'py>(
 #[pyfunction]
 #[pyo3(text_signature = "(epc)")]
 #[pyo3(name = "rotation_mcmf_to_mci")]
-unsafe fn py_rotation_mcmf_to_mci<'py>(
-    py: Python<'py>,
-    epc: &PyEpoch,
-) -> Bound<'py, PyArray<f64, Ix2>> {
-    let mat = frames::rotation_mcmf_to_mci(epc.obj);
-    matrix_to_numpy!(py, mat, 3, 3, f64)
+fn py_rotation_mcmf_to_mci<'py>(py: Python<'py>, epc: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_epoch_rotation(py, epc, frames::rotation_mcmf_to_mci, frames::rotations_mcmf_to_mci)
 }
 
 /// Transforms a Cartesian Mars-inertial (MCI) position into the equivalent
 /// Cartesian Mars-fixed (MCMF) position.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation
-///     x_mci (numpy.ndarray or list): Cartesian MCI position (m), shape `(3,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x_mci (numpy.ndarray or list): Cartesian MCI position (m), shape `(3,)`, or a batch
+///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
+///     axis (int, optional): Axis of `x_mci` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: Cartesian MCMF position (m), shape `(3,)`
+///     numpy.ndarray: Cartesian MCMF position (m), shape `(3,)` for a single
+///         input, or the batch layout of `x_mci` (shape `(n, 3)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Example:
 ///     ```python
@@ -1024,27 +1031,33 @@ unsafe fn py_rotation_mcmf_to_mci<'py>(
 ///     x_mcmf = bh.position_mci_to_mcmf(epc, [bh.R_MARS + 400e3, 0.0, 0.0])
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(epc, x_mci)")]
+#[pyo3(signature = (epc, x_mci, axis=-1))]
+#[pyo3(text_signature = "(epc, x_mci, axis=-1)")]
 #[pyo3(name = "position_mci_to_mcmf")]
 fn py_position_mci_to_mcmf<'py>(
     py: Python<'py>,
-    epc: &PyEpoch,
-    x_mci: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::position_mci_to_mcmf(epc.obj, pyany_to_svector::<3>(&x_mci)?);
-
-    Ok(vector_to_numpy!(py, vec, 3, f64))
+    epc: &Bound<'py, PyAny>,
+    x_mci: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_epoch_vec::<3>(py, epc, x_mci, axis, frames::position_mci_to_mcmf, frames::positions_mci_to_mcmf)
 }
 
 /// Transforms a Cartesian Mars-fixed (MCMF) position into the equivalent
 /// Cartesian Mars-inertial (MCI) position.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation
-///     x_mcmf (numpy.ndarray or list): Cartesian MCMF position (m), shape `(3,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x_mcmf (numpy.ndarray or list): Cartesian MCMF position (m), shape `(3,)`, or a batch
+///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
+///     axis (int, optional): Axis of `x_mcmf` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: Cartesian MCI position (m), shape `(3,)`
+///     numpy.ndarray: Cartesian MCI position (m), shape `(3,)` for a single
+///         input, or the batch layout of `x_mcmf` (shape `(n, 3)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Example:
 ///     ```python
@@ -1054,16 +1067,16 @@ fn py_position_mci_to_mcmf<'py>(
 ///     x_mci = bh.position_mcmf_to_mci(epc, [bh.R_MARS, 0.0, 0.0])
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(epc, x_mcmf)")]
+#[pyo3(signature = (epc, x_mcmf, axis=-1))]
+#[pyo3(text_signature = "(epc, x_mcmf, axis=-1)")]
 #[pyo3(name = "position_mcmf_to_mci")]
 fn py_position_mcmf_to_mci<'py>(
     py: Python<'py>,
-    epc: &PyEpoch,
-    x_mcmf: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::position_mcmf_to_mci(epc.obj, pyany_to_svector::<3>(&x_mcmf)?);
-
-    Ok(vector_to_numpy!(py, vec, 3, f64))
+    epc: &Bound<'py, PyAny>,
+    x_mcmf: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_epoch_vec::<3>(py, epc, x_mcmf, axis, frames::position_mcmf_to_mci, frames::positions_mcmf_to_mci)
 }
 
 /// Transforms a Cartesian Mars-inertial (MCI) state (position and velocity)
@@ -1073,11 +1086,17 @@ fn py_position_mcmf_to_mci<'py>(
 /// Mars' rotation.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation
-///     x_mci (numpy.ndarray or list): Cartesian MCI state `[position (m), velocity (m/s)]`, shape `(6,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x_mci (numpy.ndarray or list): Cartesian MCI state `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
+///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
+///     axis (int, optional): Axis of `x_mci` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: Cartesian MCMF state `[position (m), velocity (m/s)]`, shape `(6,)`
+///     numpy.ndarray: Cartesian MCMF state `[position (m), velocity (m/s)]`, shape `(6,)` for a single
+///         input, or the batch layout of `x_mci` (shape `(n, 6)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Example:
 ///     ```python
@@ -1088,16 +1107,16 @@ fn py_position_mcmf_to_mci<'py>(
 ///     x_mcmf = bh.state_mci_to_mcmf(epc, x_mci)
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(epc, x_mci)")]
+#[pyo3(signature = (epc, x_mci, axis=-1))]
+#[pyo3(text_signature = "(epc, x_mci, axis=-1)")]
 #[pyo3(name = "state_mci_to_mcmf")]
 fn py_state_mci_to_mcmf<'py>(
     py: Python<'py>,
-    epc: &PyEpoch,
-    x_mci: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::state_mci_to_mcmf(epc.obj, pyany_to_svector::<6>(&x_mci)?);
-
-    Ok(vector_to_numpy!(py, vec, 6, f64))
+    epc: &Bound<'py, PyAny>,
+    x_mci: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_epoch_vec::<6>(py, epc, x_mci, axis, frames::state_mci_to_mcmf, frames::states_mci_to_mcmf)
 }
 
 /// Transforms a Cartesian Mars-fixed (MCMF) state (position and velocity)
@@ -1105,11 +1124,17 @@ fn py_state_mci_to_mcmf<'py>(
 /// `state_mci_to_mcmf`.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation
-///     x_mcmf (numpy.ndarray or list): Cartesian MCMF state `[position (m), velocity (m/s)]`, shape `(6,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x_mcmf (numpy.ndarray or list): Cartesian MCMF state `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
+///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
+///     axis (int, optional): Axis of `x_mcmf` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: Cartesian MCI state `[position (m), velocity (m/s)]`, shape `(6,)`
+///     numpy.ndarray: Cartesian MCI state `[position (m), velocity (m/s)]`, shape `(6,)` for a single
+///         input, or the batch layout of `x_mcmf` (shape `(n, 6)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Example:
 ///     ```python
@@ -1121,16 +1146,16 @@ fn py_state_mci_to_mcmf<'py>(
 ///     x_mci2 = bh.state_mcmf_to_mci(epc, x_mcmf)
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(epc, x_mcmf)")]
+#[pyo3(signature = (epc, x_mcmf, axis=-1))]
+#[pyo3(text_signature = "(epc, x_mcmf, axis=-1)")]
 #[pyo3(name = "state_mcmf_to_mci")]
 fn py_state_mcmf_to_mci<'py>(
     py: Python<'py>,
-    epc: &PyEpoch,
-    x_mcmf: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::state_mcmf_to_mci(epc.obj, pyany_to_svector::<6>(&x_mcmf)?);
-
-    Ok(vector_to_numpy!(py, vec, 6, f64))
+    epc: &Bound<'py, PyAny>,
+    x_mcmf: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_epoch_vec::<6>(py, epc, x_mcmf, axis, frames::state_mcmf_to_mci, frames::states_mcmf_to_mci)
 }
 
 /// Transforms a Cartesian Earth-inertial (ECI) position into the equivalent
@@ -1142,11 +1167,17 @@ fn py_state_mcmf_to_mci<'py>(
 /// loaded.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation
-///     x_eci (numpy.ndarray or list): Cartesian ECI position (m), shape `(3,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x_eci (numpy.ndarray or list): Cartesian ECI position (m), shape `(3,)`, or a batch
+///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
+///     axis (int, optional): Axis of `x_eci` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: Cartesian EMBI position (m), shape `(3,)`
+///     numpy.ndarray: Cartesian EMBI position (m), shape `(3,)` for a single
+///         input, or the batch layout of `x_eci` (shape `(n, 3)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Example:
 ///     ```python
@@ -1156,16 +1187,16 @@ fn py_state_mcmf_to_mci<'py>(
 ///     x_emb = bh.position_eci_to_emb(epc, [7e6, 0.0, 0.0])
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(epc, x_eci)")]
+#[pyo3(signature = (epc, x_eci, axis=-1))]
+#[pyo3(text_signature = "(epc, x_eci, axis=-1)")]
 #[pyo3(name = "position_eci_to_emb")]
 fn py_position_eci_to_emb<'py>(
     py: Python<'py>,
-    epc: &PyEpoch,
-    x_eci: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::position_eci_to_emb(epc.obj, pyany_to_svector::<3>(&x_eci)?);
-
-    Ok(vector_to_numpy!(py, vec, 3, f64))
+    epc: &Bound<'py, PyAny>,
+    x_eci: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_epoch_vec::<3>(py, epc, x_eci, axis, frames::position_eci_to_emb, frames::positions_eci_to_emb)
 }
 
 /// Transforms a Cartesian Earth-Moon-barycenter inertial (EMBI) position
@@ -1177,11 +1208,17 @@ fn py_position_eci_to_emb<'py>(
 /// loaded.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation
-///     x_emb (numpy.ndarray or list): Cartesian EMBI position (m), shape `(3,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x_emb (numpy.ndarray or list): Cartesian EMBI position (m), shape `(3,)`, or a batch
+///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
+///     axis (int, optional): Axis of `x_emb` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: Cartesian ECI position (m), shape `(3,)`
+///     numpy.ndarray: Cartesian ECI position (m), shape `(3,)` for a single
+///         input, or the batch layout of `x_emb` (shape `(n, 3)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Example:
 ///     ```python
@@ -1191,16 +1228,16 @@ fn py_position_eci_to_emb<'py>(
 ///     x_eci = bh.position_emb_to_eci(epc, [7e6, 0.0, 0.0])
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(epc, x_emb)")]
+#[pyo3(signature = (epc, x_emb, axis=-1))]
+#[pyo3(text_signature = "(epc, x_emb, axis=-1)")]
 #[pyo3(name = "position_emb_to_eci")]
 fn py_position_emb_to_eci<'py>(
     py: Python<'py>,
-    epc: &PyEpoch,
-    x_emb: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::position_emb_to_eci(epc.obj, pyany_to_svector::<3>(&x_emb)?);
-
-    Ok(vector_to_numpy!(py, vec, 3, f64))
+    epc: &Bound<'py, PyAny>,
+    x_emb: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_epoch_vec::<3>(py, epc, x_emb, axis, frames::position_emb_to_eci, frames::positions_emb_to_eci)
 }
 
 /// Transforms a Cartesian Earth-inertial (ECI) state (position and velocity)
@@ -1213,11 +1250,17 @@ fn py_position_emb_to_eci<'py>(
 /// loaded.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation
-///     x_eci (numpy.ndarray or list): Cartesian ECI state (m; m/s), shape `(6,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x_eci (numpy.ndarray or list): Cartesian ECI state (m; m/s), shape `(6,)`, or a batch
+///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
+///     axis (int, optional): Axis of `x_eci` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: Cartesian EMBI state (m; m/s), shape `(6,)`
+///     numpy.ndarray: Cartesian EMBI state (m; m/s), shape `(6,)` for a single
+///         input, or the batch layout of `x_eci` (shape `(n, 6)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Example:
 ///     ```python
@@ -1227,16 +1270,16 @@ fn py_position_emb_to_eci<'py>(
 ///     x_emb = bh.state_eci_to_emb(epc, [7e6, 0.0, 0.0, 0.0, 7.5e3, 0.0])
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(epc, x_eci)")]
+#[pyo3(signature = (epc, x_eci, axis=-1))]
+#[pyo3(text_signature = "(epc, x_eci, axis=-1)")]
 #[pyo3(name = "state_eci_to_emb")]
 fn py_state_eci_to_emb<'py>(
     py: Python<'py>,
-    epc: &PyEpoch,
-    x_eci: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::state_eci_to_emb(epc.obj, pyany_to_svector::<6>(&x_eci)?);
-
-    Ok(vector_to_numpy!(py, vec, 6, f64))
+    epc: &Bound<'py, PyAny>,
+    x_eci: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_epoch_vec::<6>(py, epc, x_eci, axis, frames::state_eci_to_emb, frames::states_eci_to_emb)
 }
 
 /// Transforms a Cartesian Earth-Moon-barycenter inertial (EMBI) state
@@ -1249,11 +1292,17 @@ fn py_state_eci_to_emb<'py>(
 /// loaded.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation
-///     x_emb (numpy.ndarray or list): Cartesian EMBI state (m; m/s), shape `(6,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x_emb (numpy.ndarray or list): Cartesian EMBI state (m; m/s), shape `(6,)`, or a batch
+///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
+///     axis (int, optional): Axis of `x_emb` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: Cartesian ECI state (m; m/s), shape `(6,)`
+///     numpy.ndarray: Cartesian ECI state (m; m/s), shape `(6,)` for a single
+///         input, or the batch layout of `x_emb` (shape `(n, 6)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Example:
 ///     ```python
@@ -1263,16 +1312,16 @@ fn py_state_eci_to_emb<'py>(
 ///     x_eci = bh.state_emb_to_eci(epc, [7e6, 0.0, 0.0, 0.0, 7.5e3, 0.0])
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(epc, x_emb)")]
+#[pyo3(signature = (epc, x_emb, axis=-1))]
+#[pyo3(text_signature = "(epc, x_emb, axis=-1)")]
 #[pyo3(name = "state_emb_to_eci")]
 fn py_state_emb_to_eci<'py>(
     py: Python<'py>,
-    epc: &PyEpoch,
-    x_emb: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::state_emb_to_eci(epc.obj, pyany_to_svector::<6>(&x_emb)?);
-
-    Ok(vector_to_numpy!(py, vec, 6, f64))
+    epc: &Bound<'py, PyAny>,
+    x_emb: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_epoch_vec::<6>(py, epc, x_emb, axis, frames::state_emb_to_eci, frames::states_emb_to_eci)
 }
 
 
@@ -1284,11 +1333,17 @@ fn py_state_emb_to_eci<'py>(
 /// the default `de440s` ephemeris if no SPK kernel is loaded.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation
-///     x_eci (numpy.ndarray or list): Cartesian ECI position (m), shape `(3,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x_eci (numpy.ndarray or list): Cartesian ECI position (m), shape `(3,)`, or a batch
+///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
+///     axis (int, optional): Axis of `x_eci` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: Cartesian MCI position (m), shape `(3,)`
+///     numpy.ndarray: Cartesian MCI position (m), shape `(3,)` for a single
+///         input, or the batch layout of `x_eci` (shape `(n, 3)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Example:
 ///     ```python
@@ -1298,16 +1353,16 @@ fn py_state_emb_to_eci<'py>(
 ///     x_mci = bh.position_eci_to_mci(epc, [1e7, 2e7, 3e7])
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(epc, x_eci)")]
+#[pyo3(signature = (epc, x_eci, axis=-1))]
+#[pyo3(text_signature = "(epc, x_eci, axis=-1)")]
 #[pyo3(name = "position_eci_to_mci")]
 fn py_position_eci_to_mci<'py>(
     py: Python<'py>,
-    epc: &PyEpoch,
-    x_eci: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::position_eci_to_mci(epc.obj, pyany_to_svector::<3>(&x_eci)?);
-
-    Ok(vector_to_numpy!(py, vec, 3, f64))
+    epc: &Bound<'py, PyAny>,
+    x_eci: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_epoch_vec::<3>(py, epc, x_eci, axis, frames::position_eci_to_mci, frames::positions_eci_to_mci)
 }
 
 /// Transforms a Cartesian Mars-inertial (MCI) position into the equivalent
@@ -1318,11 +1373,17 @@ fn py_position_eci_to_mci<'py>(
 /// the default `de440s` ephemeris if no SPK kernel is loaded.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation
-///     x_mci (numpy.ndarray or list): Cartesian MCI position (m), shape `(3,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x_mci (numpy.ndarray or list): Cartesian MCI position (m), shape `(3,)`, or a batch
+///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
+///     axis (int, optional): Axis of `x_mci` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: Cartesian ECI position (m), shape `(3,)`
+///     numpy.ndarray: Cartesian ECI position (m), shape `(3,)` for a single
+///         input, or the batch layout of `x_mci` (shape `(n, 3)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Example:
 ///     ```python
@@ -1332,16 +1393,16 @@ fn py_position_eci_to_mci<'py>(
 ///     x_eci = bh.position_mci_to_eci(epc, [1e7, 2e7, 3e7])
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(epc, x_mci)")]
+#[pyo3(signature = (epc, x_mci, axis=-1))]
+#[pyo3(text_signature = "(epc, x_mci, axis=-1)")]
 #[pyo3(name = "position_mci_to_eci")]
 fn py_position_mci_to_eci<'py>(
     py: Python<'py>,
-    epc: &PyEpoch,
-    x_mci: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::position_mci_to_eci(epc.obj, pyany_to_svector::<3>(&x_mci)?);
-
-    Ok(vector_to_numpy!(py, vec, 3, f64))
+    epc: &Bound<'py, PyAny>,
+    x_mci: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_epoch_vec::<3>(py, epc, x_mci, axis, frames::position_mci_to_eci, frames::positions_mci_to_eci)
 }
 
 /// Transforms a Cartesian Earth-inertial (ECI) state (position and velocity)
@@ -1352,11 +1413,17 @@ fn py_position_mci_to_eci<'py>(
 /// the default `de440s` ephemeris if no SPK kernel is loaded.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation
-///     x_eci (numpy.ndarray or list): Cartesian ECI state `[position (m), velocity (m/s)]`, shape `(6,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x_eci (numpy.ndarray or list): Cartesian ECI state `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
+///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
+///     axis (int, optional): Axis of `x_eci` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: Cartesian MCI state `[position (m), velocity (m/s)]`, shape `(6,)`
+///     numpy.ndarray: Cartesian MCI state `[position (m), velocity (m/s)]`, shape `(6,)` for a single
+///         input, or the batch layout of `x_eci` (shape `(n, 6)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Example:
 ///     ```python
@@ -1366,16 +1433,16 @@ fn py_position_mci_to_eci<'py>(
 ///     x_mci = bh.state_eci_to_mci(epc, [1e7, 2e7, 3e7, 1.0, 2.0, 3.0])
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(epc, x_eci)")]
+#[pyo3(signature = (epc, x_eci, axis=-1))]
+#[pyo3(text_signature = "(epc, x_eci, axis=-1)")]
 #[pyo3(name = "state_eci_to_mci")]
 fn py_state_eci_to_mci<'py>(
     py: Python<'py>,
-    epc: &PyEpoch,
-    x_eci: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::state_eci_to_mci(epc.obj, pyany_to_svector::<6>(&x_eci)?);
-
-    Ok(vector_to_numpy!(py, vec, 6, f64))
+    epc: &Bound<'py, PyAny>,
+    x_eci: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_epoch_vec::<6>(py, epc, x_eci, axis, frames::state_eci_to_mci, frames::states_eci_to_mci)
 }
 
 /// Transforms a Cartesian Mars-inertial (MCI) state (position and velocity)
@@ -1386,11 +1453,17 @@ fn py_state_eci_to_mci<'py>(
 /// the default `de440s` ephemeris if no SPK kernel is loaded.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation
-///     x_mci (numpy.ndarray or list): Cartesian MCI state `[position (m), velocity (m/s)]`, shape `(6,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x_mci (numpy.ndarray or list): Cartesian MCI state `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
+///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
+///     axis (int, optional): Axis of `x_mci` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: Cartesian ECI state `[position (m), velocity (m/s)]`, shape `(6,)`
+///     numpy.ndarray: Cartesian ECI state `[position (m), velocity (m/s)]`, shape `(6,)` for a single
+///         input, or the batch layout of `x_mci` (shape `(n, 6)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Example:
 ///     ```python
@@ -1400,16 +1473,16 @@ fn py_state_eci_to_mci<'py>(
 ///     x_eci = bh.state_mci_to_eci(epc, [1e7, 2e7, 3e7, 1.0, 2.0, 3.0])
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(epc, x_mci)")]
+#[pyo3(signature = (epc, x_mci, axis=-1))]
+#[pyo3(text_signature = "(epc, x_mci, axis=-1)")]
 #[pyo3(name = "state_mci_to_eci")]
 fn py_state_mci_to_eci<'py>(
     py: Python<'py>,
-    epc: &PyEpoch,
-    x_mci: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::state_mci_to_eci(epc.obj, pyany_to_svector::<6>(&x_mci)?);
-
-    Ok(vector_to_numpy!(py, vec, 6, f64))
+    epc: &Bound<'py, PyAny>,
+    x_mci: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_epoch_vec::<6>(py, epc, x_mci, axis, frames::state_mci_to_eci, frames::states_mci_to_eci)
 }
 
 // ============================================================================
@@ -1424,10 +1497,12 @@ fn py_state_mci_to_eci<'py>(
 /// if needed).
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation matrix
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation matrix. A sequence evaluates
+///         one matrix per epoch.
 ///
 /// Returns:
-///     numpy.ndarray: 3x3 rotation matrix transforming LCI -> LFPA
+///     numpy.ndarray: 3x3 rotation matrix transforming LCI -> LFPA, shape `(3, 3)` for a single epoch or `(n, 3, 3)`
+///         for a sequence of `n` epochs.
 ///
 /// Example:
 ///     ```python
@@ -1439,22 +1514,20 @@ fn py_state_mci_to_eci<'py>(
 #[pyfunction]
 #[pyo3(text_signature = "(epc)")]
 #[pyo3(name = "rotation_lci_to_lfpa")]
-unsafe fn py_rotation_lci_to_lfpa<'py>(
-    py: Python<'py>,
-    epc: &PyEpoch,
-) -> Bound<'py, PyArray<f64, Ix2>> {
-    let mat = frames::rotation_lci_to_lfpa(epc.obj);
-    matrix_to_numpy!(py, mat, 3, 3, f64)
+fn py_rotation_lci_to_lfpa<'py>(py: Python<'py>, epc: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_epoch_rotation(py, epc, frames::rotation_lci_to_lfpa, frames::rotations_lci_to_lfpa)
 }
 
 /// Computes the rotation matrix from Lunar-Fixed Principal Axis (LFPA) to
 /// Lunar-Centered Inertial (LCI). Inverse of `rotation_lci_to_lfpa`.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation matrix
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation matrix. A sequence evaluates
+///         one matrix per epoch.
 ///
 /// Returns:
-///     numpy.ndarray: 3x3 rotation matrix transforming LFPA -> LCI
+///     numpy.ndarray: 3x3 rotation matrix transforming LFPA -> LCI, shape `(3, 3)` for a single epoch or `(n, 3, 3)`
+///         for a sequence of `n` epochs.
 ///
 /// Example:
 ///     ```python
@@ -1466,12 +1539,8 @@ unsafe fn py_rotation_lci_to_lfpa<'py>(
 #[pyfunction]
 #[pyo3(text_signature = "(epc)")]
 #[pyo3(name = "rotation_lfpa_to_lci")]
-unsafe fn py_rotation_lfpa_to_lci<'py>(
-    py: Python<'py>,
-    epc: &PyEpoch,
-) -> Bound<'py, PyArray<f64, Ix2>> {
-    let mat = frames::rotation_lfpa_to_lci(epc.obj);
-    matrix_to_numpy!(py, mat, 3, 3, f64)
+fn py_rotation_lfpa_to_lci<'py>(py: Python<'py>, epc: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_epoch_rotation(py, epc, frames::rotation_lfpa_to_lci, frames::rotations_lfpa_to_lci)
 }
 
 /// Computes the constant rotation matrix from Lunar-Fixed Mean Earth/polar-axis
@@ -1522,10 +1591,12 @@ unsafe fn py_rotation_lfpa_to_lfme<'py>(py: Python<'py>) -> Bound<'py, PyArray<f
 /// if needed).
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation matrix
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation matrix. A sequence evaluates
+///         one matrix per epoch.
 ///
 /// Returns:
-///     numpy.ndarray: 3x3 rotation matrix transforming LCI -> LFME
+///     numpy.ndarray: 3x3 rotation matrix transforming LCI -> LFME, shape `(3, 3)` for a single epoch or `(n, 3, 3)`
+///         for a sequence of `n` epochs.
 ///
 /// Example:
 ///     ```python
@@ -1537,22 +1608,20 @@ unsafe fn py_rotation_lfpa_to_lfme<'py>(py: Python<'py>) -> Bound<'py, PyArray<f
 #[pyfunction]
 #[pyo3(text_signature = "(epc)")]
 #[pyo3(name = "rotation_lci_to_lfme")]
-unsafe fn py_rotation_lci_to_lfme<'py>(
-    py: Python<'py>,
-    epc: &PyEpoch,
-) -> Bound<'py, PyArray<f64, Ix2>> {
-    let mat = frames::rotation_lci_to_lfme(epc.obj);
-    matrix_to_numpy!(py, mat, 3, 3, f64)
+fn py_rotation_lci_to_lfme<'py>(py: Python<'py>, epc: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_epoch_rotation(py, epc, frames::rotation_lci_to_lfme, frames::rotations_lci_to_lfme)
 }
 
 /// Computes the rotation matrix from Lunar-Fixed Mean Earth/polar-axis (LFME)
 /// to Lunar-Centered Inertial (LCI). Inverse of `rotation_lci_to_lfme`.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation matrix
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation matrix. A sequence evaluates
+///         one matrix per epoch.
 ///
 /// Returns:
-///     numpy.ndarray: 3x3 rotation matrix transforming LFME -> LCI
+///     numpy.ndarray: 3x3 rotation matrix transforming LFME -> LCI, shape `(3, 3)` for a single epoch or `(n, 3, 3)`
+///         for a sequence of `n` epochs.
 ///
 /// Example:
 ///     ```python
@@ -1564,23 +1633,25 @@ unsafe fn py_rotation_lci_to_lfme<'py>(
 #[pyfunction]
 #[pyo3(text_signature = "(epc)")]
 #[pyo3(name = "rotation_lfme_to_lci")]
-unsafe fn py_rotation_lfme_to_lci<'py>(
-    py: Python<'py>,
-    epc: &PyEpoch,
-) -> Bound<'py, PyArray<f64, Ix2>> {
-    let mat = frames::rotation_lfme_to_lci(epc.obj);
-    matrix_to_numpy!(py, mat, 3, 3, f64)
+fn py_rotation_lfme_to_lci<'py>(py: Python<'py>, epc: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_epoch_rotation(py, epc, frames::rotation_lfme_to_lci, frames::rotations_lfme_to_lci)
 }
 
 /// Transforms a Cartesian Lunar-inertial (LCI) position into the equivalent
 /// Cartesian Lunar-Fixed Principal Axis (LFPA) position.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation
-///     x_lci (numpy.ndarray or list): Cartesian LCI position (m), shape `(3,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x_lci (numpy.ndarray or list): Cartesian LCI position (m), shape `(3,)`, or a batch
+///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
+///     axis (int, optional): Axis of `x_lci` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: Cartesian LFPA position (m), shape `(3,)`
+///     numpy.ndarray: Cartesian LFPA position (m), shape `(3,)` for a single
+///         input, or the batch layout of `x_lci` (shape `(n, 3)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Example:
 ///     ```python
@@ -1590,27 +1661,33 @@ unsafe fn py_rotation_lfme_to_lci<'py>(
 ///     x_lfpa = bh.position_lci_to_lfpa(epc, [bh.R_MOON + 100e3, 0.0, 0.0])
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(epc, x_lci)")]
+#[pyo3(signature = (epc, x_lci, axis=-1))]
+#[pyo3(text_signature = "(epc, x_lci, axis=-1)")]
 #[pyo3(name = "position_lci_to_lfpa")]
 fn py_position_lci_to_lfpa<'py>(
     py: Python<'py>,
-    epc: &PyEpoch,
-    x_lci: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::position_lci_to_lfpa(epc.obj, pyany_to_svector::<3>(&x_lci)?);
-
-    Ok(vector_to_numpy!(py, vec, 3, f64))
+    epc: &Bound<'py, PyAny>,
+    x_lci: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_epoch_vec::<3>(py, epc, x_lci, axis, frames::position_lci_to_lfpa, frames::positions_lci_to_lfpa)
 }
 
 /// Transforms a Cartesian Lunar-Fixed Principal Axis (LFPA) position into the
 /// equivalent Cartesian Lunar-inertial (LCI) position.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation
-///     x_lfpa (numpy.ndarray or list): Cartesian LFPA position (m), shape `(3,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x_lfpa (numpy.ndarray or list): Cartesian LFPA position (m), shape `(3,)`, or a batch
+///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
+///     axis (int, optional): Axis of `x_lfpa` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: Cartesian LCI position (m), shape `(3,)`
+///     numpy.ndarray: Cartesian LCI position (m), shape `(3,)` for a single
+///         input, or the batch layout of `x_lfpa` (shape `(n, 3)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Example:
 ///     ```python
@@ -1620,27 +1697,33 @@ fn py_position_lci_to_lfpa<'py>(
 ///     x_lci = bh.position_lfpa_to_lci(epc, [bh.R_MOON, 0.0, 0.0])
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(epc, x_lfpa)")]
+#[pyo3(signature = (epc, x_lfpa, axis=-1))]
+#[pyo3(text_signature = "(epc, x_lfpa, axis=-1)")]
 #[pyo3(name = "position_lfpa_to_lci")]
 fn py_position_lfpa_to_lci<'py>(
     py: Python<'py>,
-    epc: &PyEpoch,
-    x_lfpa: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::position_lfpa_to_lci(epc.obj, pyany_to_svector::<3>(&x_lfpa)?);
-
-    Ok(vector_to_numpy!(py, vec, 3, f64))
+    epc: &Bound<'py, PyAny>,
+    x_lfpa: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_epoch_vec::<3>(py, epc, x_lfpa, axis, frames::position_lfpa_to_lci, frames::positions_lfpa_to_lci)
 }
 
 /// Transforms a Cartesian Lunar-inertial (LCI) position into the equivalent
 /// Cartesian Lunar-Fixed Mean Earth/polar-axis (LFME) position.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation
-///     x_lci (numpy.ndarray or list): Cartesian LCI position (m), shape `(3,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x_lci (numpy.ndarray or list): Cartesian LCI position (m), shape `(3,)`, or a batch
+///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
+///     axis (int, optional): Axis of `x_lci` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: Cartesian LFME position (m), shape `(3,)`
+///     numpy.ndarray: Cartesian LFME position (m), shape `(3,)` for a single
+///         input, or the batch layout of `x_lci` (shape `(n, 3)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Example:
 ///     ```python
@@ -1650,27 +1733,33 @@ fn py_position_lfpa_to_lci<'py>(
 ///     x_lfme = bh.position_lci_to_lfme(epc, [bh.R_MOON + 100e3, 0.0, 0.0])
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(epc, x_lci)")]
+#[pyo3(signature = (epc, x_lci, axis=-1))]
+#[pyo3(text_signature = "(epc, x_lci, axis=-1)")]
 #[pyo3(name = "position_lci_to_lfme")]
 fn py_position_lci_to_lfme<'py>(
     py: Python<'py>,
-    epc: &PyEpoch,
-    x_lci: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::position_lci_to_lfme(epc.obj, pyany_to_svector::<3>(&x_lci)?);
-
-    Ok(vector_to_numpy!(py, vec, 3, f64))
+    epc: &Bound<'py, PyAny>,
+    x_lci: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_epoch_vec::<3>(py, epc, x_lci, axis, frames::position_lci_to_lfme, frames::positions_lci_to_lfme)
 }
 
 /// Transforms a Cartesian Lunar-Fixed Mean Earth/polar-axis (LFME) position
 /// into the equivalent Cartesian Lunar-inertial (LCI) position.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation
-///     x_lfme (numpy.ndarray or list): Cartesian LFME position (m), shape `(3,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x_lfme (numpy.ndarray or list): Cartesian LFME position (m), shape `(3,)`, or a batch
+///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
+///     axis (int, optional): Axis of `x_lfme` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: Cartesian LCI position (m), shape `(3,)`
+///     numpy.ndarray: Cartesian LCI position (m), shape `(3,)` for a single
+///         input, or the batch layout of `x_lfme` (shape `(n, 3)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Example:
 ///     ```python
@@ -1680,16 +1769,16 @@ fn py_position_lci_to_lfme<'py>(
 ///     x_lci = bh.position_lfme_to_lci(epc, [bh.R_MOON, 0.0, 0.0])
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(epc, x_lfme)")]
+#[pyo3(signature = (epc, x_lfme, axis=-1))]
+#[pyo3(text_signature = "(epc, x_lfme, axis=-1)")]
 #[pyo3(name = "position_lfme_to_lci")]
 fn py_position_lfme_to_lci<'py>(
     py: Python<'py>,
-    epc: &PyEpoch,
-    x_lfme: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::position_lfme_to_lci(epc.obj, pyany_to_svector::<3>(&x_lfme)?);
-
-    Ok(vector_to_numpy!(py, vec, 3, f64))
+    epc: &Bound<'py, PyAny>,
+    x_lfme: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_epoch_vec::<3>(py, epc, x_lfme, axis, frames::position_lfme_to_lci, frames::positions_lfme_to_lci)
 }
 
 /// Transforms a Cartesian Lunar-inertial (LCI) state (position and velocity)
@@ -1699,11 +1788,17 @@ fn py_position_lfme_to_lci<'py>(
 /// the Moon's rotation.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation
-///     x_lci (numpy.ndarray or list): Cartesian LCI state `[position (m), velocity (m/s)]`, shape `(6,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x_lci (numpy.ndarray or list): Cartesian LCI state `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
+///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
+///     axis (int, optional): Axis of `x_lci` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: Cartesian LFPA state `[position (m), velocity (m/s)]`, shape `(6,)`
+///     numpy.ndarray: Cartesian LFPA state `[position (m), velocity (m/s)]`, shape `(6,)` for a single
+///         input, or the batch layout of `x_lci` (shape `(n, 6)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Example:
 ///     ```python
@@ -1714,16 +1809,16 @@ fn py_position_lfme_to_lci<'py>(
 ///     x_lfpa = bh.state_lci_to_lfpa(epc, x_lci)
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(epc, x_lci)")]
+#[pyo3(signature = (epc, x_lci, axis=-1))]
+#[pyo3(text_signature = "(epc, x_lci, axis=-1)")]
 #[pyo3(name = "state_lci_to_lfpa")]
 fn py_state_lci_to_lfpa<'py>(
     py: Python<'py>,
-    epc: &PyEpoch,
-    x_lci: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::state_lci_to_lfpa(epc.obj, pyany_to_svector::<6>(&x_lci)?);
-
-    Ok(vector_to_numpy!(py, vec, 6, f64))
+    epc: &Bound<'py, PyAny>,
+    x_lci: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_epoch_vec::<6>(py, epc, x_lci, axis, frames::state_lci_to_lfpa, frames::states_lci_to_lfpa)
 }
 
 /// Transforms a Cartesian Lunar-Fixed Principal Axis (LFPA) state (position
@@ -1731,11 +1826,17 @@ fn py_state_lci_to_lfpa<'py>(
 /// Inverse of `state_lci_to_lfpa`.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation
-///     x_lfpa (numpy.ndarray or list): Cartesian LFPA state `[position (m), velocity (m/s)]`, shape `(6,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x_lfpa (numpy.ndarray or list): Cartesian LFPA state `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
+///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
+///     axis (int, optional): Axis of `x_lfpa` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: Cartesian LCI state `[position (m), velocity (m/s)]`, shape `(6,)`
+///     numpy.ndarray: Cartesian LCI state `[position (m), velocity (m/s)]`, shape `(6,)` for a single
+///         input, or the batch layout of `x_lfpa` (shape `(n, 6)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Example:
 ///     ```python
@@ -1747,16 +1848,16 @@ fn py_state_lci_to_lfpa<'py>(
 ///     x_lci2 = bh.state_lfpa_to_lci(epc, x_lfpa)
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(epc, x_lfpa)")]
+#[pyo3(signature = (epc, x_lfpa, axis=-1))]
+#[pyo3(text_signature = "(epc, x_lfpa, axis=-1)")]
 #[pyo3(name = "state_lfpa_to_lci")]
 fn py_state_lfpa_to_lci<'py>(
     py: Python<'py>,
-    epc: &PyEpoch,
-    x_lfpa: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::state_lfpa_to_lci(epc.obj, pyany_to_svector::<6>(&x_lfpa)?);
-
-    Ok(vector_to_numpy!(py, vec, 6, f64))
+    epc: &Bound<'py, PyAny>,
+    x_lfpa: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_epoch_vec::<6>(py, epc, x_lfpa, axis, frames::state_lfpa_to_lci, frames::states_lfpa_to_lci)
 }
 
 /// Transforms a Cartesian Lunar-inertial (LCI) state (position and velocity)
@@ -1764,11 +1865,17 @@ fn py_state_lfpa_to_lci<'py>(
 /// state.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation
-///     x_lci (numpy.ndarray or list): Cartesian LCI state `[position (m), velocity (m/s)]`, shape `(6,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x_lci (numpy.ndarray or list): Cartesian LCI state `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
+///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
+///     axis (int, optional): Axis of `x_lci` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: Cartesian LFME state `[position (m), velocity (m/s)]`, shape `(6,)`
+///     numpy.ndarray: Cartesian LFME state `[position (m), velocity (m/s)]`, shape `(6,)` for a single
+///         input, or the batch layout of `x_lci` (shape `(n, 6)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Example:
 ///     ```python
@@ -1779,16 +1886,16 @@ fn py_state_lfpa_to_lci<'py>(
 ///     x_lfme = bh.state_lci_to_lfme(epc, x_lci)
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(epc, x_lci)")]
+#[pyo3(signature = (epc, x_lci, axis=-1))]
+#[pyo3(text_signature = "(epc, x_lci, axis=-1)")]
 #[pyo3(name = "state_lci_to_lfme")]
 fn py_state_lci_to_lfme<'py>(
     py: Python<'py>,
-    epc: &PyEpoch,
-    x_lci: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::state_lci_to_lfme(epc.obj, pyany_to_svector::<6>(&x_lci)?);
-
-    Ok(vector_to_numpy!(py, vec, 6, f64))
+    epc: &Bound<'py, PyAny>,
+    x_lci: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_epoch_vec::<6>(py, epc, x_lci, axis, frames::state_lci_to_lfme, frames::states_lci_to_lfme)
 }
 
 /// Transforms a Cartesian Lunar-Fixed Mean Earth/polar-axis (LFME) state
@@ -1796,11 +1903,17 @@ fn py_state_lci_to_lfme<'py>(
 /// state. Inverse of `state_lci_to_lfme`.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation
-///     x_lfme (numpy.ndarray or list): Cartesian LFME state `[position (m), velocity (m/s)]`, shape `(6,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x_lfme (numpy.ndarray or list): Cartesian LFME state `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
+///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
+///     axis (int, optional): Axis of `x_lfme` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: Cartesian LCI state `[position (m), velocity (m/s)]`, shape `(6,)`
+///     numpy.ndarray: Cartesian LCI state `[position (m), velocity (m/s)]`, shape `(6,)` for a single
+///         input, or the batch layout of `x_lfme` (shape `(n, 6)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Example:
 ///     ```python
@@ -1812,16 +1925,16 @@ fn py_state_lci_to_lfme<'py>(
 ///     x_lci2 = bh.state_lfme_to_lci(epc, x_lfme)
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(epc, x_lfme)")]
+#[pyo3(signature = (epc, x_lfme, axis=-1))]
+#[pyo3(text_signature = "(epc, x_lfme, axis=-1)")]
 #[pyo3(name = "state_lfme_to_lci")]
 fn py_state_lfme_to_lci<'py>(
     py: Python<'py>,
-    epc: &PyEpoch,
-    x_lfme: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::state_lfme_to_lci(epc.obj, pyany_to_svector::<6>(&x_lfme)?);
-
-    Ok(vector_to_numpy!(py, vec, 6, f64))
+    epc: &Bound<'py, PyAny>,
+    x_lfme: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_epoch_vec::<6>(py, epc, x_lfme, axis, frames::state_lfme_to_lci, frames::states_lfme_to_lci)
 }
 
 /// Transforms a Cartesian Earth-inertial (ECI) position into the equivalent
@@ -1831,11 +1944,17 @@ fn py_state_lfme_to_lci<'py>(
 /// the default `de440s` ephemeris if no SPK kernel is loaded.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation
-///     x_eci (numpy.ndarray or list): Cartesian ECI position (m), shape `(3,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x_eci (numpy.ndarray or list): Cartesian ECI position (m), shape `(3,)`, or a batch
+///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
+///     axis (int, optional): Axis of `x_eci` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: Cartesian LCI position (m), shape `(3,)`
+///     numpy.ndarray: Cartesian LCI position (m), shape `(3,)` for a single
+///         input, or the batch layout of `x_eci` (shape `(n, 3)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Example:
 ///     ```python
@@ -1845,16 +1964,16 @@ fn py_state_lfme_to_lci<'py>(
 ///     x_lci = bh.position_eci_to_lci(epc, [1e7, 2e7, 3e7])
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(epc, x_eci)")]
+#[pyo3(signature = (epc, x_eci, axis=-1))]
+#[pyo3(text_signature = "(epc, x_eci, axis=-1)")]
 #[pyo3(name = "position_eci_to_lci")]
 fn py_position_eci_to_lci<'py>(
     py: Python<'py>,
-    epc: &PyEpoch,
-    x_eci: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::position_eci_to_lci(epc.obj, pyany_to_svector::<3>(&x_eci)?);
-
-    Ok(vector_to_numpy!(py, vec, 3, f64))
+    epc: &Bound<'py, PyAny>,
+    x_eci: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_epoch_vec::<3>(py, epc, x_eci, axis, frames::position_eci_to_lci, frames::positions_eci_to_lci)
 }
 
 /// Transforms a Cartesian Lunar-inertial (LCI) position into the equivalent
@@ -1863,11 +1982,17 @@ fn py_position_eci_to_lci<'py>(
 /// Auto-initializes the default `de440s` ephemeris if no SPK kernel is loaded.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation
-///     x_lci (numpy.ndarray or list): Cartesian LCI position (m), shape `(3,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x_lci (numpy.ndarray or list): Cartesian LCI position (m), shape `(3,)`, or a batch
+///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
+///     axis (int, optional): Axis of `x_lci` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: Cartesian ECI position (m), shape `(3,)`
+///     numpy.ndarray: Cartesian ECI position (m), shape `(3,)` for a single
+///         input, or the batch layout of `x_lci` (shape `(n, 3)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Example:
 ///     ```python
@@ -1877,16 +2002,16 @@ fn py_position_eci_to_lci<'py>(
 ///     x_eci = bh.position_lci_to_eci(epc, [1e7, 2e7, 3e7])
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(epc, x_lci)")]
+#[pyo3(signature = (epc, x_lci, axis=-1))]
+#[pyo3(text_signature = "(epc, x_lci, axis=-1)")]
 #[pyo3(name = "position_lci_to_eci")]
 fn py_position_lci_to_eci<'py>(
     py: Python<'py>,
-    epc: &PyEpoch,
-    x_lci: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::position_lci_to_eci(epc.obj, pyany_to_svector::<3>(&x_lci)?);
-
-    Ok(vector_to_numpy!(py, vec, 3, f64))
+    epc: &Bound<'py, PyAny>,
+    x_lci: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_epoch_vec::<3>(py, epc, x_lci, axis, frames::position_lci_to_eci, frames::positions_lci_to_eci)
 }
 
 /// Transforms a Cartesian Earth-inertial (ECI) state (position and velocity)
@@ -1896,11 +2021,17 @@ fn py_position_lci_to_eci<'py>(
 /// the default `de440s` ephemeris if no SPK kernel is loaded.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation
-///     x_eci (numpy.ndarray or list): Cartesian ECI state `[position (m), velocity (m/s)]`, shape `(6,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x_eci (numpy.ndarray or list): Cartesian ECI state `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
+///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
+///     axis (int, optional): Axis of `x_eci` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: Cartesian LCI state `[position (m), velocity (m/s)]`, shape `(6,)`
+///     numpy.ndarray: Cartesian LCI state `[position (m), velocity (m/s)]`, shape `(6,)` for a single
+///         input, or the batch layout of `x_eci` (shape `(n, 6)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Example:
 ///     ```python
@@ -1910,16 +2041,16 @@ fn py_position_lci_to_eci<'py>(
 ///     x_lci = bh.state_eci_to_lci(epc, [1e7, 2e7, 3e7, 1.0, 2.0, 3.0])
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(epc, x_eci)")]
+#[pyo3(signature = (epc, x_eci, axis=-1))]
+#[pyo3(text_signature = "(epc, x_eci, axis=-1)")]
 #[pyo3(name = "state_eci_to_lci")]
 fn py_state_eci_to_lci<'py>(
     py: Python<'py>,
-    epc: &PyEpoch,
-    x_eci: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::state_eci_to_lci(epc.obj, pyany_to_svector::<6>(&x_eci)?);
-
-    Ok(vector_to_numpy!(py, vec, 6, f64))
+    epc: &Bound<'py, PyAny>,
+    x_eci: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_epoch_vec::<6>(py, epc, x_eci, axis, frames::state_eci_to_lci, frames::states_eci_to_lci)
 }
 
 /// Transforms a Cartesian Lunar-inertial (LCI) state (position and velocity)
@@ -1928,11 +2059,17 @@ fn py_state_eci_to_lci<'py>(
 /// Auto-initializes the default `de440s` ephemeris if no SPK kernel is loaded.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation
-///     x_lci (numpy.ndarray or list): Cartesian LCI state `[position (m), velocity (m/s)]`, shape `(6,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x_lci (numpy.ndarray or list): Cartesian LCI state `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
+///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
+///     axis (int, optional): Axis of `x_lci` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: Cartesian ECI state `[position (m), velocity (m/s)]`, shape `(6,)`
+///     numpy.ndarray: Cartesian ECI state `[position (m), velocity (m/s)]`, shape `(6,)` for a single
+///         input, or the batch layout of `x_lci` (shape `(n, 6)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Example:
 ///     ```python
@@ -1942,16 +2079,16 @@ fn py_state_eci_to_lci<'py>(
 ///     x_eci = bh.state_lci_to_eci(epc, [1e7, 2e7, 3e7, 1.0, 2.0, 3.0])
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(epc, x_lci)")]
+#[pyo3(signature = (epc, x_lci, axis=-1))]
+#[pyo3(text_signature = "(epc, x_lci, axis=-1)")]
 #[pyo3(name = "state_lci_to_eci")]
 fn py_state_lci_to_eci<'py>(
     py: Python<'py>,
-    epc: &PyEpoch,
-    x_lci: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::state_lci_to_eci(epc.obj, pyany_to_svector::<6>(&x_lci)?);
-
-    Ok(vector_to_numpy!(py, vec, 6, f64))
+    epc: &Bound<'py, PyAny>,
+    x_lci: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_epoch_vec::<6>(py, epc, x_lci, axis, frames::state_lci_to_eci, frames::states_lci_to_eci)
 }
 
 // ============================================================================
@@ -1966,10 +2103,12 @@ fn py_state_lci_to_eci<'py>(
 /// loaded.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one matrix per epoch.
 ///
 /// Returns:
-///     numpy.ndarray: 3x3 rotation matrix transforming GCRF -> EMR axes
+///     numpy.ndarray: 3x3 rotation matrix transforming GCRF -> EMR axes, shape `(3, 3)` for a single epoch or `(n, 3, 3)`
+///         for a sequence of `n` epochs.
 ///
 /// Raises:
 ///     RuntimeError: If the SPK lookup fails at `epc`
@@ -1984,13 +2123,8 @@ fn py_state_lci_to_eci<'py>(
 #[pyfunction]
 #[pyo3(text_signature = "(epc)")]
 #[pyo3(name = "rotation_gcrf_to_emr")]
-unsafe fn py_rotation_gcrf_to_emr<'py>(
-    py: Python<'py>,
-    epc: &PyEpoch,
-) -> PyResult<Bound<'py, PyArray<f64, Ix2>>> {
-    let mat = frames::rotation_gcrf_to_emr(epc.obj)
-        .map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))?;
-    Ok(matrix_to_numpy!(py, mat, 3, 3, f64))
+fn py_rotation_gcrf_to_emr<'py>(py: Python<'py>, epc: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyAny>> {
+    try_dispatch_epoch_rotation(py, epc, frames::rotation_gcrf_to_emr, frames::rotations_gcrf_to_emr)
 }
 
 /// Computes the rotation matrix from Earth-Moon Rotating (EMR) frame axes to
@@ -2000,10 +2134,12 @@ unsafe fn py_rotation_gcrf_to_emr<'py>(
 /// loaded.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one matrix per epoch.
 ///
 /// Returns:
-///     numpy.ndarray: 3x3 rotation matrix transforming EMR -> GCRF axes
+///     numpy.ndarray: 3x3 rotation matrix transforming EMR -> GCRF axes, shape `(3, 3)` for a single epoch or `(n, 3, 3)`
+///         for a sequence of `n` epochs.
 ///
 /// Raises:
 ///     RuntimeError: If the SPK lookup fails at `epc`
@@ -2018,13 +2154,8 @@ unsafe fn py_rotation_gcrf_to_emr<'py>(
 #[pyfunction]
 #[pyo3(text_signature = "(epc)")]
 #[pyo3(name = "rotation_emr_to_gcrf")]
-unsafe fn py_rotation_emr_to_gcrf<'py>(
-    py: Python<'py>,
-    epc: &PyEpoch,
-) -> PyResult<Bound<'py, PyArray<f64, Ix2>>> {
-    let mat = frames::rotation_emr_to_gcrf(epc.obj)
-        .map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))?;
-    Ok(matrix_to_numpy!(py, mat, 3, 3, f64))
+fn py_rotation_emr_to_gcrf<'py>(py: Python<'py>, epc: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyAny>> {
+    try_dispatch_epoch_rotation(py, epc, frames::rotation_emr_to_gcrf, frames::rotations_emr_to_gcrf)
 }
 
 /// Transforms a Cartesian GCRF position into the equivalent Earth-Moon
@@ -2035,11 +2166,17 @@ unsafe fn py_rotation_emr_to_gcrf<'py>(
 /// loaded.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation
-///     x_gcrf (numpy.ndarray or list): Cartesian GCRF position (m), shape `(3,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x_gcrf (numpy.ndarray or list): Cartesian GCRF position (m), shape `(3,)`, or a batch
+///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
+///     axis (int, optional): Axis of `x_gcrf` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: Cartesian EMR position (m), shape `(3,)`
+///     numpy.ndarray: Cartesian EMR position (m), shape `(3,)` for a single
+///         input, or the batch layout of `x_gcrf` (shape `(n, 3)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Raises:
 ///     RuntimeError: If the SPK lookup fails at `epc`
@@ -2052,16 +2189,16 @@ unsafe fn py_rotation_emr_to_gcrf<'py>(
 ///     x_emr = bh.position_gcrf_to_emr(epc, [1e8, -2e8, 5e7])
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(epc, x_gcrf)")]
+#[pyo3(signature = (epc, x_gcrf, axis=-1))]
+#[pyo3(text_signature = "(epc, x_gcrf, axis=-1)")]
 #[pyo3(name = "position_gcrf_to_emr")]
 fn py_position_gcrf_to_emr<'py>(
     py: Python<'py>,
-    epc: &PyEpoch,
-    x_gcrf: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::position_gcrf_to_emr(epc.obj, pyany_to_svector::<3>(&x_gcrf)?)
-        .map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))?;
-    Ok(vector_to_numpy!(py, vec, 3, f64))
+    epc: &Bound<'py, PyAny>,
+    x_gcrf: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    try_dispatch_epoch_vec::<3>(py, epc, x_gcrf, axis, frames::position_gcrf_to_emr, frames::positions_gcrf_to_emr)
 }
 
 /// Transforms a Cartesian Earth-Moon Rotating (EMR) frame position into the
@@ -2071,11 +2208,17 @@ fn py_position_gcrf_to_emr<'py>(
 /// loaded.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation
-///     x_emr (numpy.ndarray or list): Cartesian EMR position (m), shape `(3,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x_emr (numpy.ndarray or list): Cartesian EMR position (m), shape `(3,)`, or a batch
+///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
+///     axis (int, optional): Axis of `x_emr` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: Cartesian GCRF position (m), shape `(3,)`
+///     numpy.ndarray: Cartesian GCRF position (m), shape `(3,)` for a single
+///         input, or the batch layout of `x_emr` (shape `(n, 3)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Raises:
 ///     RuntimeError: If the SPK lookup fails at `epc`
@@ -2088,16 +2231,16 @@ fn py_position_gcrf_to_emr<'py>(
 ///     x_gcrf = bh.position_emr_to_gcrf(epc, [3.8e8, 0.0, 0.0])
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(epc, x_emr)")]
+#[pyo3(signature = (epc, x_emr, axis=-1))]
+#[pyo3(text_signature = "(epc, x_emr, axis=-1)")]
 #[pyo3(name = "position_emr_to_gcrf")]
 fn py_position_emr_to_gcrf<'py>(
     py: Python<'py>,
-    epc: &PyEpoch,
-    x_emr: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::position_emr_to_gcrf(epc.obj, pyany_to_svector::<3>(&x_emr)?)
-        .map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))?;
-    Ok(vector_to_numpy!(py, vec, 3, f64))
+    epc: &Bound<'py, PyAny>,
+    x_emr: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    try_dispatch_epoch_vec::<3>(py, epc, x_emr, axis, frames::position_emr_to_gcrf, frames::positions_emr_to_gcrf)
 }
 
 /// Transforms a Cartesian GCRF state (position and velocity) into the
@@ -2110,11 +2253,17 @@ fn py_position_emr_to_gcrf<'py>(
 /// loaded.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation
-///     x_gcrf (numpy.ndarray or list): Cartesian GCRF state `[position (m), velocity (m/s)]`, shape `(6,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x_gcrf (numpy.ndarray or list): Cartesian GCRF state `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
+///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
+///     axis (int, optional): Axis of `x_gcrf` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: Cartesian EMR state `[position (m), velocity (m/s)]`, shape `(6,)`
+///     numpy.ndarray: Cartesian EMR state `[position (m), velocity (m/s)]`, shape `(6,)` for a single
+///         input, or the batch layout of `x_gcrf` (shape `(n, 6)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Raises:
 ///     RuntimeError: If the SPK lookup fails at `epc`
@@ -2127,16 +2276,16 @@ fn py_position_emr_to_gcrf<'py>(
 ///     x_emr = bh.state_gcrf_to_emr(epc, [1e8, -2e8, 5e7, 1.0e3, -2.0e3, 0.5e3])
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(epc, x_gcrf)")]
+#[pyo3(signature = (epc, x_gcrf, axis=-1))]
+#[pyo3(text_signature = "(epc, x_gcrf, axis=-1)")]
 #[pyo3(name = "state_gcrf_to_emr")]
 fn py_state_gcrf_to_emr<'py>(
     py: Python<'py>,
-    epc: &PyEpoch,
-    x_gcrf: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::state_gcrf_to_emr(epc.obj, pyany_to_svector::<6>(&x_gcrf)?)
-        .map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))?;
-    Ok(vector_to_numpy!(py, vec, 6, f64))
+    epc: &Bound<'py, PyAny>,
+    x_gcrf: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    try_dispatch_epoch_vec::<6>(py, epc, x_gcrf, axis, frames::state_gcrf_to_emr, frames::states_gcrf_to_emr)
 }
 
 /// Transforms a Cartesian Earth-Moon Rotating (EMR) frame state (position
@@ -2147,11 +2296,17 @@ fn py_state_gcrf_to_emr<'py>(
 /// loaded.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation
-///     x_emr (numpy.ndarray or list): Cartesian EMR state `[position (m), velocity (m/s)]`, shape `(6,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x_emr (numpy.ndarray or list): Cartesian EMR state `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
+///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
+///     axis (int, optional): Axis of `x_emr` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: Cartesian GCRF state `[position (m), velocity (m/s)]`, shape `(6,)`
+///     numpy.ndarray: Cartesian GCRF state `[position (m), velocity (m/s)]`, shape `(6,)` for a single
+///         input, or the batch layout of `x_emr` (shape `(n, 6)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Raises:
 ///     RuntimeError: If the SPK lookup fails at `epc`
@@ -2165,16 +2320,16 @@ fn py_state_gcrf_to_emr<'py>(
 ///     x_gcrf = bh.state_emr_to_gcrf(epc, x_emr)
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(epc, x_emr)")]
+#[pyo3(signature = (epc, x_emr, axis=-1))]
+#[pyo3(text_signature = "(epc, x_emr, axis=-1)")]
 #[pyo3(name = "state_emr_to_gcrf")]
 fn py_state_emr_to_gcrf<'py>(
     py: Python<'py>,
-    epc: &PyEpoch,
-    x_emr: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::state_emr_to_gcrf(epc.obj, pyany_to_svector::<6>(&x_emr)?)
-        .map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))?;
-    Ok(vector_to_numpy!(py, vec, 6, f64))
+    epc: &Bound<'py, PyAny>,
+    x_emr: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    try_dispatch_epoch_vec::<6>(py, epc, x_emr, axis, frames::state_emr_to_gcrf, frames::states_emr_to_gcrf)
 }
 
 /// Computes the rotation matrix from GCRF axes to Sun-Earth Rotating (SER)
@@ -2185,10 +2340,12 @@ fn py_state_emr_to_gcrf<'py>(
 /// loaded.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one matrix per epoch.
 ///
 /// Returns:
-///     numpy.ndarray: 3x3 rotation matrix transforming GCRF -> SER axes
+///     numpy.ndarray: 3x3 rotation matrix transforming GCRF -> SER axes, shape `(3, 3)` for a single epoch or `(n, 3, 3)`
+///         for a sequence of `n` epochs.
 ///
 /// Raises:
 ///     RuntimeError: If the SPK lookup fails at `epc`
@@ -2203,13 +2360,8 @@ fn py_state_emr_to_gcrf<'py>(
 #[pyfunction]
 #[pyo3(text_signature = "(epc)")]
 #[pyo3(name = "rotation_gcrf_to_ser")]
-unsafe fn py_rotation_gcrf_to_ser<'py>(
-    py: Python<'py>,
-    epc: &PyEpoch,
-) -> PyResult<Bound<'py, PyArray<f64, Ix2>>> {
-    let mat = frames::rotation_gcrf_to_ser(epc.obj)
-        .map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))?;
-    Ok(matrix_to_numpy!(py, mat, 3, 3, f64))
+fn py_rotation_gcrf_to_ser<'py>(py: Python<'py>, epc: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyAny>> {
+    try_dispatch_epoch_rotation(py, epc, frames::rotation_gcrf_to_ser, frames::rotations_gcrf_to_ser)
 }
 
 /// Computes the rotation matrix from Sun-Earth Rotating (SER) frame axes to
@@ -2219,10 +2371,12 @@ unsafe fn py_rotation_gcrf_to_ser<'py>(
 /// loaded.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one matrix per epoch.
 ///
 /// Returns:
-///     numpy.ndarray: 3x3 rotation matrix transforming SER -> GCRF axes
+///     numpy.ndarray: 3x3 rotation matrix transforming SER -> GCRF axes, shape `(3, 3)` for a single epoch or `(n, 3, 3)`
+///         for a sequence of `n` epochs.
 ///
 /// Raises:
 ///     RuntimeError: If the SPK lookup fails at `epc`
@@ -2237,13 +2391,8 @@ unsafe fn py_rotation_gcrf_to_ser<'py>(
 #[pyfunction]
 #[pyo3(text_signature = "(epc)")]
 #[pyo3(name = "rotation_ser_to_gcrf")]
-unsafe fn py_rotation_ser_to_gcrf<'py>(
-    py: Python<'py>,
-    epc: &PyEpoch,
-) -> PyResult<Bound<'py, PyArray<f64, Ix2>>> {
-    let mat = frames::rotation_ser_to_gcrf(epc.obj)
-        .map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))?;
-    Ok(matrix_to_numpy!(py, mat, 3, 3, f64))
+fn py_rotation_ser_to_gcrf<'py>(py: Python<'py>, epc: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyAny>> {
+    try_dispatch_epoch_rotation(py, epc, frames::rotation_ser_to_gcrf, frames::rotations_ser_to_gcrf)
 }
 
 /// Transforms a Cartesian GCRF position into the equivalent Sun-Earth
@@ -2254,11 +2403,17 @@ unsafe fn py_rotation_ser_to_gcrf<'py>(
 /// loaded.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation
-///     x_gcrf (numpy.ndarray or list): Cartesian GCRF position (m), shape `(3,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x_gcrf (numpy.ndarray or list): Cartesian GCRF position (m), shape `(3,)`, or a batch
+///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
+///     axis (int, optional): Axis of `x_gcrf` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: Cartesian SER position (m), shape `(3,)`
+///     numpy.ndarray: Cartesian SER position (m), shape `(3,)` for a single
+///         input, or the batch layout of `x_gcrf` (shape `(n, 3)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Raises:
 ///     RuntimeError: If the SPK lookup fails at `epc`
@@ -2271,16 +2426,16 @@ unsafe fn py_rotation_ser_to_gcrf<'py>(
 ///     x_ser = bh.position_gcrf_to_ser(epc, [1e8, -2e8, 5e7])
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(epc, x_gcrf)")]
+#[pyo3(signature = (epc, x_gcrf, axis=-1))]
+#[pyo3(text_signature = "(epc, x_gcrf, axis=-1)")]
 #[pyo3(name = "position_gcrf_to_ser")]
 fn py_position_gcrf_to_ser<'py>(
     py: Python<'py>,
-    epc: &PyEpoch,
-    x_gcrf: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::position_gcrf_to_ser(epc.obj, pyany_to_svector::<3>(&x_gcrf)?)
-        .map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))?;
-    Ok(vector_to_numpy!(py, vec, 3, f64))
+    epc: &Bound<'py, PyAny>,
+    x_gcrf: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    try_dispatch_epoch_vec::<3>(py, epc, x_gcrf, axis, frames::position_gcrf_to_ser, frames::positions_gcrf_to_ser)
 }
 
 /// Transforms a Cartesian Sun-Earth Rotating (SER) frame position into the
@@ -2290,11 +2445,17 @@ fn py_position_gcrf_to_ser<'py>(
 /// loaded.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation
-///     x_ser (numpy.ndarray or list): Cartesian SER position (m), shape `(3,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x_ser (numpy.ndarray or list): Cartesian SER position (m), shape `(3,)`, or a batch
+///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
+///     axis (int, optional): Axis of `x_ser` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: Cartesian GCRF position (m), shape `(3,)`
+///     numpy.ndarray: Cartesian GCRF position (m), shape `(3,)` for a single
+///         input, or the batch layout of `x_ser` (shape `(n, 3)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Raises:
 ///     RuntimeError: If the SPK lookup fails at `epc`
@@ -2307,16 +2468,16 @@ fn py_position_gcrf_to_ser<'py>(
 ///     x_gcrf = bh.position_ser_to_gcrf(epc, [1.5e11, 0.0, 0.0])
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(epc, x_ser)")]
+#[pyo3(signature = (epc, x_ser, axis=-1))]
+#[pyo3(text_signature = "(epc, x_ser, axis=-1)")]
 #[pyo3(name = "position_ser_to_gcrf")]
 fn py_position_ser_to_gcrf<'py>(
     py: Python<'py>,
-    epc: &PyEpoch,
-    x_ser: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::position_ser_to_gcrf(epc.obj, pyany_to_svector::<3>(&x_ser)?)
-        .map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))?;
-    Ok(vector_to_numpy!(py, vec, 3, f64))
+    epc: &Bound<'py, PyAny>,
+    x_ser: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    try_dispatch_epoch_vec::<3>(py, epc, x_ser, axis, frames::position_ser_to_gcrf, frames::positions_ser_to_gcrf)
 }
 
 /// Transforms a Cartesian GCRF state (position and velocity) into the
@@ -2329,11 +2490,17 @@ fn py_position_ser_to_gcrf<'py>(
 /// loaded.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation
-///     x_gcrf (numpy.ndarray or list): Cartesian GCRF state `[position (m), velocity (m/s)]`, shape `(6,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x_gcrf (numpy.ndarray or list): Cartesian GCRF state `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
+///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
+///     axis (int, optional): Axis of `x_gcrf` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: Cartesian SER state `[position (m), velocity (m/s)]`, shape `(6,)`
+///     numpy.ndarray: Cartesian SER state `[position (m), velocity (m/s)]`, shape `(6,)` for a single
+///         input, or the batch layout of `x_gcrf` (shape `(n, 6)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Raises:
 ///     RuntimeError: If the SPK lookup fails at `epc`
@@ -2346,16 +2513,16 @@ fn py_position_ser_to_gcrf<'py>(
 ///     x_ser = bh.state_gcrf_to_ser(epc, [1e8, -2e8, 5e7, 1.0e3, -2.0e3, 0.5e3])
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(epc, x_gcrf)")]
+#[pyo3(signature = (epc, x_gcrf, axis=-1))]
+#[pyo3(text_signature = "(epc, x_gcrf, axis=-1)")]
 #[pyo3(name = "state_gcrf_to_ser")]
 fn py_state_gcrf_to_ser<'py>(
     py: Python<'py>,
-    epc: &PyEpoch,
-    x_gcrf: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::state_gcrf_to_ser(epc.obj, pyany_to_svector::<6>(&x_gcrf)?)
-        .map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))?;
-    Ok(vector_to_numpy!(py, vec, 6, f64))
+    epc: &Bound<'py, PyAny>,
+    x_gcrf: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    try_dispatch_epoch_vec::<6>(py, epc, x_gcrf, axis, frames::state_gcrf_to_ser, frames::states_gcrf_to_ser)
 }
 
 /// Transforms a Cartesian Sun-Earth Rotating (SER) frame state (position
@@ -2366,11 +2533,17 @@ fn py_state_gcrf_to_ser<'py>(
 /// loaded.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation
-///     x_ser (numpy.ndarray or list): Cartesian SER state `[position (m), velocity (m/s)]`, shape `(6,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x_ser (numpy.ndarray or list): Cartesian SER state `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
+///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
+///     axis (int, optional): Axis of `x_ser` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: Cartesian GCRF state `[position (m), velocity (m/s)]`, shape `(6,)`
+///     numpy.ndarray: Cartesian GCRF state `[position (m), velocity (m/s)]`, shape `(6,)` for a single
+///         input, or the batch layout of `x_ser` (shape `(n, 6)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Raises:
 ///     RuntimeError: If the SPK lookup fails at `epc`
@@ -2384,16 +2557,16 @@ fn py_state_gcrf_to_ser<'py>(
 ///     x_gcrf = bh.state_ser_to_gcrf(epc, x_ser)
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(epc, x_ser)")]
+#[pyo3(signature = (epc, x_ser, axis=-1))]
+#[pyo3(text_signature = "(epc, x_ser, axis=-1)")]
 #[pyo3(name = "state_ser_to_gcrf")]
 fn py_state_ser_to_gcrf<'py>(
     py: Python<'py>,
-    epc: &PyEpoch,
-    x_ser: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::state_ser_to_gcrf(epc.obj, pyany_to_svector::<6>(&x_ser)?)
-        .map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))?;
-    Ok(vector_to_numpy!(py, vec, 6, f64))
+    epc: &Bound<'py, PyAny>,
+    x_ser: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    try_dispatch_epoch_vec::<6>(py, epc, x_ser, axis, frames::state_ser_to_gcrf, frames::states_ser_to_gcrf)
 }
 
 /// Computes the rotation matrix from GCRF axes to Geocentric Solar Ecliptic
@@ -2404,10 +2577,12 @@ fn py_state_ser_to_gcrf<'py>(
 /// loaded.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one matrix per epoch.
 ///
 /// Returns:
-///     numpy.ndarray: 3x3 rotation matrix transforming GCRF -> GSE axes
+///     numpy.ndarray: 3x3 rotation matrix transforming GCRF -> GSE axes, shape `(3, 3)` for a single epoch or `(n, 3, 3)`
+///         for a sequence of `n` epochs.
 ///
 /// Raises:
 ///     RuntimeError: If the SPK lookup fails at `epc`
@@ -2422,13 +2597,8 @@ fn py_state_ser_to_gcrf<'py>(
 #[pyfunction]
 #[pyo3(text_signature = "(epc)")]
 #[pyo3(name = "rotation_gcrf_to_gse")]
-unsafe fn py_rotation_gcrf_to_gse<'py>(
-    py: Python<'py>,
-    epc: &PyEpoch,
-) -> PyResult<Bound<'py, PyArray<f64, Ix2>>> {
-    let mat = frames::rotation_gcrf_to_gse(epc.obj)
-        .map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))?;
-    Ok(matrix_to_numpy!(py, mat, 3, 3, f64))
+fn py_rotation_gcrf_to_gse<'py>(py: Python<'py>, epc: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyAny>> {
+    try_dispatch_epoch_rotation(py, epc, frames::rotation_gcrf_to_gse, frames::rotations_gcrf_to_gse)
 }
 
 /// Computes the rotation matrix from Geocentric Solar Ecliptic (GSE) frame
@@ -2438,10 +2608,12 @@ unsafe fn py_rotation_gcrf_to_gse<'py>(
 /// loaded.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one matrix per epoch.
 ///
 /// Returns:
-///     numpy.ndarray: 3x3 rotation matrix transforming GSE -> GCRF axes
+///     numpy.ndarray: 3x3 rotation matrix transforming GSE -> GCRF axes, shape `(3, 3)` for a single epoch or `(n, 3, 3)`
+///         for a sequence of `n` epochs.
 ///
 /// Raises:
 ///     RuntimeError: If the SPK lookup fails at `epc`
@@ -2456,13 +2628,8 @@ unsafe fn py_rotation_gcrf_to_gse<'py>(
 #[pyfunction]
 #[pyo3(text_signature = "(epc)")]
 #[pyo3(name = "rotation_gse_to_gcrf")]
-unsafe fn py_rotation_gse_to_gcrf<'py>(
-    py: Python<'py>,
-    epc: &PyEpoch,
-) -> PyResult<Bound<'py, PyArray<f64, Ix2>>> {
-    let mat = frames::rotation_gse_to_gcrf(epc.obj)
-        .map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))?;
-    Ok(matrix_to_numpy!(py, mat, 3, 3, f64))
+fn py_rotation_gse_to_gcrf<'py>(py: Python<'py>, epc: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyAny>> {
+    try_dispatch_epoch_rotation(py, epc, frames::rotation_gse_to_gcrf, frames::rotations_gse_to_gcrf)
 }
 
 /// Transforms a Cartesian GCRF position into the equivalent Geocentric
@@ -2472,11 +2639,17 @@ unsafe fn py_rotation_gse_to_gcrf<'py>(
 /// loaded.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation
-///     x_gcrf (numpy.ndarray or list): Cartesian GCRF position (m), shape `(3,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x_gcrf (numpy.ndarray or list): Cartesian GCRF position (m), shape `(3,)`, or a batch
+///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
+///     axis (int, optional): Axis of `x_gcrf` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: Cartesian GSE position (m), shape `(3,)`
+///     numpy.ndarray: Cartesian GSE position (m), shape `(3,)` for a single
+///         input, or the batch layout of `x_gcrf` (shape `(n, 3)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Raises:
 ///     RuntimeError: If the SPK lookup fails at `epc`
@@ -2489,16 +2662,16 @@ unsafe fn py_rotation_gse_to_gcrf<'py>(
 ///     x_gse = bh.position_gcrf_to_gse(epc, [1e8, -2e8, 5e7])
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(epc, x_gcrf)")]
+#[pyo3(signature = (epc, x_gcrf, axis=-1))]
+#[pyo3(text_signature = "(epc, x_gcrf, axis=-1)")]
 #[pyo3(name = "position_gcrf_to_gse")]
 fn py_position_gcrf_to_gse<'py>(
     py: Python<'py>,
-    epc: &PyEpoch,
-    x_gcrf: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::position_gcrf_to_gse(epc.obj, pyany_to_svector::<3>(&x_gcrf)?)
-        .map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))?;
-    Ok(vector_to_numpy!(py, vec, 3, f64))
+    epc: &Bound<'py, PyAny>,
+    x_gcrf: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    try_dispatch_epoch_vec::<3>(py, epc, x_gcrf, axis, frames::position_gcrf_to_gse, frames::positions_gcrf_to_gse)
 }
 
 /// Transforms a Cartesian Geocentric Solar Ecliptic (GSE) frame position
@@ -2509,11 +2682,17 @@ fn py_position_gcrf_to_gse<'py>(
 /// loaded.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation
-///     x_gse (numpy.ndarray or list): Cartesian GSE position (m), shape `(3,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x_gse (numpy.ndarray or list): Cartesian GSE position (m), shape `(3,)`, or a batch
+///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
+///     axis (int, optional): Axis of `x_gse` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: Cartesian GCRF position (m), shape `(3,)`
+///     numpy.ndarray: Cartesian GCRF position (m), shape `(3,)` for a single
+///         input, or the batch layout of `x_gse` (shape `(n, 3)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Raises:
 ///     RuntimeError: If the SPK lookup fails at `epc`
@@ -2526,16 +2705,16 @@ fn py_position_gcrf_to_gse<'py>(
 ///     x_gcrf = bh.position_gse_to_gcrf(epc, [1.5e11, 0.0, 0.0])
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(epc, x_gse)")]
+#[pyo3(signature = (epc, x_gse, axis=-1))]
+#[pyo3(text_signature = "(epc, x_gse, axis=-1)")]
 #[pyo3(name = "position_gse_to_gcrf")]
 fn py_position_gse_to_gcrf<'py>(
     py: Python<'py>,
-    epc: &PyEpoch,
-    x_gse: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::position_gse_to_gcrf(epc.obj, pyany_to_svector::<3>(&x_gse)?)
-        .map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))?;
-    Ok(vector_to_numpy!(py, vec, 3, f64))
+    epc: &Bound<'py, PyAny>,
+    x_gse: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    try_dispatch_epoch_vec::<3>(py, epc, x_gse, axis, frames::position_gse_to_gcrf, frames::positions_gse_to_gcrf)
 }
 
 /// Transforms a Cartesian GCRF state (position and velocity) into the
@@ -2547,11 +2726,17 @@ fn py_position_gse_to_gcrf<'py>(
 /// loaded.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation
-///     x_gcrf (numpy.ndarray or list): Cartesian GCRF state `[position (m), velocity (m/s)]`, shape `(6,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x_gcrf (numpy.ndarray or list): Cartesian GCRF state `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
+///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
+///     axis (int, optional): Axis of `x_gcrf` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: Cartesian GSE state `[position (m), velocity (m/s)]`, shape `(6,)`
+///     numpy.ndarray: Cartesian GSE state `[position (m), velocity (m/s)]`, shape `(6,)` for a single
+///         input, or the batch layout of `x_gcrf` (shape `(n, 6)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Raises:
 ///     RuntimeError: If the SPK lookup fails at `epc`
@@ -2564,16 +2749,16 @@ fn py_position_gse_to_gcrf<'py>(
 ///     x_gse = bh.state_gcrf_to_gse(epc, [1e8, -2e8, 5e7, 1.0e3, -2.0e3, 0.5e3])
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(epc, x_gcrf)")]
+#[pyo3(signature = (epc, x_gcrf, axis=-1))]
+#[pyo3(text_signature = "(epc, x_gcrf, axis=-1)")]
 #[pyo3(name = "state_gcrf_to_gse")]
 fn py_state_gcrf_to_gse<'py>(
     py: Python<'py>,
-    epc: &PyEpoch,
-    x_gcrf: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::state_gcrf_to_gse(epc.obj, pyany_to_svector::<6>(&x_gcrf)?)
-        .map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))?;
-    Ok(vector_to_numpy!(py, vec, 6, f64))
+    epc: &Bound<'py, PyAny>,
+    x_gcrf: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    try_dispatch_epoch_vec::<6>(py, epc, x_gcrf, axis, frames::state_gcrf_to_gse, frames::states_gcrf_to_gse)
 }
 
 /// Transforms a Cartesian Geocentric Solar Ecliptic (GSE) frame state
@@ -2584,11 +2769,17 @@ fn py_state_gcrf_to_gse<'py>(
 /// loaded.
 ///
 /// Args:
-///     epc (Epoch): Epoch instant for computation of the transformation
-///     x_gse (numpy.ndarray or list): Cartesian GSE state `[position (m), velocity (m/s)]`, shape `(6,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x_gse (numpy.ndarray or list): Cartesian GSE state `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
+///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
+///     axis (int, optional): Axis of `x_gse` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: Cartesian GCRF state `[position (m), velocity (m/s)]`, shape `(6,)`
+///     numpy.ndarray: Cartesian GCRF state `[position (m), velocity (m/s)]`, shape `(6,)` for a single
+///         input, or the batch layout of `x_gse` (shape `(n, 6)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Raises:
 ///     RuntimeError: If the SPK lookup fails at `epc`
@@ -2602,16 +2793,16 @@ fn py_state_gcrf_to_gse<'py>(
 ///     x_gcrf = bh.state_gse_to_gcrf(epc, x_gse)
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(epc, x_gse)")]
+#[pyo3(signature = (epc, x_gse, axis=-1))]
+#[pyo3(text_signature = "(epc, x_gse, axis=-1)")]
 #[pyo3(name = "state_gse_to_gcrf")]
 fn py_state_gse_to_gcrf<'py>(
     py: Python<'py>,
-    epc: &PyEpoch,
-    x_gse: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::state_gse_to_gcrf(epc.obj, pyany_to_svector::<6>(&x_gse)?)
-        .map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))?;
-    Ok(vector_to_numpy!(py, vec, 6, f64))
+    epc: &Bound<'py, PyAny>,
+    x_gse: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    try_dispatch_epoch_vec::<6>(py, epc, x_gse, axis, frames::state_gse_to_gcrf, frames::states_gse_to_gcrf)
 }
 
 // ============================================================================
@@ -2994,10 +3185,12 @@ impl PyReferenceFrame {
 /// Args:
 ///     from_frame (ReferenceFrame): Source reference frame
 ///     to_frame (ReferenceFrame): Target reference frame
-///     epc (Epoch): Epoch instant for computation of the transformation
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one matrix per epoch.
 ///
 /// Returns:
-///     numpy.ndarray: 3x3 rotation matrix transforming `from_frame` -> `to_frame`
+///     numpy.ndarray: 3x3 rotation matrix transforming `from_frame` -> `to_frame`, shape `(3, 3)` for a single epoch or `(n, 3, 3)`
+///         for a sequence of `n` epochs.
 ///
 /// Raises:
 ///     RuntimeError: If either frame's orientation cannot be evaluated at `epc`
@@ -3012,15 +3205,19 @@ impl PyReferenceFrame {
 #[pyfunction]
 #[pyo3(text_signature = "(from_frame, to_frame, epc)")]
 #[pyo3(name = "rotation_frame_to_frame")]
-unsafe fn py_rotation_frame_to_frame<'py>(
+fn py_rotation_frame_to_frame<'py>(
     py: Python<'py>,
     from_frame: PyReferenceFrame,
     to_frame: PyReferenceFrame,
-    epc: &PyEpoch,
-) -> PyResult<Bound<'py, PyArray<f64, Ix2>>> {
-    let mat = frames::rotation_frame_to_frame(from_frame.frame, to_frame.frame, epc.obj)
-        .map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))?;
-    Ok(matrix_to_numpy!(py, mat, 3, 3, f64))
+    epc: &Bound<'py, PyAny>,
+) -> PyResult<Bound<'py, PyAny>> {
+    let (from, to) = (from_frame.frame, to_frame.frame);
+    try_dispatch_epoch_rotation(
+        py,
+        epc,
+        |e| frames::rotation_frame_to_frame(from, to, e),
+        |es| frames::rotations_frame_to_frame(from, to, es),
+    )
 }
 
 /// Registers (or replaces) a user-defined body-fixed frame under `key`.
@@ -3125,11 +3322,17 @@ fn py_unregister_custom_frame(key: u32) -> bool {
 /// Args:
 ///     from_frame (ReferenceFrame): Source reference frame
 ///     to_frame (ReferenceFrame): Target reference frame
-///     epc (Epoch): Epoch instant for computation of the transformation
-///     x (numpy.ndarray or list): Cartesian position in `from_frame` axes/center (m), shape `(3,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x (numpy.ndarray or list): Cartesian position in `from_frame` axes/center (m), shape `(3,)`, or a batch
+///         of vectors with the 3 components along `axis` (for example shape `(n, 3)`).
+///     axis (int, optional): Axis of `x` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: Cartesian position in `to_frame` axes/center (m), shape `(3,)`
+///     numpy.ndarray: Cartesian position in `to_frame` axes/center (m), shape `(3,)` for a single
+///         input, or the batch layout of `x` (shape `(n, 3)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Raises:
 ///     RuntimeError: If either frame's orientation cannot be evaluated at
@@ -3145,24 +3348,26 @@ fn py_unregister_custom_frame(key: u32) -> bool {
 ///     x_itrf = bh.position_frame_to_frame(bh.ReferenceFrame.GCRF, bh.ReferenceFrame.ITRF, epc, x_gcrf)
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(from_frame, to_frame, epc, x)")]
+#[pyo3(signature = (from_frame, to_frame, epc, x, axis=-1))]
+#[pyo3(text_signature = "(from_frame, to_frame, epc, x, axis=-1)")]
 #[pyo3(name = "position_frame_to_frame")]
 fn py_position_frame_to_frame<'py>(
     py: Python<'py>,
     from_frame: PyReferenceFrame,
     to_frame: PyReferenceFrame,
-    epc: &PyEpoch,
-    x: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::position_frame_to_frame(
-        from_frame.frame,
-        to_frame.frame,
-        epc.obj,
-        pyany_to_svector::<3>(&x)?,
+    epc: &Bound<'py, PyAny>,
+    x: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    let (from, to) = (from_frame.frame, to_frame.frame);
+    try_dispatch_epoch_vec::<3>(
+        py,
+        epc,
+        x,
+        axis,
+        |e, v| frames::position_frame_to_frame(from, to, e, v),
+        |es, vs| frames::positions_frame_to_frame(from, to, es, vs),
     )
-    .map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))?;
-
-    Ok(vector_to_numpy!(py, vec, 3, f64))
 }
 
 /// Transforms a Cartesian state (position and velocity) from `from_frame` to
@@ -3181,11 +3386,17 @@ fn py_position_frame_to_frame<'py>(
 /// Args:
 ///     from_frame (ReferenceFrame): Source reference frame
 ///     to_frame (ReferenceFrame): Target reference frame
-///     epc (Epoch): Epoch instant for computation of the transformation
-///     x (numpy.ndarray or list): Cartesian state in `from_frame` axes/center `[position (m), velocity (m/s)]`, shape `(6,)`
+///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
+///         one epoch per vector (or broadcasts a single vector across all epochs).
+///     x (numpy.ndarray or list): Cartesian state in `from_frame` axes/center `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
+///         of vectors with the 6 components along `axis` (for example shape `(n, 6)`).
+///     axis (int, optional): Axis of `x` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: Cartesian state in `to_frame` axes/center `[position (m), velocity (m/s)]`, shape `(6,)`
+///     numpy.ndarray: Cartesian state in `to_frame` axes/center `[position (m), velocity (m/s)]`, shape `(6,)` for a single
+///         input, or the batch layout of `x` (shape `(n, 6)` for a single vector
+///         with a sequence of `n` epochs).
 ///
 /// Raises:
 ///     RuntimeError: If either frame's orientation cannot be evaluated at
@@ -3201,22 +3412,24 @@ fn py_position_frame_to_frame<'py>(
 ///     x_lfpa = bh.state_frame_to_frame(bh.ReferenceFrame.GCRF, bh.ReferenceFrame.LFPA, epc, x_gcrf)
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(from_frame, to_frame, epc, x)")]
+#[pyo3(signature = (from_frame, to_frame, epc, x, axis=-1))]
+#[pyo3(text_signature = "(from_frame, to_frame, epc, x, axis=-1)")]
 #[pyo3(name = "state_frame_to_frame")]
 fn py_state_frame_to_frame<'py>(
     py: Python<'py>,
     from_frame: PyReferenceFrame,
     to_frame: PyReferenceFrame,
-    epc: &PyEpoch,
-    x: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = frames::state_frame_to_frame(
-        from_frame.frame,
-        to_frame.frame,
-        epc.obj,
-        pyany_to_svector::<6>(&x)?,
+    epc: &Bound<'py, PyAny>,
+    x: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    let (from, to) = (from_frame.frame, to_frame.frame);
+    try_dispatch_epoch_vec::<6>(
+        py,
+        epc,
+        x,
+        axis,
+        |e, v| frames::state_frame_to_frame(from, to, e, v),
+        |es, vs| frames::states_frame_to_frame(from, to, es, vs),
     )
-    .map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))?;
-
-    Ok(vector_to_numpy!(py, vec, 6, f64))
 }

--- a/docs/learn/frames/vectorized.md
+++ b/docs/learn/frames/vectorized.md
@@ -19,6 +19,8 @@ Epoch arguments accept an `Epoch` or any sequence of `Epoch` objects (list, tupl
 
 Rotation-matrix functions such as `rotation_eci_to_ecef` accept a sequence of epochs and return an `(n, 3, 3)` array.
 
+The same rules apply to every frame family: ECI/ECEF and GCRF/ITRF, EME2000, the lunar (LCI, LFPA, LFME), Mars (MCI, MCMF), and Earth-Moon barycenter (EMBI) frames, the EMR/SER/GSE synodic frames, `rotation_icrf_to_body_fixed_iau`, and the generic `rotation_frame_to_frame`, `position_frame_to_frame`, and `state_frame_to_frame` router. Functions that can fail for a single input (synodic and router transforms, IAU rotations) raise the same `RuntimeError` for a batch.
+
 === "Python"
 
     ``` python

--- a/src/frames/emb.rs
+++ b/src/frames/emb.rs
@@ -27,6 +27,16 @@ use crate::utils::batch::batch_map_epochs;
 ///
 /// # Returns
 /// - Earth position relative to the EMB. Units: (*m*)
+///
+/// # Examples
+///
+/// ```ignore
+/// use brahe::time::{Epoch, TimeSystem};
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let offset = earth_emb_offset_position(epc);
+/// // x_emb = x_eci + offset
+/// ```
 fn earth_emb_offset_position(epc: Epoch) -> Vector3<f64> {
     spk_position(NAIFId::Earth, NAIFId::EarthMoonBarycenter, epc)
         .expect("SPK query failed: ensure a DE kernel is available (auto-init de440s)")
@@ -39,6 +49,16 @@ fn earth_emb_offset_position(epc: Epoch) -> Vector3<f64> {
 ///
 /// # Returns
 /// - Earth state relative to the EMB (position, velocity). Units: (*m*; *m/s*)
+///
+/// # Examples
+///
+/// ```ignore
+/// use brahe::time::{Epoch, TimeSystem};
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let offset = earth_emb_offset_state(epc);
+/// // x_emb = x_eci + offset
+/// ```
 fn earth_emb_offset_state(epc: Epoch) -> SVector6 {
     spk_state(NAIFId::Earth, NAIFId::EarthMoonBarycenter, epc)
         .expect("SPK query failed: ensure a DE kernel is available (auto-init de440s)")

--- a/src/frames/emb.rs
+++ b/src/frames/emb.rs
@@ -17,6 +17,32 @@ use nalgebra::Vector3;
 use crate::math::linalg::SVector6;
 use crate::spice::{NAIFId, spk_position, spk_state};
 use crate::time::Epoch;
+use crate::utils::BraheError;
+use crate::utils::batch::batch_map_epochs;
+
+/// Earth position relative to the Earth-Moon barycenter in ICRF axes.
+///
+/// # Arguments
+/// - `epc`: Epoch instant
+///
+/// # Returns
+/// - Earth position relative to the EMB. Units: (*m*)
+fn earth_emb_offset_position(epc: Epoch) -> Vector3<f64> {
+    spk_position(NAIFId::Earth, NAIFId::EarthMoonBarycenter, epc)
+        .expect("SPK query failed: ensure a DE kernel is available (auto-init de440s)")
+}
+
+/// Earth state relative to the Earth-Moon barycenter in ICRF axes.
+///
+/// # Arguments
+/// - `epc`: Epoch instant
+///
+/// # Returns
+/// - Earth state relative to the EMB (position, velocity). Units: (*m*; *m/s*)
+fn earth_emb_offset_state(epc: Epoch) -> SVector6 {
+    spk_state(NAIFId::Earth, NAIFId::EarthMoonBarycenter, epc)
+        .expect("SPK query failed: ensure a DE kernel is available (auto-init de440s)")
+}
 
 /// Transforms a Cartesian Earth-inertial (ECI) position into the equivalent
 /// Cartesian Earth-Moon-barycenter inertial (EMBI) position.
@@ -45,8 +71,7 @@ use crate::time::Epoch;
 /// let x_emb = position_eci_to_emb(epc, x_eci);
 /// ```
 pub fn position_eci_to_emb(epc: Epoch, x_eci: Vector3<f64>) -> Vector3<f64> {
-    let offset = spk_position(NAIFId::Earth, NAIFId::EarthMoonBarycenter, epc)
-        .expect("SPK query failed: ensure a DE kernel is available (auto-init de440s)");
+    let offset = earth_emb_offset_position(epc);
     x_eci + offset
 }
 
@@ -79,8 +104,7 @@ pub fn position_eci_to_emb(epc: Epoch, x_eci: Vector3<f64>) -> Vector3<f64> {
 /// assert!((x_rt - x_eci).norm() < 1e-6);
 /// ```
 pub fn position_emb_to_eci(epc: Epoch, x_emb: Vector3<f64>) -> Vector3<f64> {
-    let offset = spk_position(NAIFId::Earth, NAIFId::EarthMoonBarycenter, epc)
-        .expect("SPK query failed: ensure a DE kernel is available (auto-init de440s)");
+    let offset = earth_emb_offset_position(epc);
     x_emb - offset
 }
 
@@ -114,8 +138,7 @@ pub fn position_emb_to_eci(epc: Epoch, x_emb: Vector3<f64>) -> Vector3<f64> {
 /// let x_emb = state_eci_to_emb(epc, x_eci);
 /// ```
 pub fn state_eci_to_emb(epc: Epoch, x_eci: SVector6) -> SVector6 {
-    let offset = spk_state(NAIFId::Earth, NAIFId::EarthMoonBarycenter, epc)
-        .expect("SPK query failed: ensure a DE kernel is available (auto-init de440s)");
+    let offset = earth_emb_offset_state(epc);
     x_eci + offset
 }
 
@@ -148,9 +171,150 @@ pub fn state_eci_to_emb(epc: Epoch, x_eci: SVector6) -> SVector6 {
 /// assert!((x_rt - x_eci).norm() < 1e-6);
 /// ```
 pub fn state_emb_to_eci(epc: Epoch, x_emb: SVector6) -> SVector6 {
-    let offset = spk_state(NAIFId::Earth, NAIFId::EarthMoonBarycenter, epc)
-        .expect("SPK query failed: ensure a DE kernel is available (auto-init de440s)");
+    let offset = earth_emb_offset_state(epc);
     x_emb - offset
+}
+
+/// Transforms a batch of Cartesian positions from ECI to the Earth-Moon barycentric inertial frame.
+///
+/// Batch form of [`position_eci_to_emb`]. `epochs` and the vector argument follow the
+/// broadcast rule: each has length 1 or the common batch length. A single
+/// epoch evaluates the transformation context once and applies it to every
+/// element. Evaluation runs on the global thread pool for large inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x_eci`: Cartesian ECI positions, length 1 or the batch length. Units: (*m*)
+///
+/// # Returns
+/// - Cartesian EMBI positions in input order. Units: (*m*)
+/// - Error if the lengths do not satisfy the broadcast rule
+///
+/// # Examples:
+/// ```
+/// use brahe::frames::positions_eci_to_emb;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use nalgebra::Vector3;
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let positions = vec![Vector3::new(7.0e6, 1.0e6, -2.0e6); 3];
+/// let out = positions_eci_to_emb(&[epc], &positions).unwrap();
+/// assert_eq!(out.len(), 3);
+/// ```
+pub fn positions_eci_to_emb(
+    epochs: &[Epoch],
+    x_eci: &[Vector3<f64>],
+) -> Result<Vec<Vector3<f64>>, BraheError> {
+    batch_map_epochs(epochs, x_eci, earth_emb_offset_position, |offset, x| {
+        x + offset
+    })
+}
+
+/// Transforms a batch of Cartesian positions from the Earth-Moon barycentric inertial frame to ECI.
+///
+/// Batch form of [`position_emb_to_eci`]. `epochs` and the vector argument follow the
+/// broadcast rule: each has length 1 or the common batch length. A single
+/// epoch evaluates the transformation context once and applies it to every
+/// element. Evaluation runs on the global thread pool for large inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x_emb`: Cartesian EMBI positions, length 1 or the batch length. Units: (*m*)
+///
+/// # Returns
+/// - Cartesian ECI positions in input order. Units: (*m*)
+/// - Error if the lengths do not satisfy the broadcast rule
+///
+/// # Examples:
+/// ```
+/// use brahe::frames::positions_emb_to_eci;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use nalgebra::Vector3;
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let positions = vec![Vector3::new(7.0e6, 1.0e6, -2.0e6); 3];
+/// let out = positions_emb_to_eci(&[epc], &positions).unwrap();
+/// assert_eq!(out.len(), 3);
+/// ```
+pub fn positions_emb_to_eci(
+    epochs: &[Epoch],
+    x_emb: &[Vector3<f64>],
+) -> Result<Vec<Vector3<f64>>, BraheError> {
+    batch_map_epochs(epochs, x_emb, earth_emb_offset_position, |offset, x| {
+        x - offset
+    })
+}
+
+/// Transforms a batch of Cartesian states from ECI to the Earth-Moon barycentric inertial frame.
+///
+/// Batch form of [`state_eci_to_emb`]. `epochs` and the vector argument follow the
+/// broadcast rule: each has length 1 or the common batch length. A single
+/// epoch evaluates the transformation context once and applies it to every
+/// element. Evaluation runs on the global thread pool for large inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x_eci`: Cartesian ECI states (position, velocity), length 1 or the batch length. Units: (*m*; *m/s*)
+///
+/// # Returns
+/// - Cartesian EMBI states (position, velocity) in input order. Units: (*m*; *m/s*)
+/// - Error if the lengths do not satisfy the broadcast rule
+///
+/// # Examples:
+/// ```
+/// use brahe::frames::states_eci_to_emb;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use brahe::vector6_from_array;
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let epochs = vec![epc, epc + 60.0, epc + 120.0];
+/// let states = vec![vector6_from_array([7.0e6, 0.0, 0.0, 0.0, 7.5e3, 0.0]); 3];
+/// let out = states_eci_to_emb(&epochs, &states).unwrap();
+/// assert_eq!(out.len(), 3);
+/// ```
+pub fn states_eci_to_emb(
+    epochs: &[Epoch],
+    x_eci: &[SVector6],
+) -> Result<Vec<SVector6>, BraheError> {
+    batch_map_epochs(epochs, x_eci, earth_emb_offset_state, |offset, x| {
+        x + offset
+    })
+}
+
+/// Transforms a batch of Cartesian states from the Earth-Moon barycentric inertial frame to ECI.
+///
+/// Batch form of [`state_emb_to_eci`]. `epochs` and the vector argument follow the
+/// broadcast rule: each has length 1 or the common batch length. A single
+/// epoch evaluates the transformation context once and applies it to every
+/// element. Evaluation runs on the global thread pool for large inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x_emb`: Cartesian EMBI states (position, velocity), length 1 or the batch length. Units: (*m*; *m/s*)
+///
+/// # Returns
+/// - Cartesian ECI states (position, velocity) in input order. Units: (*m*; *m/s*)
+/// - Error if the lengths do not satisfy the broadcast rule
+///
+/// # Examples:
+/// ```
+/// use brahe::frames::states_emb_to_eci;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use brahe::vector6_from_array;
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let epochs = vec![epc, epc + 60.0, epc + 120.0];
+/// let states = vec![vector6_from_array([7.0e6, 0.0, 0.0, 0.0, 7.5e3, 0.0]); 3];
+/// let out = states_emb_to_eci(&epochs, &states).unwrap();
+/// assert_eq!(out.len(), 3);
+/// ```
+pub fn states_emb_to_eci(
+    epochs: &[Epoch],
+    x_emb: &[SVector6],
+) -> Result<Vec<SVector6>, BraheError> {
+    batch_map_epochs(epochs, x_emb, earth_emb_offset_state, |offset, x| {
+        x - offset
+    })
 }
 
 #[cfg(test)]
@@ -200,5 +364,41 @@ mod tests {
         for i in 0..6 {
             assert_abs_diff_eq!(x_rt[i], x_eci[i], epsilon = 1e-9);
         }
+    }
+
+    #[test]
+    #[serial]
+    fn test_batch_eci_emb_matches_scalar() {
+        setup_global_test_spice();
+        let epc0 = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+        let epochs: Vec<Epoch> = (0..3).map(|i| epc0 + 3600.0 * i as f64).collect();
+        let states: Vec<SVector6> = (0..3)
+            .map(|i| vector6_from_array([7.0e6 + 1e3 * i as f64, 1.0e6, -2.0e6, 0.0, 7.5e3, 0.0]))
+            .collect();
+        let positions: Vec<Vector3<f64>> = states
+            .iter()
+            .map(|s| Vector3::new(s[0], s[1], s[2]))
+            .collect();
+
+        let p = positions_eci_to_emb(&epochs, &positions).unwrap();
+        let p_shared = positions_eci_to_emb(&epochs[..1], &positions).unwrap();
+        let p_back = positions_emb_to_eci(&epochs, &p).unwrap();
+        let s = states_eci_to_emb(&epochs, &states).unwrap();
+        let s_shared = states_eci_to_emb(&epochs[..1], &states).unwrap();
+        let s_back = states_emb_to_eci(&epochs, &s).unwrap();
+        for i in 0..3 {
+            assert_eq!(p[i], position_eci_to_emb(epochs[i], positions[i]));
+            assert_eq!(p_shared[i], position_eci_to_emb(epochs[0], positions[i]));
+            assert_eq!(p_back[i], position_emb_to_eci(epochs[i], p[i]));
+            assert_eq!(s[i], state_eci_to_emb(epochs[i], states[i]));
+            assert_eq!(s_shared[i], state_eci_to_emb(epochs[0], states[i]));
+            assert_eq!(s_back[i], state_emb_to_eci(epochs[i], s[i]));
+        }
+        let one = states_emb_to_eci(&epochs, &states[..1]).unwrap();
+        for i in 0..3 {
+            assert_eq!(one[i], state_emb_to_eci(epochs[i], states[0]));
+        }
+        assert!(states_eci_to_emb(&epochs[..2], &states).is_err());
+        assert!(positions_eci_to_emb(&epochs[..1], &[]).unwrap().is_empty());
     }
 }

--- a/src/frames/emb.rs
+++ b/src/frames/emb.rs
@@ -225,9 +225,12 @@ pub fn positions_eci_to_emb(
     epochs: &[Epoch],
     x_eci: &[Vector3<f64>],
 ) -> Result<Vec<Vector3<f64>>, BraheError> {
-    batch_map_epochs(epochs, x_eci, earth_emb_offset_position, |offset, x| {
-        x + offset
-    })
+    batch_map_epochs(
+        earth_emb_offset_position,
+        |offset, x| x + offset,
+        epochs,
+        x_eci,
+    )
 }
 
 /// Transforms a batch of Cartesian positions from the Earth-Moon barycentric inertial frame to ECI.
@@ -260,9 +263,12 @@ pub fn positions_emb_to_eci(
     epochs: &[Epoch],
     x_emb: &[Vector3<f64>],
 ) -> Result<Vec<Vector3<f64>>, BraheError> {
-    batch_map_epochs(epochs, x_emb, earth_emb_offset_position, |offset, x| {
-        x - offset
-    })
+    batch_map_epochs(
+        earth_emb_offset_position,
+        |offset, x| x - offset,
+        epochs,
+        x_emb,
+    )
 }
 
 /// Transforms a batch of Cartesian states from ECI to the Earth-Moon barycentric inertial frame.
@@ -296,9 +302,12 @@ pub fn states_eci_to_emb(
     epochs: &[Epoch],
     x_eci: &[SVector6],
 ) -> Result<Vec<SVector6>, BraheError> {
-    batch_map_epochs(epochs, x_eci, earth_emb_offset_state, |offset, x| {
-        x + offset
-    })
+    batch_map_epochs(
+        earth_emb_offset_state,
+        |offset, x| x + offset,
+        epochs,
+        x_eci,
+    )
 }
 
 /// Transforms a batch of Cartesian states from the Earth-Moon barycentric inertial frame to ECI.
@@ -332,9 +341,12 @@ pub fn states_emb_to_eci(
     epochs: &[Epoch],
     x_emb: &[SVector6],
 ) -> Result<Vec<SVector6>, BraheError> {
-    batch_map_epochs(epochs, x_emb, earth_emb_offset_state, |offset, x| {
-        x - offset
-    })
+    batch_map_epochs(
+        earth_emb_offset_state,
+        |offset, x| x - offset,
+        epochs,
+        x_emb,
+    )
 }
 
 #[cfg(test)]

--- a/src/frames/iau_rotation.rs
+++ b/src/frames/iau_rotation.rs
@@ -677,7 +677,7 @@ pub fn rotations_icrf_to_body_fixed_iau(
     naif_id: i32,
     epochs: &[Epoch],
 ) -> Result<Vec<SMatrix3>, BraheError> {
-    try_batch_map(epochs, |epc| rotation_icrf_to_body_fixed_iau(naif_id, *epc))
+    try_batch_map(|epc| rotation_icrf_to_body_fixed_iau(naif_id, *epc), epochs)
 }
 
 /// Computes the angular velocity [rad/s] of a body-fixed frame with

--- a/src/frames/iau_rotation.rs
+++ b/src/frames/iau_rotation.rs
@@ -50,6 +50,7 @@ use crate::constants::{AngleFormat, SECONDS_PER_JULIAN_CENTURY};
 use crate::math::SMatrix3;
 use crate::time::{Epoch, TimeSystem};
 use crate::utils::BraheError;
+use crate::utils::batch::try_batch_map;
 
 /// IAU/WGCCRE rotation model for a single body: polynomial pole
 /// right-ascension, pole declination, and prime-meridian coefficients,
@@ -649,6 +650,36 @@ pub fn rotation_icrf_to_body_fixed_iau(naif_id: i32, epc: Epoch) -> Result<SMatr
     Ok(rz(angles[2]) * rx(angles[1]) * rz(angles[0]))
 }
 
+/// Computes the ICRF-to-body-fixed IAU rotation matrix for `naif_id` at each epoch in `epochs`.
+///
+/// Batch form of [`rotation_icrf_to_body_fixed_iau`]. Evaluation runs on the global thread pool
+/// for large inputs.
+///
+/// # Arguments
+/// - `naif_id`: NAIF ID of the body
+/// - `epochs`: Epoch instants for computation of the transformation matrices
+///
+/// # Returns
+/// - Rotation matrices transforming ICRF -> body-fixed, one per epoch, in input order
+/// - Error if no IAU rotation model exists for `naif_id`
+///
+/// # Examples:
+/// ```
+/// use brahe::frames::rotations_icrf_to_body_fixed_iau;
+/// use brahe::time::{Epoch, TimeSystem};
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let epochs = vec![epc, epc + 60.0];
+/// let r = rotations_icrf_to_body_fixed_iau(499, &epochs).unwrap();
+/// assert_eq!(r.len(), 2);
+/// ```
+pub fn rotations_icrf_to_body_fixed_iau(
+    naif_id: i32,
+    epochs: &[Epoch],
+) -> Result<Vec<SMatrix3>, BraheError> {
+    try_batch_map(epochs, |epc| rotation_icrf_to_body_fixed_iau(naif_id, *epc))
+}
+
 /// Computes the angular velocity [rad/s] of a body-fixed frame with
 /// respect to the inertial frame, expressed in the body-fixed frame,
 /// given 3-1-3 Euler angles and their rates.
@@ -678,6 +709,7 @@ pub(crate) fn euler313_omega_body(angles: Vector3<f64>, rates: Vector3<f64>) -> 
 mod tests {
     use approx::assert_abs_diff_eq;
     use nalgebra::Vector3;
+    use serial_test::parallel;
 
     use super::*;
     use crate::time::{Epoch, TimeSystem};
@@ -986,6 +1018,26 @@ mod tests {
         println!(
             "IAU rotation vs ANISE (pck11.pca), 25 epochs 2000-2050, bodies {:?}: max |ΔR| = {:.3e}",
             bodies, max_dev
+        );
+    }
+
+    #[test]
+    #[parallel]
+    fn test_rotations_icrf_to_body_fixed_iau_match_scalar() {
+        let epc0 = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+        let epochs: Vec<Epoch> = (0..3).map(|i| epc0 + 3600.0 * i as f64).collect();
+        let r = rotations_icrf_to_body_fixed_iau(499, &epochs).unwrap();
+        for i in 0..3 {
+            assert_eq!(
+                r[i],
+                rotation_icrf_to_body_fixed_iau(499, epochs[i]).unwrap()
+            );
+        }
+        assert!(rotations_icrf_to_body_fixed_iau(999999, &epochs).is_err());
+        assert!(
+            rotations_icrf_to_body_fixed_iau(499, &[])
+                .unwrap()
+                .is_empty()
         );
     }
 }

--- a/src/frames/lunar.rs
+++ b/src/frames/lunar.rs
@@ -715,7 +715,7 @@ pub fn state_lci_to_eci(epc: Epoch, x_lci: SVector6) -> SVector6 {
 /// assert_eq!(r.len(), 2);
 /// ```
 pub fn rotations_lci_to_lfpa(epochs: &[Epoch]) -> Vec<SMatrix3> {
-    batch_map(epochs, |epc| rotation_lci_to_lfpa(*epc))
+    batch_map(|epc| rotation_lci_to_lfpa(*epc), epochs)
 }
 
 /// Computes the LFPA-to-LCI rotation matrix for each epoch in `epochs`.
@@ -740,7 +740,7 @@ pub fn rotations_lci_to_lfpa(epochs: &[Epoch]) -> Vec<SMatrix3> {
 /// assert_eq!(r.len(), 2);
 /// ```
 pub fn rotations_lfpa_to_lci(epochs: &[Epoch]) -> Vec<SMatrix3> {
-    batch_map(epochs, |epc| rotation_lfpa_to_lci(*epc))
+    batch_map(|epc| rotation_lfpa_to_lci(*epc), epochs)
 }
 
 /// Computes the LCI-to-LFME rotation matrix for each epoch in `epochs`.
@@ -765,7 +765,7 @@ pub fn rotations_lfpa_to_lci(epochs: &[Epoch]) -> Vec<SMatrix3> {
 /// assert_eq!(r.len(), 2);
 /// ```
 pub fn rotations_lci_to_lfme(epochs: &[Epoch]) -> Vec<SMatrix3> {
-    batch_map(epochs, |epc| rotation_lci_to_lfme(*epc))
+    batch_map(|epc| rotation_lci_to_lfme(*epc), epochs)
 }
 
 /// Computes the LFME-to-LCI rotation matrix for each epoch in `epochs`.
@@ -790,7 +790,7 @@ pub fn rotations_lci_to_lfme(epochs: &[Epoch]) -> Vec<SMatrix3> {
 /// assert_eq!(r.len(), 2);
 /// ```
 pub fn rotations_lfme_to_lci(epochs: &[Epoch]) -> Vec<SMatrix3> {
-    batch_map(epochs, |epc| rotation_lfme_to_lci(*epc))
+    batch_map(|epc| rotation_lfme_to_lci(*epc), epochs)
 }
 
 /// Transforms a batch of Cartesian positions from LCI to LFPA.
@@ -823,7 +823,7 @@ pub fn positions_lci_to_lfpa(
     epochs: &[Epoch],
     x_lci: &[Vector3<f64>],
 ) -> Result<Vec<Vector3<f64>>, BraheError> {
-    batch_map_epochs(epochs, x_lci, rotation_lci_to_lfpa, |r, x| r * x)
+    batch_map_epochs(rotation_lci_to_lfpa, |r, x| r * x, epochs, x_lci)
 }
 
 /// Transforms a batch of Cartesian positions from LFPA to LCI.
@@ -856,7 +856,7 @@ pub fn positions_lfpa_to_lci(
     epochs: &[Epoch],
     x_lfpa: &[Vector3<f64>],
 ) -> Result<Vec<Vector3<f64>>, BraheError> {
-    batch_map_epochs(epochs, x_lfpa, rotation_lfpa_to_lci, |r, x| r * x)
+    batch_map_epochs(rotation_lfpa_to_lci, |r, x| r * x, epochs, x_lfpa)
 }
 
 /// Transforms a batch of Cartesian positions from LCI to LFME.
@@ -889,7 +889,7 @@ pub fn positions_lci_to_lfme(
     epochs: &[Epoch],
     x_lci: &[Vector3<f64>],
 ) -> Result<Vec<Vector3<f64>>, BraheError> {
-    batch_map_epochs(epochs, x_lci, rotation_lci_to_lfme, |r, x| r * x)
+    batch_map_epochs(rotation_lci_to_lfme, |r, x| r * x, epochs, x_lci)
 }
 
 /// Transforms a batch of Cartesian positions from LFME to LCI.
@@ -922,7 +922,7 @@ pub fn positions_lfme_to_lci(
     epochs: &[Epoch],
     x_lfme: &[Vector3<f64>],
 ) -> Result<Vec<Vector3<f64>>, BraheError> {
-    batch_map_epochs(epochs, x_lfme, rotation_lfme_to_lci, |r, x| r * x)
+    batch_map_epochs(rotation_lfme_to_lci, |r, x| r * x, epochs, x_lfme)
 }
 
 /// Transforms a batch of Cartesian states from LCI to LFPA.
@@ -956,7 +956,7 @@ pub fn states_lci_to_lfpa(
     epochs: &[Epoch],
     x_lci: &[SVector6],
 ) -> Result<Vec<SVector6>, BraheError> {
-    batch_map_epochs(epochs, x_lci, lfpa_context, apply_state_icrf_to_rotating)
+    batch_map_epochs(lfpa_context, apply_state_icrf_to_rotating, epochs, x_lci)
 }
 
 /// Transforms a batch of Cartesian states from LFPA to LCI.
@@ -990,7 +990,7 @@ pub fn states_lfpa_to_lci(
     epochs: &[Epoch],
     x_lfpa: &[SVector6],
 ) -> Result<Vec<SVector6>, BraheError> {
-    batch_map_epochs(epochs, x_lfpa, lfpa_context, apply_state_rotating_to_icrf)
+    batch_map_epochs(lfpa_context, apply_state_rotating_to_icrf, epochs, x_lfpa)
 }
 
 /// Transforms a batch of Cartesian states from LCI to LFME.
@@ -1024,7 +1024,7 @@ pub fn states_lci_to_lfme(
     epochs: &[Epoch],
     x_lci: &[SVector6],
 ) -> Result<Vec<SVector6>, BraheError> {
-    batch_map_epochs(epochs, x_lci, lfme_context, apply_state_icrf_to_rotating)
+    batch_map_epochs(lfme_context, apply_state_icrf_to_rotating, epochs, x_lci)
 }
 
 /// Transforms a batch of Cartesian states from LFME to LCI.
@@ -1058,7 +1058,7 @@ pub fn states_lfme_to_lci(
     epochs: &[Epoch],
     x_lfme: &[SVector6],
 ) -> Result<Vec<SVector6>, BraheError> {
-    batch_map_epochs(epochs, x_lfme, lfme_context, apply_state_rotating_to_icrf)
+    batch_map_epochs(lfme_context, apply_state_rotating_to_icrf, epochs, x_lfme)
 }
 
 /// Transforms a batch of Cartesian positions from ECI to LCI.
@@ -1091,9 +1091,12 @@ pub fn positions_eci_to_lci(
     epochs: &[Epoch],
     x_eci: &[Vector3<f64>],
 ) -> Result<Vec<Vector3<f64>>, BraheError> {
-    batch_map_epochs(epochs, x_eci, moon_earth_offset_position, |offset, x| {
-        x - offset
-    })
+    batch_map_epochs(
+        moon_earth_offset_position,
+        |offset, x| x - offset,
+        epochs,
+        x_eci,
+    )
 }
 
 /// Transforms a batch of Cartesian positions from LCI to ECI.
@@ -1126,9 +1129,12 @@ pub fn positions_lci_to_eci(
     epochs: &[Epoch],
     x_lci: &[Vector3<f64>],
 ) -> Result<Vec<Vector3<f64>>, BraheError> {
-    batch_map_epochs(epochs, x_lci, moon_earth_offset_position, |offset, x| {
-        x + offset
-    })
+    batch_map_epochs(
+        moon_earth_offset_position,
+        |offset, x| x + offset,
+        epochs,
+        x_lci,
+    )
 }
 
 /// Transforms a batch of Cartesian states from ECI to LCI.
@@ -1162,9 +1168,12 @@ pub fn states_eci_to_lci(
     epochs: &[Epoch],
     x_eci: &[SVector6],
 ) -> Result<Vec<SVector6>, BraheError> {
-    batch_map_epochs(epochs, x_eci, moon_earth_offset_state, |offset, x| {
-        x - offset
-    })
+    batch_map_epochs(
+        moon_earth_offset_state,
+        |offset, x| x - offset,
+        epochs,
+        x_eci,
+    )
 }
 
 /// Transforms a batch of Cartesian states from LCI to ECI.
@@ -1198,9 +1207,12 @@ pub fn states_lci_to_eci(
     epochs: &[Epoch],
     x_lci: &[SVector6],
 ) -> Result<Vec<SVector6>, BraheError> {
-    batch_map_epochs(epochs, x_lci, moon_earth_offset_state, |offset, x| {
-        x + offset
-    })
+    batch_map_epochs(
+        moon_earth_offset_state,
+        |offset, x| x + offset,
+        epochs,
+        x_lci,
+    )
 }
 
 #[cfg(test)]

--- a/src/frames/lunar.rs
+++ b/src/frames/lunar.rs
@@ -359,6 +359,16 @@ pub fn position_lfme_to_lci(epc: Epoch, x_lfme: Vector3<f64>) -> Vector3<f64> {
 ///
 /// # Returns
 /// - LCI -> LFPA rotation matrix and LFPA angular velocity (rad/s)
+///
+/// # Examples
+///
+/// ```ignore
+/// use brahe::time::{Epoch, TimeSystem};
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let c = lfpa_context(epc);
+/// // c.r_mat rotates LCI -> LFPA; c.omega_b is the LFPA angular velocity
+/// ```
 fn lfpa_context(epc: Epoch) -> RotatingFrameContext {
     ensure_lunar_pck_loaded();
     let (angles, rates) = crate::spice::pck_euler_angles(MOON_PA_FRAME_ID, epc)
@@ -378,6 +388,16 @@ fn lfpa_context(epc: Epoch) -> RotatingFrameContext {
 ///
 /// # Returns
 /// - LCI -> LFME rotation matrix and LFME angular velocity (rad/s)
+///
+/// # Examples
+///
+/// ```ignore
+/// use brahe::time::{Epoch, TimeSystem};
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let c = lfme_context(epc);
+/// // c.r_mat rotates LCI -> LFME; c.omega_b is the LFME angular velocity
+/// ```
 fn lfme_context(epc: Epoch) -> RotatingFrameContext {
     ensure_lunar_pck_loaded();
     let (angles, rates) = crate::spice::pck_euler_angles(MOON_PA_FRAME_ID, epc)
@@ -395,6 +415,16 @@ fn lfme_context(epc: Epoch) -> RotatingFrameContext {
 ///
 /// # Returns
 /// - Moon position relative to the Earth. Units: (*m*)
+///
+/// # Examples
+///
+/// ```ignore
+/// use brahe::time::{Epoch, TimeSystem};
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let offset = moon_earth_offset_position(epc);
+/// // x_lci = x_eci - offset
+/// ```
 fn moon_earth_offset_position(epc: Epoch) -> Vector3<f64> {
     spk_position(NAIFId::Moon, NAIFId::Earth, epc)
         .expect("SPK query failed: ensure a DE kernel is available (auto-init de440s)")
@@ -407,6 +437,16 @@ fn moon_earth_offset_position(epc: Epoch) -> Vector3<f64> {
 ///
 /// # Returns
 /// - Moon state relative to the Earth (position, velocity). Units: (*m*; *m/s*)
+///
+/// # Examples
+///
+/// ```ignore
+/// use brahe::time::{Epoch, TimeSystem};
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let offset = moon_earth_offset_state(epc);
+/// // x_lci = x_eci - offset
+/// ```
 fn moon_earth_offset_state(epc: Epoch) -> SVector6 {
     spk_state(NAIFId::Moon, NAIFId::Earth, epc)
         .expect("SPK query failed: ensure a DE kernel is available (auto-init de440s)")

--- a/src/frames/lunar.rs
+++ b/src/frames/lunar.rs
@@ -65,8 +65,13 @@ use crate::constants::AS2RAD;
 use crate::math::{SMatrix3, SVector6};
 use crate::spice::{NAIFId, spk_position, spk_state};
 use crate::time::Epoch;
+use crate::utils::BraheError;
+use crate::utils::batch::{batch_map, batch_map_epochs};
 
 use super::iau_rotation::{euler313_omega_body, rx, ry, rz};
+use super::transform::{
+    RotatingFrameContext, apply_state_icrf_to_rotating, apply_state_rotating_to_icrf,
+};
 
 /// NAIF frame class ID of the DE440 lunar principal-axis frame
 /// (`MOON_PA_DE440`), as defined in NAIF's lunar frames kernel.
@@ -346,6 +351,67 @@ pub fn position_lfme_to_lci(epc: Epoch, x_lfme: Vector3<f64>) -> Vector3<f64> {
     rotation_lfme_to_lci(epc) * x_lfme
 }
 
+/// Rotation matrix and body-frame angular velocity of the lunar
+/// principal-axis frame (LFPA) at `epc`.
+///
+/// # Arguments
+/// - `epc`: Epoch instant
+///
+/// # Returns
+/// - LCI -> LFPA rotation matrix and LFPA angular velocity (rad/s)
+fn lfpa_context(epc: Epoch) -> RotatingFrameContext {
+    ensure_lunar_pck_loaded();
+    let (angles, rates) = crate::spice::pck_euler_angles(MOON_PA_FRAME_ID, epc)
+        .unwrap_or_else(|e| panic!("Lunar PCK orientation query failed: {}", e));
+    let r_mat = crate::spice::pck_rotation_matrix(MOON_PA_FRAME_ID, epc)
+        .unwrap_or_else(|e| panic!("Lunar PCK orientation query failed: {}", e))
+        .to_matrix();
+    let omega_b = euler313_omega_body(angles, rates);
+    RotatingFrameContext { r_mat, omega_b }
+}
+
+/// Rotation matrix and body-frame angular velocity of the lunar mean
+/// Earth/polar-axis frame (LFME) at `epc`.
+///
+/// # Arguments
+/// - `epc`: Epoch instant
+///
+/// # Returns
+/// - LCI -> LFME rotation matrix and LFME angular velocity (rad/s)
+fn lfme_context(epc: Epoch) -> RotatingFrameContext {
+    ensure_lunar_pck_loaded();
+    let (angles, rates) = crate::spice::pck_euler_angles(MOON_PA_FRAME_ID, epc)
+        .unwrap_or_else(|e| panic!("Lunar PCK orientation query failed: {}", e));
+    let r_pa_to_me = rotation_lfpa_to_lfme();
+    let r_mat = r_pa_to_me * rotation_lci_to_lfpa(epc);
+    let omega_b = r_pa_to_me * euler313_omega_body(angles, rates);
+    RotatingFrameContext { r_mat, omega_b }
+}
+
+/// Moon position relative to the Earth in ICRF axes.
+///
+/// # Arguments
+/// - `epc`: Epoch instant
+///
+/// # Returns
+/// - Moon position relative to the Earth. Units: (*m*)
+fn moon_earth_offset_position(epc: Epoch) -> Vector3<f64> {
+    spk_position(NAIFId::Moon, NAIFId::Earth, epc)
+        .expect("SPK query failed: ensure a DE kernel is available (auto-init de440s)")
+}
+
+/// Moon state relative to the Earth in ICRF axes.
+///
+/// # Arguments
+/// - `epc`: Epoch instant
+///
+/// # Returns
+/// - Moon state relative to the Earth (position, velocity). Units: (*m*; *m/s*)
+fn moon_earth_offset_state(epc: Epoch) -> SVector6 {
+    spk_state(NAIFId::Moon, NAIFId::Earth, epc)
+        .expect("SPK query failed: ensure a DE kernel is available (auto-init de440s)")
+}
+
 /// Transforms a Cartesian Lunar-inertial (LCI) state (position and
 /// velocity) into the equivalent Cartesian Lunar-Fixed Principal Axis
 /// (LFPA) state.
@@ -375,21 +441,7 @@ pub fn position_lfme_to_lci(epc: Epoch, x_lfme: Vector3<f64>) -> Vector3<f64> {
 /// let x_lfpa = state_lci_to_lfpa(epc, x_lci);
 /// ```
 pub fn state_lci_to_lfpa(epc: Epoch, x_lci: SVector6) -> SVector6 {
-    ensure_lunar_pck_loaded();
-    let (angles, rates) = crate::spice::pck_euler_angles(MOON_PA_FRAME_ID, epc)
-        .unwrap_or_else(|e| panic!("Lunar PCK orientation query failed: {}", e));
-    let r_mat = crate::spice::pck_rotation_matrix(MOON_PA_FRAME_ID, epc)
-        .unwrap_or_else(|e| panic!("Lunar PCK orientation query failed: {}", e))
-        .to_matrix();
-    let omega_b = euler313_omega_body(angles, rates);
-
-    let r = x_lci.fixed_rows::<3>(0);
-    let v = x_lci.fixed_rows::<3>(3);
-
-    let r_b: Vector3<f64> = r_mat * r;
-    let v_b: Vector3<f64> = r_mat * v - omega_b.cross(&r_b);
-
-    SVector6::new(r_b[0], r_b[1], r_b[2], v_b[0], v_b[1], v_b[2])
+    apply_state_icrf_to_rotating(&lfpa_context(epc), &x_lci)
 }
 
 /// Transforms a Cartesian Lunar-Fixed Principal Axis (LFPA) state
@@ -422,21 +474,7 @@ pub fn state_lci_to_lfpa(epc: Epoch, x_lci: SVector6) -> SVector6 {
 /// let x_lci2 = state_lfpa_to_lci(epc, x_lfpa);
 /// ```
 pub fn state_lfpa_to_lci(epc: Epoch, x_lfpa: SVector6) -> SVector6 {
-    ensure_lunar_pck_loaded();
-    let (angles, rates) = crate::spice::pck_euler_angles(MOON_PA_FRAME_ID, epc)
-        .unwrap_or_else(|e| panic!("Lunar PCK orientation query failed: {}", e));
-    let r_mat = crate::spice::pck_rotation_matrix(MOON_PA_FRAME_ID, epc)
-        .unwrap_or_else(|e| panic!("Lunar PCK orientation query failed: {}", e))
-        .to_matrix();
-    let omega_b = euler313_omega_body(angles, rates);
-
-    let r_b: Vector3<f64> = x_lfpa.fixed_rows::<3>(0).into_owned();
-    let v_b: Vector3<f64> = x_lfpa.fixed_rows::<3>(3).into_owned();
-
-    let r: Vector3<f64> = r_mat.transpose() * r_b;
-    let v: Vector3<f64> = r_mat.transpose() * (v_b + omega_b.cross(&r_b));
-
-    SVector6::new(r[0], r[1], r[2], v[0], v[1], v[2])
+    apply_state_rotating_to_icrf(&lfpa_context(epc), &x_lfpa)
 }
 
 /// Transforms a Cartesian Lunar-inertial (LCI) state (position and
@@ -468,20 +506,7 @@ pub fn state_lfpa_to_lci(epc: Epoch, x_lfpa: SVector6) -> SVector6 {
 /// let x_lfme = state_lci_to_lfme(epc, x_lci);
 /// ```
 pub fn state_lci_to_lfme(epc: Epoch, x_lci: SVector6) -> SVector6 {
-    ensure_lunar_pck_loaded();
-    let (angles, rates) = crate::spice::pck_euler_angles(MOON_PA_FRAME_ID, epc)
-        .unwrap_or_else(|e| panic!("Lunar PCK orientation query failed: {}", e));
-    let r_pa_to_me = rotation_lfpa_to_lfme();
-    let r_mat = r_pa_to_me * rotation_lci_to_lfpa(epc);
-    let omega_b = r_pa_to_me * euler313_omega_body(angles, rates);
-
-    let r = x_lci.fixed_rows::<3>(0);
-    let v = x_lci.fixed_rows::<3>(3);
-
-    let r_b: Vector3<f64> = r_mat * r;
-    let v_b: Vector3<f64> = r_mat * v - omega_b.cross(&r_b);
-
-    SVector6::new(r_b[0], r_b[1], r_b[2], v_b[0], v_b[1], v_b[2])
+    apply_state_icrf_to_rotating(&lfme_context(epc), &x_lci)
 }
 
 /// Transforms a Cartesian Lunar-Fixed Mean Earth/polar-axis (LFME) state
@@ -510,20 +535,7 @@ pub fn state_lci_to_lfme(epc: Epoch, x_lci: SVector6) -> SVector6 {
 /// let x_lci2 = state_lfme_to_lci(epc, x_lfme);
 /// ```
 pub fn state_lfme_to_lci(epc: Epoch, x_lfme: SVector6) -> SVector6 {
-    ensure_lunar_pck_loaded();
-    let (angles, rates) = crate::spice::pck_euler_angles(MOON_PA_FRAME_ID, epc)
-        .unwrap_or_else(|e| panic!("Lunar PCK orientation query failed: {}", e));
-    let r_pa_to_me = rotation_lfpa_to_lfme();
-    let r_mat = r_pa_to_me * rotation_lci_to_lfpa(epc);
-    let omega_b = r_pa_to_me * euler313_omega_body(angles, rates);
-
-    let r_b: Vector3<f64> = x_lfme.fixed_rows::<3>(0).into_owned();
-    let v_b: Vector3<f64> = x_lfme.fixed_rows::<3>(3).into_owned();
-
-    let r: Vector3<f64> = r_mat.transpose() * r_b;
-    let v: Vector3<f64> = r_mat.transpose() * (v_b + omega_b.cross(&r_b));
-
-    SVector6::new(r[0], r[1], r[2], v[0], v[1], v[2])
+    apply_state_rotating_to_icrf(&lfme_context(epc), &x_lfme)
 }
 
 /// Transforms a Cartesian Earth-inertial (ECI) position into the
@@ -554,9 +566,7 @@ pub fn state_lfme_to_lci(epc: Epoch, x_lfme: SVector6) -> SVector6 {
 /// let x_lci = position_eci_to_lci(epc, x_eci);
 /// ```
 pub fn position_eci_to_lci(epc: Epoch, x_eci: Vector3<f64>) -> Vector3<f64> {
-    let offset = spk_position(NAIFId::Moon, NAIFId::Earth, epc)
-        .expect("SPK query failed: ensure a DE kernel is available (auto-init de440s)");
-    x_eci - offset
+    x_eci - moon_earth_offset_position(epc)
 }
 
 /// Transforms a Cartesian Lunar-inertial (LCI) position into the
@@ -583,9 +593,7 @@ pub fn position_eci_to_lci(epc: Epoch, x_eci: Vector3<f64>) -> Vector3<f64> {
 /// let x_eci = position_lci_to_eci(epc, x_lci);
 /// ```
 pub fn position_lci_to_eci(epc: Epoch, x_lci: Vector3<f64>) -> Vector3<f64> {
-    let offset = spk_position(NAIFId::Moon, NAIFId::Earth, epc)
-        .expect("SPK query failed: ensure a DE kernel is available (auto-init de440s)");
-    x_lci + offset
+    x_lci + moon_earth_offset_position(epc)
 }
 
 /// Transforms a Cartesian Earth-inertial (ECI) state (position and
@@ -615,9 +623,7 @@ pub fn position_lci_to_eci(epc: Epoch, x_lci: Vector3<f64>) -> Vector3<f64> {
 /// let x_lci = state_eci_to_lci(epc, x_eci);
 /// ```
 pub fn state_eci_to_lci(epc: Epoch, x_eci: SVector6) -> SVector6 {
-    let offset = spk_state(NAIFId::Moon, NAIFId::Earth, epc)
-        .expect("SPK query failed: ensure a DE kernel is available (auto-init de440s)");
-    x_eci - offset
+    x_eci - moon_earth_offset_state(epc)
 }
 
 /// Transforms a Cartesian Lunar-inertial (LCI) state (position and
@@ -644,9 +650,517 @@ pub fn state_eci_to_lci(epc: Epoch, x_eci: SVector6) -> SVector6 {
 /// let x_eci = state_lci_to_eci(epc, x_lci);
 /// ```
 pub fn state_lci_to_eci(epc: Epoch, x_lci: SVector6) -> SVector6 {
-    let offset = spk_state(NAIFId::Moon, NAIFId::Earth, epc)
-        .expect("SPK query failed: ensure a DE kernel is available (auto-init de440s)");
-    x_lci + offset
+    x_lci + moon_earth_offset_state(epc)
+}
+
+/// Computes the LCI-to-LFPA rotation matrix for each epoch in `epochs`.
+///
+/// Batch form of [`rotation_lci_to_lfpa`]. Evaluation runs on the global thread pool
+/// for large inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants for computation of the transformation matrices
+///
+/// # Returns
+/// - Rotation matrices transforming LCI -> LFPA, one per epoch, in input order
+///
+/// # Examples:
+/// ```
+/// use brahe::frames::rotations_lci_to_lfpa;
+/// use brahe::time::{Epoch, TimeSystem};
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let epochs = vec![epc, epc + 60.0];
+/// let r = rotations_lci_to_lfpa(&epochs);
+/// assert_eq!(r.len(), 2);
+/// ```
+pub fn rotations_lci_to_lfpa(epochs: &[Epoch]) -> Vec<SMatrix3> {
+    batch_map(epochs, |epc| rotation_lci_to_lfpa(*epc))
+}
+
+/// Computes the LFPA-to-LCI rotation matrix for each epoch in `epochs`.
+///
+/// Batch form of [`rotation_lfpa_to_lci`]. Evaluation runs on the global thread pool
+/// for large inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants for computation of the transformation matrices
+///
+/// # Returns
+/// - Rotation matrices transforming LFPA -> LCI, one per epoch, in input order
+///
+/// # Examples:
+/// ```
+/// use brahe::frames::rotations_lfpa_to_lci;
+/// use brahe::time::{Epoch, TimeSystem};
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let epochs = vec![epc, epc + 60.0];
+/// let r = rotations_lfpa_to_lci(&epochs);
+/// assert_eq!(r.len(), 2);
+/// ```
+pub fn rotations_lfpa_to_lci(epochs: &[Epoch]) -> Vec<SMatrix3> {
+    batch_map(epochs, |epc| rotation_lfpa_to_lci(*epc))
+}
+
+/// Computes the LCI-to-LFME rotation matrix for each epoch in `epochs`.
+///
+/// Batch form of [`rotation_lci_to_lfme`]. Evaluation runs on the global thread pool
+/// for large inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants for computation of the transformation matrices
+///
+/// # Returns
+/// - Rotation matrices transforming LCI -> LFME, one per epoch, in input order
+///
+/// # Examples:
+/// ```
+/// use brahe::frames::rotations_lci_to_lfme;
+/// use brahe::time::{Epoch, TimeSystem};
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let epochs = vec![epc, epc + 60.0];
+/// let r = rotations_lci_to_lfme(&epochs);
+/// assert_eq!(r.len(), 2);
+/// ```
+pub fn rotations_lci_to_lfme(epochs: &[Epoch]) -> Vec<SMatrix3> {
+    batch_map(epochs, |epc| rotation_lci_to_lfme(*epc))
+}
+
+/// Computes the LFME-to-LCI rotation matrix for each epoch in `epochs`.
+///
+/// Batch form of [`rotation_lfme_to_lci`]. Evaluation runs on the global thread pool
+/// for large inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants for computation of the transformation matrices
+///
+/// # Returns
+/// - Rotation matrices transforming LFME -> LCI, one per epoch, in input order
+///
+/// # Examples:
+/// ```
+/// use brahe::frames::rotations_lfme_to_lci;
+/// use brahe::time::{Epoch, TimeSystem};
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let epochs = vec![epc, epc + 60.0];
+/// let r = rotations_lfme_to_lci(&epochs);
+/// assert_eq!(r.len(), 2);
+/// ```
+pub fn rotations_lfme_to_lci(epochs: &[Epoch]) -> Vec<SMatrix3> {
+    batch_map(epochs, |epc| rotation_lfme_to_lci(*epc))
+}
+
+/// Transforms a batch of Cartesian positions from LCI to LFPA.
+///
+/// Batch form of [`position_lci_to_lfpa`]. `epochs` and the vector argument follow the
+/// broadcast rule: each has length 1 or the common batch length. A single
+/// epoch evaluates the transformation context once and applies it to every
+/// element. Evaluation runs on the global thread pool for large inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x_lci`: Cartesian LCI positions, length 1 or the batch length. Units: (*m*)
+///
+/// # Returns
+/// - Cartesian LFPA positions in input order. Units: (*m*)
+/// - Error if the lengths do not satisfy the broadcast rule
+///
+/// # Examples:
+/// ```
+/// use brahe::frames::positions_lci_to_lfpa;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use nalgebra::Vector3;
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let positions = vec![Vector3::new(1.9e6, 0.0, 0.0); 3];
+/// let out = positions_lci_to_lfpa(&[epc], &positions).unwrap();
+/// assert_eq!(out.len(), 3);
+/// ```
+pub fn positions_lci_to_lfpa(
+    epochs: &[Epoch],
+    x_lci: &[Vector3<f64>],
+) -> Result<Vec<Vector3<f64>>, BraheError> {
+    batch_map_epochs(epochs, x_lci, rotation_lci_to_lfpa, |r, x| r * x)
+}
+
+/// Transforms a batch of Cartesian positions from LFPA to LCI.
+///
+/// Batch form of [`position_lfpa_to_lci`]. `epochs` and the vector argument follow the
+/// broadcast rule: each has length 1 or the common batch length. A single
+/// epoch evaluates the transformation context once and applies it to every
+/// element. Evaluation runs on the global thread pool for large inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x_lfpa`: Cartesian LFPA positions, length 1 or the batch length. Units: (*m*)
+///
+/// # Returns
+/// - Cartesian LCI positions in input order. Units: (*m*)
+/// - Error if the lengths do not satisfy the broadcast rule
+///
+/// # Examples:
+/// ```
+/// use brahe::frames::positions_lfpa_to_lci;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use nalgebra::Vector3;
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let positions = vec![Vector3::new(1.9e6, 0.0, 0.0); 3];
+/// let out = positions_lfpa_to_lci(&[epc], &positions).unwrap();
+/// assert_eq!(out.len(), 3);
+/// ```
+pub fn positions_lfpa_to_lci(
+    epochs: &[Epoch],
+    x_lfpa: &[Vector3<f64>],
+) -> Result<Vec<Vector3<f64>>, BraheError> {
+    batch_map_epochs(epochs, x_lfpa, rotation_lfpa_to_lci, |r, x| r * x)
+}
+
+/// Transforms a batch of Cartesian positions from LCI to LFME.
+///
+/// Batch form of [`position_lci_to_lfme`]. `epochs` and the vector argument follow the
+/// broadcast rule: each has length 1 or the common batch length. A single
+/// epoch evaluates the transformation context once and applies it to every
+/// element. Evaluation runs on the global thread pool for large inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x_lci`: Cartesian LCI positions, length 1 or the batch length. Units: (*m*)
+///
+/// # Returns
+/// - Cartesian LFME positions in input order. Units: (*m*)
+/// - Error if the lengths do not satisfy the broadcast rule
+///
+/// # Examples:
+/// ```
+/// use brahe::frames::positions_lci_to_lfme;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use nalgebra::Vector3;
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let positions = vec![Vector3::new(1.9e6, 0.0, 0.0); 3];
+/// let out = positions_lci_to_lfme(&[epc], &positions).unwrap();
+/// assert_eq!(out.len(), 3);
+/// ```
+pub fn positions_lci_to_lfme(
+    epochs: &[Epoch],
+    x_lci: &[Vector3<f64>],
+) -> Result<Vec<Vector3<f64>>, BraheError> {
+    batch_map_epochs(epochs, x_lci, rotation_lci_to_lfme, |r, x| r * x)
+}
+
+/// Transforms a batch of Cartesian positions from LFME to LCI.
+///
+/// Batch form of [`position_lfme_to_lci`]. `epochs` and the vector argument follow the
+/// broadcast rule: each has length 1 or the common batch length. A single
+/// epoch evaluates the transformation context once and applies it to every
+/// element. Evaluation runs on the global thread pool for large inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x_lfme`: Cartesian LFME positions, length 1 or the batch length. Units: (*m*)
+///
+/// # Returns
+/// - Cartesian LCI positions in input order. Units: (*m*)
+/// - Error if the lengths do not satisfy the broadcast rule
+///
+/// # Examples:
+/// ```
+/// use brahe::frames::positions_lfme_to_lci;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use nalgebra::Vector3;
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let positions = vec![Vector3::new(1.9e6, 0.0, 0.0); 3];
+/// let out = positions_lfme_to_lci(&[epc], &positions).unwrap();
+/// assert_eq!(out.len(), 3);
+/// ```
+pub fn positions_lfme_to_lci(
+    epochs: &[Epoch],
+    x_lfme: &[Vector3<f64>],
+) -> Result<Vec<Vector3<f64>>, BraheError> {
+    batch_map_epochs(epochs, x_lfme, rotation_lfme_to_lci, |r, x| r * x)
+}
+
+/// Transforms a batch of Cartesian states from LCI to LFPA.
+///
+/// Batch form of [`state_lci_to_lfpa`]. `epochs` and the vector argument follow the
+/// broadcast rule: each has length 1 or the common batch length. A single
+/// epoch evaluates the transformation context once and applies it to every
+/// element. Evaluation runs on the global thread pool for large inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x_lci`: Cartesian LCI states (position, velocity), length 1 or the batch length. Units: (*m*; *m/s*)
+///
+/// # Returns
+/// - Cartesian LFPA states (position, velocity) in input order. Units: (*m*; *m/s*)
+/// - Error if the lengths do not satisfy the broadcast rule
+///
+/// # Examples:
+/// ```
+/// use brahe::frames::states_lci_to_lfpa;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use brahe::vector6_from_array;
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let epochs = vec![epc, epc + 60.0, epc + 120.0];
+/// let states = vec![vector6_from_array([1.9e6, 0.0, 0.0, 0.0, 1.6e3, 0.0]); 3];
+/// let out = states_lci_to_lfpa(&epochs, &states).unwrap();
+/// assert_eq!(out.len(), 3);
+/// ```
+pub fn states_lci_to_lfpa(
+    epochs: &[Epoch],
+    x_lci: &[SVector6],
+) -> Result<Vec<SVector6>, BraheError> {
+    batch_map_epochs(epochs, x_lci, lfpa_context, apply_state_icrf_to_rotating)
+}
+
+/// Transforms a batch of Cartesian states from LFPA to LCI.
+///
+/// Batch form of [`state_lfpa_to_lci`]. `epochs` and the vector argument follow the
+/// broadcast rule: each has length 1 or the common batch length. A single
+/// epoch evaluates the transformation context once and applies it to every
+/// element. Evaluation runs on the global thread pool for large inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x_lfpa`: Cartesian LFPA states (position, velocity), length 1 or the batch length. Units: (*m*; *m/s*)
+///
+/// # Returns
+/// - Cartesian LCI states (position, velocity) in input order. Units: (*m*; *m/s*)
+/// - Error if the lengths do not satisfy the broadcast rule
+///
+/// # Examples:
+/// ```
+/// use brahe::frames::states_lfpa_to_lci;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use brahe::vector6_from_array;
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let epochs = vec![epc, epc + 60.0, epc + 120.0];
+/// let states = vec![vector6_from_array([1.9e6, 0.0, 0.0, 0.0, 1.6e3, 0.0]); 3];
+/// let out = states_lfpa_to_lci(&epochs, &states).unwrap();
+/// assert_eq!(out.len(), 3);
+/// ```
+pub fn states_lfpa_to_lci(
+    epochs: &[Epoch],
+    x_lfpa: &[SVector6],
+) -> Result<Vec<SVector6>, BraheError> {
+    batch_map_epochs(epochs, x_lfpa, lfpa_context, apply_state_rotating_to_icrf)
+}
+
+/// Transforms a batch of Cartesian states from LCI to LFME.
+///
+/// Batch form of [`state_lci_to_lfme`]. `epochs` and the vector argument follow the
+/// broadcast rule: each has length 1 or the common batch length. A single
+/// epoch evaluates the transformation context once and applies it to every
+/// element. Evaluation runs on the global thread pool for large inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x_lci`: Cartesian LCI states (position, velocity), length 1 or the batch length. Units: (*m*; *m/s*)
+///
+/// # Returns
+/// - Cartesian LFME states (position, velocity) in input order. Units: (*m*; *m/s*)
+/// - Error if the lengths do not satisfy the broadcast rule
+///
+/// # Examples:
+/// ```
+/// use brahe::frames::states_lci_to_lfme;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use brahe::vector6_from_array;
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let epochs = vec![epc, epc + 60.0, epc + 120.0];
+/// let states = vec![vector6_from_array([1.9e6, 0.0, 0.0, 0.0, 1.6e3, 0.0]); 3];
+/// let out = states_lci_to_lfme(&epochs, &states).unwrap();
+/// assert_eq!(out.len(), 3);
+/// ```
+pub fn states_lci_to_lfme(
+    epochs: &[Epoch],
+    x_lci: &[SVector6],
+) -> Result<Vec<SVector6>, BraheError> {
+    batch_map_epochs(epochs, x_lci, lfme_context, apply_state_icrf_to_rotating)
+}
+
+/// Transforms a batch of Cartesian states from LFME to LCI.
+///
+/// Batch form of [`state_lfme_to_lci`]. `epochs` and the vector argument follow the
+/// broadcast rule: each has length 1 or the common batch length. A single
+/// epoch evaluates the transformation context once and applies it to every
+/// element. Evaluation runs on the global thread pool for large inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x_lfme`: Cartesian LFME states (position, velocity), length 1 or the batch length. Units: (*m*; *m/s*)
+///
+/// # Returns
+/// - Cartesian LCI states (position, velocity) in input order. Units: (*m*; *m/s*)
+/// - Error if the lengths do not satisfy the broadcast rule
+///
+/// # Examples:
+/// ```
+/// use brahe::frames::states_lfme_to_lci;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use brahe::vector6_from_array;
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let epochs = vec![epc, epc + 60.0, epc + 120.0];
+/// let states = vec![vector6_from_array([1.9e6, 0.0, 0.0, 0.0, 1.6e3, 0.0]); 3];
+/// let out = states_lfme_to_lci(&epochs, &states).unwrap();
+/// assert_eq!(out.len(), 3);
+/// ```
+pub fn states_lfme_to_lci(
+    epochs: &[Epoch],
+    x_lfme: &[SVector6],
+) -> Result<Vec<SVector6>, BraheError> {
+    batch_map_epochs(epochs, x_lfme, lfme_context, apply_state_rotating_to_icrf)
+}
+
+/// Transforms a batch of Cartesian positions from ECI to LCI.
+///
+/// Batch form of [`position_eci_to_lci`]. `epochs` and the vector argument follow the
+/// broadcast rule: each has length 1 or the common batch length. A single
+/// epoch evaluates the transformation context once and applies it to every
+/// element. Evaluation runs on the global thread pool for large inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x_eci`: Cartesian ECI positions, length 1 or the batch length. Units: (*m*)
+///
+/// # Returns
+/// - Cartesian LCI positions in input order. Units: (*m*)
+/// - Error if the lengths do not satisfy the broadcast rule
+///
+/// # Examples:
+/// ```
+/// use brahe::frames::positions_eci_to_lci;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use nalgebra::Vector3;
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let positions = vec![Vector3::new(7.0e6, 1.0e6, -2.0e6); 3];
+/// let out = positions_eci_to_lci(&[epc], &positions).unwrap();
+/// assert_eq!(out.len(), 3);
+/// ```
+pub fn positions_eci_to_lci(
+    epochs: &[Epoch],
+    x_eci: &[Vector3<f64>],
+) -> Result<Vec<Vector3<f64>>, BraheError> {
+    batch_map_epochs(epochs, x_eci, moon_earth_offset_position, |offset, x| {
+        x - offset
+    })
+}
+
+/// Transforms a batch of Cartesian positions from LCI to ECI.
+///
+/// Batch form of [`position_lci_to_eci`]. `epochs` and the vector argument follow the
+/// broadcast rule: each has length 1 or the common batch length. A single
+/// epoch evaluates the transformation context once and applies it to every
+/// element. Evaluation runs on the global thread pool for large inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x_lci`: Cartesian LCI positions, length 1 or the batch length. Units: (*m*)
+///
+/// # Returns
+/// - Cartesian ECI positions in input order. Units: (*m*)
+/// - Error if the lengths do not satisfy the broadcast rule
+///
+/// # Examples:
+/// ```
+/// use brahe::frames::positions_lci_to_eci;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use nalgebra::Vector3;
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let positions = vec![Vector3::new(7.0e6, 1.0e6, -2.0e6); 3];
+/// let out = positions_lci_to_eci(&[epc], &positions).unwrap();
+/// assert_eq!(out.len(), 3);
+/// ```
+pub fn positions_lci_to_eci(
+    epochs: &[Epoch],
+    x_lci: &[Vector3<f64>],
+) -> Result<Vec<Vector3<f64>>, BraheError> {
+    batch_map_epochs(epochs, x_lci, moon_earth_offset_position, |offset, x| {
+        x + offset
+    })
+}
+
+/// Transforms a batch of Cartesian states from ECI to LCI.
+///
+/// Batch form of [`state_eci_to_lci`]. `epochs` and the vector argument follow the
+/// broadcast rule: each has length 1 or the common batch length. A single
+/// epoch evaluates the transformation context once and applies it to every
+/// element. Evaluation runs on the global thread pool for large inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x_eci`: Cartesian ECI states (position, velocity), length 1 or the batch length. Units: (*m*; *m/s*)
+///
+/// # Returns
+/// - Cartesian LCI states (position, velocity) in input order. Units: (*m*; *m/s*)
+/// - Error if the lengths do not satisfy the broadcast rule
+///
+/// # Examples:
+/// ```
+/// use brahe::frames::states_eci_to_lci;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use brahe::vector6_from_array;
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let epochs = vec![epc, epc + 60.0, epc + 120.0];
+/// let states = vec![vector6_from_array([7.0e6, 0.0, 0.0, 0.0, 7.5e3, 0.0]); 3];
+/// let out = states_eci_to_lci(&epochs, &states).unwrap();
+/// assert_eq!(out.len(), 3);
+/// ```
+pub fn states_eci_to_lci(
+    epochs: &[Epoch],
+    x_eci: &[SVector6],
+) -> Result<Vec<SVector6>, BraheError> {
+    batch_map_epochs(epochs, x_eci, moon_earth_offset_state, |offset, x| {
+        x - offset
+    })
+}
+
+/// Transforms a batch of Cartesian states from LCI to ECI.
+///
+/// Batch form of [`state_lci_to_eci`]. `epochs` and the vector argument follow the
+/// broadcast rule: each has length 1 or the common batch length. A single
+/// epoch evaluates the transformation context once and applies it to every
+/// element. Evaluation runs on the global thread pool for large inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x_lci`: Cartesian LCI states (position, velocity), length 1 or the batch length. Units: (*m*; *m/s*)
+///
+/// # Returns
+/// - Cartesian ECI states (position, velocity) in input order. Units: (*m*; *m/s*)
+/// - Error if the lengths do not satisfy the broadcast rule
+///
+/// # Examples:
+/// ```
+/// use brahe::frames::states_lci_to_eci;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use brahe::vector6_from_array;
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let epochs = vec![epc, epc + 60.0, epc + 120.0];
+/// let states = vec![vector6_from_array([7.0e6, 0.0, 0.0, 0.0, 7.5e3, 0.0]); 3];
+/// let out = states_lci_to_eci(&epochs, &states).unwrap();
+/// assert_eq!(out.len(), 3);
+/// ```
+pub fn states_lci_to_eci(
+    epochs: &[Epoch],
+    x_lci: &[SVector6],
+) -> Result<Vec<SVector6>, BraheError> {
+    batch_map_epochs(epochs, x_lci, moon_earth_offset_state, |offset, x| {
+        x + offset
+    })
 }
 
 #[cfg(test)]
@@ -988,5 +1502,103 @@ mod tests {
         // the real PCK (real cache; tolerated failure keeps this test
         // offline-safe when nothing later needs the kernel).
         let _ = load_spice_kernel("moon_pa_de440");
+    }
+
+    #[test]
+    #[serial]
+    fn test_batch_lunar_frames_match_scalar() {
+        setup_global_test_spice();
+        let epc0 = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+        let epochs: Vec<Epoch> = (0..3).map(|i| epc0 + 3600.0 * i as f64).collect();
+        let states: Vec<SVector6> = (0..3)
+            .map(|i| {
+                vector6_from_array([R_MOON + 100e3 + 1e3 * i as f64, 0.0, 0.0, 0.0, 1.6e3, 0.0])
+            })
+            .collect();
+        let positions: Vec<Vector3<f64>> = states
+            .iter()
+            .map(|s| Vector3::new(s[0], s[1], s[2]))
+            .collect();
+
+        for i in 0..3 {
+            let e = epochs[i];
+            assert_eq!(rotations_lci_to_lfpa(&epochs)[i], rotation_lci_to_lfpa(e));
+            assert_eq!(rotations_lfpa_to_lci(&epochs)[i], rotation_lfpa_to_lci(e));
+            assert_eq!(rotations_lci_to_lfme(&epochs)[i], rotation_lci_to_lfme(e));
+            assert_eq!(rotations_lfme_to_lci(&epochs)[i], rotation_lfme_to_lci(e));
+
+            assert_eq!(
+                positions_lci_to_lfpa(&epochs, &positions).unwrap()[i],
+                position_lci_to_lfpa(e, positions[i])
+            );
+            assert_eq!(
+                positions_lfpa_to_lci(&epochs, &positions).unwrap()[i],
+                position_lfpa_to_lci(e, positions[i])
+            );
+            assert_eq!(
+                positions_lci_to_lfme(&epochs, &positions).unwrap()[i],
+                position_lci_to_lfme(e, positions[i])
+            );
+            assert_eq!(
+                positions_lfme_to_lci(&epochs, &positions).unwrap()[i],
+                position_lfme_to_lci(e, positions[i])
+            );
+            assert_eq!(
+                positions_lci_to_lfpa(&epochs[..1], &positions).unwrap()[i],
+                position_lci_to_lfpa(epochs[0], positions[i])
+            );
+
+            assert_eq!(
+                states_lci_to_lfpa(&epochs, &states).unwrap()[i],
+                state_lci_to_lfpa(e, states[i])
+            );
+            assert_eq!(
+                states_lfpa_to_lci(&epochs, &states).unwrap()[i],
+                state_lfpa_to_lci(e, states[i])
+            );
+            assert_eq!(
+                states_lci_to_lfme(&epochs, &states).unwrap()[i],
+                state_lci_to_lfme(e, states[i])
+            );
+            assert_eq!(
+                states_lfme_to_lci(&epochs, &states).unwrap()[i],
+                state_lfme_to_lci(e, states[i])
+            );
+            assert_eq!(
+                states_lci_to_lfme(&epochs[..1], &states).unwrap()[i],
+                state_lci_to_lfme(epochs[0], states[i])
+            );
+
+            assert_eq!(
+                positions_eci_to_lci(&epochs, &positions).unwrap()[i],
+                position_eci_to_lci(e, positions[i])
+            );
+            assert_eq!(
+                positions_lci_to_eci(&epochs, &positions).unwrap()[i],
+                position_lci_to_eci(e, positions[i])
+            );
+            assert_eq!(
+                states_eci_to_lci(&epochs, &states).unwrap()[i],
+                state_eci_to_lci(e, states[i])
+            );
+            assert_eq!(
+                states_lci_to_eci(&epochs, &states).unwrap()[i],
+                state_lci_to_eci(e, states[i])
+            );
+            assert_eq!(
+                states_eci_to_lci(&epochs, &states[..1]).unwrap()[i],
+                state_eci_to_lci(e, states[0])
+            );
+        }
+
+        let lfpa = states_lci_to_lfpa(&epochs, &states).unwrap();
+        let back = states_lfpa_to_lci(&epochs, &lfpa).unwrap();
+        for i in 0..3 {
+            for k in 0..3 {
+                assert_abs_diff_eq!(back[i][k], states[i][k], epsilon = 1e-6);
+            }
+        }
+        assert!(states_lci_to_lfpa(&epochs[..2], &states).is_err());
+        assert!(rotations_lci_to_lfpa(&[]).is_empty());
     }
 }

--- a/src/frames/mars.rs
+++ b/src/frames/mars.rs
@@ -196,6 +196,16 @@ pub fn position_mcmf_to_mci(epc: Epoch, x_mcmf: Vector3<f64>) -> Vector3<f64> {
 ///
 /// # Returns
 /// - MCI -> MCMF rotation matrix and MCMF angular velocity (rad/s)
+///
+/// # Examples
+///
+/// ```ignore
+/// use brahe::time::{Epoch, TimeSystem};
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let c = mcmf_context(epc);
+/// // c.r_mat rotates MCI -> MCMF; c.omega_b is the MCMF angular velocity
+/// ```
 fn mcmf_context(epc: Epoch) -> RotatingFrameContext {
     let (angles, rates) = body_fixed_iau_angles_and_rates(NAIFId::Mars.id(), epc)
         .expect("IAU Mars rotation model missing from embedded WGCCRE table — this is a bug");
@@ -211,6 +221,16 @@ fn mcmf_context(epc: Epoch) -> RotatingFrameContext {
 ///
 /// # Returns
 /// - Mars position relative to the Earth. Units: (*m*)
+///
+/// # Examples
+///
+/// ```ignore
+/// use brahe::time::{Epoch, TimeSystem};
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let offset = mars_earth_offset_position(epc);
+/// // x_mci = x_eci - offset
+/// ```
 fn mars_earth_offset_position(epc: Epoch) -> Vector3<f64> {
     ensure_mars_spk_loaded();
     spk_position(NAIFId::Mars, NAIFId::Earth, epc)
@@ -224,6 +244,16 @@ fn mars_earth_offset_position(epc: Epoch) -> Vector3<f64> {
 ///
 /// # Returns
 /// - Mars state relative to the Earth (position, velocity). Units: (*m*; *m/s*)
+///
+/// # Examples
+///
+/// ```ignore
+/// use brahe::time::{Epoch, TimeSystem};
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let offset = mars_earth_offset_state(epc);
+/// // x_mci = x_eci - offset
+/// ```
 fn mars_earth_offset_state(epc: Epoch) -> SVector6 {
     ensure_mars_spk_loaded();
     spk_state(NAIFId::Mars, NAIFId::Earth, epc)

--- a/src/frames/mars.rs
+++ b/src/frames/mars.rs
@@ -468,7 +468,7 @@ pub fn state_mci_to_eci(epc: Epoch, x_mci: SVector6) -> SVector6 {
 /// assert_eq!(r.len(), 2);
 /// ```
 pub fn rotations_mci_to_mcmf(epochs: &[Epoch]) -> Vec<SMatrix3> {
-    batch_map(epochs, |epc| rotation_mci_to_mcmf(*epc))
+    batch_map(|epc| rotation_mci_to_mcmf(*epc), epochs)
 }
 
 /// Computes the MCMF-to-MCI rotation matrix for each epoch in `epochs`.
@@ -493,7 +493,7 @@ pub fn rotations_mci_to_mcmf(epochs: &[Epoch]) -> Vec<SMatrix3> {
 /// assert_eq!(r.len(), 2);
 /// ```
 pub fn rotations_mcmf_to_mci(epochs: &[Epoch]) -> Vec<SMatrix3> {
-    batch_map(epochs, |epc| rotation_mcmf_to_mci(*epc))
+    batch_map(|epc| rotation_mcmf_to_mci(*epc), epochs)
 }
 
 /// Transforms a batch of Cartesian positions from MCI to MCMF.
@@ -526,7 +526,7 @@ pub fn positions_mci_to_mcmf(
     epochs: &[Epoch],
     x_mci: &[Vector3<f64>],
 ) -> Result<Vec<Vector3<f64>>, BraheError> {
-    batch_map_epochs(epochs, x_mci, rotation_mci_to_mcmf, |r, x| r * x)
+    batch_map_epochs(rotation_mci_to_mcmf, |r, x| r * x, epochs, x_mci)
 }
 
 /// Transforms a batch of Cartesian positions from MCMF to MCI.
@@ -559,7 +559,7 @@ pub fn positions_mcmf_to_mci(
     epochs: &[Epoch],
     x_mcmf: &[Vector3<f64>],
 ) -> Result<Vec<Vector3<f64>>, BraheError> {
-    batch_map_epochs(epochs, x_mcmf, rotation_mcmf_to_mci, |r, x| r * x)
+    batch_map_epochs(rotation_mcmf_to_mci, |r, x| r * x, epochs, x_mcmf)
 }
 
 /// Transforms a batch of Cartesian states from MCI to MCMF.
@@ -593,7 +593,7 @@ pub fn states_mci_to_mcmf(
     epochs: &[Epoch],
     x_mci: &[SVector6],
 ) -> Result<Vec<SVector6>, BraheError> {
-    batch_map_epochs(epochs, x_mci, mcmf_context, apply_state_icrf_to_rotating)
+    batch_map_epochs(mcmf_context, apply_state_icrf_to_rotating, epochs, x_mci)
 }
 
 /// Transforms a batch of Cartesian states from MCMF to MCI.
@@ -627,7 +627,7 @@ pub fn states_mcmf_to_mci(
     epochs: &[Epoch],
     x_mcmf: &[SVector6],
 ) -> Result<Vec<SVector6>, BraheError> {
-    batch_map_epochs(epochs, x_mcmf, mcmf_context, apply_state_rotating_to_icrf)
+    batch_map_epochs(mcmf_context, apply_state_rotating_to_icrf, epochs, x_mcmf)
 }
 
 /// Transforms a batch of Cartesian positions from ECI to MCI.
@@ -660,9 +660,12 @@ pub fn positions_eci_to_mci(
     epochs: &[Epoch],
     x_eci: &[Vector3<f64>],
 ) -> Result<Vec<Vector3<f64>>, BraheError> {
-    batch_map_epochs(epochs, x_eci, mars_earth_offset_position, |offset, x| {
-        x - offset
-    })
+    batch_map_epochs(
+        mars_earth_offset_position,
+        |offset, x| x - offset,
+        epochs,
+        x_eci,
+    )
 }
 
 /// Transforms a batch of Cartesian positions from MCI to ECI.
@@ -695,9 +698,12 @@ pub fn positions_mci_to_eci(
     epochs: &[Epoch],
     x_mci: &[Vector3<f64>],
 ) -> Result<Vec<Vector3<f64>>, BraheError> {
-    batch_map_epochs(epochs, x_mci, mars_earth_offset_position, |offset, x| {
-        x + offset
-    })
+    batch_map_epochs(
+        mars_earth_offset_position,
+        |offset, x| x + offset,
+        epochs,
+        x_mci,
+    )
 }
 
 /// Transforms a batch of Cartesian states from ECI to MCI.
@@ -731,9 +737,12 @@ pub fn states_eci_to_mci(
     epochs: &[Epoch],
     x_eci: &[SVector6],
 ) -> Result<Vec<SVector6>, BraheError> {
-    batch_map_epochs(epochs, x_eci, mars_earth_offset_state, |offset, x| {
-        x - offset
-    })
+    batch_map_epochs(
+        mars_earth_offset_state,
+        |offset, x| x - offset,
+        epochs,
+        x_eci,
+    )
 }
 
 /// Transforms a batch of Cartesian states from MCI to ECI.
@@ -767,9 +776,12 @@ pub fn states_mci_to_eci(
     epochs: &[Epoch],
     x_mci: &[SVector6],
 ) -> Result<Vec<SVector6>, BraheError> {
-    batch_map_epochs(epochs, x_mci, mars_earth_offset_state, |offset, x| {
-        x + offset
-    })
+    batch_map_epochs(
+        mars_earth_offset_state,
+        |offset, x| x + offset,
+        epochs,
+        x_mci,
+    )
 }
 
 #[cfg(test)]

--- a/src/frames/mars.rs
+++ b/src/frames/mars.rs
@@ -23,9 +23,14 @@ use nalgebra::Vector3;
 use crate::math::{SMatrix3, SVector6};
 use crate::spice::{NAIFId, spk_position, spk_state};
 use crate::time::Epoch;
+use crate::utils::BraheError;
+use crate::utils::batch::{batch_map, batch_map_epochs};
 
 use super::iau_rotation::{
     body_fixed_iau_angles_and_rates, euler313_omega_body, rotation_icrf_to_body_fixed_iau,
+};
+use super::transform::{
+    RotatingFrameContext, apply_state_icrf_to_rotating, apply_state_rotating_to_icrf,
 };
 
 /// Idempotently loads the `mar099s` Mars satellite ephemeris kernel
@@ -183,6 +188,48 @@ pub fn position_mcmf_to_mci(epc: Epoch, x_mcmf: Vector3<f64>) -> Vector3<f64> {
     rotation_mcmf_to_mci(epc) * x_mcmf
 }
 
+/// Rotation matrix and body-frame angular velocity of the Mars-fixed frame
+/// (MCMF) at `epc`.
+///
+/// # Arguments
+/// - `epc`: Epoch instant
+///
+/// # Returns
+/// - MCI -> MCMF rotation matrix and MCMF angular velocity (rad/s)
+fn mcmf_context(epc: Epoch) -> RotatingFrameContext {
+    let (angles, rates) = body_fixed_iau_angles_and_rates(NAIFId::Mars.id(), epc)
+        .expect("IAU Mars rotation model missing from embedded WGCCRE table — this is a bug");
+    let r_mat = rotation_mci_to_mcmf(epc);
+    let omega_b = euler313_omega_body(angles, rates);
+    RotatingFrameContext { r_mat, omega_b }
+}
+
+/// Mars position relative to the Earth in ICRF axes.
+///
+/// # Arguments
+/// - `epc`: Epoch instant
+///
+/// # Returns
+/// - Mars position relative to the Earth. Units: (*m*)
+fn mars_earth_offset_position(epc: Epoch) -> Vector3<f64> {
+    ensure_mars_spk_loaded();
+    spk_position(NAIFId::Mars, NAIFId::Earth, epc)
+        .expect("SPK query failed: ensure a DE kernel is available (auto-init de440s)")
+}
+
+/// Mars state relative to the Earth in ICRF axes.
+///
+/// # Arguments
+/// - `epc`: Epoch instant
+///
+/// # Returns
+/// - Mars state relative to the Earth (position, velocity). Units: (*m*; *m/s*)
+fn mars_earth_offset_state(epc: Epoch) -> SVector6 {
+    ensure_mars_spk_loaded();
+    spk_state(NAIFId::Mars, NAIFId::Earth, epc)
+        .expect("SPK query failed: ensure a DE kernel is available (auto-init de440s)")
+}
+
 /// Transforms a Cartesian Mars-inertial state (position and velocity) into
 /// the equivalent Cartesian Mars-fixed state.
 ///
@@ -210,18 +257,7 @@ pub fn position_mcmf_to_mci(epc: Epoch, x_mcmf: Vector3<f64>) -> Vector3<f64> {
 /// let x_mcmf = state_mci_to_mcmf(epc, x_mci);
 /// ```
 pub fn state_mci_to_mcmf(epc: Epoch, x_mci: SVector6) -> SVector6 {
-    let (angles, rates) = body_fixed_iau_angles_and_rates(NAIFId::Mars.id(), epc)
-        .expect("IAU Mars rotation model missing from embedded WGCCRE table — this is a bug");
-    let r_mat = rotation_mci_to_mcmf(epc);
-    let omega_b = euler313_omega_body(angles, rates);
-
-    let r = x_mci.fixed_rows::<3>(0);
-    let v = x_mci.fixed_rows::<3>(3);
-
-    let r_b: Vector3<f64> = r_mat * r;
-    let v_b: Vector3<f64> = r_mat * v - omega_b.cross(&r_b);
-
-    SVector6::new(r_b[0], r_b[1], r_b[2], v_b[0], v_b[1], v_b[2])
+    apply_state_icrf_to_rotating(&mcmf_context(epc), &x_mci)
 }
 
 /// Transforms a Cartesian Mars-fixed state (position and velocity) into
@@ -253,18 +289,7 @@ pub fn state_mci_to_mcmf(epc: Epoch, x_mci: SVector6) -> SVector6 {
 /// let x_mci2 = state_mcmf_to_mci(epc, x_mcmf);
 /// ```
 pub fn state_mcmf_to_mci(epc: Epoch, x_mcmf: SVector6) -> SVector6 {
-    let (angles, rates) = body_fixed_iau_angles_and_rates(NAIFId::Mars.id(), epc)
-        .expect("IAU Mars rotation model missing from embedded WGCCRE table — this is a bug");
-    let r_mat = rotation_mci_to_mcmf(epc);
-    let omega_b = euler313_omega_body(angles, rates);
-
-    let r_b: Vector3<f64> = x_mcmf.fixed_rows::<3>(0).into_owned();
-    let v_b: Vector3<f64> = x_mcmf.fixed_rows::<3>(3).into_owned();
-
-    let r: Vector3<f64> = r_mat.transpose() * r_b;
-    let v: Vector3<f64> = r_mat.transpose() * (v_b + omega_b.cross(&r_b));
-
-    SVector6::new(r[0], r[1], r[2], v[0], v[1], v[2])
+    apply_state_rotating_to_icrf(&mcmf_context(epc), &x_mcmf)
 }
 
 /// Transforms a Cartesian Earth-inertial (ECI) position into the
@@ -295,10 +320,7 @@ pub fn state_mcmf_to_mci(epc: Epoch, x_mcmf: SVector6) -> SVector6 {
 /// let x_mci = position_eci_to_mci(epc, x_eci);
 /// ```
 pub fn position_eci_to_mci(epc: Epoch, x_eci: Vector3<f64>) -> Vector3<f64> {
-    ensure_mars_spk_loaded();
-    let offset = spk_position(NAIFId::Mars, NAIFId::Earth, epc)
-        .expect("SPK query failed: ensure a DE kernel is available (auto-init de440s)");
-    x_eci - offset
+    x_eci - mars_earth_offset_position(epc)
 }
 
 /// Transforms a Cartesian Mars-inertial (MCI) position into the
@@ -329,10 +351,7 @@ pub fn position_eci_to_mci(epc: Epoch, x_eci: Vector3<f64>) -> Vector3<f64> {
 /// let x_eci = position_mci_to_eci(epc, x_mci);
 /// ```
 pub fn position_mci_to_eci(epc: Epoch, x_mci: Vector3<f64>) -> Vector3<f64> {
-    ensure_mars_spk_loaded();
-    let offset = spk_position(NAIFId::Mars, NAIFId::Earth, epc)
-        .expect("SPK query failed: ensure a DE kernel is available (auto-init de440s)");
-    x_mci + offset
+    x_mci + mars_earth_offset_position(epc)
 }
 
 /// Transforms a Cartesian Earth-inertial (ECI) state (position and
@@ -363,10 +382,7 @@ pub fn position_mci_to_eci(epc: Epoch, x_mci: Vector3<f64>) -> Vector3<f64> {
 /// let x_mci = state_eci_to_mci(epc, x_eci);
 /// ```
 pub fn state_eci_to_mci(epc: Epoch, x_eci: SVector6) -> SVector6 {
-    ensure_mars_spk_loaded();
-    let offset = spk_state(NAIFId::Mars, NAIFId::Earth, epc)
-        .expect("SPK query failed: ensure a DE kernel is available (auto-init de440s)");
-    x_eci - offset
+    x_eci - mars_earth_offset_state(epc)
 }
 
 /// Transforms a Cartesian Mars-inertial (MCI) state (position and
@@ -397,10 +413,333 @@ pub fn state_eci_to_mci(epc: Epoch, x_eci: SVector6) -> SVector6 {
 /// let x_eci = state_mci_to_eci(epc, x_mci);
 /// ```
 pub fn state_mci_to_eci(epc: Epoch, x_mci: SVector6) -> SVector6 {
-    ensure_mars_spk_loaded();
-    let offset = spk_state(NAIFId::Mars, NAIFId::Earth, epc)
-        .expect("SPK query failed: ensure a DE kernel is available (auto-init de440s)");
-    x_mci + offset
+    x_mci + mars_earth_offset_state(epc)
+}
+
+/// Computes the MCI-to-MCMF rotation matrix for each epoch in `epochs`.
+///
+/// Batch form of [`rotation_mci_to_mcmf`]. Evaluation runs on the global thread pool
+/// for large inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants for computation of the transformation matrices
+///
+/// # Returns
+/// - Rotation matrices transforming MCI -> MCMF, one per epoch, in input order
+///
+/// # Examples:
+/// ```
+/// use brahe::frames::rotations_mci_to_mcmf;
+/// use brahe::time::{Epoch, TimeSystem};
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let epochs = vec![epc, epc + 60.0];
+/// let r = rotations_mci_to_mcmf(&epochs);
+/// assert_eq!(r.len(), 2);
+/// ```
+pub fn rotations_mci_to_mcmf(epochs: &[Epoch]) -> Vec<SMatrix3> {
+    batch_map(epochs, |epc| rotation_mci_to_mcmf(*epc))
+}
+
+/// Computes the MCMF-to-MCI rotation matrix for each epoch in `epochs`.
+///
+/// Batch form of [`rotation_mcmf_to_mci`]. Evaluation runs on the global thread pool
+/// for large inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants for computation of the transformation matrices
+///
+/// # Returns
+/// - Rotation matrices transforming MCMF -> MCI, one per epoch, in input order
+///
+/// # Examples:
+/// ```
+/// use brahe::frames::rotations_mcmf_to_mci;
+/// use brahe::time::{Epoch, TimeSystem};
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let epochs = vec![epc, epc + 60.0];
+/// let r = rotations_mcmf_to_mci(&epochs);
+/// assert_eq!(r.len(), 2);
+/// ```
+pub fn rotations_mcmf_to_mci(epochs: &[Epoch]) -> Vec<SMatrix3> {
+    batch_map(epochs, |epc| rotation_mcmf_to_mci(*epc))
+}
+
+/// Transforms a batch of Cartesian positions from MCI to MCMF.
+///
+/// Batch form of [`position_mci_to_mcmf`]. `epochs` and the vector argument follow the
+/// broadcast rule: each has length 1 or the common batch length. A single
+/// epoch evaluates the transformation context once and applies it to every
+/// element. Evaluation runs on the global thread pool for large inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x_mci`: Cartesian MCI positions, length 1 or the batch length. Units: (*m*)
+///
+/// # Returns
+/// - Cartesian MCMF positions in input order. Units: (*m*)
+/// - Error if the lengths do not satisfy the broadcast rule
+///
+/// # Examples:
+/// ```
+/// use brahe::frames::positions_mci_to_mcmf;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use nalgebra::Vector3;
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let positions = vec![Vector3::new(3.6e6, 0.0, 0.0); 3];
+/// let out = positions_mci_to_mcmf(&[epc], &positions).unwrap();
+/// assert_eq!(out.len(), 3);
+/// ```
+pub fn positions_mci_to_mcmf(
+    epochs: &[Epoch],
+    x_mci: &[Vector3<f64>],
+) -> Result<Vec<Vector3<f64>>, BraheError> {
+    batch_map_epochs(epochs, x_mci, rotation_mci_to_mcmf, |r, x| r * x)
+}
+
+/// Transforms a batch of Cartesian positions from MCMF to MCI.
+///
+/// Batch form of [`position_mcmf_to_mci`]. `epochs` and the vector argument follow the
+/// broadcast rule: each has length 1 or the common batch length. A single
+/// epoch evaluates the transformation context once and applies it to every
+/// element. Evaluation runs on the global thread pool for large inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x_mcmf`: Cartesian MCMF positions, length 1 or the batch length. Units: (*m*)
+///
+/// # Returns
+/// - Cartesian MCI positions in input order. Units: (*m*)
+/// - Error if the lengths do not satisfy the broadcast rule
+///
+/// # Examples:
+/// ```
+/// use brahe::frames::positions_mcmf_to_mci;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use nalgebra::Vector3;
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let positions = vec![Vector3::new(3.6e6, 0.0, 0.0); 3];
+/// let out = positions_mcmf_to_mci(&[epc], &positions).unwrap();
+/// assert_eq!(out.len(), 3);
+/// ```
+pub fn positions_mcmf_to_mci(
+    epochs: &[Epoch],
+    x_mcmf: &[Vector3<f64>],
+) -> Result<Vec<Vector3<f64>>, BraheError> {
+    batch_map_epochs(epochs, x_mcmf, rotation_mcmf_to_mci, |r, x| r * x)
+}
+
+/// Transforms a batch of Cartesian states from MCI to MCMF.
+///
+/// Batch form of [`state_mci_to_mcmf`]. `epochs` and the vector argument follow the
+/// broadcast rule: each has length 1 or the common batch length. A single
+/// epoch evaluates the transformation context once and applies it to every
+/// element. Evaluation runs on the global thread pool for large inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x_mci`: Cartesian MCI states (position, velocity), length 1 or the batch length. Units: (*m*; *m/s*)
+///
+/// # Returns
+/// - Cartesian MCMF states (position, velocity) in input order. Units: (*m*; *m/s*)
+/// - Error if the lengths do not satisfy the broadcast rule
+///
+/// # Examples:
+/// ```
+/// use brahe::frames::states_mci_to_mcmf;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use brahe::vector6_from_array;
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let epochs = vec![epc, epc + 60.0, epc + 120.0];
+/// let states = vec![vector6_from_array([3.6e6, 0.0, 0.0, 0.0, 3.4e3, 0.0]); 3];
+/// let out = states_mci_to_mcmf(&epochs, &states).unwrap();
+/// assert_eq!(out.len(), 3);
+/// ```
+pub fn states_mci_to_mcmf(
+    epochs: &[Epoch],
+    x_mci: &[SVector6],
+) -> Result<Vec<SVector6>, BraheError> {
+    batch_map_epochs(epochs, x_mci, mcmf_context, apply_state_icrf_to_rotating)
+}
+
+/// Transforms a batch of Cartesian states from MCMF to MCI.
+///
+/// Batch form of [`state_mcmf_to_mci`]. `epochs` and the vector argument follow the
+/// broadcast rule: each has length 1 or the common batch length. A single
+/// epoch evaluates the transformation context once and applies it to every
+/// element. Evaluation runs on the global thread pool for large inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x_mcmf`: Cartesian MCMF states (position, velocity), length 1 or the batch length. Units: (*m*; *m/s*)
+///
+/// # Returns
+/// - Cartesian MCI states (position, velocity) in input order. Units: (*m*; *m/s*)
+/// - Error if the lengths do not satisfy the broadcast rule
+///
+/// # Examples:
+/// ```
+/// use brahe::frames::states_mcmf_to_mci;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use brahe::vector6_from_array;
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let epochs = vec![epc, epc + 60.0, epc + 120.0];
+/// let states = vec![vector6_from_array([3.6e6, 0.0, 0.0, 0.0, 3.4e3, 0.0]); 3];
+/// let out = states_mcmf_to_mci(&epochs, &states).unwrap();
+/// assert_eq!(out.len(), 3);
+/// ```
+pub fn states_mcmf_to_mci(
+    epochs: &[Epoch],
+    x_mcmf: &[SVector6],
+) -> Result<Vec<SVector6>, BraheError> {
+    batch_map_epochs(epochs, x_mcmf, mcmf_context, apply_state_rotating_to_icrf)
+}
+
+/// Transforms a batch of Cartesian positions from ECI to MCI.
+///
+/// Batch form of [`position_eci_to_mci`]. `epochs` and the vector argument follow the
+/// broadcast rule: each has length 1 or the common batch length. A single
+/// epoch evaluates the transformation context once and applies it to every
+/// element. Evaluation runs on the global thread pool for large inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x_eci`: Cartesian ECI positions, length 1 or the batch length. Units: (*m*)
+///
+/// # Returns
+/// - Cartesian MCI positions in input order. Units: (*m*)
+/// - Error if the lengths do not satisfy the broadcast rule
+///
+/// # Examples:
+/// ```
+/// use brahe::frames::positions_eci_to_mci;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use nalgebra::Vector3;
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let positions = vec![Vector3::new(7.0e6, 1.0e6, -2.0e6); 3];
+/// let out = positions_eci_to_mci(&[epc], &positions).unwrap();
+/// assert_eq!(out.len(), 3);
+/// ```
+pub fn positions_eci_to_mci(
+    epochs: &[Epoch],
+    x_eci: &[Vector3<f64>],
+) -> Result<Vec<Vector3<f64>>, BraheError> {
+    batch_map_epochs(epochs, x_eci, mars_earth_offset_position, |offset, x| {
+        x - offset
+    })
+}
+
+/// Transforms a batch of Cartesian positions from MCI to ECI.
+///
+/// Batch form of [`position_mci_to_eci`]. `epochs` and the vector argument follow the
+/// broadcast rule: each has length 1 or the common batch length. A single
+/// epoch evaluates the transformation context once and applies it to every
+/// element. Evaluation runs on the global thread pool for large inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x_mci`: Cartesian MCI positions, length 1 or the batch length. Units: (*m*)
+///
+/// # Returns
+/// - Cartesian ECI positions in input order. Units: (*m*)
+/// - Error if the lengths do not satisfy the broadcast rule
+///
+/// # Examples:
+/// ```
+/// use brahe::frames::positions_mci_to_eci;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use nalgebra::Vector3;
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let positions = vec![Vector3::new(7.0e6, 1.0e6, -2.0e6); 3];
+/// let out = positions_mci_to_eci(&[epc], &positions).unwrap();
+/// assert_eq!(out.len(), 3);
+/// ```
+pub fn positions_mci_to_eci(
+    epochs: &[Epoch],
+    x_mci: &[Vector3<f64>],
+) -> Result<Vec<Vector3<f64>>, BraheError> {
+    batch_map_epochs(epochs, x_mci, mars_earth_offset_position, |offset, x| {
+        x + offset
+    })
+}
+
+/// Transforms a batch of Cartesian states from ECI to MCI.
+///
+/// Batch form of [`state_eci_to_mci`]. `epochs` and the vector argument follow the
+/// broadcast rule: each has length 1 or the common batch length. A single
+/// epoch evaluates the transformation context once and applies it to every
+/// element. Evaluation runs on the global thread pool for large inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x_eci`: Cartesian ECI states (position, velocity), length 1 or the batch length. Units: (*m*; *m/s*)
+///
+/// # Returns
+/// - Cartesian MCI states (position, velocity) in input order. Units: (*m*; *m/s*)
+/// - Error if the lengths do not satisfy the broadcast rule
+///
+/// # Examples:
+/// ```
+/// use brahe::frames::states_eci_to_mci;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use brahe::vector6_from_array;
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let epochs = vec![epc, epc + 60.0, epc + 120.0];
+/// let states = vec![vector6_from_array([7.0e6, 0.0, 0.0, 0.0, 7.5e3, 0.0]); 3];
+/// let out = states_eci_to_mci(&epochs, &states).unwrap();
+/// assert_eq!(out.len(), 3);
+/// ```
+pub fn states_eci_to_mci(
+    epochs: &[Epoch],
+    x_eci: &[SVector6],
+) -> Result<Vec<SVector6>, BraheError> {
+    batch_map_epochs(epochs, x_eci, mars_earth_offset_state, |offset, x| {
+        x - offset
+    })
+}
+
+/// Transforms a batch of Cartesian states from MCI to ECI.
+///
+/// Batch form of [`state_mci_to_eci`]. `epochs` and the vector argument follow the
+/// broadcast rule: each has length 1 or the common batch length. A single
+/// epoch evaluates the transformation context once and applies it to every
+/// element. Evaluation runs on the global thread pool for large inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x_mci`: Cartesian MCI states (position, velocity), length 1 or the batch length. Units: (*m*; *m/s*)
+///
+/// # Returns
+/// - Cartesian ECI states (position, velocity) in input order. Units: (*m*; *m/s*)
+/// - Error if the lengths do not satisfy the broadcast rule
+///
+/// # Examples:
+/// ```
+/// use brahe::frames::states_mci_to_eci;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use brahe::vector6_from_array;
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let epochs = vec![epc, epc + 60.0, epc + 120.0];
+/// let states = vec![vector6_from_array([7.0e6, 0.0, 0.0, 0.0, 7.5e3, 0.0]); 3];
+/// let out = states_mci_to_eci(&epochs, &states).unwrap();
+/// assert_eq!(out.len(), 3);
+/// ```
+pub fn states_mci_to_eci(
+    epochs: &[Epoch],
+    x_mci: &[SVector6],
+) -> Result<Vec<SVector6>, BraheError> {
+    batch_map_epochs(epochs, x_mci, mars_earth_offset_state, |offset, x| {
+        x + offset
+    })
 }
 
 #[cfg(test)]
@@ -580,5 +919,82 @@ mod tests {
         // the real mar099s (real cache; tolerated failure keeps this test
         // offline-safe when nothing later needs the kernel).
         let _ = load_spice_kernel("mar099s");
+    }
+
+    #[test]
+    #[serial]
+    fn test_batch_mars_frames_match_scalar() {
+        setup_global_test_spice();
+        let epc0 = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+        let epochs: Vec<Epoch> = (0..3).map(|i| epc0 + 3600.0 * i as f64).collect();
+        let states: Vec<SVector6> = (0..3)
+            .map(|i| {
+                vector6_from_array([R_MARS + 300e3 + 1e3 * i as f64, 0.0, 0.0, 0.0, 3.4e3, 0.0])
+            })
+            .collect();
+        let positions: Vec<Vector3<f64>> = states
+            .iter()
+            .map(|s| Vector3::new(s[0], s[1], s[2]))
+            .collect();
+
+        for i in 0..3 {
+            let e = epochs[i];
+            assert_eq!(rotations_mci_to_mcmf(&epochs)[i], rotation_mci_to_mcmf(e));
+            assert_eq!(rotations_mcmf_to_mci(&epochs)[i], rotation_mcmf_to_mci(e));
+            assert_eq!(
+                positions_mci_to_mcmf(&epochs, &positions).unwrap()[i],
+                position_mci_to_mcmf(e, positions[i])
+            );
+            assert_eq!(
+                positions_mcmf_to_mci(&epochs, &positions).unwrap()[i],
+                position_mcmf_to_mci(e, positions[i])
+            );
+            assert_eq!(
+                positions_mci_to_mcmf(&epochs[..1], &positions).unwrap()[i],
+                position_mci_to_mcmf(epochs[0], positions[i])
+            );
+            assert_eq!(
+                states_mci_to_mcmf(&epochs, &states).unwrap()[i],
+                state_mci_to_mcmf(e, states[i])
+            );
+            assert_eq!(
+                states_mcmf_to_mci(&epochs, &states).unwrap()[i],
+                state_mcmf_to_mci(e, states[i])
+            );
+            assert_eq!(
+                states_mci_to_mcmf(&epochs[..1], &states).unwrap()[i],
+                state_mci_to_mcmf(epochs[0], states[i])
+            );
+            assert_eq!(
+                positions_eci_to_mci(&epochs, &positions).unwrap()[i],
+                position_eci_to_mci(e, positions[i])
+            );
+            assert_eq!(
+                positions_mci_to_eci(&epochs, &positions).unwrap()[i],
+                position_mci_to_eci(e, positions[i])
+            );
+            assert_eq!(
+                states_eci_to_mci(&epochs, &states).unwrap()[i],
+                state_eci_to_mci(e, states[i])
+            );
+            assert_eq!(
+                states_mci_to_eci(&epochs, &states).unwrap()[i],
+                state_mci_to_eci(e, states[i])
+            );
+            assert_eq!(
+                states_eci_to_mci(&epochs, &states[..1]).unwrap()[i],
+                state_eci_to_mci(e, states[0])
+            );
+        }
+
+        let mcmf = states_mci_to_mcmf(&epochs, &states).unwrap();
+        let back = states_mcmf_to_mci(&epochs, &mcmf).unwrap();
+        for i in 0..3 {
+            for k in 0..3 {
+                assert_abs_diff_eq!(back[i][k], states[i][k], epsilon = 1e-6);
+            }
+        }
+        assert!(states_mci_to_mcmf(&epochs[..2], &states).is_err());
+        assert!(rotations_mci_to_mcmf(&[]).is_empty());
     }
 }

--- a/src/frames/synodic.rs
+++ b/src/frames/synodic.rs
@@ -277,6 +277,24 @@ struct SynodicStateContext {
 
 /// Apply a synodic position context: re-center from Earth to the synodic
 /// origin, then rotate into synodic axes.
+///
+/// # Arguments
+/// - `c`: Synodic axes and origin offset for the epoch
+/// - `x`: Cartesian position in Earth-centered inertial axes. Units: (*m*)
+///
+/// # Returns
+/// - Cartesian position in the synodic frame. Units: (*m*)
+///
+/// # Examples
+///
+/// ```ignore
+/// use brahe::time::{Epoch, TimeSystem};
+/// use nalgebra::Vector3;
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let c = emr_position_context(epc).unwrap();
+/// let x_emr = apply_position_inertial_to_synodic(&c, &Vector3::new(1.0e8, -2.0e8, 5.0e7));
+/// ```
 fn apply_position_inertial_to_synodic(
     c: &SynodicPositionContext,
     x: &Vector3<f64>,
@@ -286,6 +304,24 @@ fn apply_position_inertial_to_synodic(
 
 /// Apply a synodic position context in the inverse direction: rotate to ICRF
 /// axes, then re-center from the synodic origin to Earth.
+///
+/// # Arguments
+/// - `c`: Synodic axes and origin offset for the epoch
+/// - `x`: Cartesian position in the synodic frame. Units: (*m*)
+///
+/// # Returns
+/// - Cartesian position in Earth-centered inertial axes. Units: (*m*)
+///
+/// # Examples
+///
+/// ```ignore
+/// use brahe::time::{Epoch, TimeSystem};
+/// use nalgebra::Vector3;
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let c = emr_position_context(epc).unwrap();
+/// let x_gcrf = apply_position_synodic_to_inertial(&c, &Vector3::new(3.8e8, 0.0, 0.0));
+/// ```
 fn apply_position_synodic_to_inertial(
     c: &SynodicPositionContext,
     x: &Vector3<f64>,
@@ -295,17 +331,69 @@ fn apply_position_synodic_to_inertial(
 
 /// Apply a synodic state context: re-center from Earth to the synodic origin,
 /// then rotate into synodic axes with the transport term.
+///
+/// # Arguments
+/// - `c`: Synodic axes, their rate, and origin offset state for the epoch
+/// - `x`: Cartesian state in Earth-centered inertial axes (position, velocity). Units: (*m*; *m/s*)
+///
+/// # Returns
+/// - Cartesian state in the synodic frame (position, velocity). Units: (*m*; *m/s*)
+///
+/// # Examples
+///
+/// ```ignore
+/// use brahe::time::{Epoch, TimeSystem};
+/// use brahe::vector6_from_array;
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let c = emr_state_context(epc).unwrap();
+/// let x_emr = apply_state_inertial_to_synodic(&c, &vector6_from_array([1.0e8, -2.0e8, 5.0e7, 1.0e3, -2.0e3, 0.5e3]));
+/// ```
 fn apply_state_inertial_to_synodic(c: &SynodicStateContext, x: &SVector6) -> SVector6 {
     state_inertial_to_synodic(&c.r_mat, &c.r_dot_mat, x - c.offset)
 }
 
 /// Apply a synodic state context in the inverse direction.
+///
+/// # Arguments
+/// - `c`: Synodic axes, their rate, and origin offset state for the epoch
+/// - `x`: Cartesian state in the synodic frame (position, velocity). Units: (*m*; *m/s*)
+///
+/// # Returns
+/// - Cartesian state in Earth-centered inertial axes (position, velocity). Units: (*m*; *m/s*)
+///
+/// # Examples
+///
+/// ```ignore
+/// use brahe::time::{Epoch, TimeSystem};
+/// use brahe::vector6_from_array;
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let c = emr_state_context(epc).unwrap();
+/// let x_gcrf = apply_state_synodic_to_inertial(&c, &vector6_from_array([3.8e8, 0.0, 0.0, 0.0, 0.0, 0.0]));
+/// ```
 fn apply_state_synodic_to_inertial(c: &SynodicStateContext, x: &SVector6) -> SVector6 {
     state_synodic_to_inertial(&c.r_mat, &c.r_dot_mat, *x) + c.offset
 }
 
 /// EMR position context: rotation from [`emr_axes`] and the Earth -> EMB
 /// offset.
+///
+/// # Arguments
+/// - `epc`: Epoch instant
+///
+/// # Returns
+/// - EMR rotation matrix and Earth -> EMB offset. Units: (*m*)
+/// - Error if the ephemeris cannot be evaluated
+///
+/// # Examples
+///
+/// ```ignore
+/// use brahe::time::{Epoch, TimeSystem};
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let c = emr_position_context(epc).unwrap();
+/// ```
 fn emr_position_context(epc: Epoch) -> Result<SynodicPositionContext, BraheError> {
     let (r_mat, _) = emr_axes(epc)?;
     let offset = spk_position(NAIFId::EarthMoonBarycenter, NAIFId::Earth, epc)?;
@@ -314,6 +402,22 @@ fn emr_position_context(epc: Epoch) -> Result<SynodicPositionContext, BraheError
 
 /// EMR state context: rotation and rate from [`emr_axes`] and the Earth ->
 /// EMB offset state.
+///
+/// # Arguments
+/// - `epc`: Epoch instant
+///
+/// # Returns
+/// - EMR rotation matrix, its time derivative, and Earth -> EMB offset state. Units: (*m*; *m/s*)
+/// - Error if the ephemeris cannot be evaluated
+///
+/// # Examples
+///
+/// ```ignore
+/// use brahe::time::{Epoch, TimeSystem};
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let c = emr_state_context(epc).unwrap();
+/// ```
 fn emr_state_context(epc: Epoch) -> Result<SynodicStateContext, BraheError> {
     let (r_mat, r_dot_mat) = emr_axes(epc)?;
     // EMB relative to Earth in ICRF axes: re-center Earth → EMB, then rotate.
@@ -580,6 +684,22 @@ fn seb_offset_from_earth(epc: Epoch) -> Result<SVector6, BraheError> {
 
 /// SER position context: rotation from [`ser_axes`] and the Earth -> SEB
 /// offset.
+///
+/// # Arguments
+/// - `epc`: Epoch instant
+///
+/// # Returns
+/// - SER rotation matrix and Earth -> SEB offset. Units: (*m*)
+/// - Error if the ephemeris cannot be evaluated
+///
+/// # Examples
+///
+/// ```ignore
+/// use brahe::time::{Epoch, TimeSystem};
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let c = ser_position_context(epc).unwrap();
+/// ```
 fn ser_position_context(epc: Epoch) -> Result<SynodicPositionContext, BraheError> {
     let (r_mat, _) = ser_axes(epc)?;
     let offset = seb_offset_from_earth(epc)?.fixed_rows::<3>(0).into_owned();
@@ -588,6 +708,22 @@ fn ser_position_context(epc: Epoch) -> Result<SynodicPositionContext, BraheError
 
 /// SER state context: rotation and rate from [`ser_axes`] and the Earth ->
 /// SEB offset state.
+///
+/// # Arguments
+/// - `epc`: Epoch instant
+///
+/// # Returns
+/// - SER rotation matrix, its time derivative, and Earth -> SEB offset state. Units: (*m*; *m/s*)
+/// - Error if the ephemeris cannot be evaluated
+///
+/// # Examples
+///
+/// ```ignore
+/// use brahe::time::{Epoch, TimeSystem};
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let c = ser_state_context(epc).unwrap();
+/// ```
 fn ser_state_context(epc: Epoch) -> Result<SynodicStateContext, BraheError> {
     let (r_mat, r_dot_mat) = ser_axes(epc)?;
     // SEB relative to Earth in ICRF axes: re-center Earth → SEB, then rotate.

--- a/src/frames/synodic.rs
+++ b/src/frames/synodic.rs
@@ -18,6 +18,7 @@ use crate::math::{SMatrix3, SVector6};
 use crate::spice::{NAIFId, spk_acceleration, spk_position, spk_state};
 use crate::time::Epoch;
 use crate::utils::BraheError;
+use crate::utils::batch::{try_batch_map, try_batch_map_epochs};
 
 /// Computes the inertial→synodic rotation matrix `R` and its exact time
 /// derivative `Ṙ` from the relative state of the two primaries
@@ -259,6 +260,71 @@ pub(crate) fn emr_axes(epc: Epoch) -> Result<(SMatrix3, SMatrix3), BraheError> {
     generic_synodic_axes(epc, NAIFId::Earth.id(), NAIFId::Moon.id())
 }
 
+/// Synodic rotation matrix and origin offset (ICRF axes, from Earth) for a
+/// position transformation at one epoch.
+struct SynodicPositionContext {
+    r_mat: SMatrix3,
+    offset: Vector3<f64>,
+}
+
+/// Synodic rotation matrix, its time derivative, and origin offset state
+/// (ICRF axes, from Earth) for a state transformation at one epoch.
+struct SynodicStateContext {
+    r_mat: SMatrix3,
+    r_dot_mat: SMatrix3,
+    offset: SVector6,
+}
+
+/// Apply a synodic position context: re-center from Earth to the synodic
+/// origin, then rotate into synodic axes.
+fn apply_position_inertial_to_synodic(
+    c: &SynodicPositionContext,
+    x: &Vector3<f64>,
+) -> Vector3<f64> {
+    c.r_mat * (x - c.offset)
+}
+
+/// Apply a synodic position context in the inverse direction: rotate to ICRF
+/// axes, then re-center from the synodic origin to Earth.
+fn apply_position_synodic_to_inertial(
+    c: &SynodicPositionContext,
+    x: &Vector3<f64>,
+) -> Vector3<f64> {
+    c.r_mat.transpose() * x + c.offset
+}
+
+/// Apply a synodic state context: re-center from Earth to the synodic origin,
+/// then rotate into synodic axes with the transport term.
+fn apply_state_inertial_to_synodic(c: &SynodicStateContext, x: &SVector6) -> SVector6 {
+    state_inertial_to_synodic(&c.r_mat, &c.r_dot_mat, x - c.offset)
+}
+
+/// Apply a synodic state context in the inverse direction.
+fn apply_state_synodic_to_inertial(c: &SynodicStateContext, x: &SVector6) -> SVector6 {
+    state_synodic_to_inertial(&c.r_mat, &c.r_dot_mat, *x) + c.offset
+}
+
+/// EMR position context: rotation from [`emr_axes`] and the Earth -> EMB
+/// offset.
+fn emr_position_context(epc: Epoch) -> Result<SynodicPositionContext, BraheError> {
+    let (r_mat, _) = emr_axes(epc)?;
+    let offset = spk_position(NAIFId::EarthMoonBarycenter, NAIFId::Earth, epc)?;
+    Ok(SynodicPositionContext { r_mat, offset })
+}
+
+/// EMR state context: rotation and rate from [`emr_axes`] and the Earth ->
+/// EMB offset state.
+fn emr_state_context(epc: Epoch) -> Result<SynodicStateContext, BraheError> {
+    let (r_mat, r_dot_mat) = emr_axes(epc)?;
+    // EMB relative to Earth in ICRF axes: re-center Earth → EMB, then rotate.
+    let offset = spk_state(NAIFId::EarthMoonBarycenter, NAIFId::Earth, epc)?;
+    Ok(SynodicStateContext {
+        r_mat,
+        r_dot_mat,
+        offset,
+    })
+}
+
 /// Computes the rotation matrix from Geocentric Celestial Reference Frame
 /// (GCRF) to Earth-Moon Rotating (EMR) axes.
 ///
@@ -343,9 +409,10 @@ pub fn rotation_emr_to_gcrf(epc: Epoch) -> Result<SMatrix3, BraheError> {
 /// let x_emr = position_gcrf_to_emr(epc, x_gcrf).unwrap();
 /// ```
 pub fn position_gcrf_to_emr(epc: Epoch, x_gcrf: Vector3<f64>) -> Result<Vector3<f64>, BraheError> {
-    let (r_mat, _) = emr_axes(epc)?;
-    let offset = spk_position(NAIFId::EarthMoonBarycenter, NAIFId::Earth, epc)?;
-    Ok(r_mat * (x_gcrf - offset))
+    Ok(apply_position_inertial_to_synodic(
+        &emr_position_context(epc)?,
+        &x_gcrf,
+    ))
 }
 
 /// Transforms a Cartesian Earth-Moon Rotating (EMR) position into the
@@ -376,9 +443,10 @@ pub fn position_gcrf_to_emr(epc: Epoch, x_gcrf: Vector3<f64>) -> Result<Vector3<
 /// let x_gcrf2 = position_emr_to_gcrf(epc, x_emr).unwrap();
 /// ```
 pub fn position_emr_to_gcrf(epc: Epoch, x_emr: Vector3<f64>) -> Result<Vector3<f64>, BraheError> {
-    let (r_mat, _) = emr_axes(epc)?;
-    let offset = spk_position(NAIFId::EarthMoonBarycenter, NAIFId::Earth, epc)?;
-    Ok(r_mat.transpose() * x_emr + offset)
+    Ok(apply_position_synodic_to_inertial(
+        &emr_position_context(epc)?,
+        &x_emr,
+    ))
 }
 
 /// Transforms a Cartesian GCRF state (position and velocity) into the
@@ -410,13 +478,9 @@ pub fn position_emr_to_gcrf(epc: Epoch, x_emr: Vector3<f64>) -> Result<Vector3<f
 /// let x_emr = state_gcrf_to_emr(epc, x_gcrf).unwrap();
 /// ```
 pub fn state_gcrf_to_emr(epc: Epoch, x_gcrf: SVector6) -> Result<SVector6, BraheError> {
-    let (r_mat, r_dot_mat) = emr_axes(epc)?;
-    // EMB relative to Earth in ICRF axes: re-center Earth → EMB, then rotate.
-    let offset = spk_state(NAIFId::EarthMoonBarycenter, NAIFId::Earth, epc)?;
-    Ok(state_inertial_to_synodic(
-        &r_mat,
-        &r_dot_mat,
-        x_gcrf - offset,
+    Ok(apply_state_inertial_to_synodic(
+        &emr_state_context(epc)?,
+        &x_gcrf,
     ))
 }
 
@@ -448,9 +512,10 @@ pub fn state_gcrf_to_emr(epc: Epoch, x_gcrf: SVector6) -> Result<SVector6, Brahe
 /// let x_gcrf2 = state_emr_to_gcrf(epc, x_emr).unwrap();
 /// ```
 pub fn state_emr_to_gcrf(epc: Epoch, x_emr: SVector6) -> Result<SVector6, BraheError> {
-    let (r_mat, r_dot_mat) = emr_axes(epc)?;
-    let offset = spk_state(NAIFId::EarthMoonBarycenter, NAIFId::Earth, epc)?;
-    Ok(state_synodic_to_inertial(&r_mat, &r_dot_mat, x_emr) + offset)
+    Ok(apply_state_synodic_to_inertial(
+        &emr_state_context(epc)?,
+        &x_emr,
+    ))
 }
 
 /// State of the Sun-Earth barycenter (SEB) relative to the Solar System
@@ -511,6 +576,27 @@ fn seb_offset_from_earth(epc: Epoch) -> Result<SVector6, BraheError> {
     let seb = sun_earth_barycenter_state(epc)?;
     let earth = spk_state(NAIFId::Earth, NAIFId::SolarSystemBarycenter, epc)?;
     Ok(seb - earth)
+}
+
+/// SER position context: rotation from [`ser_axes`] and the Earth -> SEB
+/// offset.
+fn ser_position_context(epc: Epoch) -> Result<SynodicPositionContext, BraheError> {
+    let (r_mat, _) = ser_axes(epc)?;
+    let offset = seb_offset_from_earth(epc)?.fixed_rows::<3>(0).into_owned();
+    Ok(SynodicPositionContext { r_mat, offset })
+}
+
+/// SER state context: rotation and rate from [`ser_axes`] and the Earth ->
+/// SEB offset state.
+fn ser_state_context(epc: Epoch) -> Result<SynodicStateContext, BraheError> {
+    let (r_mat, r_dot_mat) = ser_axes(epc)?;
+    // SEB relative to Earth in ICRF axes: re-center Earth → SEB, then rotate.
+    let offset = seb_offset_from_earth(epc)?;
+    Ok(SynodicStateContext {
+        r_mat,
+        r_dot_mat,
+        offset,
+    })
 }
 
 /// Computes the rotation matrix from Geocentric Celestial Reference Frame
@@ -597,9 +683,10 @@ pub fn rotation_ser_to_gcrf(epc: Epoch) -> Result<SMatrix3, BraheError> {
 /// let x_ser = position_gcrf_to_ser(epc, x_gcrf).unwrap();
 /// ```
 pub fn position_gcrf_to_ser(epc: Epoch, x_gcrf: Vector3<f64>) -> Result<Vector3<f64>, BraheError> {
-    let (r_mat, _) = ser_axes(epc)?;
-    let offset = seb_offset_from_earth(epc)?.fixed_rows::<3>(0).into_owned();
-    Ok(r_mat * (x_gcrf - offset))
+    Ok(apply_position_inertial_to_synodic(
+        &ser_position_context(epc)?,
+        &x_gcrf,
+    ))
 }
 
 /// Transforms a Cartesian Sun-Earth Rotating (SER) position into the
@@ -630,9 +717,10 @@ pub fn position_gcrf_to_ser(epc: Epoch, x_gcrf: Vector3<f64>) -> Result<Vector3<
 /// let x_gcrf2 = position_ser_to_gcrf(epc, x_ser).unwrap();
 /// ```
 pub fn position_ser_to_gcrf(epc: Epoch, x_ser: Vector3<f64>) -> Result<Vector3<f64>, BraheError> {
-    let (r_mat, _) = ser_axes(epc)?;
-    let offset = seb_offset_from_earth(epc)?.fixed_rows::<3>(0).into_owned();
-    Ok(r_mat.transpose() * x_ser + offset)
+    Ok(apply_position_synodic_to_inertial(
+        &ser_position_context(epc)?,
+        &x_ser,
+    ))
 }
 
 /// Transforms a Cartesian GCRF state (position and velocity) into the
@@ -664,13 +752,9 @@ pub fn position_ser_to_gcrf(epc: Epoch, x_ser: Vector3<f64>) -> Result<Vector3<f
 /// let x_ser = state_gcrf_to_ser(epc, x_gcrf).unwrap();
 /// ```
 pub fn state_gcrf_to_ser(epc: Epoch, x_gcrf: SVector6) -> Result<SVector6, BraheError> {
-    let (r_mat, r_dot_mat) = ser_axes(epc)?;
-    // SEB relative to Earth in ICRF axes: re-center Earth → SEB, then rotate.
-    let offset = seb_offset_from_earth(epc)?;
-    Ok(state_inertial_to_synodic(
-        &r_mat,
-        &r_dot_mat,
-        x_gcrf - offset,
+    Ok(apply_state_inertial_to_synodic(
+        &ser_state_context(epc)?,
+        &x_gcrf,
     ))
 }
 
@@ -702,9 +786,10 @@ pub fn state_gcrf_to_ser(epc: Epoch, x_gcrf: SVector6) -> Result<SVector6, Brahe
 /// let x_gcrf2 = state_ser_to_gcrf(epc, x_ser).unwrap();
 /// ```
 pub fn state_ser_to_gcrf(epc: Epoch, x_ser: SVector6) -> Result<SVector6, BraheError> {
-    let (r_mat, r_dot_mat) = ser_axes(epc)?;
-    let offset = seb_offset_from_earth(epc)?;
-    Ok(state_synodic_to_inertial(&r_mat, &r_dot_mat, x_ser) + offset)
+    Ok(apply_state_synodic_to_inertial(
+        &ser_state_context(epc)?,
+        &x_ser,
+    ))
 }
 
 /// Computes the rotation matrix from Geocentric Celestial Reference Frame
@@ -888,6 +973,598 @@ pub fn state_gcrf_to_gse(epc: Epoch, x_gcrf: SVector6) -> Result<SVector6, Brahe
 pub fn state_gse_to_gcrf(epc: Epoch, x_gse: SVector6) -> Result<SVector6, BraheError> {
     let (r_mat, r_dot_mat) = gse_axes(epc)?;
     Ok(state_synodic_to_inertial(&r_mat, &r_dot_mat, x_gse))
+}
+
+/// Computes the GCRF to Earth-Moon Rotating (EMR) rotation matrix for each epoch in `epochs`.
+///
+/// Batch form of [`rotation_gcrf_to_emr`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants for computation of the transformation matrices
+///
+/// # Returns
+/// - Rotation matrices transforming GCRF -> EMR, one per epoch, in input order
+/// - Error if the ephemeris cannot be evaluated at any epoch
+///
+/// # Examples
+/// ```
+/// use brahe::frames::rotations_gcrf_to_emr;
+/// use brahe::time::{Epoch, TimeSystem};
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let epochs = vec![epc, epc + 3600.0];
+/// let r = rotations_gcrf_to_emr(&epochs).unwrap();
+/// assert_eq!(r.len(), 2);
+/// ```
+pub fn rotations_gcrf_to_emr(epochs: &[Epoch]) -> Result<Vec<SMatrix3>, BraheError> {
+    try_batch_map(epochs, |epc| rotation_gcrf_to_emr(*epc))
+}
+
+/// Computes the Earth-Moon Rotating (EMR) to GCRF rotation matrix for each epoch in `epochs`.
+///
+/// Batch form of [`rotation_emr_to_gcrf`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants for computation of the transformation matrices
+///
+/// # Returns
+/// - Rotation matrices transforming EMR -> GCRF, one per epoch, in input order
+/// - Error if the ephemeris cannot be evaluated at any epoch
+///
+/// # Examples
+/// ```
+/// use brahe::frames::rotations_emr_to_gcrf;
+/// use brahe::time::{Epoch, TimeSystem};
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let epochs = vec![epc, epc + 3600.0];
+/// let r = rotations_emr_to_gcrf(&epochs).unwrap();
+/// assert_eq!(r.len(), 2);
+/// ```
+pub fn rotations_emr_to_gcrf(epochs: &[Epoch]) -> Result<Vec<SMatrix3>, BraheError> {
+    try_batch_map(epochs, |epc| rotation_emr_to_gcrf(*epc))
+}
+
+/// Computes the GCRF to Sun-Earth Rotating (SER) rotation matrix for each epoch in `epochs`.
+///
+/// Batch form of [`rotation_gcrf_to_ser`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants for computation of the transformation matrices
+///
+/// # Returns
+/// - Rotation matrices transforming GCRF -> SER, one per epoch, in input order
+/// - Error if the ephemeris cannot be evaluated at any epoch
+///
+/// # Examples
+/// ```
+/// use brahe::frames::rotations_gcrf_to_ser;
+/// use brahe::time::{Epoch, TimeSystem};
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let epochs = vec![epc, epc + 3600.0];
+/// let r = rotations_gcrf_to_ser(&epochs).unwrap();
+/// assert_eq!(r.len(), 2);
+/// ```
+pub fn rotations_gcrf_to_ser(epochs: &[Epoch]) -> Result<Vec<SMatrix3>, BraheError> {
+    try_batch_map(epochs, |epc| rotation_gcrf_to_ser(*epc))
+}
+
+/// Computes the Sun-Earth Rotating (SER) to GCRF rotation matrix for each epoch in `epochs`.
+///
+/// Batch form of [`rotation_ser_to_gcrf`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants for computation of the transformation matrices
+///
+/// # Returns
+/// - Rotation matrices transforming SER -> GCRF, one per epoch, in input order
+/// - Error if the ephemeris cannot be evaluated at any epoch
+///
+/// # Examples
+/// ```
+/// use brahe::frames::rotations_ser_to_gcrf;
+/// use brahe::time::{Epoch, TimeSystem};
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let epochs = vec![epc, epc + 3600.0];
+/// let r = rotations_ser_to_gcrf(&epochs).unwrap();
+/// assert_eq!(r.len(), 2);
+/// ```
+pub fn rotations_ser_to_gcrf(epochs: &[Epoch]) -> Result<Vec<SMatrix3>, BraheError> {
+    try_batch_map(epochs, |epc| rotation_ser_to_gcrf(*epc))
+}
+
+/// Computes the GCRF to Geocentric Solar Ecliptic (GSE) rotation matrix for each epoch in `epochs`.
+///
+/// Batch form of [`rotation_gcrf_to_gse`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants for computation of the transformation matrices
+///
+/// # Returns
+/// - Rotation matrices transforming GCRF -> GSE, one per epoch, in input order
+/// - Error if the ephemeris cannot be evaluated at any epoch
+///
+/// # Examples
+/// ```
+/// use brahe::frames::rotations_gcrf_to_gse;
+/// use brahe::time::{Epoch, TimeSystem};
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let epochs = vec![epc, epc + 3600.0];
+/// let r = rotations_gcrf_to_gse(&epochs).unwrap();
+/// assert_eq!(r.len(), 2);
+/// ```
+pub fn rotations_gcrf_to_gse(epochs: &[Epoch]) -> Result<Vec<SMatrix3>, BraheError> {
+    try_batch_map(epochs, |epc| rotation_gcrf_to_gse(*epc))
+}
+
+/// Computes the Geocentric Solar Ecliptic (GSE) to GCRF rotation matrix for each epoch in `epochs`.
+///
+/// Batch form of [`rotation_gse_to_gcrf`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants for computation of the transformation matrices
+///
+/// # Returns
+/// - Rotation matrices transforming GSE -> GCRF, one per epoch, in input order
+/// - Error if the ephemeris cannot be evaluated at any epoch
+///
+/// # Examples
+/// ```
+/// use brahe::frames::rotations_gse_to_gcrf;
+/// use brahe::time::{Epoch, TimeSystem};
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let epochs = vec![epc, epc + 3600.0];
+/// let r = rotations_gse_to_gcrf(&epochs).unwrap();
+/// assert_eq!(r.len(), 2);
+/// ```
+pub fn rotations_gse_to_gcrf(epochs: &[Epoch]) -> Result<Vec<SMatrix3>, BraheError> {
+    try_batch_map(epochs, |epc| rotation_gse_to_gcrf(*epc))
+}
+
+/// Transforms a batch of Cartesian positions from GCRF to Earth-Moon Rotating (EMR).
+///
+/// Batch form of [`position_gcrf_to_emr`]. `epochs` and the vector argument follow the
+/// broadcast rule: each has length 1 or the common batch length. A single
+/// epoch evaluates the synodic axes and origin offset once and applies them
+/// to every element. Evaluation runs on the global thread pool for large
+/// inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x_gcrf`: Cartesian GCRF positions, length 1 or the batch length. Units: (*m*)
+///
+/// # Returns
+/// - Cartesian EMR positions in input order. Units: (*m*)
+/// - Error if the lengths do not satisfy the broadcast rule or the ephemeris cannot be evaluated
+///
+/// # Examples
+/// ```
+/// use brahe::frames::positions_gcrf_to_emr;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use nalgebra::Vector3;
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let positions = vec![Vector3::new(7.0e6, 1.0e6, -2.0e6); 3];
+/// let out = positions_gcrf_to_emr(&[epc], &positions).unwrap();
+/// assert_eq!(out.len(), 3);
+/// ```
+pub fn positions_gcrf_to_emr(
+    epochs: &[Epoch],
+    x_gcrf: &[Vector3<f64>],
+) -> Result<Vec<Vector3<f64>>, BraheError> {
+    try_batch_map_epochs(epochs, x_gcrf, emr_position_context, |c, x| {
+        Ok(apply_position_inertial_to_synodic(c, x))
+    })
+}
+
+/// Transforms a batch of Cartesian positions from Earth-Moon Rotating (EMR) to GCRF.
+///
+/// Batch form of [`position_emr_to_gcrf`]. `epochs` and the vector argument follow the
+/// broadcast rule: each has length 1 or the common batch length. A single
+/// epoch evaluates the synodic axes and origin offset once and applies them
+/// to every element. Evaluation runs on the global thread pool for large
+/// inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x_emr`: Cartesian EMR positions, length 1 or the batch length. Units: (*m*)
+///
+/// # Returns
+/// - Cartesian GCRF positions in input order. Units: (*m*)
+/// - Error if the lengths do not satisfy the broadcast rule or the ephemeris cannot be evaluated
+///
+/// # Examples
+/// ```
+/// use brahe::frames::positions_emr_to_gcrf;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use nalgebra::Vector3;
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let positions = vec![Vector3::new(7.0e6, 1.0e6, -2.0e6); 3];
+/// let out = positions_emr_to_gcrf(&[epc], &positions).unwrap();
+/// assert_eq!(out.len(), 3);
+/// ```
+pub fn positions_emr_to_gcrf(
+    epochs: &[Epoch],
+    x_emr: &[Vector3<f64>],
+) -> Result<Vec<Vector3<f64>>, BraheError> {
+    try_batch_map_epochs(epochs, x_emr, emr_position_context, |c, x| {
+        Ok(apply_position_synodic_to_inertial(c, x))
+    })
+}
+
+/// Transforms a batch of Cartesian positions from GCRF to Sun-Earth Rotating (SER).
+///
+/// Batch form of [`position_gcrf_to_ser`]. `epochs` and the vector argument follow the
+/// broadcast rule: each has length 1 or the common batch length. A single
+/// epoch evaluates the synodic axes and origin offset once and applies them
+/// to every element. Evaluation runs on the global thread pool for large
+/// inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x_gcrf`: Cartesian GCRF positions, length 1 or the batch length. Units: (*m*)
+///
+/// # Returns
+/// - Cartesian SER positions in input order. Units: (*m*)
+/// - Error if the lengths do not satisfy the broadcast rule or the ephemeris cannot be evaluated
+///
+/// # Examples
+/// ```
+/// use brahe::frames::positions_gcrf_to_ser;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use nalgebra::Vector3;
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let positions = vec![Vector3::new(7.0e6, 1.0e6, -2.0e6); 3];
+/// let out = positions_gcrf_to_ser(&[epc], &positions).unwrap();
+/// assert_eq!(out.len(), 3);
+/// ```
+pub fn positions_gcrf_to_ser(
+    epochs: &[Epoch],
+    x_gcrf: &[Vector3<f64>],
+) -> Result<Vec<Vector3<f64>>, BraheError> {
+    try_batch_map_epochs(epochs, x_gcrf, ser_position_context, |c, x| {
+        Ok(apply_position_inertial_to_synodic(c, x))
+    })
+}
+
+/// Transforms a batch of Cartesian positions from Sun-Earth Rotating (SER) to GCRF.
+///
+/// Batch form of [`position_ser_to_gcrf`]. `epochs` and the vector argument follow the
+/// broadcast rule: each has length 1 or the common batch length. A single
+/// epoch evaluates the synodic axes and origin offset once and applies them
+/// to every element. Evaluation runs on the global thread pool for large
+/// inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x_ser`: Cartesian SER positions, length 1 or the batch length. Units: (*m*)
+///
+/// # Returns
+/// - Cartesian GCRF positions in input order. Units: (*m*)
+/// - Error if the lengths do not satisfy the broadcast rule or the ephemeris cannot be evaluated
+///
+/// # Examples
+/// ```
+/// use brahe::frames::positions_ser_to_gcrf;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use nalgebra::Vector3;
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let positions = vec![Vector3::new(7.0e6, 1.0e6, -2.0e6); 3];
+/// let out = positions_ser_to_gcrf(&[epc], &positions).unwrap();
+/// assert_eq!(out.len(), 3);
+/// ```
+pub fn positions_ser_to_gcrf(
+    epochs: &[Epoch],
+    x_ser: &[Vector3<f64>],
+) -> Result<Vec<Vector3<f64>>, BraheError> {
+    try_batch_map_epochs(epochs, x_ser, ser_position_context, |c, x| {
+        Ok(apply_position_synodic_to_inertial(c, x))
+    })
+}
+
+/// Transforms a batch of Cartesian positions from GCRF to Geocentric Solar Ecliptic (GSE).
+///
+/// Batch form of [`position_gcrf_to_gse`]. `epochs` and the vector argument follow the
+/// broadcast rule: each has length 1 or the common batch length. A single
+/// epoch evaluates the synodic axes and origin offset once and applies them
+/// to every element. Evaluation runs on the global thread pool for large
+/// inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x_gcrf`: Cartesian GCRF positions, length 1 or the batch length. Units: (*m*)
+///
+/// # Returns
+/// - Cartesian GSE positions in input order. Units: (*m*)
+/// - Error if the lengths do not satisfy the broadcast rule or the ephemeris cannot be evaluated
+///
+/// # Examples
+/// ```
+/// use brahe::frames::positions_gcrf_to_gse;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use nalgebra::Vector3;
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let positions = vec![Vector3::new(7.0e6, 1.0e6, -2.0e6); 3];
+/// let out = positions_gcrf_to_gse(&[epc], &positions).unwrap();
+/// assert_eq!(out.len(), 3);
+/// ```
+pub fn positions_gcrf_to_gse(
+    epochs: &[Epoch],
+    x_gcrf: &[Vector3<f64>],
+) -> Result<Vec<Vector3<f64>>, BraheError> {
+    try_batch_map_epochs(epochs, x_gcrf, gse_axes, |(r_mat, _), x| Ok(r_mat * x))
+}
+
+/// Transforms a batch of Cartesian positions from Geocentric Solar Ecliptic (GSE) to GCRF.
+///
+/// Batch form of [`position_gse_to_gcrf`]. `epochs` and the vector argument follow the
+/// broadcast rule: each has length 1 or the common batch length. A single
+/// epoch evaluates the synodic axes and origin offset once and applies them
+/// to every element. Evaluation runs on the global thread pool for large
+/// inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x_gse`: Cartesian GSE positions, length 1 or the batch length. Units: (*m*)
+///
+/// # Returns
+/// - Cartesian GCRF positions in input order. Units: (*m*)
+/// - Error if the lengths do not satisfy the broadcast rule or the ephemeris cannot be evaluated
+///
+/// # Examples
+/// ```
+/// use brahe::frames::positions_gse_to_gcrf;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use nalgebra::Vector3;
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let positions = vec![Vector3::new(7.0e6, 1.0e6, -2.0e6); 3];
+/// let out = positions_gse_to_gcrf(&[epc], &positions).unwrap();
+/// assert_eq!(out.len(), 3);
+/// ```
+pub fn positions_gse_to_gcrf(
+    epochs: &[Epoch],
+    x_gse: &[Vector3<f64>],
+) -> Result<Vec<Vector3<f64>>, BraheError> {
+    try_batch_map_epochs(epochs, x_gse, gse_axes, |(r_mat, _), x| {
+        Ok(r_mat.transpose() * x)
+    })
+}
+
+/// Transforms a batch of Cartesian states from GCRF to Earth-Moon Rotating (EMR).
+///
+/// Batch form of [`state_gcrf_to_emr`]. `epochs` and the vector argument follow the
+/// broadcast rule: each has length 1 or the common batch length. A single
+/// epoch evaluates the synodic axes and origin offset once and applies them
+/// to every element. Evaluation runs on the global thread pool for large
+/// inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x_gcrf`: Cartesian GCRF states (position, velocity), length 1 or the batch length. Units: (*m*; *m/s*)
+///
+/// # Returns
+/// - Cartesian EMR states (position, velocity) in input order. Units: (*m*; *m/s*)
+/// - Error if the lengths do not satisfy the broadcast rule or the ephemeris cannot be evaluated
+///
+/// # Examples
+/// ```
+/// use brahe::frames::states_gcrf_to_emr;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use brahe::vector6_from_array;
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let epochs = vec![epc, epc + 3600.0, epc + 7200.0];
+/// let states = vec![vector6_from_array([7.0e6, 0.0, 0.0, 0.0, 7.5e3, 0.0]); 3];
+/// let out = states_gcrf_to_emr(&epochs, &states).unwrap();
+/// assert_eq!(out.len(), 3);
+/// ```
+pub fn states_gcrf_to_emr(
+    epochs: &[Epoch],
+    x_gcrf: &[SVector6],
+) -> Result<Vec<SVector6>, BraheError> {
+    try_batch_map_epochs(epochs, x_gcrf, emr_state_context, |c, x| {
+        Ok(apply_state_inertial_to_synodic(c, x))
+    })
+}
+
+/// Transforms a batch of Cartesian states from Earth-Moon Rotating (EMR) to GCRF.
+///
+/// Batch form of [`state_emr_to_gcrf`]. `epochs` and the vector argument follow the
+/// broadcast rule: each has length 1 or the common batch length. A single
+/// epoch evaluates the synodic axes and origin offset once and applies them
+/// to every element. Evaluation runs on the global thread pool for large
+/// inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x_emr`: Cartesian EMR states (position, velocity), length 1 or the batch length. Units: (*m*; *m/s*)
+///
+/// # Returns
+/// - Cartesian GCRF states (position, velocity) in input order. Units: (*m*; *m/s*)
+/// - Error if the lengths do not satisfy the broadcast rule or the ephemeris cannot be evaluated
+///
+/// # Examples
+/// ```
+/// use brahe::frames::states_emr_to_gcrf;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use brahe::vector6_from_array;
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let epochs = vec![epc, epc + 3600.0, epc + 7200.0];
+/// let states = vec![vector6_from_array([7.0e6, 0.0, 0.0, 0.0, 7.5e3, 0.0]); 3];
+/// let out = states_emr_to_gcrf(&epochs, &states).unwrap();
+/// assert_eq!(out.len(), 3);
+/// ```
+pub fn states_emr_to_gcrf(
+    epochs: &[Epoch],
+    x_emr: &[SVector6],
+) -> Result<Vec<SVector6>, BraheError> {
+    try_batch_map_epochs(epochs, x_emr, emr_state_context, |c, x| {
+        Ok(apply_state_synodic_to_inertial(c, x))
+    })
+}
+
+/// Transforms a batch of Cartesian states from GCRF to Sun-Earth Rotating (SER).
+///
+/// Batch form of [`state_gcrf_to_ser`]. `epochs` and the vector argument follow the
+/// broadcast rule: each has length 1 or the common batch length. A single
+/// epoch evaluates the synodic axes and origin offset once and applies them
+/// to every element. Evaluation runs on the global thread pool for large
+/// inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x_gcrf`: Cartesian GCRF states (position, velocity), length 1 or the batch length. Units: (*m*; *m/s*)
+///
+/// # Returns
+/// - Cartesian SER states (position, velocity) in input order. Units: (*m*; *m/s*)
+/// - Error if the lengths do not satisfy the broadcast rule or the ephemeris cannot be evaluated
+///
+/// # Examples
+/// ```
+/// use brahe::frames::states_gcrf_to_ser;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use brahe::vector6_from_array;
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let epochs = vec![epc, epc + 3600.0, epc + 7200.0];
+/// let states = vec![vector6_from_array([7.0e6, 0.0, 0.0, 0.0, 7.5e3, 0.0]); 3];
+/// let out = states_gcrf_to_ser(&epochs, &states).unwrap();
+/// assert_eq!(out.len(), 3);
+/// ```
+pub fn states_gcrf_to_ser(
+    epochs: &[Epoch],
+    x_gcrf: &[SVector6],
+) -> Result<Vec<SVector6>, BraheError> {
+    try_batch_map_epochs(epochs, x_gcrf, ser_state_context, |c, x| {
+        Ok(apply_state_inertial_to_synodic(c, x))
+    })
+}
+
+/// Transforms a batch of Cartesian states from Sun-Earth Rotating (SER) to GCRF.
+///
+/// Batch form of [`state_ser_to_gcrf`]. `epochs` and the vector argument follow the
+/// broadcast rule: each has length 1 or the common batch length. A single
+/// epoch evaluates the synodic axes and origin offset once and applies them
+/// to every element. Evaluation runs on the global thread pool for large
+/// inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x_ser`: Cartesian SER states (position, velocity), length 1 or the batch length. Units: (*m*; *m/s*)
+///
+/// # Returns
+/// - Cartesian GCRF states (position, velocity) in input order. Units: (*m*; *m/s*)
+/// - Error if the lengths do not satisfy the broadcast rule or the ephemeris cannot be evaluated
+///
+/// # Examples
+/// ```
+/// use brahe::frames::states_ser_to_gcrf;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use brahe::vector6_from_array;
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let epochs = vec![epc, epc + 3600.0, epc + 7200.0];
+/// let states = vec![vector6_from_array([7.0e6, 0.0, 0.0, 0.0, 7.5e3, 0.0]); 3];
+/// let out = states_ser_to_gcrf(&epochs, &states).unwrap();
+/// assert_eq!(out.len(), 3);
+/// ```
+pub fn states_ser_to_gcrf(
+    epochs: &[Epoch],
+    x_ser: &[SVector6],
+) -> Result<Vec<SVector6>, BraheError> {
+    try_batch_map_epochs(epochs, x_ser, ser_state_context, |c, x| {
+        Ok(apply_state_synodic_to_inertial(c, x))
+    })
+}
+
+/// Transforms a batch of Cartesian states from GCRF to Geocentric Solar Ecliptic (GSE).
+///
+/// Batch form of [`state_gcrf_to_gse`]. `epochs` and the vector argument follow the
+/// broadcast rule: each has length 1 or the common batch length. A single
+/// epoch evaluates the synodic axes and origin offset once and applies them
+/// to every element. Evaluation runs on the global thread pool for large
+/// inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x_gcrf`: Cartesian GCRF states (position, velocity), length 1 or the batch length. Units: (*m*; *m/s*)
+///
+/// # Returns
+/// - Cartesian GSE states (position, velocity) in input order. Units: (*m*; *m/s*)
+/// - Error if the lengths do not satisfy the broadcast rule or the ephemeris cannot be evaluated
+///
+/// # Examples
+/// ```
+/// use brahe::frames::states_gcrf_to_gse;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use brahe::vector6_from_array;
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let epochs = vec![epc, epc + 3600.0, epc + 7200.0];
+/// let states = vec![vector6_from_array([7.0e6, 0.0, 0.0, 0.0, 7.5e3, 0.0]); 3];
+/// let out = states_gcrf_to_gse(&epochs, &states).unwrap();
+/// assert_eq!(out.len(), 3);
+/// ```
+pub fn states_gcrf_to_gse(
+    epochs: &[Epoch],
+    x_gcrf: &[SVector6],
+) -> Result<Vec<SVector6>, BraheError> {
+    try_batch_map_epochs(epochs, x_gcrf, gse_axes, |(r_mat, r_dot_mat), x| {
+        Ok(state_inertial_to_synodic(r_mat, r_dot_mat, *x))
+    })
+}
+
+/// Transforms a batch of Cartesian states from Geocentric Solar Ecliptic (GSE) to GCRF.
+///
+/// Batch form of [`state_gse_to_gcrf`]. `epochs` and the vector argument follow the
+/// broadcast rule: each has length 1 or the common batch length. A single
+/// epoch evaluates the synodic axes and origin offset once and applies them
+/// to every element. Evaluation runs on the global thread pool for large
+/// inputs.
+///
+/// # Arguments
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x_gse`: Cartesian GSE states (position, velocity), length 1 or the batch length. Units: (*m*; *m/s*)
+///
+/// # Returns
+/// - Cartesian GCRF states (position, velocity) in input order. Units: (*m*; *m/s*)
+/// - Error if the lengths do not satisfy the broadcast rule or the ephemeris cannot be evaluated
+///
+/// # Examples
+/// ```
+/// use brahe::frames::states_gse_to_gcrf;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use brahe::vector6_from_array;
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let epochs = vec![epc, epc + 3600.0, epc + 7200.0];
+/// let states = vec![vector6_from_array([7.0e6, 0.0, 0.0, 0.0, 7.5e3, 0.0]); 3];
+/// let out = states_gse_to_gcrf(&epochs, &states).unwrap();
+/// assert_eq!(out.len(), 3);
+/// ```
+pub fn states_gse_to_gcrf(
+    epochs: &[Epoch],
+    x_gse: &[SVector6],
+) -> Result<Vec<SVector6>, BraheError> {
+    try_batch_map_epochs(epochs, x_gse, gse_axes, |(r_mat, r_dot_mat), x| {
+        Ok(state_synodic_to_inertial(r_mat, r_dot_mat, *x))
+    })
 }
 
 #[cfg(test)]
@@ -1273,5 +1950,94 @@ mod tests {
         let x_pair = pair_barycenter_state(epc, 10, 399).unwrap();
         let x_seb = sun_earth_barycenter_state(epc).unwrap();
         assert_abs_diff_eq!(x_pair, x_seb, epsilon = 0.0);
+    }
+
+    #[test]
+    #[serial]
+    fn test_batch_synodic_frames_match_scalar() {
+        setup_global_test_spice();
+        let epc0 = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+        let epochs: Vec<Epoch> = (0..3).map(|i| epc0 + 3600.0 * i as f64).collect();
+        let states: Vec<SVector6> = (0..3)
+            .map(|i| SVector6::new(7.0e6 + 1e3 * i as f64, 1.0e6, -2.0e6, 0.0, 7.5e3, 0.0))
+            .collect();
+        let positions: Vec<Vector3<f64>> = states
+            .iter()
+            .map(|s| Vector3::new(s[0], s[1], s[2]))
+            .collect();
+
+        macro_rules! check_family {
+            ($rot_f:ident, $rot_b:ident, $pos_f:ident, $pos_b:ident, $st_f:ident, $st_b:ident,
+             $rots_f:ident, $rots_b:ident, $poss_f:ident, $poss_b:ident, $sts_f:ident, $sts_b:ident) => {{
+                let rf = $rots_f(&epochs).unwrap();
+                let rb = $rots_b(&epochs).unwrap();
+                let pf = $poss_f(&epochs, &positions).unwrap();
+                let pf1 = $poss_f(&epochs[..1], &positions).unwrap();
+                let pb = $poss_b(&epochs, &pf).unwrap();
+                let sf = $sts_f(&epochs, &states).unwrap();
+                let sf1 = $sts_f(&epochs[..1], &states).unwrap();
+                let sb = $sts_b(&epochs, &sf).unwrap();
+                let one = $sts_b(&epochs, &states[..1]).unwrap();
+                for i in 0..3 {
+                    assert_eq!(rf[i], $rot_f(epochs[i]).unwrap());
+                    assert_eq!(rb[i], $rot_b(epochs[i]).unwrap());
+                    assert_eq!(pf[i], $pos_f(epochs[i], positions[i]).unwrap());
+                    assert_eq!(pf1[i], $pos_f(epochs[0], positions[i]).unwrap());
+                    assert_eq!(pb[i], $pos_b(epochs[i], pf[i]).unwrap());
+                    assert_eq!(sf[i], $st_f(epochs[i], states[i]).unwrap());
+                    assert_eq!(sf1[i], $st_f(epochs[0], states[i]).unwrap());
+                    assert_eq!(sb[i], $st_b(epochs[i], sf[i]).unwrap());
+                    assert_eq!(one[i], $st_b(epochs[i], states[0]).unwrap());
+                    for k in 0..3 {
+                        assert_abs_diff_eq!(sb[i][k], states[i][k], epsilon = 1e-3);
+                    }
+                }
+                assert!($sts_f(&epochs[..2], &states).is_err());
+                assert!($rots_f(&[]).unwrap().is_empty());
+            }};
+        }
+
+        check_family!(
+            rotation_gcrf_to_emr,
+            rotation_emr_to_gcrf,
+            position_gcrf_to_emr,
+            position_emr_to_gcrf,
+            state_gcrf_to_emr,
+            state_emr_to_gcrf,
+            rotations_gcrf_to_emr,
+            rotations_emr_to_gcrf,
+            positions_gcrf_to_emr,
+            positions_emr_to_gcrf,
+            states_gcrf_to_emr,
+            states_emr_to_gcrf
+        );
+        check_family!(
+            rotation_gcrf_to_ser,
+            rotation_ser_to_gcrf,
+            position_gcrf_to_ser,
+            position_ser_to_gcrf,
+            state_gcrf_to_ser,
+            state_ser_to_gcrf,
+            rotations_gcrf_to_ser,
+            rotations_ser_to_gcrf,
+            positions_gcrf_to_ser,
+            positions_ser_to_gcrf,
+            states_gcrf_to_ser,
+            states_ser_to_gcrf
+        );
+        check_family!(
+            rotation_gcrf_to_gse,
+            rotation_gse_to_gcrf,
+            position_gcrf_to_gse,
+            position_gse_to_gcrf,
+            state_gcrf_to_gse,
+            state_gse_to_gcrf,
+            rotations_gcrf_to_gse,
+            rotations_gse_to_gcrf,
+            positions_gcrf_to_gse,
+            positions_gse_to_gcrf,
+            states_gcrf_to_gse,
+            states_gse_to_gcrf
+        );
     }
 }

--- a/src/frames/synodic.rs
+++ b/src/frames/synodic.rs
@@ -1134,7 +1134,7 @@ pub fn state_gse_to_gcrf(epc: Epoch, x_gse: SVector6) -> Result<SVector6, BraheE
 /// assert_eq!(r.len(), 2);
 /// ```
 pub fn rotations_gcrf_to_emr(epochs: &[Epoch]) -> Result<Vec<SMatrix3>, BraheError> {
-    try_batch_map(epochs, |epc| rotation_gcrf_to_emr(*epc))
+    try_batch_map(|epc| rotation_gcrf_to_emr(*epc), epochs)
 }
 
 /// Computes the Earth-Moon Rotating (EMR) to GCRF rotation matrix for each epoch in `epochs`.
@@ -1160,7 +1160,7 @@ pub fn rotations_gcrf_to_emr(epochs: &[Epoch]) -> Result<Vec<SMatrix3>, BraheErr
 /// assert_eq!(r.len(), 2);
 /// ```
 pub fn rotations_emr_to_gcrf(epochs: &[Epoch]) -> Result<Vec<SMatrix3>, BraheError> {
-    try_batch_map(epochs, |epc| rotation_emr_to_gcrf(*epc))
+    try_batch_map(|epc| rotation_emr_to_gcrf(*epc), epochs)
 }
 
 /// Computes the GCRF to Sun-Earth Rotating (SER) rotation matrix for each epoch in `epochs`.
@@ -1186,7 +1186,7 @@ pub fn rotations_emr_to_gcrf(epochs: &[Epoch]) -> Result<Vec<SMatrix3>, BraheErr
 /// assert_eq!(r.len(), 2);
 /// ```
 pub fn rotations_gcrf_to_ser(epochs: &[Epoch]) -> Result<Vec<SMatrix3>, BraheError> {
-    try_batch_map(epochs, |epc| rotation_gcrf_to_ser(*epc))
+    try_batch_map(|epc| rotation_gcrf_to_ser(*epc), epochs)
 }
 
 /// Computes the Sun-Earth Rotating (SER) to GCRF rotation matrix for each epoch in `epochs`.
@@ -1212,7 +1212,7 @@ pub fn rotations_gcrf_to_ser(epochs: &[Epoch]) -> Result<Vec<SMatrix3>, BraheErr
 /// assert_eq!(r.len(), 2);
 /// ```
 pub fn rotations_ser_to_gcrf(epochs: &[Epoch]) -> Result<Vec<SMatrix3>, BraheError> {
-    try_batch_map(epochs, |epc| rotation_ser_to_gcrf(*epc))
+    try_batch_map(|epc| rotation_ser_to_gcrf(*epc), epochs)
 }
 
 /// Computes the GCRF to Geocentric Solar Ecliptic (GSE) rotation matrix for each epoch in `epochs`.
@@ -1238,7 +1238,7 @@ pub fn rotations_ser_to_gcrf(epochs: &[Epoch]) -> Result<Vec<SMatrix3>, BraheErr
 /// assert_eq!(r.len(), 2);
 /// ```
 pub fn rotations_gcrf_to_gse(epochs: &[Epoch]) -> Result<Vec<SMatrix3>, BraheError> {
-    try_batch_map(epochs, |epc| rotation_gcrf_to_gse(*epc))
+    try_batch_map(|epc| rotation_gcrf_to_gse(*epc), epochs)
 }
 
 /// Computes the Geocentric Solar Ecliptic (GSE) to GCRF rotation matrix for each epoch in `epochs`.
@@ -1264,7 +1264,7 @@ pub fn rotations_gcrf_to_gse(epochs: &[Epoch]) -> Result<Vec<SMatrix3>, BraheErr
 /// assert_eq!(r.len(), 2);
 /// ```
 pub fn rotations_gse_to_gcrf(epochs: &[Epoch]) -> Result<Vec<SMatrix3>, BraheError> {
-    try_batch_map(epochs, |epc| rotation_gse_to_gcrf(*epc))
+    try_batch_map(|epc| rotation_gse_to_gcrf(*epc), epochs)
 }
 
 /// Transforms a batch of Cartesian positions from GCRF to Earth-Moon Rotating (EMR).
@@ -1298,9 +1298,12 @@ pub fn positions_gcrf_to_emr(
     epochs: &[Epoch],
     x_gcrf: &[Vector3<f64>],
 ) -> Result<Vec<Vector3<f64>>, BraheError> {
-    try_batch_map_epochs(epochs, x_gcrf, emr_position_context, |c, x| {
-        Ok(apply_position_inertial_to_synodic(c, x))
-    })
+    try_batch_map_epochs(
+        emr_position_context,
+        |c, x| Ok(apply_position_inertial_to_synodic(c, x)),
+        epochs,
+        x_gcrf,
+    )
 }
 
 /// Transforms a batch of Cartesian positions from Earth-Moon Rotating (EMR) to GCRF.
@@ -1334,9 +1337,12 @@ pub fn positions_emr_to_gcrf(
     epochs: &[Epoch],
     x_emr: &[Vector3<f64>],
 ) -> Result<Vec<Vector3<f64>>, BraheError> {
-    try_batch_map_epochs(epochs, x_emr, emr_position_context, |c, x| {
-        Ok(apply_position_synodic_to_inertial(c, x))
-    })
+    try_batch_map_epochs(
+        emr_position_context,
+        |c, x| Ok(apply_position_synodic_to_inertial(c, x)),
+        epochs,
+        x_emr,
+    )
 }
 
 /// Transforms a batch of Cartesian positions from GCRF to Sun-Earth Rotating (SER).
@@ -1370,9 +1376,12 @@ pub fn positions_gcrf_to_ser(
     epochs: &[Epoch],
     x_gcrf: &[Vector3<f64>],
 ) -> Result<Vec<Vector3<f64>>, BraheError> {
-    try_batch_map_epochs(epochs, x_gcrf, ser_position_context, |c, x| {
-        Ok(apply_position_inertial_to_synodic(c, x))
-    })
+    try_batch_map_epochs(
+        ser_position_context,
+        |c, x| Ok(apply_position_inertial_to_synodic(c, x)),
+        epochs,
+        x_gcrf,
+    )
 }
 
 /// Transforms a batch of Cartesian positions from Sun-Earth Rotating (SER) to GCRF.
@@ -1406,9 +1415,12 @@ pub fn positions_ser_to_gcrf(
     epochs: &[Epoch],
     x_ser: &[Vector3<f64>],
 ) -> Result<Vec<Vector3<f64>>, BraheError> {
-    try_batch_map_epochs(epochs, x_ser, ser_position_context, |c, x| {
-        Ok(apply_position_synodic_to_inertial(c, x))
-    })
+    try_batch_map_epochs(
+        ser_position_context,
+        |c, x| Ok(apply_position_synodic_to_inertial(c, x)),
+        epochs,
+        x_ser,
+    )
 }
 
 /// Transforms a batch of Cartesian positions from GCRF to Geocentric Solar Ecliptic (GSE).
@@ -1442,7 +1454,7 @@ pub fn positions_gcrf_to_gse(
     epochs: &[Epoch],
     x_gcrf: &[Vector3<f64>],
 ) -> Result<Vec<Vector3<f64>>, BraheError> {
-    try_batch_map_epochs(epochs, x_gcrf, gse_axes, |(r_mat, _), x| Ok(r_mat * x))
+    try_batch_map_epochs(gse_axes, |(r_mat, _), x| Ok(r_mat * x), epochs, x_gcrf)
 }
 
 /// Transforms a batch of Cartesian positions from Geocentric Solar Ecliptic (GSE) to GCRF.
@@ -1476,9 +1488,12 @@ pub fn positions_gse_to_gcrf(
     epochs: &[Epoch],
     x_gse: &[Vector3<f64>],
 ) -> Result<Vec<Vector3<f64>>, BraheError> {
-    try_batch_map_epochs(epochs, x_gse, gse_axes, |(r_mat, _), x| {
-        Ok(r_mat.transpose() * x)
-    })
+    try_batch_map_epochs(
+        gse_axes,
+        |(r_mat, _), x| Ok(r_mat.transpose() * x),
+        epochs,
+        x_gse,
+    )
 }
 
 /// Transforms a batch of Cartesian states from GCRF to Earth-Moon Rotating (EMR).
@@ -1513,9 +1528,12 @@ pub fn states_gcrf_to_emr(
     epochs: &[Epoch],
     x_gcrf: &[SVector6],
 ) -> Result<Vec<SVector6>, BraheError> {
-    try_batch_map_epochs(epochs, x_gcrf, emr_state_context, |c, x| {
-        Ok(apply_state_inertial_to_synodic(c, x))
-    })
+    try_batch_map_epochs(
+        emr_state_context,
+        |c, x| Ok(apply_state_inertial_to_synodic(c, x)),
+        epochs,
+        x_gcrf,
+    )
 }
 
 /// Transforms a batch of Cartesian states from Earth-Moon Rotating (EMR) to GCRF.
@@ -1550,9 +1568,12 @@ pub fn states_emr_to_gcrf(
     epochs: &[Epoch],
     x_emr: &[SVector6],
 ) -> Result<Vec<SVector6>, BraheError> {
-    try_batch_map_epochs(epochs, x_emr, emr_state_context, |c, x| {
-        Ok(apply_state_synodic_to_inertial(c, x))
-    })
+    try_batch_map_epochs(
+        emr_state_context,
+        |c, x| Ok(apply_state_synodic_to_inertial(c, x)),
+        epochs,
+        x_emr,
+    )
 }
 
 /// Transforms a batch of Cartesian states from GCRF to Sun-Earth Rotating (SER).
@@ -1587,9 +1608,12 @@ pub fn states_gcrf_to_ser(
     epochs: &[Epoch],
     x_gcrf: &[SVector6],
 ) -> Result<Vec<SVector6>, BraheError> {
-    try_batch_map_epochs(epochs, x_gcrf, ser_state_context, |c, x| {
-        Ok(apply_state_inertial_to_synodic(c, x))
-    })
+    try_batch_map_epochs(
+        ser_state_context,
+        |c, x| Ok(apply_state_inertial_to_synodic(c, x)),
+        epochs,
+        x_gcrf,
+    )
 }
 
 /// Transforms a batch of Cartesian states from Sun-Earth Rotating (SER) to GCRF.
@@ -1624,9 +1648,12 @@ pub fn states_ser_to_gcrf(
     epochs: &[Epoch],
     x_ser: &[SVector6],
 ) -> Result<Vec<SVector6>, BraheError> {
-    try_batch_map_epochs(epochs, x_ser, ser_state_context, |c, x| {
-        Ok(apply_state_synodic_to_inertial(c, x))
-    })
+    try_batch_map_epochs(
+        ser_state_context,
+        |c, x| Ok(apply_state_synodic_to_inertial(c, x)),
+        epochs,
+        x_ser,
+    )
 }
 
 /// Transforms a batch of Cartesian states from GCRF to Geocentric Solar Ecliptic (GSE).
@@ -1661,9 +1688,12 @@ pub fn states_gcrf_to_gse(
     epochs: &[Epoch],
     x_gcrf: &[SVector6],
 ) -> Result<Vec<SVector6>, BraheError> {
-    try_batch_map_epochs(epochs, x_gcrf, gse_axes, |(r_mat, r_dot_mat), x| {
-        Ok(state_inertial_to_synodic(r_mat, r_dot_mat, *x))
-    })
+    try_batch_map_epochs(
+        gse_axes,
+        |(r_mat, r_dot_mat), x| Ok(state_inertial_to_synodic(r_mat, r_dot_mat, *x)),
+        epochs,
+        x_gcrf,
+    )
 }
 
 /// Transforms a batch of Cartesian states from Geocentric Solar Ecliptic (GSE) to GCRF.
@@ -1698,9 +1728,12 @@ pub fn states_gse_to_gcrf(
     epochs: &[Epoch],
     x_gse: &[SVector6],
 ) -> Result<Vec<SVector6>, BraheError> {
-    try_batch_map_epochs(epochs, x_gse, gse_axes, |(r_mat, r_dot_mat), x| {
-        Ok(state_synodic_to_inertial(r_mat, r_dot_mat, *x))
-    })
+    try_batch_map_epochs(
+        gse_axes,
+        |(r_mat, r_dot_mat), x| Ok(state_synodic_to_inertial(r_mat, r_dot_mat, *x)),
+        epochs,
+        x_gse,
+    )
 }
 
 #[cfg(test)]

--- a/src/frames/transform.rs
+++ b/src/frames/transform.rs
@@ -543,6 +543,17 @@ pub(crate) struct RotatingFrameContext {
 ///
 /// # Returns
 /// - Cartesian state in the body-fixed frame. Units: (*m*; *m/s*)
+///
+/// # Examples
+///
+/// ```ignore
+/// use brahe::vector6_from_array;
+/// use nalgebra::Vector3;
+/// use brahe::math::SMatrix3;
+///
+/// let c = RotatingFrameContext { r_mat: SMatrix3::identity(), omega_b: Vector3::new(0.0, 0.0, 7.29e-5) };
+/// let x_body = apply_state_icrf_to_rotating(&c, &vector6_from_array([7.0e6, 0.0, 0.0, 0.0, 7.5e3, 0.0]));
+/// ```
 pub(crate) fn apply_state_icrf_to_rotating(
     c: &RotatingFrameContext,
     x_icrf: &SVector6,
@@ -559,6 +570,17 @@ pub(crate) fn apply_state_icrf_to_rotating(
 ///
 /// # Returns
 /// - Cartesian state in ICRF axes. Units: (*m*; *m/s*)
+///
+/// # Examples
+///
+/// ```ignore
+/// use brahe::vector6_from_array;
+/// use nalgebra::Vector3;
+/// use brahe::math::SMatrix3;
+///
+/// let c = RotatingFrameContext { r_mat: SMatrix3::identity(), omega_b: Vector3::new(0.0, 0.0, 7.29e-5) };
+/// let x_icrf = apply_state_rotating_to_icrf(&c, &vector6_from_array([7.0e6, 0.0, 0.0, 0.0, 7.0e3, 0.0]));
+/// ```
 pub(crate) fn apply_state_rotating_to_icrf(
     c: &RotatingFrameContext,
     x_body: &SVector6,
@@ -771,6 +793,17 @@ struct FramePairContext {
 /// # Returns
 /// - Context holding the ICRF -> `from` matrix, the `from` -> `to` center
 ///   offset (absent when the centers coincide), and the ICRF -> `to` matrix
+///
+/// # Examples
+///
+/// ```ignore
+/// use brahe::frames::ReferenceFrame;
+/// use brahe::time::{Epoch, TimeSystem};
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let c = frame_pair_context(ReferenceFrame::GCRF, ReferenceFrame::ITRF, epc).unwrap();
+/// // c.offset is None because both frames share the Earth center
+/// ```
 fn frame_pair_context(
     from: ReferenceFrame,
     to: ReferenceFrame,
@@ -799,6 +832,18 @@ fn frame_pair_context(
 ///
 /// # Returns
 /// - Cartesian position in the target frame. Units: (*m*)
+///
+/// # Examples
+///
+/// ```ignore
+/// use brahe::frames::ReferenceFrame;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use nalgebra::Vector3;
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let c = frame_pair_context(ReferenceFrame::GCRF, ReferenceFrame::ITRF, epc).unwrap();
+/// let x_itrf = apply_position_frame_pair(&c, &Vector3::new(7.0e6, 0.0, 0.0));
+/// ```
 fn apply_position_frame_pair(c: &FramePairContext, x: &Vector3<f64>) -> Vector3<f64> {
     let x_icrf = c.r_from.transpose() * x;
     let x_translated = match c.offset {

--- a/src/frames/transform.rs
+++ b/src/frames/transform.rs
@@ -69,6 +69,7 @@ use crate::math::{SMatrix3, SVector6};
 use crate::spice::NAIFId;
 use crate::time::Epoch;
 use crate::utils::BraheError;
+use crate::utils::batch::{try_batch_map, try_batch_map_epochs};
 
 use super::eme_2000::rotation_gcrf_to_eme2000;
 use super::gcrf_itrf::rotation_gcrf_to_itrf;
@@ -526,6 +527,45 @@ fn state_rotating_to_icrf(r_mat: SMatrix3, omega_b: Vector3<f64>, x_body: SVecto
     SVector6::new(r[0], r[1], r[2], v[0], v[1], v[2])
 }
 
+/// ICRF-to-body-fixed rotation matrix and body-frame angular velocity of a
+/// rotating frame at one epoch, shared by the lunar and Mars body-fixed
+/// transformations and their batch forms.
+pub(crate) struct RotatingFrameContext {
+    pub(crate) r_mat: SMatrix3,
+    pub(crate) omega_b: Vector3<f64>,
+}
+
+/// Apply a precomputed rotating-frame context to one ICRF-axes state.
+///
+/// # Arguments
+/// - `c`: Rotation matrix and angular velocity for the epoch
+/// - `x_icrf`: Cartesian state in ICRF axes (position, velocity). Units: (*m*; *m/s*)
+///
+/// # Returns
+/// - Cartesian state in the body-fixed frame. Units: (*m*; *m/s*)
+pub(crate) fn apply_state_icrf_to_rotating(
+    c: &RotatingFrameContext,
+    x_icrf: &SVector6,
+) -> SVector6 {
+    state_icrf_to_rotating(c.r_mat, c.omega_b, *x_icrf)
+}
+
+/// Apply a precomputed rotating-frame context to one body-fixed state,
+/// producing the ICRF-axes state.
+///
+/// # Arguments
+/// - `c`: Rotation matrix and angular velocity for the epoch
+/// - `x_body`: Cartesian state in the body-fixed frame (position, velocity). Units: (*m*; *m/s*)
+///
+/// # Returns
+/// - Cartesian state in ICRF axes. Units: (*m*; *m/s*)
+pub(crate) fn apply_state_rotating_to_icrf(
+    c: &RotatingFrameContext,
+    x_body: &SVector6,
+) -> SVector6 {
+    state_rotating_to_icrf(c.r_mat, c.omega_b, *x_body)
+}
+
 /// Rotates an ICRF-axis state into the IAU/WGCCRE body-fixed frame of
 /// `naif_id`, including the velocity transport term induced by the
 /// body's rotation. Generic form of [`super::mars::state_mci_to_mcmf`],
@@ -707,16 +747,65 @@ pub fn position_frame_to_frame(
     if from == to {
         return Ok(x);
     }
+    Ok(apply_position_frame_pair(
+        &frame_pair_context(from, to, epc)?,
+        &x,
+    ))
+}
+
+/// Source and target ICRF rotation matrices and the center offset (ICRF
+/// axes) between two frames at one epoch.
+struct FramePairContext {
+    r_from: SMatrix3,
+    offset: Option<Vector3<f64>>,
+    r_to: SMatrix3,
+}
+
+/// Compute the position-transform context for a pair of frames at `epc`.
+///
+/// # Arguments
+/// - `from`: Source reference frame
+/// - `to`: Target reference frame
+/// - `epc`: Epoch instant for computation of the transformation
+///
+/// # Returns
+/// - Context holding the ICRF -> `from` matrix, the `from` -> `to` center
+///   offset (absent when the centers coincide), and the ICRF -> `to` matrix
+fn frame_pair_context(
+    from: ReferenceFrame,
+    to: ReferenceFrame,
+    epc: Epoch,
+) -> Result<FramePairContext, BraheError> {
     let r_from = icrf_to_frame_dcm(from, epc)?;
-    let x_icrf = r_from.transpose() * x;
-    let x_translated = if from.center_naif_id() == to.center_naif_id() {
-        x_icrf
+    let offset = if from.center_naif_id() == to.center_naif_id() {
+        None
     } else {
         let offset = center_offset_state(from.center_naif_id(), to.center_naif_id(), epc)?;
-        x_icrf - offset.fixed_rows::<3>(0).into_owned()
+        Some(offset.fixed_rows::<3>(0).into_owned())
     };
     let r_to = icrf_to_frame_dcm(to, epc)?;
-    Ok(r_to * x_translated)
+    Ok(FramePairContext {
+        r_from,
+        offset,
+        r_to,
+    })
+}
+
+/// Apply a precomputed frame-pair context to one position.
+///
+/// # Arguments
+/// - `c`: Frame-pair context for the epoch
+/// - `x`: Cartesian position in the source frame. Units: (*m*)
+///
+/// # Returns
+/// - Cartesian position in the target frame. Units: (*m*)
+fn apply_position_frame_pair(c: &FramePairContext, x: &Vector3<f64>) -> Vector3<f64> {
+    let x_icrf = c.r_from.transpose() * x;
+    let x_translated = match c.offset {
+        None => x_icrf,
+        Some(offset) => x_icrf - offset,
+    };
+    c.r_to * x_translated
 }
 
 /// Transforms a Cartesian state (position and velocity) from `from` to
@@ -770,6 +859,141 @@ pub fn state_frame_to_frame(
         x_icrf - center_offset_state(from.center_naif_id(), to.center_naif_id(), epc)?
     };
     to.state_from_icrf_axes(epc, x_translated)
+}
+
+/// Computes the rotation matrix from `from` to `to` for each epoch in `epochs`.
+///
+/// Batch form of [`rotation_frame_to_frame`]. Evaluation runs on the global
+/// thread pool for large inputs.
+///
+/// # Arguments
+/// - `from`: Source reference frame
+/// - `to`: Target reference frame
+/// - `epochs`: Epoch instants for computation of the transformation matrices
+///
+/// # Returns
+/// - Rotation matrices transforming `from` -> `to`, one per epoch, in input order
+/// - Error if any epoch's transformation cannot be evaluated
+///
+/// # Examples:
+/// ```
+/// use brahe::frames::{ReferenceFrame, rotations_frame_to_frame};
+/// use brahe::time::{Epoch, TimeSystem};
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let epochs = vec![epc, epc + 60.0];
+/// let r = rotations_frame_to_frame(ReferenceFrame::MCI, ReferenceFrame::MCMF, &epochs).unwrap();
+/// assert_eq!(r.len(), 2);
+/// ```
+pub fn rotations_frame_to_frame(
+    from: ReferenceFrame,
+    to: ReferenceFrame,
+    epochs: &[Epoch],
+) -> Result<Vec<SMatrix3>, BraheError> {
+    try_batch_map(epochs, |epc| rotation_frame_to_frame(from, to, *epc))
+}
+
+/// Transforms a batch of Cartesian positions from `from` to `to`.
+///
+/// Batch form of [`position_frame_to_frame`]. `epochs` and `x` follow the
+/// broadcast rule: each has length 1 or the common batch length. A single
+/// epoch computes the frame-pair rotation matrices and center offset once and
+/// applies them to every position; per-element epochs compute them per
+/// position. Evaluation runs on the global thread pool for large inputs.
+///
+/// # Arguments
+/// - `from`: Source reference frame
+/// - `to`: Target reference frame
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x`: Cartesian positions in `from`, length 1 or the batch length. Units: (*m*)
+///
+/// # Returns
+/// - Cartesian positions in `to`, in input order. Units: (*m*)
+/// - Error if the lengths do not satisfy the broadcast rule or a
+///   transformation cannot be evaluated
+///
+/// # Examples:
+/// ```
+/// use brahe::eop::*;
+/// use brahe::constants::R_EARTH;
+/// use brahe::vector3_from_array;
+/// use brahe::frames::{ReferenceFrame, positions_frame_to_frame};
+/// use brahe::time::{Epoch, TimeSystem};
+///
+/// let eop = FileEOPProvider::from_default_file(EOPType::StandardBulletinA, true, EOPExtrapolation::Zero).unwrap();
+/// set_global_eop_provider(eop);
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let positions = vec![vector3_from_array([R_EARTH + 500e3, 0.0, 0.0]); 3];
+/// let x_itrf = positions_frame_to_frame(ReferenceFrame::GCRF, ReferenceFrame::ITRF, &[epc], &positions).unwrap();
+/// assert_eq!(x_itrf.len(), 3);
+/// ```
+pub fn positions_frame_to_frame(
+    from: ReferenceFrame,
+    to: ReferenceFrame,
+    epochs: &[Epoch],
+    x: &[Vector3<f64>],
+) -> Result<Vec<Vector3<f64>>, BraheError> {
+    if from == to {
+        return try_batch_map_epochs(epochs, x, |_| Ok(()), |_, x| Ok(*x));
+    }
+    try_batch_map_epochs(
+        epochs,
+        x,
+        |epc| frame_pair_context(from, to, epc),
+        |c, x| Ok(apply_position_frame_pair(c, x)),
+    )
+}
+
+/// Transforms a batch of Cartesian states from `from` to `to`.
+///
+/// Batch form of [`state_frame_to_frame`]. `epochs` and `x` follow the
+/// broadcast rule: each has length 1 or the common batch length. The state
+/// router evaluates the scalar transformation for each element (the
+/// per-frame velocity transport terms are resolved through the frame's own
+/// state routines rather than a shared context), so the batch benefits from
+/// thread-pool evaluation for large inputs but not from shared-epoch
+/// hoisting; use the frame-specific `states_*` functions for that.
+///
+/// # Arguments
+/// - `from`: Source reference frame
+/// - `to`: Target reference frame
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `x`: Cartesian states in `from` (position, velocity), length 1 or the
+///   batch length. Units: (*m*; *m/s*)
+///
+/// # Returns
+/// - Cartesian states in `to`, in input order. Units: (*m*; *m/s*)
+/// - Error if the lengths do not satisfy the broadcast rule or a
+///   transformation cannot be evaluated
+///
+/// # Examples:
+/// ```
+/// use brahe::eop::*;
+/// use brahe::constants::R_EARTH;
+/// use brahe::vector6_from_array;
+/// use brahe::orbits::perigee_velocity;
+/// use brahe::frames::{ReferenceFrame, states_frame_to_frame};
+/// use brahe::time::{Epoch, TimeSystem};
+///
+/// let eop = FileEOPProvider::from_default_file(EOPType::StandardBulletinA, true, EOPExtrapolation::Zero).unwrap();
+/// set_global_eop_provider(eop);
+///
+/// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let v = perigee_velocity(R_EARTH + 500e3, 0.0);
+/// let states = vec![vector6_from_array([R_EARTH + 500e3, 0.0, 0.0, 0.0, v, 0.0]); 3];
+/// let x_itrf = states_frame_to_frame(ReferenceFrame::GCRF, ReferenceFrame::ITRF, &[epc], &states).unwrap();
+/// assert_eq!(x_itrf.len(), 3);
+/// ```
+pub fn states_frame_to_frame(
+    from: ReferenceFrame,
+    to: ReferenceFrame,
+    epochs: &[Epoch],
+    x: &[SVector6],
+) -> Result<Vec<SVector6>, BraheError> {
+    try_batch_map_epochs(epochs, x, Ok, |epc, x| {
+        state_frame_to_frame(from, to, *epc, *x)
+    })
 }
 
 /// State of `to_center` relative to `from_center` at `epc`, in ICRF axes.
@@ -1629,6 +1853,130 @@ mod tests {
         assert_eq!(
             f.to_string(),
             "Synodic(origin=Barycenter, primary=399, secondary=301)"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_batch_frame_to_frame_matches_scalar() {
+        setup_global_test_eop();
+        setup_global_test_spice();
+        let epc0 = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+        let epochs: Vec<Epoch> = (0..3).map(|i| epc0 + 600.0 * i as f64).collect();
+        let states: Vec<SVector6> = (0..3)
+            .map(|i| {
+                let oe =
+                    vector6_from_array([R_EARTH + 500e3, 0.01, 97.8, 15.0 + i as f64, 30.0, 45.0]);
+                state_koe_to_eci(oe, DEGREES)
+            })
+            .collect();
+        let positions: Vec<Vector3<f64>> = states
+            .iter()
+            .map(|s| Vector3::new(s[0], s[1], s[2]))
+            .collect();
+
+        let pairs = [
+            (ReferenceFrame::GCRF, ReferenceFrame::ITRF),
+            (ReferenceFrame::GCRF, ReferenceFrame::LFPA),
+            (ReferenceFrame::GCRF, ReferenceFrame::EMR),
+            (ReferenceFrame::ITRF, ReferenceFrame::MCMF),
+        ];
+        for (from, to) in pairs {
+            let rot = rotations_frame_to_frame(from, to, &epochs).unwrap();
+            let pos = positions_frame_to_frame(from, to, &epochs, &positions).unwrap();
+            let pos_shared = positions_frame_to_frame(from, to, &epochs[..1], &positions).unwrap();
+            let st = states_frame_to_frame(from, to, &epochs, &states).unwrap();
+            let st_shared = states_frame_to_frame(from, to, &epochs[..1], &states).unwrap();
+            for i in 0..3 {
+                assert_eq!(
+                    rot[i],
+                    rotation_frame_to_frame(from, to, epochs[i]).unwrap()
+                );
+                assert_eq!(
+                    pos[i],
+                    position_frame_to_frame(from, to, epochs[i], positions[i]).unwrap()
+                );
+                assert_eq!(
+                    pos_shared[i],
+                    position_frame_to_frame(from, to, epochs[0], positions[i]).unwrap()
+                );
+                assert_eq!(
+                    st[i],
+                    state_frame_to_frame(from, to, epochs[i], states[i]).unwrap()
+                );
+                assert_eq!(
+                    st_shared[i],
+                    state_frame_to_frame(from, to, epochs[0], states[i]).unwrap()
+                );
+            }
+        }
+
+        // Identity pair broadcasts without evaluation
+        let same = positions_frame_to_frame(
+            ReferenceFrame::GCRF,
+            ReferenceFrame::GCRF,
+            &epochs,
+            &positions,
+        )
+        .unwrap();
+        assert_eq!(same, positions);
+        let same = states_frame_to_frame(
+            ReferenceFrame::LCI,
+            ReferenceFrame::LCI,
+            &epochs[..1],
+            &states,
+        )
+        .unwrap();
+        assert_eq!(same, states);
+
+        // One position, many epochs
+        let one = positions_frame_to_frame(
+            ReferenceFrame::ITRF,
+            ReferenceFrame::GCRF,
+            &epochs,
+            &positions[..1],
+        )
+        .unwrap();
+        for i in 0..3 {
+            assert_eq!(
+                one[i],
+                position_frame_to_frame(
+                    ReferenceFrame::ITRF,
+                    ReferenceFrame::GCRF,
+                    epochs[i],
+                    positions[0]
+                )
+                .unwrap()
+            );
+        }
+
+        // Errors: broadcast mismatch and unsupported body
+        assert!(
+            states_frame_to_frame(
+                ReferenceFrame::GCRF,
+                ReferenceFrame::ITRF,
+                &epochs[..2],
+                &states
+            )
+            .is_err()
+        );
+        assert!(
+            rotations_frame_to_frame(
+                ReferenceFrame::GCRF,
+                ReferenceFrame::BodyFixedIAU(-1234),
+                &epochs
+            )
+            .is_err()
+        );
+        assert!(
+            positions_frame_to_frame(
+                ReferenceFrame::GCRF,
+                ReferenceFrame::ITRF,
+                &epochs[..1],
+                &[]
+            )
+            .unwrap()
+            .is_empty()
         );
     }
 }

--- a/src/frames/transform.rs
+++ b/src/frames/transform.rs
@@ -935,7 +935,7 @@ pub fn rotations_frame_to_frame(
     to: ReferenceFrame,
     epochs: &[Epoch],
 ) -> Result<Vec<SMatrix3>, BraheError> {
-    try_batch_map(epochs, |epc| rotation_frame_to_frame(from, to, *epc))
+    try_batch_map(|epc| rotation_frame_to_frame(from, to, *epc), epochs)
 }
 
 /// Transforms a batch of Cartesian positions from `from` to `to`.
@@ -980,13 +980,13 @@ pub fn positions_frame_to_frame(
     x: &[Vector3<f64>],
 ) -> Result<Vec<Vector3<f64>>, BraheError> {
     if from == to {
-        return try_batch_map_epochs(epochs, x, |_| Ok(()), |_, x| Ok(*x));
+        return try_batch_map_epochs(|_| Ok(()), |_, x| Ok(*x), epochs, x);
     }
     try_batch_map_epochs(
-        epochs,
-        x,
         |epc| frame_pair_context(from, to, epc),
         |c, x| Ok(apply_position_frame_pair(c, x)),
+        epochs,
+        x,
     )
 }
 
@@ -1036,9 +1036,12 @@ pub fn states_frame_to_frame(
     epochs: &[Epoch],
     x: &[SVector6],
 ) -> Result<Vec<SVector6>, BraheError> {
-    try_batch_map_epochs(epochs, x, Ok, |epc, x| {
-        state_frame_to_frame(from, to, *epc, *x)
-    })
+    try_batch_map_epochs(
+        Ok,
+        |epc, x| state_frame_to_frame(from, to, *epc, *x),
+        epochs,
+        x,
+    )
 }
 
 /// State of `to_center` relative to `from_center` at `epc`, in ICRF axes.

--- a/src/utils/batch.rs
+++ b/src/utils/batch.rs
@@ -216,6 +216,83 @@ pub(crate) fn batch_map_epochs<C: Sync, T: Sync, U: Send>(
     }
 }
 
+/// Evaluate a fallible `f` for every index in `0..n`, preserving order and
+/// stopping at the first error.
+///
+/// Runs on the global rayon thread pool when `n >= PARALLEL_THRESHOLD` and
+/// sequentially otherwise.
+///
+/// # Arguments
+///
+/// * `n` - Number of elements to evaluate
+/// * `f` - Fallible kernel evaluated at each index
+///
+/// # Returns
+///
+/// Vector of `n` results in index order, or the first error encountered.
+pub(crate) fn try_map_indices<U: Send, E: Send>(
+    n: usize,
+    f: impl Fn(usize) -> Result<U, E> + Sync,
+) -> Result<Vec<U>, E> {
+    if n >= PARALLEL_THRESHOLD {
+        get_thread_pool().install(|| (0..n).into_par_iter().map(&f).collect())
+    } else {
+        (0..n).map(&f).collect()
+    }
+}
+
+/// Apply a fallible `f` to every element of `inputs`.
+///
+/// # Arguments
+///
+/// * `inputs` - Elements to transform
+/// * `f` - Fallible element-wise kernel
+///
+/// # Returns
+///
+/// Vector with one output per input, in input order, or the first error.
+pub(crate) fn try_batch_map<T: Sync, U: Send, E: Send>(
+    inputs: &[T],
+    f: impl Fn(&T) -> Result<U, E> + Sync,
+) -> Result<Vec<U>, E> {
+    try_map_indices(inputs.len(), |i| f(&inputs[i]))
+}
+
+/// Apply a fallible epoch-dependent kernel across a batch, hoisting the epoch
+/// context when the batch shares a single epoch.
+///
+/// Fallible form of [`batch_map_epochs`]: both the context constructor and
+/// the kernel may fail, and the first error is returned.
+///
+/// # Arguments
+///
+/// * `epochs` - Epochs, length `1` or `N`
+/// * `inputs` - Elements to transform, length `1` or `N`
+/// * `context` - Builds the per-epoch context
+/// * `apply` - Applies a context to one input
+///
+/// # Returns
+///
+/// Vector of `N` results in index order, or an error if the lengths do not
+/// satisfy the broadcast rule or any evaluation fails.
+pub(crate) fn try_batch_map_epochs<C: Sync, T: Sync, U: Send>(
+    epochs: &[Epoch],
+    inputs: &[T],
+    context: impl Fn(Epoch) -> Result<C, BraheError> + Sync,
+    apply: impl Fn(&C, &T) -> Result<U, BraheError> + Sync,
+) -> Result<Vec<U>, BraheError> {
+    let n = broadcast_len(&[epochs.len(), inputs.len()])?;
+    if n == 0 {
+        return Ok(Vec::new());
+    }
+    if epochs.len() == 1 {
+        let c = context(epochs[0])?;
+        try_map_indices(n, |i| apply(&c, pick(inputs, i)))
+    } else {
+        try_map_indices(n, |i| apply(&context(epochs[i])?, pick(inputs, i)))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -458,5 +535,93 @@ mod tests {
 
         let out = batch_map_epochs(|e| e.gps_seconds(), |c, x| c + x, &epochs(0), &none).unwrap();
         assert!(out.is_empty());
+    }
+
+    #[test]
+    #[parallel]
+    fn test_try_batch_map_ok_and_error() {
+        let small = [1.0, 2.0, 3.0];
+        let ok: Result<Vec<f64>, String> = try_batch_map(&small, |x| Ok(x * 2.0));
+        assert_eq!(ok.unwrap(), vec![2.0, 4.0, 6.0]);
+
+        let err: Result<Vec<f64>, String> = try_batch_map(&small, |x| {
+            if *x > 2.0 {
+                Err("too big".to_string())
+            } else {
+                Ok(*x)
+            }
+        });
+        assert_eq!(err.unwrap_err(), "too big");
+
+        let large: Vec<f64> = (0..PARALLEL_THRESHOLD + 2).map(|i| i as f64).collect();
+        let out: Vec<f64> = try_batch_map(&large, |x| Ok::<f64, String>(x + 1.0)).unwrap();
+        let expected: Vec<f64> = large.iter().map(|x| x + 1.0).collect();
+        assert_eq!(out, expected);
+        let err: Result<Vec<f64>, String> = try_batch_map(&large, |x| {
+            if *x == 5.0 {
+                Err("five".to_string())
+            } else {
+                Ok(*x)
+            }
+        });
+        assert_eq!(err.unwrap_err(), "five");
+    }
+
+    #[test]
+    #[parallel]
+    fn test_try_batch_map_epochs_hoists_and_propagates_errors() {
+        let calls = AtomicUsize::new(0);
+        let inputs = [1.0, 2.0, 3.0];
+        let out = try_batch_map_epochs(
+            &epochs(1),
+            &inputs,
+            |e| {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Ok(e.gps_seconds())
+            },
+            |c, x| Ok(c + x),
+        )
+        .unwrap();
+        assert_eq!(out, vec![1.0, 2.0, 3.0]);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        let out = try_batch_map_epochs(
+            &epochs(3),
+            &inputs,
+            |e| Ok(e.gps_seconds()),
+            |c, x| Ok(c + x),
+        )
+        .unwrap();
+        assert_eq!(out.len(), 3);
+        for (got, want) in out.iter().zip([1.0, 62.0, 123.0]) {
+            assert_abs_diff_eq!(*got, want, epsilon = 1e-9);
+        }
+
+        let err = try_batch_map_epochs(
+            &epochs(1),
+            &inputs,
+            |_| Err::<f64, _>(BraheError::Error("no context".to_string())),
+            |c, x| Ok(c + x),
+        );
+        assert!(err.is_err());
+        let err = try_batch_map_epochs(
+            &epochs(3),
+            &inputs,
+            |e| Ok(e.gps_seconds()),
+            |_, x| {
+                if *x > 2.0 {
+                    Err(BraheError::Error("bad".to_string()))
+                } else {
+                    Ok(*x)
+                }
+            },
+        );
+        assert!(err.is_err());
+        assert!(try_batch_map_epochs(&epochs(2), &inputs, Ok, |_, x| Ok(*x)).is_err());
+        assert!(
+            try_batch_map_epochs(&epochs(1), &[] as &[f64], Ok, |_, x| Ok(*x))
+                .unwrap()
+                .is_empty()
+        );
     }
 }

--- a/src/utils/batch.rs
+++ b/src/utils/batch.rs
@@ -224,8 +224,8 @@ pub(crate) fn batch_map_epochs<C: Sync, T: Sync, U: Send>(
 ///
 /// # Arguments
 ///
-/// * `n` - Number of elements to evaluate
 /// * `f` - Fallible kernel evaluated at each index
+/// * `n` - Number of elements to evaluate
 ///
 /// # Returns
 ///
@@ -236,14 +236,14 @@ pub(crate) fn batch_map_epochs<C: Sync, T: Sync, U: Send>(
 /// ```ignore
 /// use crate::utils::batch::try_map_indices;
 ///
-/// let ok: Result<Vec<usize>, String> = try_map_indices(3, |i| Ok(i + 1));
+/// let ok: Result<Vec<usize>, String> = try_map_indices(|i| Ok(i + 1), 3);
 /// assert_eq!(ok.unwrap(), vec![1, 2, 3]);
-/// let err: Result<Vec<usize>, String> = try_map_indices(3, |i| if i == 1 { Err("one".into()) } else { Ok(i) });
+/// let err: Result<Vec<usize>, String> = try_map_indices(|i| if i == 1 { Err("one".into()) } else { Ok(i) }, 3);
 /// assert!(err.is_err());
 /// ```
 pub(crate) fn try_map_indices<U: Send, E: Send>(
-    n: usize,
     f: impl Fn(usize) -> Result<U, E> + Sync,
+    n: usize,
 ) -> Result<Vec<U>, E> {
     if n >= PARALLEL_THRESHOLD {
         get_thread_pool().install(|| (0..n).into_par_iter().map(&f).collect())
@@ -256,8 +256,8 @@ pub(crate) fn try_map_indices<U: Send, E: Send>(
 ///
 /// # Arguments
 ///
-/// * `inputs` - Elements to transform
 /// * `f` - Fallible element-wise kernel
+/// * `inputs` - Elements to transform
 ///
 /// # Returns
 ///
@@ -268,14 +268,14 @@ pub(crate) fn try_map_indices<U: Send, E: Send>(
 /// ```ignore
 /// use crate::utils::batch::try_batch_map;
 ///
-/// let halves: Result<Vec<f64>, String> = try_batch_map(&[2.0, 4.0], |x| Ok(x / 2.0));
+/// let halves: Result<Vec<f64>, String> = try_batch_map(|x| Ok(x / 2.0), &[2.0, 4.0]);
 /// assert_eq!(halves.unwrap(), vec![1.0, 2.0]);
 /// ```
 pub(crate) fn try_batch_map<T: Sync, U: Send, E: Send>(
-    inputs: &[T],
     f: impl Fn(&T) -> Result<U, E> + Sync,
+    inputs: &[T],
 ) -> Result<Vec<U>, E> {
-    try_map_indices(inputs.len(), |i| f(&inputs[i]))
+    try_map_indices(|i| f(&inputs[i]), inputs.len())
 }
 
 /// Apply a fallible epoch-dependent kernel across a batch, hoisting the epoch
@@ -286,10 +286,10 @@ pub(crate) fn try_batch_map<T: Sync, U: Send, E: Send>(
 ///
 /// # Arguments
 ///
-/// * `epochs` - Epochs, length `1` or `N`
-/// * `inputs` - Elements to transform, length `1` or `N`
 /// * `context` - Builds the per-epoch context
 /// * `apply` - Applies a context to one input
+/// * `epochs` - Epochs, length `1` or `N`
+/// * `inputs` - Elements to transform, length `1` or `N`
 ///
 /// # Returns
 ///
@@ -304,14 +304,14 @@ pub(crate) fn try_batch_map<T: Sync, U: Send, E: Send>(
 /// use crate::utils::batch::try_batch_map_epochs;
 ///
 /// let epochs = [Epoch::from_gps_seconds(0.0), Epoch::from_gps_seconds(60.0)];
-/// let out = try_batch_map_epochs(&epochs, &[1.0, 2.0], |e| Ok::<f64, BraheError>(e.gps_seconds()), |t, x| Ok(t + x)).unwrap();
+/// let out = try_batch_map_epochs(|e| Ok::<f64, BraheError>(e.gps_seconds()), |t, x| Ok(t + x), &epochs, &[1.0, 2.0]).unwrap();
 /// assert_eq!(out.len(), 2);
 /// ```
 pub(crate) fn try_batch_map_epochs<C: Sync, T: Sync, U: Send>(
-    epochs: &[Epoch],
-    inputs: &[T],
     context: impl Fn(Epoch) -> Result<C, BraheError> + Sync,
     apply: impl Fn(&C, &T) -> Result<U, BraheError> + Sync,
+    epochs: &[Epoch],
+    inputs: &[T],
 ) -> Result<Vec<U>, BraheError> {
     let n = broadcast_len(&[epochs.len(), inputs.len()])?;
     if n == 0 {
@@ -319,9 +319,9 @@ pub(crate) fn try_batch_map_epochs<C: Sync, T: Sync, U: Send>(
     }
     if epochs.len() == 1 {
         let c = context(epochs[0])?;
-        try_map_indices(n, |i| apply(&c, pick(inputs, i)))
+        try_map_indices(|i| apply(&c, pick(inputs, i)), n)
     } else {
-        try_map_indices(n, |i| apply(&context(epochs[i])?, pick(inputs, i)))
+        try_map_indices(|i| apply(&context(epochs[i])?, pick(inputs, i)), n)
     }
 }
 
@@ -573,29 +573,35 @@ mod tests {
     #[parallel]
     fn test_try_batch_map_ok_and_error() {
         let small = [1.0, 2.0, 3.0];
-        let ok: Result<Vec<f64>, String> = try_batch_map(&small, |x| Ok(x * 2.0));
+        let ok: Result<Vec<f64>, String> = try_batch_map(|x| Ok(x * 2.0), &small);
         assert_eq!(ok.unwrap(), vec![2.0, 4.0, 6.0]);
 
-        let err: Result<Vec<f64>, String> = try_batch_map(&small, |x| {
-            if *x > 2.0 {
-                Err("too big".to_string())
-            } else {
-                Ok(*x)
-            }
-        });
+        let err: Result<Vec<f64>, String> = try_batch_map(
+            |x| {
+                if *x > 2.0 {
+                    Err("too big".to_string())
+                } else {
+                    Ok(*x)
+                }
+            },
+            &small,
+        );
         assert_eq!(err.unwrap_err(), "too big");
 
         let large: Vec<f64> = (0..PARALLEL_THRESHOLD + 2).map(|i| i as f64).collect();
-        let out: Vec<f64> = try_batch_map(&large, |x| Ok::<f64, String>(x + 1.0)).unwrap();
+        let out: Vec<f64> = try_batch_map(|x| Ok::<f64, String>(x + 1.0), &large).unwrap();
         let expected: Vec<f64> = large.iter().map(|x| x + 1.0).collect();
         assert_eq!(out, expected);
-        let err: Result<Vec<f64>, String> = try_batch_map(&large, |x| {
-            if *x == 5.0 {
-                Err("five".to_string())
-            } else {
-                Ok(*x)
-            }
-        });
+        let err: Result<Vec<f64>, String> = try_batch_map(
+            |x| {
+                if *x == 5.0 {
+                    Err("five".to_string())
+                } else {
+                    Ok(*x)
+                }
+            },
+            &large,
+        );
         assert_eq!(err.unwrap_err(), "five");
     }
 
@@ -605,23 +611,23 @@ mod tests {
         let calls = AtomicUsize::new(0);
         let inputs = [1.0, 2.0, 3.0];
         let out = try_batch_map_epochs(
-            &epochs(1),
-            &inputs,
             |e| {
                 calls.fetch_add(1, Ordering::SeqCst);
                 Ok(e.gps_seconds())
             },
             |c, x| Ok(c + x),
+            &epochs(1),
+            &inputs,
         )
         .unwrap();
         assert_eq!(out, vec![1.0, 2.0, 3.0]);
         assert_eq!(calls.load(Ordering::SeqCst), 1);
 
         let out = try_batch_map_epochs(
-            &epochs(3),
-            &inputs,
             |e| Ok(e.gps_seconds()),
             |c, x| Ok(c + x),
+            &epochs(3),
+            &inputs,
         )
         .unwrap();
         assert_eq!(out.len(), 3);
@@ -630,15 +636,13 @@ mod tests {
         }
 
         let err = try_batch_map_epochs(
-            &epochs(1),
-            &inputs,
             |_| Err::<f64, _>(BraheError::Error("no context".to_string())),
             |c, x| Ok(c + x),
+            &epochs(1),
+            &inputs,
         );
         assert!(err.is_err());
         let err = try_batch_map_epochs(
-            &epochs(3),
-            &inputs,
             |e| Ok(e.gps_seconds()),
             |_, x| {
                 if *x > 2.0 {
@@ -647,11 +651,13 @@ mod tests {
                     Ok(*x)
                 }
             },
+            &epochs(3),
+            &inputs,
         );
         assert!(err.is_err());
-        assert!(try_batch_map_epochs(&epochs(2), &inputs, Ok, |_, x| Ok(*x)).is_err());
+        assert!(try_batch_map_epochs(Ok, |_, x| Ok(*x), &epochs(2), &inputs).is_err());
         assert!(
-            try_batch_map_epochs(&epochs(1), &[] as &[f64], Ok, |_, x| Ok(*x))
+            try_batch_map_epochs(Ok, |_, x| Ok(*x), &epochs(1), &[] as &[f64])
                 .unwrap()
                 .is_empty()
         );

--- a/src/utils/batch.rs
+++ b/src/utils/batch.rs
@@ -230,6 +230,17 @@ pub(crate) fn batch_map_epochs<C: Sync, T: Sync, U: Send>(
 /// # Returns
 ///
 /// Vector of `n` results in index order, or the first error encountered.
+///
+/// # Examples
+///
+/// ```ignore
+/// use crate::utils::batch::try_map_indices;
+///
+/// let ok: Result<Vec<usize>, String> = try_map_indices(3, |i| Ok(i + 1));
+/// assert_eq!(ok.unwrap(), vec![1, 2, 3]);
+/// let err: Result<Vec<usize>, String> = try_map_indices(3, |i| if i == 1 { Err("one".into()) } else { Ok(i) });
+/// assert!(err.is_err());
+/// ```
 pub(crate) fn try_map_indices<U: Send, E: Send>(
     n: usize,
     f: impl Fn(usize) -> Result<U, E> + Sync,
@@ -251,6 +262,15 @@ pub(crate) fn try_map_indices<U: Send, E: Send>(
 /// # Returns
 ///
 /// Vector with one output per input, in input order, or the first error.
+///
+/// # Examples
+///
+/// ```ignore
+/// use crate::utils::batch::try_batch_map;
+///
+/// let halves: Result<Vec<f64>, String> = try_batch_map(&[2.0, 4.0], |x| Ok(x / 2.0));
+/// assert_eq!(halves.unwrap(), vec![1.0, 2.0]);
+/// ```
 pub(crate) fn try_batch_map<T: Sync, U: Send, E: Send>(
     inputs: &[T],
     f: impl Fn(&T) -> Result<U, E> + Sync,
@@ -275,6 +295,18 @@ pub(crate) fn try_batch_map<T: Sync, U: Send, E: Send>(
 ///
 /// Vector of `N` results in index order, or an error if the lengths do not
 /// satisfy the broadcast rule or any evaluation fails.
+///
+/// # Examples
+///
+/// ```ignore
+/// use crate::time::Epoch;
+/// use crate::utils::BraheError;
+/// use crate::utils::batch::try_batch_map_epochs;
+///
+/// let epochs = [Epoch::from_gps_seconds(0.0), Epoch::from_gps_seconds(60.0)];
+/// let out = try_batch_map_epochs(&epochs, &[1.0, 2.0], |e| Ok::<f64, BraheError>(e.gps_seconds()), |t, x| Ok(t + x)).unwrap();
+/// assert_eq!(out.len(), 2);
+/// ```
 pub(crate) fn try_batch_map_epochs<C: Sync, T: Sync, U: Send>(
     epochs: &[Epoch],
     inputs: &[T],

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -1369,3 +1369,201 @@ def test_router_errors_on_unsupported_iau_body():
             brahe.ReferenceFrame.BodyFixedIAU(999999),
             epc,
         )
+
+
+# Batch (vectorized) planetary, synodic, and generic router tests
+def _planetary_epochs(n):
+    epc0 = brahe.Epoch.from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, brahe.UTC)
+    return [epc0 + 3600.0 * i for i in range(n)]
+
+
+def _check_batch_family(pos_fns, state_fns, rot_fns, positions, states, epochs):
+    for f in pos_fns:
+        out = f(epochs, positions)
+        assert out.shape == positions.shape
+        out1 = f(epochs[0], positions)
+        for i, e in enumerate(epochs):
+            np.testing.assert_array_equal(out[i], f(e, positions[i]))
+            np.testing.assert_array_equal(out1[i], f(epochs[0], positions[i]))
+        one = f(epochs, positions[0])
+        for i, e in enumerate(epochs):
+            np.testing.assert_array_equal(one[i], f(e, positions[0]))
+    for f in state_fns:
+        out = f(epochs, states)
+        assert out.shape == states.shape
+        out_t = f(epochs, states.T, axis=0)
+        np.testing.assert_array_equal(out_t, out.T)
+        for i, e in enumerate(epochs):
+            np.testing.assert_array_equal(out[i], f(e, states[i]))
+    for f in rot_fns:
+        R = f(epochs)
+        assert R.shape == (len(epochs), 3, 3)
+        for i, e in enumerate(epochs):
+            np.testing.assert_array_equal(R[i], f(e))
+
+
+def test_batch_lunar_frames():
+    epochs = _planetary_epochs(3)
+    states = np.array(
+        [[brahe.R_MOON + 100e3 + 1e3 * i, 1e5, 2e5, 0.0, 1.6e3, 0.0] for i in range(3)]
+    )
+    positions = states[:, :3]
+    _check_batch_family(
+        [
+            brahe.position_lci_to_lfpa,
+            brahe.position_lfpa_to_lci,
+            brahe.position_lci_to_lfme,
+            brahe.position_lfme_to_lci,
+            brahe.position_eci_to_lci,
+            brahe.position_lci_to_eci,
+        ],
+        [
+            brahe.state_lci_to_lfpa,
+            brahe.state_lfpa_to_lci,
+            brahe.state_lci_to_lfme,
+            brahe.state_lfme_to_lci,
+            brahe.state_eci_to_lci,
+            brahe.state_lci_to_eci,
+        ],
+        [
+            brahe.rotation_lci_to_lfpa,
+            brahe.rotation_lfpa_to_lci,
+            brahe.rotation_lci_to_lfme,
+            brahe.rotation_lfme_to_lci,
+        ],
+        positions,
+        states,
+        epochs,
+    )
+    lfpa = brahe.state_lci_to_lfpa(epochs, states)
+    back = brahe.state_lfpa_to_lci(epochs, lfpa)
+    np.testing.assert_allclose(back, states, atol=1e-6)
+
+
+def test_batch_mars_and_emb_frames():
+    epochs = _planetary_epochs(3)
+    states = np.array(
+        [[brahe.R_MARS + 400e3 + 1e3 * i, 0.0, 0.0, 0.0, 3.4e3, 0.0] for i in range(3)]
+    )
+    positions = states[:, :3]
+    _check_batch_family(
+        [
+            brahe.position_mci_to_mcmf,
+            brahe.position_mcmf_to_mci,
+            brahe.position_eci_to_mci,
+            brahe.position_mci_to_eci,
+            brahe.position_eci_to_emb,
+            brahe.position_emb_to_eci,
+        ],
+        [
+            brahe.state_mci_to_mcmf,
+            brahe.state_mcmf_to_mci,
+            brahe.state_eci_to_mci,
+            brahe.state_mci_to_eci,
+            brahe.state_eci_to_emb,
+            brahe.state_emb_to_eci,
+        ],
+        [brahe.rotation_mci_to_mcmf, brahe.rotation_mcmf_to_mci],
+        positions,
+        states,
+        epochs,
+    )
+
+
+def test_batch_synodic_frames():
+    epochs = _planetary_epochs(3)
+    states = np.array(
+        [[1e8 + 1e6 * i, -2e8, 5e7, 1.0e3, -2.0e3, 0.5e3] for i in range(3)]
+    )
+    positions = states[:, :3]
+    _check_batch_family(
+        [
+            brahe.position_gcrf_to_emr,
+            brahe.position_emr_to_gcrf,
+            brahe.position_gcrf_to_ser,
+            brahe.position_ser_to_gcrf,
+            brahe.position_gcrf_to_gse,
+            brahe.position_gse_to_gcrf,
+        ],
+        [
+            brahe.state_gcrf_to_emr,
+            brahe.state_emr_to_gcrf,
+            brahe.state_gcrf_to_ser,
+            brahe.state_ser_to_gcrf,
+            brahe.state_gcrf_to_gse,
+            brahe.state_gse_to_gcrf,
+        ],
+        [
+            brahe.rotation_gcrf_to_emr,
+            brahe.rotation_emr_to_gcrf,
+            brahe.rotation_gcrf_to_ser,
+            brahe.rotation_ser_to_gcrf,
+            brahe.rotation_gcrf_to_gse,
+            brahe.rotation_gse_to_gcrf,
+        ],
+        positions,
+        states,
+        epochs,
+    )
+    with pytest.raises(ValueError):
+        brahe.state_gcrf_to_emr(epochs[:2], states)
+
+
+def test_batch_iau_rotation():
+    epochs = _planetary_epochs(3)
+    R = brahe.rotation_icrf_to_body_fixed_iau(499, epochs)
+    assert R.shape == (3, 3, 3)
+    for i, e in enumerate(epochs):
+        np.testing.assert_array_equal(
+            R[i], brahe.rotation_icrf_to_body_fixed_iau(499, e)
+        )
+    with pytest.raises(RuntimeError):
+        brahe.rotation_icrf_to_body_fixed_iau(999999, epochs)
+
+
+def test_batch_frame_router(eop):
+    epochs = _planetary_epochs(3)
+    oe = np.array([brahe.R_EARTH + 500e3, 1e-3, 97.8, 75.0, 25.0, 45.0])
+    states = np.array(
+        [
+            brahe.state_koe_to_eci(
+                oe + np.array([1e3 * i, 0, 0, 0, 0, 0]), brahe.AngleFormat.DEGREES
+            )
+            for i in range(3)
+        ]
+    )
+    positions = states[:, :3]
+    RF = brahe.ReferenceFrame
+    for src, dst in [
+        (RF.GCRF, RF.ITRF),
+        (RF.GCRF, RF.LFPA),
+        (RF.GCRF, RF.EMR),
+        (RF.ITRF, RF.MCMF),
+    ]:
+        R = brahe.rotation_frame_to_frame(src, dst, epochs)
+        pos = brahe.position_frame_to_frame(src, dst, epochs, positions)
+        pos1 = brahe.position_frame_to_frame(src, dst, epochs[0], positions)
+        st = brahe.state_frame_to_frame(src, dst, epochs, states)
+        st1 = brahe.state_frame_to_frame(src, dst, epochs[0], states)
+        assert R.shape == (3, 3, 3) and pos.shape == (3, 3) and st.shape == (3, 6)
+        for i, e in enumerate(epochs):
+            np.testing.assert_array_equal(
+                R[i], brahe.rotation_frame_to_frame(src, dst, e)
+            )
+            np.testing.assert_array_equal(
+                pos[i], brahe.position_frame_to_frame(src, dst, e, positions[i])
+            )
+            np.testing.assert_array_equal(
+                pos1[i],
+                brahe.position_frame_to_frame(src, dst, epochs[0], positions[i]),
+            )
+            np.testing.assert_array_equal(
+                st[i], brahe.state_frame_to_frame(src, dst, e, states[i])
+            )
+            np.testing.assert_array_equal(
+                st1[i], brahe.state_frame_to_frame(src, dst, epochs[0], states[i])
+            )
+    same = brahe.position_frame_to_frame(RF.GCRF, RF.GCRF, epochs, positions)
+    np.testing.assert_array_equal(same, positions)
+    with pytest.raises(RuntimeError):
+        brahe.state_frame_to_frame(RF.GCRF, RF.BodyFixedIAU(-1234), epochs, states)


### PR DESCRIPTION
# Pull Request

## Description

Extends vectorization to the planetary, synodic, and generic frame transformations (52 plural functions): EMB, lunar (LCI/LFPA/LFME), Mars (MCI/MCMF), `rotation_icrf_to_body_fixed_iau`, EMR/SER/GSE, and the `rotation_/position_/state_frame_to_frame` router. Adds the fallible primitives `try_batch_map` / `try_batch_map_epochs`, a shared `RotatingFrameContext` (rotation + body-frame angular velocity) with `apply_state_icrf_to_rotating` / `apply_state_rotating_to_icrf` reused by lunar and Mars, translation-frame offset hoisting, synodic `(axes, rate, offset)` contexts, and a hoisted frame-pair context for `position_frame_to_frame`. `states_frame_to_frame` evaluates the scalar per element (the state router resolves velocity transport terms through each frame's own routine). Fallible transforms keep raising `RuntimeError` in Python.

## Changelog

### Added
- Batch lunar, Mars, EMB, IAU, synodic (EMR/SER/GSE), and generic frame-router transformations in Rust (`rotations_/positions_/states_*`, `rotations_icrf_to_body_fixed_iau`, `rotations_/positions_/states_frame_to_frame`).
- Python planetary, synodic, and router frame functions accept batches (`axis` keyword) and epoch sequences.

## Note to Reviewers
Lunar and Mars body-fixed scalars now route through the same `state_icrf_to_rotating`/`state_rotating_to_icrf` expressions the router already used, so results are unchanged bit-for-bit (asserted in tests). EMR/SER scalars are expressed as a synodic context plus apply step; GSE is unchanged.
