### PR TITLE
Vectorize coordinate transformations

### DIFF
--- a/crates/brahe-py/src/batch.rs
+++ b/crates/brahe-py/src/batch.rs
@@ -404,9 +404,10 @@ fn dispatch_vec_rotation<'py, const N: usize>(
 }
 
 /// Dispatch a two-vector transform (for example site and target) on scalar
-/// or batched arguments. Either argument may be a batch; both batched
-/// arguments must have equal batch lengths. The output takes the layout of
-/// the batched argument (the first when both are batched).
+/// or batched arguments. Either argument may be a batch; when both are
+/// batched their lengths must be equal or one of them must be 1. The output
+/// takes the layout of the batched argument with the common length (the first
+/// when both have it).
 fn dispatch_vec_pair<'py, const N: usize>(
     py: Python<'py>,
     a: &Bound<'py, PyAny>,
@@ -429,15 +430,17 @@ fn dispatch_vec_pair<'py, const N: usize>(
             return Ok(vector_to_numpy!(py, scalar(a_vecs[0], b_vecs[0]), N, f64).into_any());
         }
         (Some(la), Some(lb)) => {
-            if a_vecs.len() != b_vecs.len() {
+            if a_vecs.len() == b_vecs.len() || b_vecs.len() == 1 {
+                la
+            } else if a_vecs.len() == 1 {
+                lb
+            } else {
                 return Err(exceptions::PyValueError::new_err(format!(
                     "Batch lengths {} and {} do not match; expected equal lengths or a single vector",
                     a_vecs.len(),
                     b_vecs.len()
                 )));
             }
-            let _ = lb;
-            la
         }
         (Some(la), None) => la,
         (None, Some(lb)) => lb,

--- a/crates/brahe-py/src/batch.rs
+++ b/crates/brahe-py/src/batch.rs
@@ -343,3 +343,105 @@ fn try_dispatch_epoch_rotation<'py>(
         }
     }
 }
+
+/// Dispatch a fallible epoch-free vector transform on a single vector or a
+/// batch. The closures return `PyResult` so each binding keeps its own error
+/// mapping.
+fn try_dispatch_vec<'py, const N: usize>(
+    py: Python<'py>,
+    x: &Bound<'py, PyAny>,
+    axis: isize,
+    scalar: impl Fn(SVector<f64, N>) -> PyResult<SVector<f64, N>>,
+    batch: impl Fn(&[SVector<f64, N>]) -> PyResult<Vec<SVector<f64, N>>> + Sync,
+) -> PyResult<Bound<'py, PyAny>> {
+    match parse_vec_arg::<N>(x, axis)? {
+        VecArg::Single(v) => {
+            let out = scalar(v)?;
+            Ok(vector_to_numpy!(py, out, N, f64).into_any())
+        }
+        VecArg::Batch { vecs, layout } => {
+            let out = py.detach(|| batch(&vecs))?;
+            vecs_to_numpy(py, &layout, axis, out)
+        }
+    }
+}
+
+/// Dispatch a vector-to-rotation-matrix function on a single vector or a
+/// batch. A batch returns the batch dimensions followed by `(3, 3)`.
+fn dispatch_vec_rotation<'py, const N: usize>(
+    py: Python<'py>,
+    x: &Bound<'py, PyAny>,
+    axis: isize,
+    scalar: impl Fn(SVector<f64, N>) -> SMatrix3,
+    batch: impl Fn(&[SVector<f64, N>]) -> Vec<SMatrix3> + Sync,
+) -> PyResult<Bound<'py, PyAny>> {
+    match parse_vec_arg::<N>(x, axis)? {
+        VecArg::Single(v) => {
+            let mat = scalar(v);
+            Ok(matrix_to_numpy!(py, mat, 3, 3, f64).into_any())
+        }
+        VecArg::Batch { vecs, layout } => {
+            let out = py.detach(|| batch(&vecs));
+            let mut shape: Vec<usize> = layout
+                .shape
+                .iter()
+                .enumerate()
+                .filter(|(i, _)| *i != layout.axis)
+                .map(|(_, d)| *d)
+                .collect();
+            shape.extend([3, 3]);
+            let flat: Vec<f64> = out
+                .iter()
+                .flat_map(|m| (0..3).flat_map(move |i| (0..3).map(move |j| m[(i, j)])))
+                .collect();
+            Ok(flat
+                .into_pyarray(py)
+                .reshape(shape)
+                .map_err(|e| exceptions::PyValueError::new_err(e.to_string()))?
+                .into_any())
+        }
+    }
+}
+
+/// Dispatch a two-vector transform (for example site and target) on scalar
+/// or batched arguments. Either argument may be a batch; both batched
+/// arguments must have equal batch lengths. The output takes the layout of
+/// the batched argument (the first when both are batched).
+fn dispatch_vec_pair<'py, const N: usize>(
+    py: Python<'py>,
+    a: &Bound<'py, PyAny>,
+    b: &Bound<'py, PyAny>,
+    axis: isize,
+    scalar: impl Fn(SVector<f64, N>, SVector<f64, N>) -> SVector<f64, N>,
+    batch: impl Fn(&[SVector<f64, N>], &[SVector<f64, N>]) -> Result<Vec<SVector<f64, N>>, RustBraheError>
+    + Sync,
+) -> PyResult<Bound<'py, PyAny>> {
+    let (a_vecs, a_layout) = match parse_vec_arg::<N>(a, axis)? {
+        VecArg::Single(v) => (vec![v], None),
+        VecArg::Batch { vecs, layout } => (vecs, Some(layout)),
+    };
+    let (b_vecs, b_layout) = match parse_vec_arg::<N>(b, axis)? {
+        VecArg::Single(v) => (vec![v], None),
+        VecArg::Batch { vecs, layout } => (vecs, Some(layout)),
+    };
+    let layout = match (a_layout, b_layout) {
+        (None, None) => {
+            return Ok(vector_to_numpy!(py, scalar(a_vecs[0], b_vecs[0]), N, f64).into_any());
+        }
+        (Some(la), Some(lb)) => {
+            if a_vecs.len() != b_vecs.len() {
+                return Err(exceptions::PyValueError::new_err(format!(
+                    "Batch lengths {} and {} do not match; expected equal lengths or a single vector",
+                    a_vecs.len(),
+                    b_vecs.len()
+                )));
+            }
+            let _ = lb;
+            la
+        }
+        (Some(la), None) => la,
+        (None, Some(lb)) => lb,
+    };
+    let out = py.detach(|| batch(&a_vecs, &b_vecs))?;
+    vecs_to_numpy(py, &layout, axis, out)
+}

--- a/crates/brahe-py/src/coordinates.rs
+++ b/crates/brahe-py/src/coordinates.rs
@@ -55,9 +55,6 @@ impl PyEllipsoidalConversionType {
     }
 }
 
-#[pyfunction]
-#[pyo3(text_signature = "(x_oe, angle_format)")]
-#[pyo3(name = "state_koe_to_eci")]
 /// Convert osculating orbital elements to Cartesian state.
 ///
 /// Transforms a state vector from osculating Keplerian orbital elements to Cartesian
@@ -69,11 +66,16 @@ impl PyEllipsoidalConversionType {
 ///         inclination (radians or degrees), `RAAN` is right ascension of ascending node
 ///         (radians or degrees), `omega` is argument of periapsis (radians or degrees),
 ///         and `M` is mean anomaly (radians or degrees).
+///         Also accepts a batch of vectors with the 6 components along `axis`
+///         (for example shape `(n, 6)`).
 ///     angle_format (AngleFormat): Angle format for angular elements (`RADIANS` or `DEGREES`).
+///     axis (int, optional): Axis of `x_oe` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian state `[x, y, z, vx, vy, vz]` where position is in meters
 ///         and velocity is in meters per second.
+///         For batched input the output takes the batch layout of `x_oe`.
 ///
 /// Example:
 ///     ```python
@@ -85,20 +87,26 @@ impl PyEllipsoidalConversionType {
 ///     x_cart = bh.state_koe_to_eci(oe, bh.AngleFormat.RADIANS)
 ///     print(f"Cartesian state: {x_cart}")
 ///     ```
+#[pyfunction]
+#[pyo3(signature = (x_oe, angle_format, axis=-1))]
+#[pyo3(text_signature = "(x_oe, angle_format, axis=-1)")]
+#[pyo3(name = "state_koe_to_eci")]
 fn py_state_koe_to_eci<'py>(
     py: Python<'py>,
-    x_oe: Bound<'py, PyAny>,
+    x_oe: &Bound<'py, PyAny>,
     angle_format: &PyAngleFormat,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec =
-        coordinates::state_koe_to_eci(pyany_to_svector::<6>(&x_oe)?, angle_format.value);
-
-    Ok(vector_to_numpy!(py, vec, 6, f64))
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    let af = angle_format.value;
+    dispatch_vec::<6>(
+        py,
+        x_oe,
+        axis,
+        |v| coordinates::state_koe_to_eci(v, af),
+        |vs| coordinates::states_koe_to_eci(vs, af),
+    )
 }
 
-#[pyfunction]
-#[pyo3(text_signature = "(x_cart, angle_format)")]
-#[pyo3(name = "state_eci_to_koe")]
 /// Convert Cartesian state to osculating orbital elements.
 ///
 /// Transforms a state vector from Cartesian position and velocity coordinates to
@@ -107,7 +115,11 @@ fn py_state_koe_to_eci<'py>(
 /// Args:
 ///     x_cart (numpy.ndarray or list): Cartesian state `[x, y, z, vx, vy, vz]` where position
 ///         is in meters and velocity is in meters per second.
+///         Also accepts a batch of vectors with the 6 components along `axis`
+///         (for example shape `(n, 6)`).
 ///     angle_format (AngleFormat): Angle format for output angular elements (`RADIANS` or `DEGREES`).
+///     axis (int, optional): Axis of `x_cart` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
 ///     numpy.ndarray: Osculating orbital elements `[a, e, i, RAAN, omega, M]` where `a` is
@@ -115,6 +127,7 @@ fn py_state_koe_to_eci<'py>(
 ///         (radians or degrees), `RAAN` is right ascension of ascending node (radians or degrees),
 ///         `omega` is argument of periapsis (radians or degrees), and `M` is mean anomaly
 ///         (radians or degrees).
+///         For batched input the output takes the batch layout of `x_cart`.
 ///
 /// Example:
 ///     ```python
@@ -126,20 +139,26 @@ fn py_state_koe_to_eci<'py>(
 ///     oe = bh.state_eci_to_koe(x_cart, bh.AngleFormat.RADIANS)
 ///     print(f"Orbital elements: a={oe[0]:.0f}m, e={oe[1]:.6f}, i={oe[2]:.6f} rad")
 ///     ```
+#[pyfunction]
+#[pyo3(signature = (x_cart, angle_format, axis=-1))]
+#[pyo3(text_signature = "(x_cart, angle_format, axis=-1)")]
+#[pyo3(name = "state_eci_to_koe")]
 fn py_state_eci_to_koe<'py>(
     py: Python<'py>,
-    x_cart: Bound<'py, PyAny>,
+    x_cart: &Bound<'py, PyAny>,
     angle_format: &PyAngleFormat,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec =
-        coordinates::state_eci_to_koe(pyany_to_svector::<6>(&x_cart)?, angle_format.value);
-
-    Ok(vector_to_numpy!(py, vec, 6, f64))
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    let af = angle_format.value;
+    dispatch_vec::<6>(
+        py,
+        x_cart,
+        axis,
+        |v| coordinates::state_eci_to_koe(v, af),
+        |vs| coordinates::states_eci_to_koe(vs, af),
+    )
 }
 
-#[pyfunction]
-#[pyo3(text_signature = "(x_cart, central_body, angle_format)")]
-#[pyo3(name = "state_inertial_to_koe_for_body")]
 /// Convert a Cartesian state in a body's ICRF-aligned inertial (BCI) frame to
 /// osculating orbital elements referenced to that body's mean equator at J2000.
 ///
@@ -162,13 +181,18 @@ fn py_state_eci_to_koe<'py>(
 ///     x_cart (numpy.ndarray or list): Cartesian state `[x, y, z, vx, vy, vz]` in the
 ///         body-centered ICRF-aligned frame (e.g. LCI for the Moon, MCI for Mars),
 ///         position in meters and velocity in meters per second.
+///         Also accepts a batch of vectors with the 6 components along `axis`
+///         (for example shape `(n, 6)`).
 ///     central_body (CentralBody): Central body (supplies the GM and the IAU pole /
 ///         body-fixed frame).
 ///     angle_format (AngleFormat): Angle format for output angular elements (`RADIANS` or `DEGREES`).
+///     axis (int, optional): Axis of `x_cart` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
 ///     numpy.ndarray: Osculating orbital elements `[a, e, i, RAAN, omega, M]` referenced
 ///         to the body mean equator at J2000.
+///         For batched input the output takes the batch layout of `x_cart`.
 ///
 /// Raises:
 ///     RuntimeError: If `central_body` is a barycenter, has no positive GM, or is a
@@ -183,25 +207,34 @@ fn py_state_eci_to_koe<'py>(
 ///     x_cart = np.array([1837.4e3, 0.0, 0.0, 0.0, 1600.0, 0.0])
 ///     oe = bh.state_inertial_to_koe_for_body(x_cart, bh.CentralBody.Moon, bh.AngleFormat.RADIANS)
 ///     ```
+#[pyfunction]
+#[pyo3(signature = (x_cart, central_body, angle_format, axis=-1))]
+#[pyo3(text_signature = "(x_cart, central_body, angle_format, axis=-1)")]
+#[pyo3(name = "state_inertial_to_koe_for_body")]
 fn py_state_inertial_to_koe_for_body<'py>(
     py: Python<'py>,
-    x_cart: Bound<'py, PyAny>,
+    x_cart: &Bound<'py, PyAny>,
     central_body: &PyCentralBody,
     angle_format: &PyAngleFormat,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = coordinates::state_inertial_to_koe_for_body(
-        pyany_to_svector::<6>(&x_cart)?,
-        &central_body.body,
-        angle_format.value,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    let af = angle_format.value;
+    let body = &central_body.body;
+    try_dispatch_vec::<6>(
+        py,
+        x_cart,
+        axis,
+        |v| {
+            coordinates::state_inertial_to_koe_for_body(v, body, af)
+                .map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))
+        },
+        |vs| {
+            coordinates::states_inertial_to_koe_for_body(vs, body, af)
+                .map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))
+        },
     )
-    .map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))?;
-
-    Ok(vector_to_numpy!(py, vec, 6, f64))
 }
 
-#[pyfunction]
-#[pyo3(text_signature = "(x_oe, central_body, angle_format)")]
-#[pyo3(name = "state_koe_to_inertial_for_body")]
 /// Convert osculating orbital elements referenced to a body's mean equator at
 /// J2000 to the equivalent Cartesian state in that body's ICRF-aligned inertial
 /// (BCI) frame. Inverse of `state_inertial_to_koe_for_body`.
@@ -225,13 +258,18 @@ fn py_state_inertial_to_koe_for_body<'py>(
 ///     x_oe (numpy.ndarray or list): Osculating orbital elements `[a, e, i, RAAN, omega, M]`
 ///         referenced to the body mean equator at J2000, where the semi-major axis is in
 ///         meters and angles are in the given format.
+///         Also accepts a batch of vectors with the 6 components along `axis`
+///         (for example shape `(n, 6)`).
 ///     central_body (CentralBody): Central body (supplies the GM and the IAU pole /
 ///         body-fixed frame).
 ///     angle_format (AngleFormat): Angle format for input angular elements (`RADIANS` or `DEGREES`).
+///     axis (int, optional): Axis of `x_oe` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian state `[x, y, z, vx, vy, vz]` in the body-centered
 ///         ICRF-aligned frame. Units: (m; m/s)
+///         For batched input the output takes the batch layout of `x_oe`.
 ///
 /// Raises:
 ///     RuntimeError: If `central_body` is a barycenter, has no positive GM, or is a
@@ -246,25 +284,34 @@ fn py_state_inertial_to_koe_for_body<'py>(
 ///     oe = np.array([bh.R_MARS + 300e3, 0.01, 92.6, 45.0, 270.0, 0.0])
 ///     x_cart = bh.state_koe_to_inertial_for_body(oe, bh.CentralBody.Mars, bh.AngleFormat.DEGREES)
 ///     ```
+#[pyfunction]
+#[pyo3(signature = (x_oe, central_body, angle_format, axis=-1))]
+#[pyo3(text_signature = "(x_oe, central_body, angle_format, axis=-1)")]
+#[pyo3(name = "state_koe_to_inertial_for_body")]
 fn py_state_koe_to_inertial_for_body<'py>(
     py: Python<'py>,
-    x_oe: Bound<'py, PyAny>,
+    x_oe: &Bound<'py, PyAny>,
     central_body: &PyCentralBody,
     angle_format: &PyAngleFormat,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = coordinates::state_koe_to_inertial_for_body(
-        pyany_to_svector::<6>(&x_oe)?,
-        &central_body.body,
-        angle_format.value,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    let af = angle_format.value;
+    let body = &central_body.body;
+    try_dispatch_vec::<6>(
+        py,
+        x_oe,
+        axis,
+        |v| {
+            coordinates::state_koe_to_inertial_for_body(v, body, af)
+                .map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))
+        },
+        |vs| {
+            coordinates::states_koe_to_inertial_for_body(vs, body, af)
+                .map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))
+        },
     )
-    .map_err(|e| exceptions::PyRuntimeError::new_err(e.to_string()))?;
-
-    Ok(vector_to_numpy!(py, vec, 6, f64))
 }
 
-#[pyfunction]
-#[pyo3(text_signature = "(x_geoc, angle_format)")]
-#[pyo3(name = "position_geocentric_to_ecef")]
 /// Convert geocentric position to `ECEF` Cartesian coordinates.
 ///
 /// Transforms a position from geocentric spherical coordinates (longitude, latitude, radius)
@@ -274,10 +321,15 @@ fn py_state_koe_to_inertial_for_body<'py>(
 ///     x_geoc (numpy.ndarray or list): Geocentric position `[longitude, latitude, radius]` where
 ///         longitude is in radians or degrees, latitude is in radians or degrees, and
 ///         radius is in meters.
+///         Also accepts a batch of vectors with the 3 components along `axis`
+///         (for example shape `(n, 3)`).
 ///     angle_format (AngleFormat): Angle format for input angular coordinates (`RADIANS` or `DEGREES`).
+///     axis (int, optional): Axis of `x_geoc` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
 ///     numpy.ndarray: `ECEF` Cartesian position `[x, y, z]` in meters.
+///         For batched input the output takes the batch layout of `x_geoc`.
 ///
 /// Example:
 ///     ```python
@@ -290,21 +342,26 @@ fn py_state_koe_to_inertial_for_body<'py>(
 ///     x_ecef = bh.position_geocentric_to_ecef(x_geoc, bh.AngleFormat.RADIANS)
 ///     print(f"ECEF position: {x_ecef}")
 ///     ```
+#[pyfunction]
+#[pyo3(signature = (x_geoc, angle_format, axis=-1))]
+#[pyo3(text_signature = "(x_geoc, angle_format, axis=-1)")]
+#[pyo3(name = "position_geocentric_to_ecef")]
 fn py_position_geocentric_to_ecef<'py>(
     py: Python<'py>,
-    x_geoc: Bound<'py, PyAny>,
+    x_geoc: &Bound<'py, PyAny>,
     angle_format: &PyAngleFormat,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec =
-        coordinates::position_geocentric_to_ecef(pyany_to_svector::<3>(&x_geoc)?, angle_format.value)
-            .map_err(exceptions::PyValueError::new_err)?;
-
-    Ok(vector_to_numpy!(py, vec, 3, f64))
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    let af = angle_format.value;
+    try_dispatch_vec::<3>(
+        py,
+        x_geoc,
+        axis,
+        |v| coordinates::position_geocentric_to_ecef(v, af).map_err(exceptions::PyValueError::new_err),
+        |vs| coordinates::positions_geocentric_to_ecef(vs, af).map_err(exceptions::PyValueError::new_err),
+    )
 }
 
-#[pyfunction]
-#[pyo3(text_signature = "(x_ecef, angle_format)")]
-#[pyo3(name = "position_ecef_to_geocentric")]
 /// Convert `ECEF` Cartesian position to geocentric coordinates.
 ///
 /// Transforms a position from Earth-Centered Earth-Fixed (`ECEF`) Cartesian coordinates
@@ -312,11 +369,16 @@ fn py_position_geocentric_to_ecef<'py>(
 ///
 /// Args:
 ///     x_ecef (numpy.ndarray or list): `ECEF` Cartesian position `[x, y, z]` in meters.
+///         Also accepts a batch of vectors with the 3 components along `axis`
+///         (for example shape `(n, 3)`).
 ///     angle_format (AngleFormat): Angle format for output angular coordinates (`RADIANS` or `DEGREES`).
+///     axis (int, optional): Axis of `x_ecef` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
 ///     numpy.ndarray: Geocentric position `[longitude, latitude, radius]` where longitude
 ///         is in radians or degrees, latitude is in radians or degrees, and radius is in meters.
+///         For batched input the output takes the batch layout of `x_ecef`.
 ///
 /// Example:
 ///     ```python
@@ -328,20 +390,26 @@ fn py_position_geocentric_to_ecef<'py>(
 ///     x_geoc = bh.position_ecef_to_geocentric(x_ecef, bh.AngleFormat.DEGREES)
 ///     print(f"Geocentric: lon={x_geoc[0]:.2f}°, lat={x_geoc[1]:.2f}°, r={x_geoc[2]:.0f}m")
 ///     ```
+#[pyfunction]
+#[pyo3(signature = (x_ecef, angle_format, axis=-1))]
+#[pyo3(text_signature = "(x_ecef, angle_format, axis=-1)")]
+#[pyo3(name = "position_ecef_to_geocentric")]
 fn py_position_ecef_to_geocentric<'py>(
     py: Python<'py>,
-    x_ecef: Bound<'py, PyAny>,
+    x_ecef: &Bound<'py, PyAny>,
     angle_format: &PyAngleFormat,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec =
-        coordinates::position_ecef_to_geocentric(pyany_to_svector::<3>(&x_ecef)?, angle_format.value);
-
-    Ok(vector_to_numpy!(py, vec, 3, f64))
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    let af = angle_format.value;
+    dispatch_vec::<3>(
+        py,
+        x_ecef,
+        axis,
+        |v| coordinates::position_ecef_to_geocentric(v, af),
+        |vs| coordinates::positions_ecef_to_geocentric(vs, af),
+    )
 }
 
-#[pyfunction]
-#[pyo3(text_signature = "(x_geod, angle_format)")]
-#[pyo3(name = "position_geodetic_to_ecef")]
 /// Convert geodetic position to `ECEF` Cartesian coordinates.
 ///
 /// Transforms a position from geodetic coordinates (longitude, latitude, altitude) using
@@ -351,10 +419,15 @@ fn py_position_ecef_to_geocentric<'py>(
 ///     x_geod (numpy.ndarray or list): Geodetic position `[longitude, latitude, altitude]` where
 ///         longitude is in radians or degrees, latitude is in radians or degrees, and
 ///         altitude is in meters above the `WGS84` ellipsoid.
+///         Also accepts a batch of vectors with the 3 components along `axis`
+///         (for example shape `(n, 3)`).
 ///     angle_format (AngleFormat): Angle format for input angular coordinates (`RADIANS` or `DEGREES`).
+///     axis (int, optional): Axis of `x_geod` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
 ///     numpy.ndarray: `ECEF` Cartesian position `[x, y, z]` in meters.
+///         For batched input the output takes the batch layout of `x_geod`.
 ///
 /// Example:
 ///     ```python
@@ -367,20 +440,26 @@ fn py_position_ecef_to_geocentric<'py>(
 ///     x_ecef = bh.position_geodetic_to_ecef(x_geod, bh.AngleFormat.DEGREES)
 ///     print(f"ECEF position: {x_ecef}")
 ///     ```
+#[pyfunction]
+#[pyo3(signature = (x_geod, angle_format, axis=-1))]
+#[pyo3(text_signature = "(x_geod, angle_format, axis=-1)")]
+#[pyo3(name = "position_geodetic_to_ecef")]
 fn py_position_geodetic_to_ecef<'py>(
     py: Python<'py>,
-    x_geod: Bound<'py, PyAny>,
+    x_geod: &Bound<'py, PyAny>,
     angle_format: &PyAngleFormat,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = coordinates::position_geodetic_to_ecef(pyany_to_svector::<3>(&x_geod)?, angle_format.value)
-        .map_err(exceptions::PyValueError::new_err)?;
-
-    Ok(vector_to_numpy!(py, vec, 3, f64))
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    let af = angle_format.value;
+    try_dispatch_vec::<3>(
+        py,
+        x_geod,
+        axis,
+        |v| coordinates::position_geodetic_to_ecef(v, af).map_err(exceptions::PyValueError::new_err),
+        |vs| coordinates::positions_geodetic_to_ecef(vs, af).map_err(exceptions::PyValueError::new_err),
+    )
 }
 
-#[pyfunction]
-#[pyo3(text_signature = "(x_ecef, angle_format)")]
-#[pyo3(name = "position_ecef_to_geodetic")]
 /// Convert `ECEF` Cartesian position to geodetic coordinates.
 ///
 /// Transforms a position from Earth-Centered Earth-Fixed (`ECEF`) Cartesian coordinates
@@ -388,12 +467,17 @@ fn py_position_geodetic_to_ecef<'py>(
 ///
 /// Args:
 ///     x_ecef (numpy.ndarray or list): `ECEF` Cartesian position `[x, y, z]` in meters.
+///         Also accepts a batch of vectors with the 3 components along `axis`
+///         (for example shape `(n, 3)`).
 ///     angle_format (AngleFormat): Angle format for output angular coordinates (`RADIANS` or `DEGREES`).
+///     axis (int, optional): Axis of `x_ecef` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
 ///     numpy.ndarray: Geodetic position `[longitude, latitude, altitude]` where longitude
 ///         is in radians or degrees, latitude is in radians or degrees, and altitude
 ///         is in meters above the `WGS84` ellipsoid.
+///         For batched input the output takes the batch layout of `x_ecef`.
 ///
 /// Example:
 ///     ```python
@@ -405,20 +489,27 @@ fn py_position_geodetic_to_ecef<'py>(
 ///     x_geod = bh.position_ecef_to_geodetic(x_ecef, bh.AngleFormat.DEGREES)
 ///     print(f"Geodetic: lon={x_geod[0]:.4f}°, lat={x_geod[1]:.4f}°, alt={x_geod[2]:.0f}m")
 ///     ```
+#[pyfunction]
+#[pyo3(signature = (x_ecef, angle_format, axis=-1))]
+#[pyo3(text_signature = "(x_ecef, angle_format, axis=-1)")]
+#[pyo3(name = "position_ecef_to_geodetic")]
 fn py_position_ecef_to_geodetic<'py>(
     py: Python<'py>,
-    x_ecef: Bound<'py, PyAny>,
+    x_ecef: &Bound<'py, PyAny>,
     angle_format: &PyAngleFormat,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = coordinates::position_ecef_to_geodetic(pyany_to_svector::<3>(&x_ecef)?, angle_format.value);
-
-    Ok(vector_to_numpy!(py, vec, 3, f64))
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    let af = angle_format.value;
+    dispatch_vec::<3>(
+        py,
+        x_ecef,
+        axis,
+        |v| coordinates::position_ecef_to_geodetic(v, af),
+        |vs| coordinates::positions_ecef_to_geodetic(vs, af),
+    )
 }
 
 
-#[pyfunction]
-#[pyo3(text_signature = "(x_ellipsoid, angle_format)")]
-#[pyo3(name = "rotation_ellipsoid_to_enz")]
 /// Compute rotation matrix from ellipsoidal coordinates to East-North-Up (`ENZ`) frame.
 ///
 /// Calculates the rotation matrix that transforms vectors from an ellipsoidal coordinate
@@ -428,19 +519,35 @@ fn py_position_ecef_to_geodetic<'py>(
 /// Args:
 ///     x_ellipsoid (numpy.ndarray or list): Ellipsoidal position `[latitude, longitude, altitude/radius]`
 ///         where latitude is in radians or degrees, longitude is in radians or degrees.
+///         Also accepts a batch of vectors with the 3 components along `axis`
+///         (for example shape `(n, 3)`).
 ///     angle_format (AngleFormat): Angle format for input angular coordinates (`RADIANS` or `DEGREES`).
+///     axis (int, optional): Axis of `x_ellipsoid` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
 ///     numpy.ndarray: 3x3 rotation matrix from ellipsoidal frame to `ENZ` frame.
-fn py_rotation_ellipsoid_to_enz<'py>(py: Python<'py>, x_ellipsoid: Bound<'py, PyAny>, angle_format: &PyAngleFormat) -> PyResult<Bound<'py, PyArray<f64, Ix2>>> {
-    let mat = coordinates::rotation_ellipsoid_to_enz(pyany_to_svector::<3>(&x_ellipsoid)?, angle_format.value);
-
-    Ok(matrix_to_numpy!(py, mat, 3, 3, f64))
+///         For batched input the batch dimensions are followed by `(3, 3)`.
+#[pyfunction]
+#[pyo3(signature = (x_ellipsoid, angle_format, axis=-1))]
+#[pyo3(text_signature = "(x_ellipsoid, angle_format, axis=-1)")]
+#[pyo3(name = "rotation_ellipsoid_to_enz")]
+fn py_rotation_ellipsoid_to_enz<'py>(
+    py: Python<'py>,
+    x_ellipsoid: &Bound<'py, PyAny>,
+    angle_format: &PyAngleFormat,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    let af = angle_format.value;
+    dispatch_vec_rotation::<3>(
+        py,
+        x_ellipsoid,
+        axis,
+        |v| coordinates::rotation_ellipsoid_to_enz(v, af),
+        |vs| coordinates::rotations_ellipsoid_to_enz(vs, af),
+    )
 }
 
-#[pyfunction]
-#[pyo3(text_signature = "(x_ellipsoid, angle_format)")]
-#[pyo3(name = "rotation_enz_to_ellipsoid")]
 /// Compute rotation matrix from East-North-Up (`ENZ`) frame to ellipsoidal coordinates.
 ///
 /// Calculates the rotation matrix that transforms vectors from the local East-North-Up
@@ -450,19 +557,35 @@ fn py_rotation_ellipsoid_to_enz<'py>(py: Python<'py>, x_ellipsoid: Bound<'py, Py
 /// Args:
 ///     x_ellipsoid (numpy.ndarray or list): Ellipsoidal position `[latitude, longitude, altitude/radius]`
 ///         where latitude is in radians or degrees, longitude is in radians or degrees.
+///         Also accepts a batch of vectors with the 3 components along `axis`
+///         (for example shape `(n, 3)`).
 ///     angle_format (AngleFormat): Angle format for input angular coordinates (`RADIANS` or `DEGREES`).
+///     axis (int, optional): Axis of `x_ellipsoid` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
 ///     numpy.ndarray: 3x3 rotation matrix from `ENZ` frame to ellipsoidal frame.
-fn py_rotation_enz_to_ellipsoid<'py>(py: Python<'py>, x_ellipsoid: Bound<'py, PyAny>, angle_format: &PyAngleFormat) -> PyResult<Bound<'py, PyArray<f64, Ix2>>> {
-    let mat = coordinates::rotation_enz_to_ellipsoid(pyany_to_svector::<3>(&x_ellipsoid)?, angle_format.value);
-
-    Ok(matrix_to_numpy!(py, mat, 3, 3, f64))
+///         For batched input the batch dimensions are followed by `(3, 3)`.
+#[pyfunction]
+#[pyo3(signature = (x_ellipsoid, angle_format, axis=-1))]
+#[pyo3(text_signature = "(x_ellipsoid, angle_format, axis=-1)")]
+#[pyo3(name = "rotation_enz_to_ellipsoid")]
+fn py_rotation_enz_to_ellipsoid<'py>(
+    py: Python<'py>,
+    x_ellipsoid: &Bound<'py, PyAny>,
+    angle_format: &PyAngleFormat,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    let af = angle_format.value;
+    dispatch_vec_rotation::<3>(
+        py,
+        x_ellipsoid,
+        axis,
+        |v| coordinates::rotation_enz_to_ellipsoid(v, af),
+        |vs| coordinates::rotations_enz_to_ellipsoid(vs, af),
+    )
 }
 
-#[pyfunction]
-#[pyo3(text_signature = "(location_ecef, r_ecef, conversion_type)")]
-#[pyo3(name = "relative_position_ecef_to_enz")]
 /// Convert relative position from `ECEF` to East-North-Up (`ENZ`) frame.
 ///
 /// Transforms a relative position vector from Earth-Centered Earth-Fixed (`ECEF`) coordinates
@@ -470,11 +593,18 @@ fn py_rotation_enz_to_ellipsoid<'py>(py: Python<'py>, x_ellipsoid: Bound<'py, Py
 ///
 /// Args:
 ///     location_ecef (numpy.ndarray or list): Reference location in `ECEF` coordinates `[x, y, z]` in meters.
+///         Also accepts a batch of locations with the 3 components along `axis`;
+///         a single location is broadcast across a batch of positions and vice versa.
 ///     r_ecef (numpy.ndarray or list): Position vector in `ECEF` coordinates `[x, y, z]` in meters.
+///         Also accepts a batch of vectors with the 3 components along `axis`
+///         (for example shape `(n, 3)`).
 ///     conversion_type (EllipsoidalConversionType): Type of ellipsoidal conversion (`GEOCENTRIC` or `GEODETIC`).
+///     axis (int, optional): Axis of `location_ecef` and the position argument holding
+///         the vector components for batched input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
 ///     numpy.ndarray: Relative position in `ENZ` frame `[east, north, up]` in meters.
+///         For batched input the output takes the layout of the batched argument.
 ///
 /// Example:
 ///     ```python
@@ -487,15 +617,28 @@ fn py_rotation_enz_to_ellipsoid<'py>(py: Python<'py>, x_ellipsoid: Bound<'py, Py
 ///     enz = bh.relative_position_ecef_to_enz(station_ecef, sat_ecef, bh.EllipsoidalConversionType.GEODETIC)
 ///     print(f"ENZ: East={enz[0]/1000:.1f}km, North={enz[1]/1000:.1f}km, Up={enz[2]/1000:.1f}km")
 ///     ```
-fn py_relative_position_ecef_to_enz<'py>(py: Python<'py>, location_ecef: Bound<'py, PyAny>, r_ecef: Bound<'py, PyAny>, conversion_type: &PyEllipsoidalConversionType) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = coordinates::relative_position_ecef_to_enz(pyany_to_svector::<3>(&location_ecef)?, pyany_to_svector::<3>(&r_ecef)?, conversion_type.value);
-
-    Ok(vector_to_numpy!(py, vec, 3, f64))
+#[pyfunction]
+#[pyo3(signature = (location_ecef, r_ecef, conversion_type, axis=-1))]
+#[pyo3(text_signature = "(location_ecef, r_ecef, conversion_type, axis=-1)")]
+#[pyo3(name = "relative_position_ecef_to_enz")]
+fn py_relative_position_ecef_to_enz<'py>(
+    py: Python<'py>,
+    location_ecef: &Bound<'py, PyAny>,
+    r_ecef: &Bound<'py, PyAny>,
+    conversion_type: &PyEllipsoidalConversionType,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    let ct = conversion_type.value;
+    dispatch_vec_pair::<3>(
+        py,
+        location_ecef,
+        r_ecef,
+        axis,
+        |l, x| coordinates::relative_position_ecef_to_enz(l, x, ct),
+        |ls, xs| coordinates::relative_positions_ecef_to_enz(ls, xs, ct),
+    )
 }
 
-#[pyfunction]
-#[pyo3(text_signature = "(location_ecef, r_enz, conversion_type)")]
-#[pyo3(name = "relative_position_enz_to_ecef")]
 /// Convert relative position from East-North-Up (`ENZ`) frame to `ECEF`.
 ///
 /// Transforms a relative position vector from the local East-North-Up (`ENZ`) topocentric
@@ -503,11 +646,18 @@ fn py_relative_position_ecef_to_enz<'py>(py: Python<'py>, location_ecef: Bound<'
 ///
 /// Args:
 ///     location_ecef (numpy.ndarray or list): Reference location in `ECEF` coordinates `[x, y, z]` in meters.
+///         Also accepts a batch of locations with the 3 components along `axis`;
+///         a single location is broadcast across a batch of positions and vice versa.
 ///     r_enz (numpy.ndarray or list): Relative position in `ENZ` frame `[east, north, up]` in meters.
+///         Also accepts a batch of vectors with the 3 components along `axis`
+///         (for example shape `(n, 3)`).
 ///     conversion_type (EllipsoidalConversionType): Type of ellipsoidal conversion (`GEOCENTRIC` or `GEODETIC`).
+///     axis (int, optional): Axis of `location_ecef` and the position argument holding
+///         the vector components for batched input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
 ///     numpy.ndarray: Position vector in `ECEF` coordinates `[x, y, z]` in meters.
+///         For batched input the output takes the layout of the batched argument.
 ///
 /// Example:
 ///     ```python
@@ -520,15 +670,28 @@ fn py_relative_position_ecef_to_enz<'py>(py: Python<'py>, location_ecef: Bound<'
 ///     target_ecef = bh.relative_position_enz_to_ecef(station_ecef, enz_offset, bh.EllipsoidalConversionType.GEODETIC)
 ///     print(f"Target ECEF: {target_ecef}")
 ///     ```
-fn py_relative_position_enz_to_ecef<'py>(py: Python<'py>, location_ecef: Bound<'py, PyAny>, r_enz: Bound<'py, PyAny>, conversion_type: &PyEllipsoidalConversionType) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = coordinates::relative_position_enz_to_ecef(pyany_to_svector::<3>(&location_ecef)?, pyany_to_svector::<3>(&r_enz)?, conversion_type.value);
-
-    Ok(vector_to_numpy!(py, vec, 3, f64))
+#[pyfunction]
+#[pyo3(signature = (location_ecef, r_enz, conversion_type, axis=-1))]
+#[pyo3(text_signature = "(location_ecef, r_enz, conversion_type, axis=-1)")]
+#[pyo3(name = "relative_position_enz_to_ecef")]
+fn py_relative_position_enz_to_ecef<'py>(
+    py: Python<'py>,
+    location_ecef: &Bound<'py, PyAny>,
+    r_enz: &Bound<'py, PyAny>,
+    conversion_type: &PyEllipsoidalConversionType,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    let ct = conversion_type.value;
+    dispatch_vec_pair::<3>(
+        py,
+        location_ecef,
+        r_enz,
+        axis,
+        |l, x| coordinates::relative_position_enz_to_ecef(l, x, ct),
+        |ls, xs| coordinates::relative_positions_enz_to_ecef(ls, xs, ct),
+    )
 }
 
-#[pyfunction]
-#[pyo3(text_signature = "(x_ellipsoid, angle_format)")]
-#[pyo3(name = "rotation_ellipsoid_to_sez")]
 /// Compute rotation matrix from ellipsoidal coordinates to South-East-Zenith (`SEZ`) frame.
 ///
 /// Calculates the rotation matrix that transforms vectors from an ellipsoidal coordinate
@@ -538,10 +701,15 @@ fn py_relative_position_enz_to_ecef<'py>(py: Python<'py>, location_ecef: Bound<'
 /// Args:
 ///     x_ellipsoid (numpy.ndarray or list): Ellipsoidal position `[latitude, longitude, altitude/radius]`
 ///         where latitude is in radians or degrees, longitude is in radians or degrees.
+///         Also accepts a batch of vectors with the 3 components along `axis`
+///         (for example shape `(n, 3)`).
 ///     angle_format (AngleFormat): Angle format for input angular coordinates (`RADIANS` or `DEGREES`).
+///     axis (int, optional): Axis of `x_ellipsoid` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
 ///     numpy.ndarray: 3x3 rotation matrix from ellipsoidal frame to `SEZ` frame.
+///         For batched input the batch dimensions are followed by `(3, 3)`.
 ///
 /// Example:
 ///     ```python
@@ -554,15 +722,26 @@ fn py_relative_position_enz_to_ecef<'py>(py: Python<'py>, location_ecef: Bound<'
 ///     R_sez = bh.rotation_ellipsoid_to_sez(x_geod, bh.AngleFormat.RADIANS)
 ///     print(f"Rotation matrix shape: {R_sez.shape}")
 ///     ```
-fn py_rotation_ellipsoid_to_sez<'py>(py: Python<'py>, x_ellipsoid: Bound<'py, PyAny>, angle_format: &PyAngleFormat) -> PyResult<Bound<'py, PyArray<f64, Ix2>>> {
-    let mat = coordinates::rotation_ellipsoid_to_sez(pyany_to_svector::<3>(&x_ellipsoid)?, angle_format.value);
-
-    Ok(matrix_to_numpy!(py, mat, 3, 3, f64))
+#[pyfunction]
+#[pyo3(signature = (x_ellipsoid, angle_format, axis=-1))]
+#[pyo3(text_signature = "(x_ellipsoid, angle_format, axis=-1)")]
+#[pyo3(name = "rotation_ellipsoid_to_sez")]
+fn py_rotation_ellipsoid_to_sez<'py>(
+    py: Python<'py>,
+    x_ellipsoid: &Bound<'py, PyAny>,
+    angle_format: &PyAngleFormat,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    let af = angle_format.value;
+    dispatch_vec_rotation::<3>(
+        py,
+        x_ellipsoid,
+        axis,
+        |v| coordinates::rotation_ellipsoid_to_sez(v, af),
+        |vs| coordinates::rotations_ellipsoid_to_sez(vs, af),
+    )
 }
 
-#[pyfunction]
-#[pyo3(text_signature = "(x_ellipsoid, angle_format)")]
-#[pyo3(name = "rotation_sez_to_ellipsoid")]
 /// Compute rotation matrix from South-East-Zenith (`SEZ`) frame to ellipsoidal coordinates.
 ///
 /// Calculates the rotation matrix that transforms vectors from the local South-East-Zenith
@@ -572,10 +751,15 @@ fn py_rotation_ellipsoid_to_sez<'py>(py: Python<'py>, x_ellipsoid: Bound<'py, Py
 /// Args:
 ///     x_ellipsoid (numpy.ndarray or list): Ellipsoidal position `[latitude, longitude, altitude/radius]`
 ///         where latitude is in radians or degrees, longitude is in radians or degrees.
+///         Also accepts a batch of vectors with the 3 components along `axis`
+///         (for example shape `(n, 3)`).
 ///     angle_format (AngleFormat): Angle format for input angular coordinates (`RADIANS` or `DEGREES`).
+///     axis (int, optional): Axis of `x_ellipsoid` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
 ///     numpy.ndarray: 3x3 rotation matrix from `SEZ` frame to ellipsoidal frame.
+///         For batched input the batch dimensions are followed by `(3, 3)`.
 ///
 /// Example:
 ///     ```python
@@ -588,15 +772,26 @@ fn py_rotation_ellipsoid_to_sez<'py>(py: Python<'py>, x_ellipsoid: Bound<'py, Py
 ///     R_ellipsoid = bh.rotation_sez_to_ellipsoid(x_geod, bh.AngleFormat.RADIANS)
 ///     print(f"Rotation matrix shape: {R_ellipsoid.shape}")
 ///     ```
-fn py_rotation_sez_to_ellipsoid<'py>(py: Python<'py>, x_ellipsoid: Bound<'py, PyAny>, angle_format: &PyAngleFormat) -> PyResult<Bound<'py, PyArray<f64, Ix2>>> {
-    let mat = coordinates::rotation_sez_to_ellipsoid(pyany_to_svector::<3>(&x_ellipsoid)?, angle_format.value);
-
-    Ok(matrix_to_numpy!(py, mat, 3, 3, f64))
+#[pyfunction]
+#[pyo3(signature = (x_ellipsoid, angle_format, axis=-1))]
+#[pyo3(text_signature = "(x_ellipsoid, angle_format, axis=-1)")]
+#[pyo3(name = "rotation_sez_to_ellipsoid")]
+fn py_rotation_sez_to_ellipsoid<'py>(
+    py: Python<'py>,
+    x_ellipsoid: &Bound<'py, PyAny>,
+    angle_format: &PyAngleFormat,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    let af = angle_format.value;
+    dispatch_vec_rotation::<3>(
+        py,
+        x_ellipsoid,
+        axis,
+        |v| coordinates::rotation_sez_to_ellipsoid(v, af),
+        |vs| coordinates::rotations_sez_to_ellipsoid(vs, af),
+    )
 }
 
-#[pyfunction]
-#[pyo3(text_signature = "(location_ecef, r_ecef, conversion_type)")]
-#[pyo3(name = "relative_position_ecef_to_sez")]
 /// Convert relative position from `ECEF` to South-East-Zenith (`SEZ`) frame.
 ///
 /// Transforms a relative position vector from Earth-Centered Earth-Fixed (`ECEF`) coordinates
@@ -604,11 +799,18 @@ fn py_rotation_sez_to_ellipsoid<'py>(py: Python<'py>, x_ellipsoid: Bound<'py, Py
 ///
 /// Args:
 ///     location_ecef (numpy.ndarray or list): Reference location in `ECEF` coordinates `[x, y, z]` in meters.
+///         Also accepts a batch of locations with the 3 components along `axis`;
+///         a single location is broadcast across a batch of positions and vice versa.
 ///     r_ecef (numpy.ndarray or list): Position vector in `ECEF` coordinates `[x, y, z]` in meters.
+///         Also accepts a batch of vectors with the 3 components along `axis`
+///         (for example shape `(n, 3)`).
 ///     conversion_type (EllipsoidalConversionType): Type of ellipsoidal conversion (`GEOCENTRIC` or `GEODETIC`).
+///     axis (int, optional): Axis of `location_ecef` and the position argument holding
+///         the vector components for batched input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
 ///     numpy.ndarray: Relative position in `SEZ` frame `[south, east, zenith]` in meters.
+///         For batched input the output takes the layout of the batched argument.
 ///
 /// Example:
 ///     ```python
@@ -621,15 +823,28 @@ fn py_rotation_sez_to_ellipsoid<'py>(py: Python<'py>, x_ellipsoid: Bound<'py, Py
 ///     sez = bh.relative_position_ecef_to_sez(station_ecef, sat_ecef, bh.EllipsoidalConversionType.GEODETIC)
 ///     print(f"SEZ: South={sez[0]/1000:.1f}km, East={sez[1]/1000:.1f}km, Zenith={sez[2]/1000:.1f}km")
 ///     ```
-fn py_relative_position_ecef_to_sez<'py>(py: Python<'py>, location_ecef: Bound<'py, PyAny>, r_ecef: Bound<'py, PyAny>, conversion_type: &PyEllipsoidalConversionType) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = coordinates::relative_position_ecef_to_sez(pyany_to_svector::<3>(&location_ecef)?, pyany_to_svector::<3>(&r_ecef)?, conversion_type.value);
-
-    Ok(vector_to_numpy!(py, vec, 3, f64))
+#[pyfunction]
+#[pyo3(signature = (location_ecef, r_ecef, conversion_type, axis=-1))]
+#[pyo3(text_signature = "(location_ecef, r_ecef, conversion_type, axis=-1)")]
+#[pyo3(name = "relative_position_ecef_to_sez")]
+fn py_relative_position_ecef_to_sez<'py>(
+    py: Python<'py>,
+    location_ecef: &Bound<'py, PyAny>,
+    r_ecef: &Bound<'py, PyAny>,
+    conversion_type: &PyEllipsoidalConversionType,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    let ct = conversion_type.value;
+    dispatch_vec_pair::<3>(
+        py,
+        location_ecef,
+        r_ecef,
+        axis,
+        |l, x| coordinates::relative_position_ecef_to_sez(l, x, ct),
+        |ls, xs| coordinates::relative_positions_ecef_to_sez(ls, xs, ct),
+    )
 }
 
-#[pyfunction]
-#[pyo3(text_signature = "(location_ecef, x_sez, conversion_type)")]
-#[pyo3(name = "relative_position_sez_to_ecef")]
 /// Convert relative position from South-East-Zenith (`SEZ`) frame to `ECEF`.
 ///
 /// Transforms a relative position vector from the local South-East-Zenith (`SEZ`) topocentric
@@ -637,11 +852,18 @@ fn py_relative_position_ecef_to_sez<'py>(py: Python<'py>, location_ecef: Bound<'
 ///
 /// Args:
 ///     location_ecef (numpy.ndarray or list): Reference location in `ECEF` coordinates `[x, y, z]` in meters.
+///         Also accepts a batch of locations with the 3 components along `axis`;
+///         a single location is broadcast across a batch of positions and vice versa.
 ///     x_sez (numpy.ndarray or list): Relative position in `SEZ` frame `[south, east, zenith]` in meters.
+///         Also accepts a batch of vectors with the 3 components along `axis`
+///         (for example shape `(n, 3)`).
 ///     conversion_type (EllipsoidalConversionType): Type of ellipsoidal conversion (`GEOCENTRIC` or `GEODETIC`).
+///     axis (int, optional): Axis of `location_ecef` and the position argument holding
+///         the vector components for batched input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
 ///     numpy.ndarray: Position vector in `ECEF` coordinates `[x, y, z]` in meters.
+///         For batched input the output takes the layout of the batched argument.
 ///
 /// Example:
 ///     ```python
@@ -654,15 +876,28 @@ fn py_relative_position_ecef_to_sez<'py>(py: Python<'py>, location_ecef: Bound<'
 ///     target_ecef = bh.relative_position_sez_to_ecef(station_ecef, sez_offset, bh.EllipsoidalConversionType.GEODETIC)
 ///     print(f"Target ECEF: {target_ecef}")
 ///     ```
-fn py_relative_position_sez_to_ecef<'py>(py: Python<'py>, location_ecef: Bound<'py, PyAny>, x_sez: Bound<'py, PyAny>, conversion_type: &PyEllipsoidalConversionType) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = coordinates::relative_position_sez_to_ecef(pyany_to_svector::<3>(&location_ecef)?, pyany_to_svector::<3>(&x_sez)?, conversion_type.value);
-
-    Ok(vector_to_numpy!(py, vec, 3, f64))
+#[pyfunction]
+#[pyo3(signature = (location_ecef, x_sez, conversion_type, axis=-1))]
+#[pyo3(text_signature = "(location_ecef, x_sez, conversion_type, axis=-1)")]
+#[pyo3(name = "relative_position_sez_to_ecef")]
+fn py_relative_position_sez_to_ecef<'py>(
+    py: Python<'py>,
+    location_ecef: &Bound<'py, PyAny>,
+    x_sez: &Bound<'py, PyAny>,
+    conversion_type: &PyEllipsoidalConversionType,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    let ct = conversion_type.value;
+    dispatch_vec_pair::<3>(
+        py,
+        location_ecef,
+        x_sez,
+        axis,
+        |l, x| coordinates::relative_position_sez_to_ecef(l, x, ct),
+        |ls, xs| coordinates::relative_positions_sez_to_ecef(ls, xs, ct),
+    )
 }
 
-#[pyfunction]
-#[pyo3(text_signature = "(x_enz, angle_format)")]
-#[pyo3(name = "position_enz_to_azel")]
 /// Convert position from East-North-Up (`ENZ`) frame to azimuth-elevation-range.
 ///
 /// Transforms a position from the local East-North-Up (`ENZ`) topocentric frame to
@@ -670,11 +905,16 @@ fn py_relative_position_sez_to_ecef<'py>(py: Python<'py>, location_ecef: Bound<'
 ///
 /// Args:
 ///     x_enz (numpy.ndarray or list): Position in `ENZ` frame `[east, north, up]` in meters.
+///         Also accepts a batch of vectors with the 3 components along `axis`
+///         (for example shape `(n, 3)`).
 ///     angle_format (AngleFormat): Angle format for output angular coordinates (`RADIANS` or `DEGREES`).
+///     axis (int, optional): Axis of `x_enz` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
 ///     numpy.ndarray: Azimuth-elevation-range `[azimuth, elevation, range]` where azimuth
 ///         and elevation are in radians or degrees, and range is in meters.
+///         For batched input the output takes the batch layout of `x_enz`.
 ///
 /// Example:
 ///     ```python
@@ -686,15 +926,26 @@ fn py_relative_position_sez_to_ecef<'py>(py: Python<'py>, location_ecef: Bound<'
 ///     azel = bh.position_enz_to_azel(enz, bh.AngleFormat.DEGREES)
 ///     print(f"Az={azel[0]:.1f}°, El={azel[1]:.1f}°, Range={azel[2]/1000:.1f}km")
 ///     ```
-fn py_position_enz_to_azel<'py>(py: Python<'py>, x_enz: Bound<'py, PyAny>, angle_format: &PyAngleFormat) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = coordinates::position_enz_to_azel(pyany_to_svector::<3>(&x_enz)?, angle_format.value);
-
-    Ok(vector_to_numpy!(py, vec, 3, f64))
+#[pyfunction]
+#[pyo3(signature = (x_enz, angle_format, axis=-1))]
+#[pyo3(text_signature = "(x_enz, angle_format, axis=-1)")]
+#[pyo3(name = "position_enz_to_azel")]
+fn py_position_enz_to_azel<'py>(
+    py: Python<'py>,
+    x_enz: &Bound<'py, PyAny>,
+    angle_format: &PyAngleFormat,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    let af = angle_format.value;
+    dispatch_vec::<3>(
+        py,
+        x_enz,
+        axis,
+        |v| coordinates::position_enz_to_azel(v, af),
+        |vs| coordinates::positions_enz_to_azel(vs, af),
+    )
 }
 
-#[pyfunction]
-#[pyo3(text_signature = "(x_sez, angle_format)")]
-#[pyo3(name = "position_sez_to_azel")]
 /// Convert position from South-East-Zenith (`SEZ`) frame to azimuth-elevation-range.
 ///
 /// Transforms a position from the local South-East-Zenith (`SEZ`) topocentric frame to
@@ -702,11 +953,16 @@ fn py_position_enz_to_azel<'py>(py: Python<'py>, x_enz: Bound<'py, PyAny>, angle
 ///
 /// Args:
 ///     x_sez (numpy.ndarray or list): Position in `SEZ` frame `[south, east, zenith]` in meters.
+///         Also accepts a batch of vectors with the 3 components along `axis`
+///         (for example shape `(n, 3)`).
 ///     angle_format (AngleFormat): Angle format for output angular coordinates (`RADIANS` or `DEGREES`).
+///     axis (int, optional): Axis of `x_sez` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
 ///     numpy.ndarray: Azimuth-elevation-range `[azimuth, elevation, range]` where azimuth
 ///         and elevation are in radians or degrees, and range is in meters.
+///         For batched input the output takes the batch layout of `x_sez`.
 ///
 /// Example:
 ///     ```python
@@ -718,15 +974,26 @@ fn py_position_enz_to_azel<'py>(py: Python<'py>, x_enz: Bound<'py, PyAny>, angle
 ///     azel = bh.position_sez_to_azel(sez, bh.AngleFormat.DEGREES)
 ///     print(f"Az={azel[0]:.1f}°, El={azel[1]:.1f}°, Range={azel[2]/1000:.1f}km")
 ///     ```
-fn py_position_sez_to_azel<'py>(py: Python<'py>, x_sez: Bound<'py, PyAny>, angle_format: &PyAngleFormat) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = coordinates::position_sez_to_azel(pyany_to_svector::<3>(&x_sez)?, angle_format.value);
-
-    Ok(vector_to_numpy!(py, vec, 3, f64))
+#[pyfunction]
+#[pyo3(signature = (x_sez, angle_format, axis=-1))]
+#[pyo3(text_signature = "(x_sez, angle_format, axis=-1)")]
+#[pyo3(name = "position_sez_to_azel")]
+fn py_position_sez_to_azel<'py>(
+    py: Python<'py>,
+    x_sez: &Bound<'py, PyAny>,
+    angle_format: &PyAngleFormat,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    let af = angle_format.value;
+    dispatch_vec::<3>(
+        py,
+        x_sez,
+        axis,
+        |v| coordinates::position_sez_to_azel(v, af),
+        |vs| coordinates::positions_sez_to_azel(vs, af),
+    )
 }
 
-#[pyfunction]
-#[pyo3(text_signature = "(x_radec, angle_format)")]
-#[pyo3(name = "position_radec_to_inertial")]
 /// Convert a right ascension, declination, and range into the equivalent
 /// Cartesian inertial position.
 ///
@@ -734,10 +1001,15 @@ fn py_position_sez_to_azel<'py>(py: Python<'py>, x_sez: Bound<'py, PyAny>, angle
 ///     x_radec (numpy.ndarray or list): Right ascension, declination, and range
 ///         `[ra, dec, range]` where right ascension and declination are in
 ///         radians or degrees, and range is in meters.
+///         Also accepts a batch of vectors with the 3 components along `axis`
+///         (for example shape `(n, 3)`).
 ///     angle_format (AngleFormat): Angle format for angular elements (`RADIANS` or `DEGREES`).
+///     axis (int, optional): Axis of `x_radec` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian inertial position `[x, y, z]` in meters.
+///         For batched input the output takes the batch layout of `x_radec`.
 ///
 /// Example:
 ///     ```python
@@ -748,20 +1020,26 @@ fn py_position_sez_to_azel<'py>(py: Python<'py>, x_sez: Bound<'py, PyAny>, angle
 ///     x_inertial = bh.position_radec_to_inertial(x_radec, bh.AngleFormat.DEGREES)
 ///     print(f"Inertial position: {x_inertial}")
 ///     ```
+#[pyfunction]
+#[pyo3(signature = (x_radec, angle_format, axis=-1))]
+#[pyo3(text_signature = "(x_radec, angle_format, axis=-1)")]
+#[pyo3(name = "position_radec_to_inertial")]
 fn py_position_radec_to_inertial<'py>(
     py: Python<'py>,
-    x_radec: Bound<'py, PyAny>,
+    x_radec: &Bound<'py, PyAny>,
     angle_format: &PyAngleFormat,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec =
-        coordinates::position_radec_to_inertial(pyany_to_svector::<3>(&x_radec)?, angle_format.value);
-
-    Ok(vector_to_numpy!(py, vec, 3, f64))
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    let af = angle_format.value;
+    dispatch_vec::<3>(
+        py,
+        x_radec,
+        axis,
+        |v| coordinates::position_radec_to_inertial(v, af),
+        |vs| coordinates::positions_radec_to_inertial(vs, af),
+    )
 }
 
-#[pyfunction]
-#[pyo3(text_signature = "(x_inertial, angle_format)")]
-#[pyo3(name = "position_inertial_to_radec")]
 /// Convert a Cartesian inertial position into the equivalent right ascension,
 /// declination, and range.
 ///
@@ -772,11 +1050,16 @@ fn py_position_radec_to_inertial<'py>(
 ///
 /// Args:
 ///     x_inertial (numpy.ndarray or list): Cartesian inertial position `[x, y, z]` in meters.
+///         Also accepts a batch of vectors with the 3 components along `axis`
+///         (for example shape `(n, 3)`).
 ///     angle_format (AngleFormat): Angle format for angular output (`RADIANS` or `DEGREES`).
+///     axis (int, optional): Axis of `x_inertial` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
 ///     numpy.ndarray: Right ascension, declination, and range `[ra, dec, range]` where
 ///         right ascension and declination are in radians or degrees, and range is in meters.
+///         For batched input the output takes the batch layout of `x_inertial`.
 ///
 /// Example:
 ///     ```python
@@ -787,22 +1070,26 @@ fn py_position_radec_to_inertial<'py>(
 ///     x_radec = bh.position_inertial_to_radec(x_inertial, bh.AngleFormat.DEGREES)
 ///     print(f"RA/Dec: {x_radec}")
 ///     ```
+#[pyfunction]
+#[pyo3(signature = (x_inertial, angle_format, axis=-1))]
+#[pyo3(text_signature = "(x_inertial, angle_format, axis=-1)")]
+#[pyo3(name = "position_inertial_to_radec")]
 fn py_position_inertial_to_radec<'py>(
     py: Python<'py>,
-    x_inertial: Bound<'py, PyAny>,
+    x_inertial: &Bound<'py, PyAny>,
     angle_format: &PyAngleFormat,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = coordinates::position_inertial_to_radec(
-        pyany_to_svector::<3>(&x_inertial)?,
-        angle_format.value,
-    );
-
-    Ok(vector_to_numpy!(py, vec, 3, f64))
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    let af = angle_format.value;
+    dispatch_vec::<3>(
+        py,
+        x_inertial,
+        axis,
+        |v| coordinates::position_inertial_to_radec(v, af),
+        |vs| coordinates::positions_inertial_to_radec(vs, af),
+    )
 }
 
-#[pyfunction]
-#[pyo3(text_signature = "(x_radec, angle_format)")]
-#[pyo3(name = "state_radec_to_inertial")]
 /// Convert a right ascension, declination, range, and their rates into the
 /// equivalent Cartesian inertial position and velocity.
 ///
@@ -811,11 +1098,16 @@ fn py_position_inertial_to_radec<'py>(
 ///         `[ra, dec, range, ra_rate, dec_rate, range_rate]` where right ascension,
 ///         declination, and their rates are in radians (or radians/s) or degrees
 ///         (or degrees/s), and range/range_rate are in meters and meters/s.
+///         Also accepts a batch of vectors with the 6 components along `axis`
+///         (for example shape `(n, 6)`).
 ///     angle_format (AngleFormat): Angle format for angular elements and rates (`RADIANS` or `DEGREES`).
+///     axis (int, optional): Axis of `x_radec` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian inertial position and velocity `[x, y, z, vx, vy, vz]`
 ///         in meters and meters per second.
+///         For batched input the output takes the batch layout of `x_radec`.
 ///
 /// Example:
 ///     ```python
@@ -826,20 +1118,26 @@ fn py_position_inertial_to_radec<'py>(
 ///     x_inertial = bh.state_radec_to_inertial(x_radec, bh.AngleFormat.DEGREES)
 ///     print(f"Inertial state: {x_inertial}")
 ///     ```
+#[pyfunction]
+#[pyo3(signature = (x_radec, angle_format, axis=-1))]
+#[pyo3(text_signature = "(x_radec, angle_format, axis=-1)")]
+#[pyo3(name = "state_radec_to_inertial")]
 fn py_state_radec_to_inertial<'py>(
     py: Python<'py>,
-    x_radec: Bound<'py, PyAny>,
+    x_radec: &Bound<'py, PyAny>,
     angle_format: &PyAngleFormat,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec =
-        coordinates::state_radec_to_inertial(pyany_to_svector::<6>(&x_radec)?, angle_format.value);
-
-    Ok(vector_to_numpy!(py, vec, 6, f64))
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    let af = angle_format.value;
+    dispatch_vec::<6>(
+        py,
+        x_radec,
+        axis,
+        |v| coordinates::state_radec_to_inertial(v, af),
+        |vs| coordinates::states_radec_to_inertial(vs, af),
+    )
 }
 
-#[pyfunction]
-#[pyo3(text_signature = "(x_inertial, angle_format)")]
-#[pyo3(name = "state_inertial_to_radec")]
 /// Convert a Cartesian inertial position and velocity into the equivalent
 /// right ascension, declination, range, and their rates.
 ///
@@ -851,13 +1149,18 @@ fn py_state_radec_to_inertial<'py>(
 /// Args:
 ///     x_inertial (numpy.ndarray or list): Cartesian inertial position and velocity
 ///         `[x, y, z, vx, vy, vz]` in meters and meters per second.
+///         Also accepts a batch of vectors with the 6 components along `axis`
+///         (for example shape `(n, 6)`).
 ///     angle_format (AngleFormat): Angle format for angular output and rates (`RADIANS` or `DEGREES`).
+///     axis (int, optional): Axis of `x_inertial` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
 ///     numpy.ndarray: Right ascension, declination, range, and rates
 ///         `[ra, dec, range, ra_rate, dec_rate, range_rate]` where right ascension,
 ///         declination, and their rates are in radians (or radians/s) or degrees
 ///         (or degrees/s), and range/range_rate are in meters and meters/s.
+///         For batched input the output takes the batch layout of `x_inertial`.
 ///
 /// Example:
 ///     ```python
@@ -868,20 +1171,26 @@ fn py_state_radec_to_inertial<'py>(
 ///     x_radec = bh.state_inertial_to_radec(x_inertial, bh.AngleFormat.DEGREES)
 ///     print(f"RA/Dec state: {x_radec}")
 ///     ```
+#[pyfunction]
+#[pyo3(signature = (x_inertial, angle_format, axis=-1))]
+#[pyo3(text_signature = "(x_inertial, angle_format, axis=-1)")]
+#[pyo3(name = "state_inertial_to_radec")]
 fn py_state_inertial_to_radec<'py>(
     py: Python<'py>,
-    x_inertial: Bound<'py, PyAny>,
+    x_inertial: &Bound<'py, PyAny>,
     angle_format: &PyAngleFormat,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec =
-        coordinates::state_inertial_to_radec(pyany_to_svector::<6>(&x_inertial)?, angle_format.value);
-
-    Ok(vector_to_numpy!(py, vec, 6, f64))
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    let af = angle_format.value;
+    dispatch_vec::<6>(
+        py,
+        x_inertial,
+        axis,
+        |v| coordinates::state_inertial_to_radec(v, af),
+        |vs| coordinates::states_inertial_to_radec(vs, af),
+    )
 }
 
-#[pyfunction]
-#[pyo3(text_signature = "(x_radec, site_geodetic, epc, angle_format)")]
-#[pyo3(name = "position_radec_to_azel")]
 /// Convert a topocentric right ascension, declination, and range into the
 /// equivalent azimuth, elevation, and range as seen from a given site.
 ///
@@ -901,17 +1210,25 @@ fn py_state_inertial_to_radec<'py>(
 ///     x_radec (numpy.ndarray or list): Topocentric right ascension, declination, and range
 ///         `[ra, dec, range]` where right ascension and declination are in radians or
 ///         degrees, and range is in meters.
+///         Also accepts a batch of vectors with the 3 components along `axis`
+///         (for example shape `(n, 3)`).
 ///     site_geodetic (numpy.ndarray or list): Geodetic coordinates of the observing site
 ///         `[lon, lat, alt]` where longitude and latitude are in radians or degrees,
 ///         and altitude is in meters.
-///     epc (Epoch): Epoch of the observation, used to rotate between the inertial and
+///     epc (Epoch or Sequence[Epoch]): Epoch of the observation, used to rotate between the inertial and
 ///         Earth-fixed frames.
+///         A sequence evaluates one epoch per vector (or broadcasts a single
+///         vector across all epochs).
 ///     angle_format (AngleFormat): Angle format for angular elements (`RADIANS` or `DEGREES`).
+///     axis (int, optional): Axis of `x_radec` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
 ///     numpy.ndarray: Azimuth (clockwise from North), elevation, and range
 ///         `[az, el, range]` where azimuth and elevation are in radians or degrees,
 ///         and range is in meters.
+///         For batched input the output takes the batch layout of `x_radec` (shape
+///         `(n, 3)` for a single vector with a sequence of `n` epochs).
 ///
 /// Example:
 ///     ```python
@@ -925,26 +1242,30 @@ fn py_state_inertial_to_radec<'py>(
 ///     # Requires a global EOP provider to be initialized first.
 ///     x_azel = bh.position_radec_to_azel(x_radec, site, epc, bh.AngleFormat.DEGREES)
 ///     ```
+#[pyfunction]
+#[pyo3(signature = (x_radec, site_geodetic, epc, angle_format, axis=-1))]
+#[pyo3(text_signature = "(x_radec, site_geodetic, epc, angle_format, axis=-1)")]
+#[pyo3(name = "position_radec_to_azel")]
 fn py_position_radec_to_azel<'py>(
     py: Python<'py>,
-    x_radec: Bound<'py, PyAny>,
-    site_geodetic: Bound<'py, PyAny>,
-    epc: &PyEpoch,
+    x_radec: &Bound<'py, PyAny>,
+    site_geodetic: &Bound<'py, PyAny>,
+    epc: &Bound<'py, PyAny>,
     angle_format: &PyAngleFormat,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = coordinates::position_radec_to_azel(
-        pyany_to_svector::<3>(&x_radec)?,
-        pyany_to_svector::<3>(&site_geodetic)?,
-        epc.obj,
-        angle_format.value,
-    );
-
-    Ok(vector_to_numpy!(py, vec, 3, f64))
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    let af = angle_format.value;
+    let site = pyany_to_svector::<3>(site_geodetic)?;
+    dispatch_epoch_vec::<3>(
+        py,
+        epc,
+        x_radec,
+        axis,
+        |e, v| coordinates::position_radec_to_azel(v, site, e, af),
+        |es, vs| coordinates::positions_radec_to_azel(vs, site, es, af),
+    )
 }
 
-#[pyfunction]
-#[pyo3(text_signature = "(x_azel, site_geodetic, epc, angle_format)")]
-#[pyo3(name = "position_azel_to_radec")]
 /// Convert an azimuth, elevation, and range as seen from a given site into
 /// the equivalent topocentric right ascension, declination, and range.
 ///
@@ -962,17 +1283,25 @@ fn py_position_radec_to_azel<'py>(
 ///     x_azel (numpy.ndarray or list): Azimuth (clockwise from North), elevation, and
 ///         range `[az, el, range]` where azimuth and elevation are in radians or
 ///         degrees, and range is in meters.
+///         Also accepts a batch of vectors with the 3 components along `axis`
+///         (for example shape `(n, 3)`).
 ///     site_geodetic (numpy.ndarray or list): Geodetic coordinates of the observing site
 ///         `[lon, lat, alt]` where longitude and latitude are in radians or degrees,
 ///         and altitude is in meters.
-///     epc (Epoch): Epoch of the observation, used to rotate between the Earth-fixed
+///     epc (Epoch or Sequence[Epoch]): Epoch of the observation, used to rotate between the Earth-fixed
 ///         and inertial frames.
+///         A sequence evaluates one epoch per vector (or broadcasts a single
+///         vector across all epochs).
 ///     angle_format (AngleFormat): Angle format for angular elements (`RADIANS` or `DEGREES`).
+///     axis (int, optional): Axis of `x_azel` holding the vector components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
 ///     numpy.ndarray: Topocentric right ascension, declination, and range
 ///         `[ra, dec, range]` where right ascension and declination are in radians
 ///         or degrees, and range is in meters.
+///         For batched input the output takes the batch layout of `x_azel` (shape
+///         `(n, 3)` for a single vector with a sequence of `n` epochs).
 ///
 /// Example:
 ///     ```python
@@ -986,21 +1315,28 @@ fn py_position_radec_to_azel<'py>(
 ///     # Requires a global EOP provider to be initialized first.
 ///     x_radec = bh.position_azel_to_radec(x_azel, site, epc, bh.AngleFormat.DEGREES)
 ///     ```
+#[pyfunction]
+#[pyo3(signature = (x_azel, site_geodetic, epc, angle_format, axis=-1))]
+#[pyo3(text_signature = "(x_azel, site_geodetic, epc, angle_format, axis=-1)")]
+#[pyo3(name = "position_azel_to_radec")]
 fn py_position_azel_to_radec<'py>(
     py: Python<'py>,
-    x_azel: Bound<'py, PyAny>,
-    site_geodetic: Bound<'py, PyAny>,
-    epc: &PyEpoch,
+    x_azel: &Bound<'py, PyAny>,
+    site_geodetic: &Bound<'py, PyAny>,
+    epc: &Bound<'py, PyAny>,
     angle_format: &PyAngleFormat,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let vec = coordinates::position_azel_to_radec(
-        pyany_to_svector::<3>(&x_azel)?,
-        pyany_to_svector::<3>(&site_geodetic)?,
-        epc.obj,
-        angle_format.value,
-    );
-
-    Ok(vector_to_numpy!(py, vec, 3, f64))
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    let af = angle_format.value;
+    let site = pyany_to_svector::<3>(site_geodetic)?;
+    dispatch_epoch_vec::<3>(
+        py,
+        epc,
+        x_azel,
+        axis,
+        |e, v| coordinates::position_azel_to_radec(v, site, e, af),
+        |es, vs| coordinates::positions_azel_to_radec(vs, site, es, af),
+    )
 }
 
 #[pyfunction]

--- a/crates/brahe-py/src/coordinates.rs
+++ b/crates/brahe-py/src/coordinates.rs
@@ -69,8 +69,10 @@ impl PyEllipsoidalConversionType {
 ///         Also accepts a batch of vectors with the 6 components along `axis`
 ///         (for example shape `(n, 6)`).
 ///     angle_format (AngleFormat): Angle format for angular elements (`RADIANS` or `DEGREES`).
-///     axis (int, optional): Axis of `x_oe` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_oe` along which the 6 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 6)` the components lie along the last axis, so the default `-1`
+///         applies; a `(6, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian state `[x, y, z, vx, vy, vz]` where position is in meters
@@ -118,8 +120,10 @@ fn py_state_koe_to_eci<'py>(
 ///         Also accepts a batch of vectors with the 6 components along `axis`
 ///         (for example shape `(n, 6)`).
 ///     angle_format (AngleFormat): Angle format for output angular elements (`RADIANS` or `DEGREES`).
-///     axis (int, optional): Axis of `x_cart` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_cart` along which the 6 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 6)` the components lie along the last axis, so the default `-1`
+///         applies; a `(6, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Osculating orbital elements `[a, e, i, RAAN, omega, M]` where `a` is
@@ -186,8 +190,10 @@ fn py_state_eci_to_koe<'py>(
 ///     central_body (CentralBody): Central body (supplies the GM and the IAU pole /
 ///         body-fixed frame).
 ///     angle_format (AngleFormat): Angle format for output angular elements (`RADIANS` or `DEGREES`).
-///     axis (int, optional): Axis of `x_cart` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_cart` along which the 6 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 6)` the components lie along the last axis, so the default `-1`
+///         applies; a `(6, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Osculating orbital elements `[a, e, i, RAAN, omega, M]` referenced
@@ -263,8 +269,10 @@ fn py_state_inertial_to_koe_for_body<'py>(
 ///     central_body (CentralBody): Central body (supplies the GM and the IAU pole /
 ///         body-fixed frame).
 ///     angle_format (AngleFormat): Angle format for input angular elements (`RADIANS` or `DEGREES`).
-///     axis (int, optional): Axis of `x_oe` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_oe` along which the 6 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 6)` the components lie along the last axis, so the default `-1`
+///         applies; a `(6, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian state `[x, y, z, vx, vy, vz]` in the body-centered
@@ -324,8 +332,10 @@ fn py_state_koe_to_inertial_for_body<'py>(
 ///         Also accepts a batch of vectors with the 3 components along `axis`
 ///         (for example shape `(n, 3)`).
 ///     angle_format (AngleFormat): Angle format for input angular coordinates (`RADIANS` or `DEGREES`).
-///     axis (int, optional): Axis of `x_geoc` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_geoc` along which the 3 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 3)` the components lie along the last axis, so the default `-1`
+///         applies; a `(3, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: `ECEF` Cartesian position `[x, y, z]` in meters.
@@ -372,8 +382,10 @@ fn py_position_geocentric_to_ecef<'py>(
 ///         Also accepts a batch of vectors with the 3 components along `axis`
 ///         (for example shape `(n, 3)`).
 ///     angle_format (AngleFormat): Angle format for output angular coordinates (`RADIANS` or `DEGREES`).
-///     axis (int, optional): Axis of `x_ecef` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_ecef` along which the 3 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 3)` the components lie along the last axis, so the default `-1`
+///         applies; a `(3, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Geocentric position `[longitude, latitude, radius]` where longitude
@@ -422,8 +434,10 @@ fn py_position_ecef_to_geocentric<'py>(
 ///         Also accepts a batch of vectors with the 3 components along `axis`
 ///         (for example shape `(n, 3)`).
 ///     angle_format (AngleFormat): Angle format for input angular coordinates (`RADIANS` or `DEGREES`).
-///     axis (int, optional): Axis of `x_geod` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_geod` along which the 3 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 3)` the components lie along the last axis, so the default `-1`
+///         applies; a `(3, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: `ECEF` Cartesian position `[x, y, z]` in meters.
@@ -470,8 +484,10 @@ fn py_position_geodetic_to_ecef<'py>(
 ///         Also accepts a batch of vectors with the 3 components along `axis`
 ///         (for example shape `(n, 3)`).
 ///     angle_format (AngleFormat): Angle format for output angular coordinates (`RADIANS` or `DEGREES`).
-///     axis (int, optional): Axis of `x_ecef` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_ecef` along which the 3 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 3)` the components lie along the last axis, so the default `-1`
+///         applies; a `(3, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Geodetic position `[longitude, latitude, altitude]` where longitude
@@ -522,8 +538,10 @@ fn py_position_ecef_to_geodetic<'py>(
 ///         Also accepts a batch of vectors with the 3 components along `axis`
 ///         (for example shape `(n, 3)`).
 ///     angle_format (AngleFormat): Angle format for input angular coordinates (`RADIANS` or `DEGREES`).
-///     axis (int, optional): Axis of `x_ellipsoid` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_ellipsoid` along which the 3 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 3)` the components lie along the last axis, so the default `-1`
+///         applies; a `(3, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: 3x3 rotation matrix from ellipsoidal frame to `ENZ` frame.
@@ -560,8 +578,10 @@ fn py_rotation_ellipsoid_to_enz<'py>(
 ///         Also accepts a batch of vectors with the 3 components along `axis`
 ///         (for example shape `(n, 3)`).
 ///     angle_format (AngleFormat): Angle format for input angular coordinates (`RADIANS` or `DEGREES`).
-///     axis (int, optional): Axis of `x_ellipsoid` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_ellipsoid` along which the 3 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 3)` the components lie along the last axis, so the default `-1`
+///         applies; a `(3, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: 3x3 rotation matrix from `ENZ` frame to ellipsoidal frame.
@@ -599,8 +619,10 @@ fn py_rotation_enz_to_ellipsoid<'py>(
 ///         Also accepts a batch of vectors with the 3 components along `axis`
 ///         (for example shape `(n, 3)`).
 ///     conversion_type (EllipsoidalConversionType): Type of ellipsoidal conversion (`GEOCENTRIC` or `GEODETIC`).
-///     axis (int, optional): Axis of `location_ecef` and the position argument holding
-///         the vector components for batched input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `location_ecef` along which the 3 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 3)` the components lie along the last axis, so the default `-1`
+///         applies; a `(3, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Relative position in `ENZ` frame `[east, north, up]` in meters.
@@ -652,8 +674,10 @@ fn py_relative_position_ecef_to_enz<'py>(
 ///         Also accepts a batch of vectors with the 3 components along `axis`
 ///         (for example shape `(n, 3)`).
 ///     conversion_type (EllipsoidalConversionType): Type of ellipsoidal conversion (`GEOCENTRIC` or `GEODETIC`).
-///     axis (int, optional): Axis of `location_ecef` and the position argument holding
-///         the vector components for batched input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `location_ecef` along which the 3 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 3)` the components lie along the last axis, so the default `-1`
+///         applies; a `(3, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Position vector in `ECEF` coordinates `[x, y, z]` in meters.
@@ -704,8 +728,10 @@ fn py_relative_position_enz_to_ecef<'py>(
 ///         Also accepts a batch of vectors with the 3 components along `axis`
 ///         (for example shape `(n, 3)`).
 ///     angle_format (AngleFormat): Angle format for input angular coordinates (`RADIANS` or `DEGREES`).
-///     axis (int, optional): Axis of `x_ellipsoid` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_ellipsoid` along which the 3 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 3)` the components lie along the last axis, so the default `-1`
+///         applies; a `(3, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: 3x3 rotation matrix from ellipsoidal frame to `SEZ` frame.
@@ -754,8 +780,10 @@ fn py_rotation_ellipsoid_to_sez<'py>(
 ///         Also accepts a batch of vectors with the 3 components along `axis`
 ///         (for example shape `(n, 3)`).
 ///     angle_format (AngleFormat): Angle format for input angular coordinates (`RADIANS` or `DEGREES`).
-///     axis (int, optional): Axis of `x_ellipsoid` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_ellipsoid` along which the 3 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 3)` the components lie along the last axis, so the default `-1`
+///         applies; a `(3, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: 3x3 rotation matrix from `SEZ` frame to ellipsoidal frame.
@@ -805,8 +833,10 @@ fn py_rotation_sez_to_ellipsoid<'py>(
 ///         Also accepts a batch of vectors with the 3 components along `axis`
 ///         (for example shape `(n, 3)`).
 ///     conversion_type (EllipsoidalConversionType): Type of ellipsoidal conversion (`GEOCENTRIC` or `GEODETIC`).
-///     axis (int, optional): Axis of `location_ecef` and the position argument holding
-///         the vector components for batched input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `location_ecef` along which the 3 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 3)` the components lie along the last axis, so the default `-1`
+///         applies; a `(3, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Relative position in `SEZ` frame `[south, east, zenith]` in meters.
@@ -858,8 +888,10 @@ fn py_relative_position_ecef_to_sez<'py>(
 ///         Also accepts a batch of vectors with the 3 components along `axis`
 ///         (for example shape `(n, 3)`).
 ///     conversion_type (EllipsoidalConversionType): Type of ellipsoidal conversion (`GEOCENTRIC` or `GEODETIC`).
-///     axis (int, optional): Axis of `location_ecef` and the position argument holding
-///         the vector components for batched input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `location_ecef` along which the 3 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 3)` the components lie along the last axis, so the default `-1`
+///         applies; a `(3, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Position vector in `ECEF` coordinates `[x, y, z]` in meters.
@@ -908,8 +940,10 @@ fn py_relative_position_sez_to_ecef<'py>(
 ///         Also accepts a batch of vectors with the 3 components along `axis`
 ///         (for example shape `(n, 3)`).
 ///     angle_format (AngleFormat): Angle format for output angular coordinates (`RADIANS` or `DEGREES`).
-///     axis (int, optional): Axis of `x_enz` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_enz` along which the 3 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 3)` the components lie along the last axis, so the default `-1`
+///         applies; a `(3, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Azimuth-elevation-range `[azimuth, elevation, range]` where azimuth
@@ -956,8 +990,10 @@ fn py_position_enz_to_azel<'py>(
 ///         Also accepts a batch of vectors with the 3 components along `axis`
 ///         (for example shape `(n, 3)`).
 ///     angle_format (AngleFormat): Angle format for output angular coordinates (`RADIANS` or `DEGREES`).
-///     axis (int, optional): Axis of `x_sez` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_sez` along which the 3 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 3)` the components lie along the last axis, so the default `-1`
+///         applies; a `(3, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Azimuth-elevation-range `[azimuth, elevation, range]` where azimuth
@@ -1004,8 +1040,10 @@ fn py_position_sez_to_azel<'py>(
 ///         Also accepts a batch of vectors with the 3 components along `axis`
 ///         (for example shape `(n, 3)`).
 ///     angle_format (AngleFormat): Angle format for angular elements (`RADIANS` or `DEGREES`).
-///     axis (int, optional): Axis of `x_radec` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_radec` along which the 3 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 3)` the components lie along the last axis, so the default `-1`
+///         applies; a `(3, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian inertial position `[x, y, z]` in meters.
@@ -1053,8 +1091,10 @@ fn py_position_radec_to_inertial<'py>(
 ///         Also accepts a batch of vectors with the 3 components along `axis`
 ///         (for example shape `(n, 3)`).
 ///     angle_format (AngleFormat): Angle format for angular output (`RADIANS` or `DEGREES`).
-///     axis (int, optional): Axis of `x_inertial` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_inertial` along which the 3 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 3)` the components lie along the last axis, so the default `-1`
+///         applies; a `(3, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Right ascension, declination, and range `[ra, dec, range]` where
@@ -1101,8 +1141,10 @@ fn py_position_inertial_to_radec<'py>(
 ///         Also accepts a batch of vectors with the 6 components along `axis`
 ///         (for example shape `(n, 6)`).
 ///     angle_format (AngleFormat): Angle format for angular elements and rates (`RADIANS` or `DEGREES`).
-///     axis (int, optional): Axis of `x_radec` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_radec` along which the 6 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 6)` the components lie along the last axis, so the default `-1`
+///         applies; a `(6, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Cartesian inertial position and velocity `[x, y, z, vx, vy, vz]`
@@ -1152,8 +1194,10 @@ fn py_state_radec_to_inertial<'py>(
 ///         Also accepts a batch of vectors with the 6 components along `axis`
 ///         (for example shape `(n, 6)`).
 ///     angle_format (AngleFormat): Angle format for angular output and rates (`RADIANS` or `DEGREES`).
-///     axis (int, optional): Axis of `x_inertial` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_inertial` along which the 6 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 6)` the components lie along the last axis, so the default `-1`
+///         applies; a `(6, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Right ascension, declination, range, and rates
@@ -1220,8 +1264,10 @@ fn py_state_inertial_to_radec<'py>(
 ///         A sequence evaluates one epoch per vector (or broadcasts a single
 ///         vector across all epochs).
 ///     angle_format (AngleFormat): Angle format for angular elements (`RADIANS` or `DEGREES`).
-///     axis (int, optional): Axis of `x_radec` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_radec` along which the 3 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 3)` the components lie along the last axis, so the default `-1`
+///         applies; a `(3, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Azimuth (clockwise from North), elevation, and range
@@ -1293,8 +1339,10 @@ fn py_position_radec_to_azel<'py>(
 ///         A sequence evaluates one epoch per vector (or broadcasts a single
 ///         vector across all epochs).
 ///     angle_format (AngleFormat): Angle format for angular elements (`RADIANS` or `DEGREES`).
-///     axis (int, optional): Axis of `x_azel` holding the vector components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `x_azel` along which the 3 components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 3)` the components lie along the last axis, so the default `-1`
+///         applies; a `(3, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Topocentric right ascension, declination, and range

--- a/docs/learn/coordinates/index.md
+++ b/docs/learn/coordinates/index.md
@@ -4,6 +4,10 @@ Coordinate systems and transformations are fundamental to astrodynamics. Differe
 
 Brahe provides coordinate transformation functions for converting between different coordinate representations and reference frames.
 
+## Batch Input
+
+Every coordinate transformation function accepts a batch of vectors in a single call. Passing an `(n, 6)` array to `state_koe_to_eci` or an `(n, 3)` array to `position_ecef_to_geodetic` transforms every row and returns an array of the same shape; the `axis` keyword (default `-1`) names the dimension holding the vector components. The topocentric relative-position functions broadcast a single site across a batch of positions, and `position_radec_to_azel` accepts a sequence of epochs. The rules are the same as for the frame transformations; see [Vectorized Transformations](../frames/vectorized.md).
+
 ## Coordinate Systems in Brahe
 
 ### Cartesian State Vectors

--- a/src/coordinates/cartesian.rs
+++ b/src/coordinates/cartesian.rs
@@ -18,6 +18,7 @@ use crate::orbits;
 use crate::propagators::CentralBody;
 use crate::time::{Epoch, TimeSystem};
 use crate::utils::BraheError;
+use crate::utils::batch::{batch_map, try_batch_map};
 
 /// Convert an osculating orbital element state vector into the equivalent
 /// Cartesian (position and velocity) inertial state.
@@ -553,17 +554,141 @@ pub fn state_inertial_to_koe_for_body(
     Ok(state_inertial_to_koe_gm(x_eq, gm, angle_format))
 }
 
+/// Converts a batch of Keplerian orbital elements to Cartesian ECI states.
+///
+/// Batch form of [`state_koe_to_eci`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// # Arguments
+/// - `x_oe`: Keplerian element sets `[a, e, i, Ω, ω, M]`. Units: (*m*, dimensionless, angles per `angle_format`)
+/// - `angle_format`: Format of the angular elements
+///
+/// # Returns
+/// - Cartesian ECI states (position, velocity) in input order. Units: (*m*; *m/s*)
+///
+/// # Examples
+/// ```
+/// use brahe::constants::{R_EARTH, AngleFormat};
+/// use brahe::coordinates::states_koe_to_eci;
+/// use brahe::vector6_from_array;
+///
+/// let elements = vec![vector6_from_array([R_EARTH + 500e3, 0.01, 97.8, 15.0, 30.0, 45.0]); 3];
+/// let states = states_koe_to_eci(&elements, AngleFormat::Degrees);
+/// assert_eq!(states.len(), 3);
+/// ```
+pub fn states_koe_to_eci(x_oe: &[SVector6], angle_format: AngleFormat) -> Vec<SVector6> {
+    batch_map(x_oe, |x| state_koe_to_eci(*x, angle_format))
+}
+
+/// Converts a batch of Cartesian ECI states to Keplerian orbital elements.
+///
+/// Batch form of [`state_eci_to_koe`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// # Arguments
+/// - `x_cart`: Cartesian ECI states (position, velocity). Units: (*m*; *m/s*)
+/// - `angle_format`: Format of the returned angular elements
+///
+/// # Returns
+/// - Keplerian element sets `[a, e, i, Ω, ω, M]` in input order. Units: (*m*, dimensionless, angles per `angle_format`)
+///
+/// # Examples
+/// ```
+/// use brahe::constants::{R_EARTH, AngleFormat};
+/// use brahe::coordinates::{state_koe_to_eci, states_eci_to_koe};
+/// use brahe::vector6_from_array;
+///
+/// let x = state_koe_to_eci(vector6_from_array([R_EARTH + 500e3, 0.01, 97.8, 15.0, 30.0, 45.0]), AngleFormat::Degrees);
+/// let elements = states_eci_to_koe(&[x, x], AngleFormat::Degrees);
+/// assert_eq!(elements.len(), 2);
+/// ```
+pub fn states_eci_to_koe(x_cart: &[SVector6], angle_format: AngleFormat) -> Vec<SVector6> {
+    batch_map(x_cart, |x| state_eci_to_koe(*x, angle_format))
+}
+
+/// Converts a batch of Keplerian elements to Cartesian inertial states about `central_body`.
+///
+/// Batch form of [`state_koe_to_inertial_for_body`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// # Arguments
+/// - `x_oe`: Keplerian element sets `[a, e, i, Ω, ω, M]`. Units: (*m*, dimensionless, angles per `angle_format`)
+/// - `central_body`: Central body supplying the gravitational parameter and equatorial basis
+/// - `angle_format`: Format of the angular elements
+///
+/// # Returns
+/// - Cartesian inertial states (position, velocity) in input order. Units: (*m*; *m/s*)
+/// - Error if the body's equatorial basis cannot be resolved
+///
+/// # Examples
+/// ```
+/// use brahe::constants::{R_MOON, AngleFormat};
+/// use brahe::coordinates::states_koe_to_inertial_for_body;
+/// use brahe::propagators::CentralBody;
+/// use brahe::vector6_from_array;
+///
+/// let elements = vec![vector6_from_array([R_MOON + 100e3, 0.01, 30.0, 0.0, 0.0, 0.0]); 2];
+/// let states = states_koe_to_inertial_for_body(&elements, &CentralBody::Moon, AngleFormat::Degrees).unwrap();
+/// assert_eq!(states.len(), 2);
+/// ```
+pub fn states_koe_to_inertial_for_body(
+    x_oe: &[SVector6],
+    central_body: &CentralBody,
+    angle_format: AngleFormat,
+) -> Result<Vec<SVector6>, BraheError> {
+    try_batch_map(x_oe, |x| {
+        state_koe_to_inertial_for_body(*x, central_body, angle_format)
+    })
+}
+
+/// Converts a batch of Cartesian inertial states about `central_body` to Keplerian elements.
+///
+/// Batch form of [`state_inertial_to_koe_for_body`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// # Arguments
+/// - `x_cart`: Cartesian inertial states (position, velocity). Units: (*m*; *m/s*)
+/// - `central_body`: Central body supplying the gravitational parameter and equatorial basis
+/// - `angle_format`: Format of the returned angular elements
+///
+/// # Returns
+/// - Keplerian element sets `[a, e, i, Ω, ω, M]` in input order. Units: (*m*, dimensionless, angles per `angle_format`)
+/// - Error if the body's equatorial basis cannot be resolved
+///
+/// # Examples
+/// ```
+/// use brahe::constants::{R_MOON, AngleFormat};
+/// use brahe::coordinates::{state_koe_to_inertial_for_body, states_inertial_to_koe_for_body};
+/// use brahe::propagators::CentralBody;
+/// use brahe::vector6_from_array;
+///
+/// let x = state_koe_to_inertial_for_body(vector6_from_array([R_MOON + 100e3, 0.01, 30.0, 0.0, 0.0, 0.0]), &CentralBody::Moon, AngleFormat::Degrees).unwrap();
+/// let elements = states_inertial_to_koe_for_body(&[x, x], &CentralBody::Moon, AngleFormat::Degrees).unwrap();
+/// assert_eq!(elements.len(), 2);
+/// ```
+pub fn states_inertial_to_koe_for_body(
+    x_cart: &[SVector6],
+    central_body: &CentralBody,
+    angle_format: AngleFormat,
+) -> Result<Vec<SVector6>, BraheError> {
+    try_batch_map(x_cart, |x| {
+        state_inertial_to_koe_for_body(*x, central_body, angle_format)
+    })
+}
+
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use approx::assert_abs_diff_eq;
     use nalgebra::Vector3;
     use rstest::rstest;
+    use serial_test::parallel;
 
     use crate::constants::{DEG2RAD, DEGREES, R_EARTH, R_MARS, RADIANS};
     use crate::coordinates::*;
     use crate::math::*;
     use crate::orbits::*;
+    use crate::propagators::CentralBody;
     use crate::utils::testing::setup_global_test_eop;
 
     #[test]
@@ -811,5 +936,48 @@ mod tests {
         });
         assert!(state_koe_to_inertial_for_body(osc, &no_frame, DEGREES).is_err());
         assert!(state_inertial_to_koe_for_body(osc, &no_frame, DEGREES).is_err());
+    }
+
+    #[test]
+    #[parallel]
+    fn test_batch_koe_eci_match_scalar() {
+        let elements: Vec<SVector6> = (0..3)
+            .map(|i| {
+                vector6_from_array([
+                    R_EARTH + 500e3 + 1e3 * i as f64,
+                    0.01,
+                    97.8,
+                    15.0 + i as f64,
+                    30.0,
+                    45.0,
+                ])
+            })
+            .collect();
+        let states = states_koe_to_eci(&elements, DEGREES);
+        let back = states_eci_to_koe(&states, DEGREES);
+        let moon = states_koe_to_inertial_for_body(&elements, &CentralBody::Moon, DEGREES).unwrap();
+        let moon_back =
+            states_inertial_to_koe_for_body(&moon, &CentralBody::Moon, DEGREES).unwrap();
+        for i in 0..3 {
+            assert_eq!(states[i], state_koe_to_eci(elements[i], DEGREES));
+            assert_eq!(back[i], state_eci_to_koe(states[i], DEGREES));
+            assert_eq!(
+                moon[i],
+                state_koe_to_inertial_for_body(elements[i], &CentralBody::Moon, DEGREES).unwrap()
+            );
+            assert_eq!(
+                moon_back[i],
+                state_inertial_to_koe_for_body(moon[i], &CentralBody::Moon, DEGREES).unwrap()
+            );
+            for k in 0..6 {
+                assert_abs_diff_eq!(back[i][k], elements[i][k], epsilon = 1e-6);
+            }
+        }
+        assert!(states_koe_to_eci(&[], DEGREES).is_empty());
+        assert!(
+            states_koe_to_inertial_for_body(&[], &CentralBody::Earth, DEGREES)
+                .unwrap()
+                .is_empty()
+        );
     }
 }

--- a/src/coordinates/cartesian.rs
+++ b/src/coordinates/cartesian.rs
@@ -577,7 +577,7 @@ pub fn state_inertial_to_koe_for_body(
 /// assert_eq!(states.len(), 3);
 /// ```
 pub fn states_koe_to_eci(x_oe: &[SVector6], angle_format: AngleFormat) -> Vec<SVector6> {
-    batch_map(x_oe, |x| state_koe_to_eci(*x, angle_format))
+    batch_map(|x| state_koe_to_eci(*x, angle_format), x_oe)
 }
 
 /// Converts a batch of Cartesian ECI states to Keplerian orbital elements.
@@ -603,7 +603,7 @@ pub fn states_koe_to_eci(x_oe: &[SVector6], angle_format: AngleFormat) -> Vec<SV
 /// assert_eq!(elements.len(), 2);
 /// ```
 pub fn states_eci_to_koe(x_cart: &[SVector6], angle_format: AngleFormat) -> Vec<SVector6> {
-    batch_map(x_cart, |x| state_eci_to_koe(*x, angle_format))
+    batch_map(|x| state_eci_to_koe(*x, angle_format), x_cart)
 }
 
 /// Converts a batch of Keplerian elements to Cartesian inertial states about `central_body`.
@@ -636,9 +636,10 @@ pub fn states_koe_to_inertial_for_body(
     central_body: &CentralBody,
     angle_format: AngleFormat,
 ) -> Result<Vec<SVector6>, BraheError> {
-    try_batch_map(x_oe, |x| {
-        state_koe_to_inertial_for_body(*x, central_body, angle_format)
-    })
+    try_batch_map(
+        |x| state_koe_to_inertial_for_body(*x, central_body, angle_format),
+        x_oe,
+    )
 }
 
 /// Converts a batch of Cartesian inertial states about `central_body` to Keplerian elements.
@@ -671,9 +672,10 @@ pub fn states_inertial_to_koe_for_body(
     central_body: &CentralBody,
     angle_format: AngleFormat,
 ) -> Result<Vec<SVector6>, BraheError> {
-    try_batch_map(x_cart, |x| {
-        state_inertial_to_koe_for_body(*x, central_body, angle_format)
-    })
+    try_batch_map(
+        |x| state_inertial_to_koe_for_body(*x, central_body, angle_format),
+        x_cart,
+    )
 }
 
 #[cfg(test)]

--- a/src/coordinates/geocentric.rs
+++ b/src/coordinates/geocentric.rs
@@ -8,6 +8,7 @@ use nalgebra::Vector3;
 
 use crate::constants;
 use crate::constants::AngleFormat;
+use crate::utils::batch::{batch_map, try_batch_map};
 
 /// Convert geocentric position to equivalent Earth-fixed position.
 ///
@@ -105,10 +106,70 @@ pub fn position_ecef_to_geocentric(
     }
 }
 
+/// Converts a batch of geocentric positions to ECEF Cartesian positions.
+///
+/// Batch form of [`position_geocentric_to_ecef`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// # Arguments
+/// - `x_geoc`: Geocentric positions `[lon, lat, radius]`. Units: (angles per `angle_format`, *m*)
+/// - `angle_format`: Format of the angular coordinates
+///
+/// # Returns
+/// - Cartesian ECEF positions in input order. Units: (*m*)
+/// - Error if any latitude lies outside ±90°
+///
+/// # Examples
+/// ```
+/// use brahe::constants::{R_EARTH, AngleFormat};
+/// use brahe::coordinates::positions_geocentric_to_ecef;
+/// use nalgebra::Vector3;
+///
+/// let sites = vec![Vector3::new(-122.4, 37.8, R_EARTH), Vector3::new(151.2, -33.9, R_EARTH)];
+/// let ecef = positions_geocentric_to_ecef(&sites, AngleFormat::Degrees).unwrap();
+/// assert_eq!(ecef.len(), 2);
+/// ```
+pub fn positions_geocentric_to_ecef(
+    x_geoc: &[Vector3<f64>],
+    angle_format: AngleFormat,
+) -> Result<Vec<Vector3<f64>>, String> {
+    try_batch_map(x_geoc, |x| position_geocentric_to_ecef(*x, angle_format))
+}
+
+/// Converts a batch of ECEF Cartesian positions to geocentric positions.
+///
+/// Batch form of [`position_ecef_to_geocentric`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// # Arguments
+/// - `x_ecef`: Cartesian ECEF positions. Units: (*m*)
+/// - `angle_format`: Format of the returned angular coordinates
+///
+/// # Returns
+/// - Geocentric positions `[lon, lat, radius]` in input order. Units: (angles per `angle_format`, *m*)
+///
+/// # Examples
+/// ```
+/// use brahe::constants::{R_EARTH, AngleFormat};
+/// use brahe::coordinates::positions_ecef_to_geocentric;
+/// use nalgebra::Vector3;
+///
+/// let ecef = vec![Vector3::new(R_EARTH, 0.0, 0.0), Vector3::new(0.0, R_EARTH, 0.0)];
+/// let geoc = positions_ecef_to_geocentric(&ecef, AngleFormat::Degrees);
+/// assert_eq!(geoc.len(), 2);
+/// ```
+pub fn positions_ecef_to_geocentric(
+    x_ecef: &[Vector3<f64>],
+    angle_format: AngleFormat,
+) -> Vec<Vector3<f64>> {
+    batch_map(x_ecef, |x| position_ecef_to_geocentric(*x, angle_format))
+}
+
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use approx::assert_abs_diff_eq;
+    use serial_test::parallel;
 
     use crate::constants::{DEGREES, RADIANS, WGS84_A};
 
@@ -190,5 +251,35 @@ mod tests {
         assert!(position_geocentric_to_ecef(Vector3::new(0.0, 90.1, 0.0), DEGREES).is_err());
 
         assert!(position_geocentric_to_ecef(Vector3::new(0.0, -90.1, 0.0), DEGREES).is_err());
+    }
+
+    #[test]
+    #[parallel]
+    fn test_batch_geocentric_ecef_match_scalar() {
+        let sites = vec![
+            Vector3::new(-122.4, 37.8, constants::R_EARTH),
+            Vector3::new(151.2, -33.9, constants::R_EARTH + 100.0),
+            Vector3::new(0.0, 0.0, constants::R_EARTH + 500e3),
+        ];
+        let ecef = positions_geocentric_to_ecef(&sites, AngleFormat::Degrees).unwrap();
+        let back = positions_ecef_to_geocentric(&ecef, AngleFormat::Degrees);
+        for i in 0..3 {
+            assert_eq!(
+                ecef[i],
+                position_geocentric_to_ecef(sites[i], AngleFormat::Degrees).unwrap()
+            );
+            assert_eq!(
+                back[i],
+                position_ecef_to_geocentric(ecef[i], AngleFormat::Degrees)
+            );
+            for k in 0..3 {
+                assert_abs_diff_eq!(back[i][k], sites[i][k], epsilon = 1e-6);
+            }
+        }
+        assert!(
+            positions_geocentric_to_ecef(&[Vector3::new(0.0, 95.0, 0.0)], AngleFormat::Degrees)
+                .is_err()
+        );
+        assert!(positions_ecef_to_geocentric(&[], AngleFormat::Degrees).is_empty());
     }
 }

--- a/src/coordinates/geocentric.rs
+++ b/src/coordinates/geocentric.rs
@@ -133,7 +133,7 @@ pub fn positions_geocentric_to_ecef(
     x_geoc: &[Vector3<f64>],
     angle_format: AngleFormat,
 ) -> Result<Vec<Vector3<f64>>, String> {
-    try_batch_map(x_geoc, |x| position_geocentric_to_ecef(*x, angle_format))
+    try_batch_map(|x| position_geocentric_to_ecef(*x, angle_format), x_geoc)
 }
 
 /// Converts a batch of ECEF Cartesian positions to geocentric positions.
@@ -162,7 +162,7 @@ pub fn positions_ecef_to_geocentric(
     x_ecef: &[Vector3<f64>],
     angle_format: AngleFormat,
 ) -> Vec<Vector3<f64>> {
-    batch_map(x_ecef, |x| position_ecef_to_geocentric(*x, angle_format))
+    batch_map(|x| position_ecef_to_geocentric(*x, angle_format), x_ecef)
 }
 
 #[cfg(test)]

--- a/src/coordinates/geodetic.rs
+++ b/src/coordinates/geodetic.rs
@@ -159,7 +159,7 @@ pub fn positions_geodetic_to_ecef(
     x_geod: &[Vector3<f64>],
     angle_format: AngleFormat,
 ) -> Result<Vec<Vector3<f64>>, String> {
-    try_batch_map(x_geod, |x| position_geodetic_to_ecef(*x, angle_format))
+    try_batch_map(|x| position_geodetic_to_ecef(*x, angle_format), x_geod)
 }
 
 /// Converts a batch of ECEF Cartesian positions to geodetic positions.
@@ -188,7 +188,7 @@ pub fn positions_ecef_to_geodetic(
     x_ecef: &[Vector3<f64>],
     angle_format: AngleFormat,
 ) -> Vec<Vector3<f64>> {
-    batch_map(x_ecef, |x| position_ecef_to_geodetic(*x, angle_format))
+    batch_map(|x| position_ecef_to_geodetic(*x, angle_format), x_ecef)
 }
 
 #[cfg(test)]

--- a/src/coordinates/geodetic.rs
+++ b/src/coordinates/geodetic.rs
@@ -8,6 +8,7 @@ use nalgebra::Vector3;
 
 use crate::constants;
 use crate::constants::AngleFormat;
+use crate::utils::batch::{batch_map, try_batch_map};
 
 const ECC2: f64 = constants::WGS84_F * (2.0 - constants::WGS84_F);
 
@@ -131,10 +132,70 @@ pub fn position_ecef_to_geodetic(x_ecef: Vector3<f64>, angle_format: AngleFormat
     }
 }
 
+/// Converts a batch of geodetic positions to ECEF Cartesian positions.
+///
+/// Batch form of [`position_geodetic_to_ecef`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// # Arguments
+/// - `x_geod`: Geodetic positions `[lon, lat, alt]`. Units: (angles per `angle_format`, *m*)
+/// - `angle_format`: Format of the angular coordinates
+///
+/// # Returns
+/// - Cartesian ECEF positions in input order. Units: (*m*)
+/// - Error if any latitude lies outside ±90°
+///
+/// # Examples
+/// ```
+/// use brahe::constants::AngleFormat;
+/// use brahe::coordinates::positions_geodetic_to_ecef;
+/// use nalgebra::Vector3;
+///
+/// let sites = vec![Vector3::new(-122.4, 37.8, 0.0), Vector3::new(151.2, -33.9, 100.0)];
+/// let ecef = positions_geodetic_to_ecef(&sites, AngleFormat::Degrees).unwrap();
+/// assert_eq!(ecef.len(), 2);
+/// ```
+pub fn positions_geodetic_to_ecef(
+    x_geod: &[Vector3<f64>],
+    angle_format: AngleFormat,
+) -> Result<Vec<Vector3<f64>>, String> {
+    try_batch_map(x_geod, |x| position_geodetic_to_ecef(*x, angle_format))
+}
+
+/// Converts a batch of ECEF Cartesian positions to geodetic positions.
+///
+/// Batch form of [`position_ecef_to_geodetic`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// # Arguments
+/// - `x_ecef`: Cartesian ECEF positions. Units: (*m*)
+/// - `angle_format`: Format of the returned angular coordinates
+///
+/// # Returns
+/// - Geodetic positions `[lon, lat, alt]` in input order. Units: (angles per `angle_format`, *m*)
+///
+/// # Examples
+/// ```
+/// use brahe::constants::{R_EARTH, AngleFormat};
+/// use brahe::coordinates::positions_ecef_to_geodetic;
+/// use nalgebra::Vector3;
+///
+/// let ecef = vec![Vector3::new(R_EARTH, 0.0, 0.0), Vector3::new(0.0, R_EARTH, 0.0)];
+/// let geod = positions_ecef_to_geodetic(&ecef, AngleFormat::Degrees);
+/// assert_eq!(geod.len(), 2);
+/// ```
+pub fn positions_ecef_to_geodetic(
+    x_ecef: &[Vector3<f64>],
+    angle_format: AngleFormat,
+) -> Vec<Vector3<f64>> {
+    batch_map(x_ecef, |x| position_ecef_to_geodetic(*x, angle_format))
+}
+
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use approx::assert_abs_diff_eq;
+    use serial_test::parallel;
 
     use crate::constants::{DEGREES, RADIANS, WGS84_A, WGS84_F};
 
@@ -216,5 +277,29 @@ mod tests {
         assert!(position_geodetic_to_ecef(Vector3::new(0.0, 90.1, 0.0), DEGREES).is_err());
 
         assert!(position_geodetic_to_ecef(Vector3::new(0.0, -90.1, 0.0), DEGREES).is_err());
+    }
+
+    #[test]
+    #[parallel]
+    fn test_batch_geodetic_ecef_match_scalar() {
+        let sites = vec![
+            Vector3::new(-122.4, 37.8, 0.0),
+            Vector3::new(151.2, -33.9, 100.0),
+            Vector3::new(0.0, 0.0, 500e3),
+        ];
+        let ecef = positions_geodetic_to_ecef(&sites, DEGREES).unwrap();
+        let back = positions_ecef_to_geodetic(&ecef, DEGREES);
+        for i in 0..3 {
+            assert_eq!(
+                ecef[i],
+                position_geodetic_to_ecef(sites[i], DEGREES).unwrap()
+            );
+            assert_eq!(back[i], position_ecef_to_geodetic(ecef[i], DEGREES));
+            for k in 0..3 {
+                assert_abs_diff_eq!(back[i][k], sites[i][k], epsilon = 1e-6);
+            }
+        }
+        assert!(positions_geodetic_to_ecef(&[Vector3::new(0.0, 95.0, 0.0)], DEGREES).is_err());
+        assert!(positions_ecef_to_geodetic(&[], DEGREES).is_empty());
     }
 }

--- a/src/coordinates/polygon.rs
+++ b/src/coordinates/polygon.rs
@@ -212,7 +212,7 @@ fn point_in_polygon_internal(lon: f64, lat: f64, vertices: &[(f64, f64)]) -> boo
 /// assert_eq!(inside, vec![true, false]);
 /// ```
 pub fn points_in_polygon(points: &[(f64, f64)], vertices: &[(f64, f64)]) -> Vec<bool> {
-    batch_map(points, |(lon, lat)| point_in_polygon(*lon, *lat, vertices))
+    batch_map(|(lon, lat)| point_in_polygon(*lon, *lat, vertices), points)
 }
 
 #[cfg(test)]

--- a/src/coordinates/polygon.rs
+++ b/src/coordinates/polygon.rs
@@ -7,6 +7,8 @@
 
 use std::f64::consts::PI;
 
+use crate::utils::batch::batch_map;
+
 /// Check if a polygon crosses the anti-meridian (±180° longitude boundary).
 ///
 /// A polygon crosses the anti-meridian if any two consecutive vertices have
@@ -189,12 +191,37 @@ fn point_in_polygon_internal(lon: f64, lat: f64, vertices: &[(f64, f64)]) -> boo
     inside
 }
 
+/// Tests a batch of points for containment in a spherical polygon.
+///
+/// Batch form of [`point_in_polygon`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// # Arguments
+/// - `points`: `(lon, lat)` pairs to test. Units: (*rad*)
+/// - `vertices`: Closed polygon vertices `(lon, lat)`. Units: (*rad*)
+///
+/// # Returns
+/// - Containment flag for each point, in input order
+///
+/// # Examples
+/// ```
+/// use brahe::coordinates::points_in_polygon;
+///
+/// let square = [(0.0, 0.0), (0.1, 0.0), (0.1, 0.1), (0.0, 0.1), (0.0, 0.0)];
+/// let inside = points_in_polygon(&[(0.05, 0.05), (0.5, 0.5)], &square);
+/// assert_eq!(inside, vec![true, false]);
+/// ```
+pub fn points_in_polygon(points: &[(f64, f64)], vertices: &[(f64, f64)]) -> Vec<bool> {
+    batch_map(points, |(lon, lat)| point_in_polygon(*lon, *lat, vertices))
+}
+
 #[cfg(test)]
 #[allow(non_snake_case)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use approx::assert_abs_diff_eq;
+    use serial_test::parallel;
 
     // Helper to convert degrees to radians for cleaner test code
     fn deg_to_rad(deg: f64) -> f64 {
@@ -647,5 +674,27 @@ mod tests {
             deg_to_rad(75.0),
             &vertices
         ));
+    }
+
+    #[test]
+    #[parallel]
+    fn test_points_in_polygon_matches_scalar() {
+        let square = [(0.0, 0.0), (0.1, 0.0), (0.1, 0.1), (0.0, 0.1), (0.0, 0.0)];
+        let points = [(0.05, 0.05), (0.5, 0.5), (0.0, 0.05), (-0.01, 0.05)];
+        let flags = points_in_polygon(&points, &square);
+        assert_eq!(flags.len(), points.len());
+        for (i, (lon, lat)) in points.iter().enumerate() {
+            assert_eq!(flags[i], point_in_polygon(*lon, *lat, &square));
+        }
+        assert!(flags[0]);
+        assert!(!flags[1]);
+
+        let strip = [(3.0, 0.0), (-3.0, 0.0), (-3.0, 0.1), (3.0, 0.1), (3.0, 0.0)];
+        let pts = [(3.1, 0.05), (-3.1, 0.05), (0.0, 0.05)];
+        let flags = points_in_polygon(&pts, &strip);
+        for (i, (lon, lat)) in pts.iter().enumerate() {
+            assert_eq!(flags[i], point_in_polygon(*lon, *lat, &strip));
+        }
+        assert!(points_in_polygon(&[], &square).is_empty());
     }
 }

--- a/src/coordinates/radec.rs
+++ b/src/coordinates/radec.rs
@@ -7,8 +7,10 @@ use crate::coordinates::topocentric::{
     position_enz_to_azel, rotation_ellipsoid_to_enz, rotation_enz_to_ellipsoid,
 };
 use crate::frames::{rotation_ecef_to_eci, rotation_eci_to_ecef};
-use crate::math::{SVector3, SVector6};
+use crate::math::{SMatrix3, SVector3, SVector6};
 use crate::time::{Epoch, TimeSystem};
+use crate::utils::BraheError;
+use crate::utils::batch::{batch_map, batch_map_epochs};
 
 /// Convert a right ascension, declination, and range into the equivalent
 /// Cartesian inertial position.
@@ -421,12 +423,43 @@ pub fn position_radec_to_azel(
     epc: Epoch,
     angle_format: AngleFormat,
 ) -> SVector3 {
+    apply_position_radec_to_azel(
+        &radec_azel_context(epc, site_geodetic, angle_format),
+        &x_radec,
+        angle_format,
+    )
+}
+
+/// ECI-to-ECEF and ECEF-to-ENZ rotation matrices for a site at one epoch.
+struct RadecAzelContext {
+    r_eci_ecef: SMatrix3,
+    r_ecef_enz: SMatrix3,
+}
+
+/// Compute the topocentric context for `site_geodetic` at `epc`.
+fn radec_azel_context(
+    epc: Epoch,
+    site_geodetic: SVector3,
+    angle_format: AngleFormat,
+) -> RadecAzelContext {
+    RadecAzelContext {
+        r_eci_ecef: rotation_eci_to_ecef(epc),
+        r_ecef_enz: rotation_ellipsoid_to_enz(site_geodetic, angle_format),
+    }
+}
+
+/// Apply a topocentric context to one right ascension/declination position.
+fn apply_position_radec_to_azel(
+    c: &RadecAzelContext,
+    x_radec: &SVector3,
+    angle_format: AngleFormat,
+) -> SVector3 {
     let range = x_radec[2];
 
     let d_eci =
         position_radec_to_inertial(SVector3::new(x_radec[0], x_radec[1], 1.0), angle_format);
-    let d_ecef = rotation_eci_to_ecef(epc) * d_eci;
-    let d_enz = rotation_ellipsoid_to_enz(site_geodetic, angle_format) * d_ecef;
+    let d_ecef = c.r_eci_ecef * d_eci;
+    let d_enz = c.r_ecef_enz * d_ecef;
 
     position_enz_to_azel(d_enz * range, angle_format)
 }
@@ -476,6 +509,37 @@ pub fn position_azel_to_radec(
     epc: Epoch,
     angle_format: AngleFormat,
 ) -> SVector3 {
+    apply_position_azel_to_radec(
+        &azel_radec_context(epc, site_geodetic, angle_format),
+        &x_azel,
+        angle_format,
+    )
+}
+
+/// ENZ-to-ECEF and ECEF-to-ECI rotation matrices for a site at one epoch.
+struct AzelRadecContext {
+    r_enz_ecef: SMatrix3,
+    r_ecef_eci: SMatrix3,
+}
+
+/// Compute the inverse topocentric context for `site_geodetic` at `epc`.
+fn azel_radec_context(
+    epc: Epoch,
+    site_geodetic: SVector3,
+    angle_format: AngleFormat,
+) -> AzelRadecContext {
+    AzelRadecContext {
+        r_enz_ecef: rotation_enz_to_ellipsoid(site_geodetic, angle_format),
+        r_ecef_eci: rotation_ecef_to_eci(epc),
+    }
+}
+
+/// Apply an inverse topocentric context to one azimuth/elevation position.
+fn apply_position_azel_to_radec(
+    c: &AzelRadecContext,
+    x_azel: &SVector3,
+    angle_format: AngleFormat,
+) -> SVector3 {
     let (az, el) = match angle_format {
         AngleFormat::Degrees => (x_azel[0] * DEG2RAD, x_azel[1] * DEG2RAD),
         AngleFormat::Radians => (x_azel[0], x_azel[1]),
@@ -483,11 +547,224 @@ pub fn position_azel_to_radec(
     let range = x_azel[2];
 
     let d_enz = SVector3::new(el.cos() * az.sin(), el.cos() * az.cos(), el.sin());
-    let d_ecef = rotation_enz_to_ellipsoid(site_geodetic, angle_format) * d_enz;
-    let d_eci = rotation_ecef_to_eci(epc) * d_ecef;
+    let d_ecef = c.r_enz_ecef * d_enz;
+    let d_eci = c.r_ecef_eci * d_ecef;
 
     let radec_dir = position_inertial_to_radec(d_eci, angle_format);
     SVector3::new(radec_dir[0], radec_dir[1], range)
+}
+
+/// Converts a batch of right ascension/declination positions to inertial Cartesian positions.
+///
+/// Batch form of [`position_radec_to_inertial`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// # Arguments
+/// - `x_radec`: `[ra, dec, range]` positions. Units: (angles per `angle_format`, *m*)
+/// - `angle_format`: Format of the angular coordinates
+///
+/// # Returns
+/// - Inertial Cartesian positions in input order. Units: (*m*)
+///
+/// # Examples
+/// ```
+/// use brahe::constants::AngleFormat;
+/// use brahe::coordinates::positions_radec_to_inertial;
+/// use brahe::vector3_from_array;
+///
+/// let radec = vec![vector3_from_array([30.0, 10.0, 1.0e6]); 3];
+/// let out = positions_radec_to_inertial(&radec, AngleFormat::Degrees);
+/// assert_eq!(out.len(), 3);
+/// ```
+pub fn positions_radec_to_inertial(
+    x_radec: &[SVector3],
+    angle_format: AngleFormat,
+) -> Vec<SVector3> {
+    batch_map(x_radec, |x| position_radec_to_inertial(*x, angle_format))
+}
+
+/// Converts a batch of inertial Cartesian positions to right ascension/declination positions.
+///
+/// Batch form of [`position_inertial_to_radec`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// # Arguments
+/// - `x_inertial`: Inertial Cartesian positions. Units: (*m*)
+/// - `angle_format`: Format of the returned angular coordinates
+///
+/// # Returns
+/// - `[ra, dec, range]` positions in input order. Units: (angles per `angle_format`, *m*)
+///
+/// # Examples
+/// ```
+/// use brahe::constants::AngleFormat;
+/// use brahe::coordinates::positions_inertial_to_radec;
+/// use brahe::vector3_from_array;
+///
+/// let x = vec![vector3_from_array([1.0e6, 2.0e6, 3.0e6]); 3];
+/// let out = positions_inertial_to_radec(&x, AngleFormat::Degrees);
+/// assert_eq!(out.len(), 3);
+/// ```
+pub fn positions_inertial_to_radec(
+    x_inertial: &[SVector3],
+    angle_format: AngleFormat,
+) -> Vec<SVector3> {
+    batch_map(x_inertial, |x| position_inertial_to_radec(*x, angle_format))
+}
+
+/// Converts a batch of right ascension/declination states to inertial Cartesian states.
+///
+/// Batch form of [`state_radec_to_inertial`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// # Arguments
+/// - `x_radec`: `[ra, dec, range, ra_rate, dec_rate, range_rate]` states. Units: (angles per `angle_format`, *m*, rates per second)
+/// - `angle_format`: Format of the angular coordinates
+///
+/// # Returns
+/// - Inertial Cartesian states (position, velocity) in input order. Units: (*m*; *m/s*)
+///
+/// # Examples
+/// ```
+/// use brahe::constants::AngleFormat;
+/// use brahe::coordinates::states_radec_to_inertial;
+/// use brahe::vector6_from_array;
+///
+/// let radec = vec![vector6_from_array([30.0, 10.0, 1.0e6, 0.01, 0.01, 10.0]); 3];
+/// let out = states_radec_to_inertial(&radec, AngleFormat::Degrees);
+/// assert_eq!(out.len(), 3);
+/// ```
+pub fn states_radec_to_inertial(x_radec: &[SVector6], angle_format: AngleFormat) -> Vec<SVector6> {
+    batch_map(x_radec, |x| state_radec_to_inertial(*x, angle_format))
+}
+
+/// Converts a batch of inertial Cartesian states to right ascension/declination states.
+///
+/// Batch form of [`state_inertial_to_radec`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// # Arguments
+/// - `x_inertial`: Inertial Cartesian states (position, velocity). Units: (*m*; *m/s*)
+/// - `angle_format`: Format of the returned angular coordinates
+///
+/// # Returns
+/// - `[ra, dec, range, ra_rate, dec_rate, range_rate]` states in input order. Units: (angles per `angle_format`, *m*, rates per second)
+///
+/// # Examples
+/// ```
+/// use brahe::constants::AngleFormat;
+/// use brahe::coordinates::states_inertial_to_radec;
+/// use brahe::vector6_from_array;
+///
+/// let x = vec![vector6_from_array([1.0e6, 2.0e6, 3.0e6, 1.0, 2.0, 3.0]); 3];
+/// let out = states_inertial_to_radec(&x, AngleFormat::Degrees);
+/// assert_eq!(out.len(), 3);
+/// ```
+pub fn states_inertial_to_radec(
+    x_inertial: &[SVector6],
+    angle_format: AngleFormat,
+) -> Vec<SVector6> {
+    batch_map(x_inertial, |x| state_inertial_to_radec(*x, angle_format))
+}
+
+/// Converts a batch of right ascension/declination positions to azimuth/elevation as seen from a site.
+///
+/// Batch form of [`position_radec_to_azel`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// `x_radec` and `epochs` follow the broadcast rule: each has length 1 or the
+/// common batch length. A single epoch computes the ECI-to-ECEF and site
+/// rotation matrices once and applies them to every position.
+///
+/// # Arguments
+/// - `x_radec`: `[ra, dec, range]` positions, length 1 or the batch length. Units: (angles per `angle_format`, *m*)
+/// - `site_geodetic`: Site geodetic position `[lon, lat, alt]`. Units: (angles per `angle_format`, *m*)
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `angle_format`: Format of the angular coordinates
+///
+/// # Returns
+/// - `[az, el, range]` positions in input order. Units: (angles per `angle_format`, *m*)
+/// - Error if `x_radec` and `epochs` do not satisfy the broadcast rule
+///
+/// # Examples
+/// ```
+/// use brahe::eop::*;
+/// use brahe::constants::AngleFormat;
+/// use brahe::coordinates::positions_radec_to_azel;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use brahe::vector3_from_array;
+///
+/// let eop = FileEOPProvider::from_default_file(EOPType::StandardBulletinA, true, EOPExtrapolation::Zero).unwrap();
+/// set_global_eop_provider(eop);
+///
+/// let epc = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let site = vector3_from_array([-122.4, 37.8, 0.0]);
+/// let radec = vec![vector3_from_array([30.0, 10.0, 1.0e6]); 3];
+/// let azel = positions_radec_to_azel(&radec, site, &[epc], AngleFormat::Degrees).unwrap();
+/// assert_eq!(azel.len(), 3);
+/// ```
+pub fn positions_radec_to_azel(
+    x_radec: &[SVector3],
+    site_geodetic: SVector3,
+    epochs: &[Epoch],
+    angle_format: AngleFormat,
+) -> Result<Vec<SVector3>, BraheError> {
+    batch_map_epochs(
+        epochs,
+        x_radec,
+        |epc| radec_azel_context(epc, site_geodetic, angle_format),
+        |c, x| apply_position_radec_to_azel(c, x, angle_format),
+    )
+}
+
+/// Converts a batch of azimuth/elevation positions seen from a site to right ascension/declination.
+///
+/// Batch form of [`position_azel_to_radec`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// `x_azel` and `epochs` follow the broadcast rule: each has length 1 or the
+/// common batch length. A single epoch computes the site and ECEF-to-ECI
+/// rotation matrices once and applies them to every position.
+///
+/// # Arguments
+/// - `x_azel`: `[az, el, range]` positions, length 1 or the batch length. Units: (angles per `angle_format`, *m*)
+/// - `site_geodetic`: Site geodetic position `[lon, lat, alt]`. Units: (angles per `angle_format`, *m*)
+/// - `epochs`: Epoch instants, length 1 or the batch length
+/// - `angle_format`: Format of the angular coordinates
+///
+/// # Returns
+/// - `[ra, dec, range]` positions in input order. Units: (angles per `angle_format`, *m*)
+/// - Error if `x_azel` and `epochs` do not satisfy the broadcast rule
+///
+/// # Examples
+/// ```
+/// use brahe::eop::*;
+/// use brahe::constants::AngleFormat;
+/// use brahe::coordinates::positions_azel_to_radec;
+/// use brahe::time::{Epoch, TimeSystem};
+/// use brahe::vector3_from_array;
+///
+/// let eop = FileEOPProvider::from_default_file(EOPType::StandardBulletinA, true, EOPExtrapolation::Zero).unwrap();
+/// set_global_eop_provider(eop);
+///
+/// let epc = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let site = vector3_from_array([-122.4, 37.8, 0.0]);
+/// let azel = vec![vector3_from_array([120.0, 45.0, 1.0e6]); 3];
+/// let radec = positions_azel_to_radec(&azel, site, &[epc], AngleFormat::Degrees).unwrap();
+/// assert_eq!(radec.len(), 3);
+/// ```
+pub fn positions_azel_to_radec(
+    x_azel: &[SVector3],
+    site_geodetic: SVector3,
+    epochs: &[Epoch],
+    angle_format: AngleFormat,
+) -> Result<Vec<SVector3>, BraheError> {
+    batch_map_epochs(
+        epochs,
+        x_azel,
+        |epc| azel_radec_context(epc, site_geodetic, angle_format),
+        |c, x| apply_position_azel_to_radec(c, x, angle_format),
+    )
 }
 
 #[cfg(test)]
@@ -968,5 +1245,91 @@ mod tests {
         for k in 0..6 {
             assert_abs_diff_eq!(s_deg[k], s_rad[k], epsilon = 1e-12);
         }
+    }
+
+    #[test]
+    #[parallel]
+    fn test_batch_radec_inertial_match_scalar() {
+        let radec3 = vec![
+            SVector3::new(30.0, 10.0, 1.0e6),
+            SVector3::new(200.0, -45.0, 2.0e6),
+            SVector3::new(359.0, 80.0, 3.0e6),
+        ];
+        let out = positions_radec_to_inertial(&radec3, AngleFormat::Degrees);
+        let back = positions_inertial_to_radec(&out, AngleFormat::Degrees);
+        let radec6: Vec<SVector6> = radec3
+            .iter()
+            .map(|r| SVector6::new(r[0], r[1], r[2], 0.01, -0.02, 5.0))
+            .collect();
+        let out6 = states_radec_to_inertial(&radec6, AngleFormat::Degrees);
+        let back6 = states_inertial_to_radec(&out6, AngleFormat::Degrees);
+        for i in 0..3 {
+            assert_eq!(
+                out[i],
+                position_radec_to_inertial(radec3[i], AngleFormat::Degrees)
+            );
+            assert_eq!(
+                back[i],
+                position_inertial_to_radec(out[i], AngleFormat::Degrees)
+            );
+            assert_eq!(
+                out6[i],
+                state_radec_to_inertial(radec6[i], AngleFormat::Degrees)
+            );
+            assert_eq!(
+                back6[i],
+                state_inertial_to_radec(out6[i], AngleFormat::Degrees)
+            );
+            for k in 0..3 {
+                assert_abs_diff_eq!(back[i][k], radec3[i][k], epsilon = 1e-6);
+            }
+        }
+        assert!(positions_radec_to_inertial(&[], AngleFormat::Degrees).is_empty());
+    }
+
+    #[test]
+    #[serial]
+    fn test_batch_radec_azel_match_scalar() {
+        setup_global_test_eop();
+        let epc0 = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
+        let epochs: Vec<Epoch> = (0..3).map(|i| epc0 + 600.0 * i as f64).collect();
+        let site = SVector3::new(-122.4, 37.8, 0.0);
+        let radec = vec![
+            SVector3::new(30.0, 10.0, 1.0e6),
+            SVector3::new(200.0, -45.0, 2.0e6),
+            SVector3::new(359.0, 80.0, 3.0e6),
+        ];
+        let azel = positions_radec_to_azel(&radec, site, &epochs, AngleFormat::Degrees).unwrap();
+        let azel_shared =
+            positions_radec_to_azel(&radec, site, &epochs[..1], AngleFormat::Degrees).unwrap();
+        let back = positions_azel_to_radec(&azel, site, &epochs, AngleFormat::Degrees).unwrap();
+        let back_shared =
+            positions_azel_to_radec(&azel, site, &epochs[..1], AngleFormat::Degrees).unwrap();
+        let one =
+            positions_radec_to_azel(&radec[..1], site, &epochs, AngleFormat::Degrees).unwrap();
+        for i in 0..3 {
+            assert_eq!(
+                azel[i],
+                position_radec_to_azel(radec[i], site, epochs[i], AngleFormat::Degrees)
+            );
+            assert_eq!(
+                azel_shared[i],
+                position_radec_to_azel(radec[i], site, epochs[0], AngleFormat::Degrees)
+            );
+            assert_eq!(
+                back[i],
+                position_azel_to_radec(azel[i], site, epochs[i], AngleFormat::Degrees)
+            );
+            assert_eq!(
+                back_shared[i],
+                position_azel_to_radec(azel[i], site, epochs[0], AngleFormat::Degrees)
+            );
+            assert_eq!(
+                one[i],
+                position_radec_to_azel(radec[0], site, epochs[i], AngleFormat::Degrees)
+            );
+            assert_abs_diff_eq!(back[i][2], radec[i][2], epsilon = 1e-6);
+        }
+        assert!(positions_radec_to_azel(&radec, site, &epochs[..2], AngleFormat::Degrees).is_err());
     }
 }

--- a/src/coordinates/radec.rs
+++ b/src/coordinates/radec.rs
@@ -658,7 +658,7 @@ pub fn positions_radec_to_inertial(
     x_radec: &[SVector3],
     angle_format: AngleFormat,
 ) -> Vec<SVector3> {
-    batch_map(x_radec, |x| position_radec_to_inertial(*x, angle_format))
+    batch_map(|x| position_radec_to_inertial(*x, angle_format), x_radec)
 }
 
 /// Converts a batch of inertial Cartesian positions to right ascension/declination positions.
@@ -687,7 +687,7 @@ pub fn positions_inertial_to_radec(
     x_inertial: &[SVector3],
     angle_format: AngleFormat,
 ) -> Vec<SVector3> {
-    batch_map(x_inertial, |x| position_inertial_to_radec(*x, angle_format))
+    batch_map(|x| position_inertial_to_radec(*x, angle_format), x_inertial)
 }
 
 /// Converts a batch of right ascension/declination states to inertial Cartesian states.
@@ -713,7 +713,7 @@ pub fn positions_inertial_to_radec(
 /// assert_eq!(out.len(), 3);
 /// ```
 pub fn states_radec_to_inertial(x_radec: &[SVector6], angle_format: AngleFormat) -> Vec<SVector6> {
-    batch_map(x_radec, |x| state_radec_to_inertial(*x, angle_format))
+    batch_map(|x| state_radec_to_inertial(*x, angle_format), x_radec)
 }
 
 /// Converts a batch of inertial Cartesian states to right ascension/declination states.
@@ -742,7 +742,7 @@ pub fn states_inertial_to_radec(
     x_inertial: &[SVector6],
     angle_format: AngleFormat,
 ) -> Vec<SVector6> {
-    batch_map(x_inertial, |x| state_inertial_to_radec(*x, angle_format))
+    batch_map(|x| state_inertial_to_radec(*x, angle_format), x_inertial)
 }
 
 /// Converts a batch of right ascension/declination positions to azimuth/elevation as seen from a site.
@@ -788,10 +788,10 @@ pub fn positions_radec_to_azel(
     angle_format: AngleFormat,
 ) -> Result<Vec<SVector3>, BraheError> {
     batch_map_epochs(
-        epochs,
-        x_radec,
         |epc| radec_azel_context(epc, site_geodetic, angle_format),
         |c, x| apply_position_radec_to_azel(c, x, angle_format),
+        epochs,
+        x_radec,
     )
 }
 
@@ -838,10 +838,10 @@ pub fn positions_azel_to_radec(
     angle_format: AngleFormat,
 ) -> Result<Vec<SVector3>, BraheError> {
     batch_map_epochs(
-        epochs,
-        x_azel,
         |epc| azel_radec_context(epc, site_geodetic, angle_format),
         |c, x| apply_position_azel_to_radec(c, x, angle_format),
+        epochs,
+        x_azel,
     )
 }
 

--- a/src/coordinates/radec.rs
+++ b/src/coordinates/radec.rs
@@ -437,6 +437,25 @@ struct RadecAzelContext {
 }
 
 /// Compute the topocentric context for `site_geodetic` at `epc`.
+///
+/// # Arguments
+/// - `epc`: Epoch instant
+/// - `site_geodetic`: Site geodetic position `[lon, lat, alt]`. Units: (angles per `angle_format`, *m*)
+/// - `angle_format`: Format of the angular site coordinates
+///
+/// # Returns
+/// - ECI-to-ECEF and ECEF-to-ENZ rotation matrices for the site at `epc`
+///
+/// # Examples
+///
+/// ```ignore
+/// use brahe::constants::AngleFormat;
+/// use brahe::math::SVector3;
+/// use brahe::time::{Epoch, TimeSystem};
+///
+/// let epc = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let c = radec_azel_context(epc, SVector3::new(-122.4, 37.8, 0.0), AngleFormat::Degrees);
+/// ```
 fn radec_azel_context(
     epc: Epoch,
     site_geodetic: SVector3,
@@ -449,6 +468,26 @@ fn radec_azel_context(
 }
 
 /// Apply a topocentric context to one right ascension/declination position.
+///
+/// # Arguments
+/// - `c`: Topocentric context for the site and epoch
+/// - `x_radec`: `[ra, dec, range]`. Units: (angles per `angle_format`, *m*)
+/// - `angle_format`: Format of the angular coordinates
+///
+/// # Returns
+/// - `[az, el, range]`. Units: (angles per `angle_format`, *m*)
+///
+/// # Examples
+///
+/// ```ignore
+/// use brahe::constants::AngleFormat;
+/// use brahe::math::SVector3;
+/// use brahe::time::{Epoch, TimeSystem};
+///
+/// let epc = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let c = radec_azel_context(epc, SVector3::new(-122.4, 37.8, 0.0), AngleFormat::Degrees);
+/// let azel = apply_position_radec_to_azel(&c, &SVector3::new(30.0, 10.0, 1.0e6), AngleFormat::Degrees);
+/// ```
 fn apply_position_radec_to_azel(
     c: &RadecAzelContext,
     x_radec: &SVector3,
@@ -523,6 +562,25 @@ struct AzelRadecContext {
 }
 
 /// Compute the inverse topocentric context for `site_geodetic` at `epc`.
+///
+/// # Arguments
+/// - `epc`: Epoch instant
+/// - `site_geodetic`: Site geodetic position `[lon, lat, alt]`. Units: (angles per `angle_format`, *m*)
+/// - `angle_format`: Format of the angular site coordinates
+///
+/// # Returns
+/// - ENZ-to-ECEF and ECEF-to-ECI rotation matrices for the site at `epc`
+///
+/// # Examples
+///
+/// ```ignore
+/// use brahe::constants::AngleFormat;
+/// use brahe::math::SVector3;
+/// use brahe::time::{Epoch, TimeSystem};
+///
+/// let epc = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let c = azel_radec_context(epc, SVector3::new(-122.4, 37.8, 0.0), AngleFormat::Degrees);
+/// ```
 fn azel_radec_context(
     epc: Epoch,
     site_geodetic: SVector3,
@@ -535,6 +593,26 @@ fn azel_radec_context(
 }
 
 /// Apply an inverse topocentric context to one azimuth/elevation position.
+///
+/// # Arguments
+/// - `c`: Inverse topocentric context for the site and epoch
+/// - `x_azel`: `[az, el, range]`. Units: (angles per `angle_format`, *m*)
+/// - `angle_format`: Format of the angular coordinates
+///
+/// # Returns
+/// - `[ra, dec, range]`. Units: (angles per `angle_format`, *m*)
+///
+/// # Examples
+///
+/// ```ignore
+/// use brahe::constants::AngleFormat;
+/// use brahe::math::SVector3;
+/// use brahe::time::{Epoch, TimeSystem};
+///
+/// let epc = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
+/// let c = azel_radec_context(epc, SVector3::new(-122.4, 37.8, 0.0), AngleFormat::Degrees);
+/// let radec = apply_position_azel_to_radec(&c, &SVector3::new(120.0, 45.0, 1.0e6), AngleFormat::Degrees);
+/// ```
 fn apply_position_azel_to_radec(
     c: &AzelRadecContext,
     x_azel: &SVector3,

--- a/src/coordinates/topocentric.rs
+++ b/src/coordinates/topocentric.rs
@@ -13,6 +13,8 @@ use crate::constants::AngleFormat;
 use crate::coordinates::coordinate_types::EllipsoidalConversionType;
 use crate::coordinates::geocentric::position_ecef_to_geocentric;
 use crate::coordinates::geodetic::position_ecef_to_geodetic;
+use crate::utils::BraheError;
+use crate::utils::batch::{batch_map, batch_zip};
 
 /// Compute the rotation matrix from body-fixed to East-North-Zenith (ENZ)
 /// Cartesian coordinates for a given set of coordinates on an ellipsoidal body.
@@ -82,6 +84,96 @@ pub fn rotation_enz_to_ellipsoid(x_ellipsoid: Vector3<f64>, angle_format: AngleF
     rotation_ellipsoid_to_enz(x_ellipsoid, angle_format).transpose()
 }
 
+/// Rotation matrix from ECEF axes to the ENZ frame of `location_ecef`.
+fn enz_rotation_at(
+    location_ecef: Vector3<f64>,
+    conversion_type: EllipsoidalConversionType,
+) -> SMatrix3 {
+    match conversion_type {
+        EllipsoidalConversionType::Geocentric => rotation_ellipsoid_to_enz(
+            position_ecef_to_geocentric(location_ecef, AngleFormat::Radians),
+            AngleFormat::Radians,
+        ),
+        EllipsoidalConversionType::Geodetic => rotation_ellipsoid_to_enz(
+            position_ecef_to_geodetic(location_ecef, AngleFormat::Radians),
+            AngleFormat::Radians,
+        ),
+    }
+}
+
+/// Rotation matrix from the ENZ frame of `location_ecef` to ECEF axes.
+fn enz_inverse_rotation_at(
+    location_ecef: Vector3<f64>,
+    conversion_type: EllipsoidalConversionType,
+) -> SMatrix3 {
+    match conversion_type {
+        EllipsoidalConversionType::Geocentric => rotation_enz_to_ellipsoid(
+            position_ecef_to_geocentric(location_ecef, AngleFormat::Radians),
+            AngleFormat::Radians,
+        ),
+        EllipsoidalConversionType::Geodetic => rotation_enz_to_ellipsoid(
+            position_ecef_to_geodetic(location_ecef, AngleFormat::Radians),
+            AngleFormat::Radians,
+        ),
+    }
+}
+
+/// Rotation matrix from ECEF axes to the SEZ frame of `location_ecef`.
+fn sez_rotation_at(
+    location_ecef: Vector3<f64>,
+    conversion_type: EllipsoidalConversionType,
+) -> SMatrix3 {
+    match conversion_type {
+        EllipsoidalConversionType::Geocentric => rotation_ellipsoid_to_sez(
+            position_ecef_to_geocentric(location_ecef, AngleFormat::Radians),
+            AngleFormat::Radians,
+        ),
+        EllipsoidalConversionType::Geodetic => rotation_ellipsoid_to_sez(
+            position_ecef_to_geodetic(location_ecef, AngleFormat::Radians),
+            AngleFormat::Radians,
+        ),
+    }
+}
+
+/// Rotation matrix from the SEZ frame of `location_ecef` to ECEF axes.
+fn sez_inverse_rotation_at(
+    location_ecef: Vector3<f64>,
+    conversion_type: EllipsoidalConversionType,
+) -> SMatrix3 {
+    match conversion_type {
+        EllipsoidalConversionType::Geocentric => rotation_sez_to_ellipsoid(
+            position_ecef_to_geocentric(location_ecef, AngleFormat::Radians),
+            AngleFormat::Radians,
+        ),
+        EllipsoidalConversionType::Geodetic => rotation_sez_to_ellipsoid(
+            position_ecef_to_geodetic(location_ecef, AngleFormat::Radians),
+            AngleFormat::Radians,
+        ),
+    }
+}
+
+/// Express `r_ecef` relative to `location_ecef` in the local frame given by
+/// `rot` (ECEF -> local).
+fn apply_relative_ecef_to_local(
+    rot: &SMatrix3,
+    location_ecef: &Vector3<f64>,
+    r_ecef: &Vector3<f64>,
+) -> Vector3<f64> {
+    let r = r_ecef - location_ecef;
+    rot * r
+}
+
+/// Express a local-frame relative position as an ECEF position, given `rot`
+/// (local -> ECEF).
+fn apply_relative_local_to_ecef(
+    rot: &SMatrix3,
+    location_ecef: &Vector3<f64>,
+    r_local: &Vector3<f64>,
+) -> Vector3<f64> {
+    let r = *r_local;
+    location_ecef + rot * r
+}
+
 /// Computes the relative state in East-North-Zenith (ENZ) coordinates for a target
 /// object in the ECEF frame with respect to a fixed location (station) also in
 /// the ECEF frame.
@@ -107,27 +199,16 @@ pub fn rotation_enz_to_ellipsoid(x_ellipsoid: Vector3<f64>, angle_format: AngleF
 ///     x_station, x_sat, EllipsoidalConversionType::Geocentric
 /// );
 /// ```
-#[allow(non_snake_case)]
 pub fn relative_position_ecef_to_enz(
     location_ecef: Vector3<f64>,
     r_ecef: Vector3<f64>,
     conversion_type: EllipsoidalConversionType,
 ) -> Vector3<f64> {
-    // Create ENZ rotation matrix
-    let E = match conversion_type {
-        EllipsoidalConversionType::Geocentric => rotation_ellipsoid_to_enz(
-            position_ecef_to_geocentric(location_ecef, AngleFormat::Radians),
-            AngleFormat::Radians,
-        ),
-        EllipsoidalConversionType::Geodetic => rotation_ellipsoid_to_enz(
-            position_ecef_to_geodetic(location_ecef, AngleFormat::Radians),
-            AngleFormat::Radians,
-        ),
-    };
-
-    // Compute range transformation
-    let r = r_ecef - location_ecef;
-    E * r
+    apply_relative_ecef_to_local(
+        &enz_rotation_at(location_ecef, conversion_type),
+        &location_ecef,
+        &r_ecef,
+    )
 }
 
 /// Computes the absolute Earth-fixed coordinates for an object given its relative
@@ -155,27 +236,16 @@ pub fn relative_position_ecef_to_enz(
 ///     x_station, r_enz, EllipsoidalConversionType::Geocentric
 /// );
 /// ```
-#[allow(non_snake_case)]
 pub fn relative_position_enz_to_ecef(
     location_ecef: Vector3<f64>,
     r_enz: Vector3<f64>,
     conversion_type: EllipsoidalConversionType,
 ) -> Vector3<f64> {
-    // Create ENZ rotation matrix
-    let Et = match conversion_type {
-        EllipsoidalConversionType::Geocentric => rotation_enz_to_ellipsoid(
-            position_ecef_to_geocentric(location_ecef, AngleFormat::Radians),
-            AngleFormat::Radians,
-        ),
-        EllipsoidalConversionType::Geodetic => rotation_enz_to_ellipsoid(
-            position_ecef_to_geodetic(location_ecef, AngleFormat::Radians),
-            AngleFormat::Radians,
-        ),
-    };
-
-    // Compute range transformation
-    let r = r_enz;
-    location_ecef + Et * r
+    apply_relative_local_to_ecef(
+        &enz_inverse_rotation_at(location_ecef, conversion_type),
+        &location_ecef,
+        &r_enz,
+    )
 }
 
 /// Compute the rotation matrix from body-fixed to South-East-Zenith (SEZ)
@@ -271,27 +341,16 @@ pub fn rotation_sez_to_ellipsoid(x_ellipsoid: Vector3<f64>, angle_format: AngleF
 ///     x_station, x_sat, EllipsoidalConversionType::Geocentric
 /// );
 /// ```
-#[allow(non_snake_case)]
 pub fn relative_position_ecef_to_sez(
     location_ecef: Vector3<f64>,
     r_ecef: Vector3<f64>,
     conversion_type: EllipsoidalConversionType,
 ) -> Vector3<f64> {
-    // Create ENZ rotation matrix
-    let E = match conversion_type {
-        EllipsoidalConversionType::Geocentric => rotation_ellipsoid_to_sez(
-            position_ecef_to_geocentric(location_ecef, AngleFormat::Radians),
-            AngleFormat::Radians,
-        ),
-        EllipsoidalConversionType::Geodetic => rotation_ellipsoid_to_sez(
-            position_ecef_to_geodetic(location_ecef, AngleFormat::Radians),
-            AngleFormat::Radians,
-        ),
-    };
-
-    // Compute range transformation
-    let r = r_ecef - location_ecef;
-    E * r
+    apply_relative_ecef_to_local(
+        &sez_rotation_at(location_ecef, conversion_type),
+        &location_ecef,
+        &r_ecef,
+    )
 }
 
 /// Computes the absolute Earth-fixed coordinates for an object given its relative
@@ -319,27 +378,16 @@ pub fn relative_position_ecef_to_sez(
 ///     x_station, r_sez, EllipsoidalConversionType::Geocentric
 /// );
 /// ```
-#[allow(non_snake_case)]
 pub fn relative_position_sez_to_ecef(
     location_ecef: Vector3<f64>,
     x_sez: Vector3<f64>,
     conversion_type: EllipsoidalConversionType,
 ) -> Vector3<f64> {
-    // Create SEZ rotation matrix
-    let Et = match conversion_type {
-        EllipsoidalConversionType::Geocentric => rotation_sez_to_ellipsoid(
-            position_ecef_to_geocentric(location_ecef, AngleFormat::Radians),
-            AngleFormat::Radians,
-        ),
-        EllipsoidalConversionType::Geodetic => rotation_sez_to_ellipsoid(
-            position_ecef_to_geodetic(location_ecef, AngleFormat::Radians),
-            AngleFormat::Radians,
-        ),
-    };
-
-    // Compute range transformation
-    let r = x_sez;
-    location_ecef + Et * r
+    apply_relative_local_to_ecef(
+        &sez_inverse_rotation_at(location_ecef, conversion_type),
+        &location_ecef,
+        &x_sez,
+    )
 }
 
 /// Converts East-North-Zenith topocentric coordinates of an location
@@ -432,10 +480,365 @@ pub fn position_sez_to_azel(x_sez: Vector3<f64>, angle_format: AngleFormat) -> V
     }
 }
 
+/// Computes the ellipsoidal-to-ENZ rotation matrix for each site in `x_ellipsoid`.
+///
+/// Batch form of [`rotation_ellipsoid_to_enz`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// # Arguments
+/// - `x_ellipsoid`: Ellipsoidal (geodetic or geocentric) site positions `[lon, lat, alt]`. Units: (angles per `angle_format`, *m*)
+/// - `angle_format`: Format of the angular coordinates
+///
+/// # Returns
+/// - Rotation matrices transforming ellipsoidal -> ENZ, one per site, in input order
+///
+/// # Examples
+/// ```
+/// use brahe::constants::AngleFormat;
+/// use brahe::coordinates::rotations_ellipsoid_to_enz;
+/// use nalgebra::Vector3;
+///
+/// let sites = vec![Vector3::new(-122.4, 37.8, 0.0), Vector3::new(151.2, -33.9, 0.0)];
+/// let r = rotations_ellipsoid_to_enz(&sites, AngleFormat::Degrees);
+/// assert_eq!(r.len(), 2);
+/// ```
+pub fn rotations_ellipsoid_to_enz(
+    x_ellipsoid: &[Vector3<f64>],
+    angle_format: AngleFormat,
+) -> Vec<SMatrix3> {
+    batch_map(x_ellipsoid, |x| rotation_ellipsoid_to_enz(*x, angle_format))
+}
+
+/// Computes the ENZ-to-ellipsoidal rotation matrix for each site in `x_ellipsoid`.
+///
+/// Batch form of [`rotation_enz_to_ellipsoid`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// # Arguments
+/// - `x_ellipsoid`: Ellipsoidal (geodetic or geocentric) site positions `[lon, lat, alt]`. Units: (angles per `angle_format`, *m*)
+/// - `angle_format`: Format of the angular coordinates
+///
+/// # Returns
+/// - Rotation matrices transforming ENZ -> ellipsoidal, one per site, in input order
+///
+/// # Examples
+/// ```
+/// use brahe::constants::AngleFormat;
+/// use brahe::coordinates::rotations_enz_to_ellipsoid;
+/// use nalgebra::Vector3;
+///
+/// let sites = vec![Vector3::new(-122.4, 37.8, 0.0), Vector3::new(151.2, -33.9, 0.0)];
+/// let r = rotations_enz_to_ellipsoid(&sites, AngleFormat::Degrees);
+/// assert_eq!(r.len(), 2);
+/// ```
+pub fn rotations_enz_to_ellipsoid(
+    x_ellipsoid: &[Vector3<f64>],
+    angle_format: AngleFormat,
+) -> Vec<SMatrix3> {
+    batch_map(x_ellipsoid, |x| rotation_enz_to_ellipsoid(*x, angle_format))
+}
+
+/// Computes the ellipsoidal-to-SEZ rotation matrix for each site in `x_ellipsoid`.
+///
+/// Batch form of [`rotation_ellipsoid_to_sez`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// # Arguments
+/// - `x_ellipsoid`: Ellipsoidal (geodetic or geocentric) site positions `[lon, lat, alt]`. Units: (angles per `angle_format`, *m*)
+/// - `angle_format`: Format of the angular coordinates
+///
+/// # Returns
+/// - Rotation matrices transforming ellipsoidal -> SEZ, one per site, in input order
+///
+/// # Examples
+/// ```
+/// use brahe::constants::AngleFormat;
+/// use brahe::coordinates::rotations_ellipsoid_to_sez;
+/// use nalgebra::Vector3;
+///
+/// let sites = vec![Vector3::new(-122.4, 37.8, 0.0), Vector3::new(151.2, -33.9, 0.0)];
+/// let r = rotations_ellipsoid_to_sez(&sites, AngleFormat::Degrees);
+/// assert_eq!(r.len(), 2);
+/// ```
+pub fn rotations_ellipsoid_to_sez(
+    x_ellipsoid: &[Vector3<f64>],
+    angle_format: AngleFormat,
+) -> Vec<SMatrix3> {
+    batch_map(x_ellipsoid, |x| rotation_ellipsoid_to_sez(*x, angle_format))
+}
+
+/// Computes the SEZ-to-ellipsoidal rotation matrix for each site in `x_ellipsoid`.
+///
+/// Batch form of [`rotation_sez_to_ellipsoid`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// # Arguments
+/// - `x_ellipsoid`: Ellipsoidal (geodetic or geocentric) site positions `[lon, lat, alt]`. Units: (angles per `angle_format`, *m*)
+/// - `angle_format`: Format of the angular coordinates
+///
+/// # Returns
+/// - Rotation matrices transforming SEZ -> ellipsoidal, one per site, in input order
+///
+/// # Examples
+/// ```
+/// use brahe::constants::AngleFormat;
+/// use brahe::coordinates::rotations_sez_to_ellipsoid;
+/// use nalgebra::Vector3;
+///
+/// let sites = vec![Vector3::new(-122.4, 37.8, 0.0), Vector3::new(151.2, -33.9, 0.0)];
+/// let r = rotations_sez_to_ellipsoid(&sites, AngleFormat::Degrees);
+/// assert_eq!(r.len(), 2);
+/// ```
+pub fn rotations_sez_to_ellipsoid(
+    x_ellipsoid: &[Vector3<f64>],
+    angle_format: AngleFormat,
+) -> Vec<SMatrix3> {
+    batch_map(x_ellipsoid, |x| rotation_sez_to_ellipsoid(*x, angle_format))
+}
+
+/// Transforms a batch of positions between ECEF and the local ENZ frame of one or more sites.
+///
+/// Batch form of [`relative_position_ecef_to_enz`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// `location_ecef` and the relative-position argument follow the broadcast
+/// rule: each has length 1 or the common batch length. A single location
+/// computes its rotation matrix once and applies it to every position.
+///
+/// # Arguments
+/// - `location_ecef`: Cartesian ECEF site positions, length 1 or the batch length. Units: (*m*)
+/// - `r_ecef`: Cartesian ECEF positions, length 1 or the batch length. Units: (*m*)
+/// - `conversion_type`: Ellipsoidal conversion used to orient the local frame
+///
+/// # Returns
+/// - Relative positions in the local ENZ frame in input order. Units: (*m*)
+/// - Error if the lengths do not satisfy the broadcast rule
+///
+/// # Examples
+/// ```
+/// use brahe::constants::{AngleFormat, R_EARTH};
+/// use brahe::coordinates::{EllipsoidalConversionType, position_geodetic_to_ecef, relative_positions_ecef_to_enz};
+/// use nalgebra::Vector3;
+///
+/// let station = position_geodetic_to_ecef(Vector3::new(-122.4, 37.8, 0.0), AngleFormat::Degrees).unwrap();
+/// let targets = vec![Vector3::new(R_EARTH + 500e3, 0.0, 0.0), Vector3::new(0.0, R_EARTH + 500e3, 0.0)];
+/// let out = relative_positions_ecef_to_enz(&[station], &targets, EllipsoidalConversionType::Geodetic).unwrap();
+/// assert_eq!(out.len(), 2);
+/// ```
+pub fn relative_positions_ecef_to_enz(
+    location_ecef: &[Vector3<f64>],
+    r_ecef: &[Vector3<f64>],
+    conversion_type: EllipsoidalConversionType,
+) -> Result<Vec<Vector3<f64>>, BraheError> {
+    if location_ecef.len() == 1 {
+        let rot = enz_rotation_at(location_ecef[0], conversion_type);
+        return Ok(batch_map(r_ecef, |x| {
+            apply_relative_ecef_to_local(&rot, &location_ecef[0], x)
+        }));
+    }
+    batch_zip(location_ecef, r_ecef, |loc, x| {
+        relative_position_ecef_to_enz(*loc, *x, conversion_type)
+    })
+}
+
+/// Transforms a batch of positions between ECEF and the local ENZ frame of one or more sites.
+///
+/// Batch form of [`relative_position_enz_to_ecef`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// `location_ecef` and the relative-position argument follow the broadcast
+/// rule: each has length 1 or the common batch length. A single location
+/// computes its rotation matrix once and applies it to every position.
+///
+/// # Arguments
+/// - `location_ecef`: Cartesian ECEF site positions, length 1 or the batch length. Units: (*m*)
+/// - `r_enz`: Relative positions in the local ENZ frame, length 1 or the batch length. Units: (*m*)
+/// - `conversion_type`: Ellipsoidal conversion used to orient the local frame
+///
+/// # Returns
+/// - Cartesian ECEF positions in input order. Units: (*m*)
+/// - Error if the lengths do not satisfy the broadcast rule
+///
+/// # Examples
+/// ```
+/// use brahe::constants::{AngleFormat, R_EARTH};
+/// use brahe::coordinates::{EllipsoidalConversionType, position_geodetic_to_ecef, relative_positions_enz_to_ecef};
+/// use nalgebra::Vector3;
+///
+/// let station = position_geodetic_to_ecef(Vector3::new(-122.4, 37.8, 0.0), AngleFormat::Degrees).unwrap();
+/// let targets = vec![Vector3::new(R_EARTH + 500e3, 0.0, 0.0), Vector3::new(0.0, R_EARTH + 500e3, 0.0)];
+/// let out = relative_positions_enz_to_ecef(&[station], &targets, EllipsoidalConversionType::Geodetic).unwrap();
+/// assert_eq!(out.len(), 2);
+/// ```
+pub fn relative_positions_enz_to_ecef(
+    location_ecef: &[Vector3<f64>],
+    r_enz: &[Vector3<f64>],
+    conversion_type: EllipsoidalConversionType,
+) -> Result<Vec<Vector3<f64>>, BraheError> {
+    if location_ecef.len() == 1 {
+        let rot = enz_inverse_rotation_at(location_ecef[0], conversion_type);
+        return Ok(batch_map(r_enz, |x| {
+            apply_relative_local_to_ecef(&rot, &location_ecef[0], x)
+        }));
+    }
+    batch_zip(location_ecef, r_enz, |loc, x| {
+        relative_position_enz_to_ecef(*loc, *x, conversion_type)
+    })
+}
+
+/// Transforms a batch of positions between ECEF and the local SEZ frame of one or more sites.
+///
+/// Batch form of [`relative_position_ecef_to_sez`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// `location_ecef` and the relative-position argument follow the broadcast
+/// rule: each has length 1 or the common batch length. A single location
+/// computes its rotation matrix once and applies it to every position.
+///
+/// # Arguments
+/// - `location_ecef`: Cartesian ECEF site positions, length 1 or the batch length. Units: (*m*)
+/// - `r_ecef`: Cartesian ECEF positions, length 1 or the batch length. Units: (*m*)
+/// - `conversion_type`: Ellipsoidal conversion used to orient the local frame
+///
+/// # Returns
+/// - Relative positions in the local SEZ frame in input order. Units: (*m*)
+/// - Error if the lengths do not satisfy the broadcast rule
+///
+/// # Examples
+/// ```
+/// use brahe::constants::{AngleFormat, R_EARTH};
+/// use brahe::coordinates::{EllipsoidalConversionType, position_geodetic_to_ecef, relative_positions_ecef_to_sez};
+/// use nalgebra::Vector3;
+///
+/// let station = position_geodetic_to_ecef(Vector3::new(-122.4, 37.8, 0.0), AngleFormat::Degrees).unwrap();
+/// let targets = vec![Vector3::new(R_EARTH + 500e3, 0.0, 0.0), Vector3::new(0.0, R_EARTH + 500e3, 0.0)];
+/// let out = relative_positions_ecef_to_sez(&[station], &targets, EllipsoidalConversionType::Geodetic).unwrap();
+/// assert_eq!(out.len(), 2);
+/// ```
+pub fn relative_positions_ecef_to_sez(
+    location_ecef: &[Vector3<f64>],
+    r_ecef: &[Vector3<f64>],
+    conversion_type: EllipsoidalConversionType,
+) -> Result<Vec<Vector3<f64>>, BraheError> {
+    if location_ecef.len() == 1 {
+        let rot = sez_rotation_at(location_ecef[0], conversion_type);
+        return Ok(batch_map(r_ecef, |x| {
+            apply_relative_ecef_to_local(&rot, &location_ecef[0], x)
+        }));
+    }
+    batch_zip(location_ecef, r_ecef, |loc, x| {
+        relative_position_ecef_to_sez(*loc, *x, conversion_type)
+    })
+}
+
+/// Transforms a batch of positions between ECEF and the local SEZ frame of one or more sites.
+///
+/// Batch form of [`relative_position_sez_to_ecef`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// `location_ecef` and the relative-position argument follow the broadcast
+/// rule: each has length 1 or the common batch length. A single location
+/// computes its rotation matrix once and applies it to every position.
+///
+/// # Arguments
+/// - `location_ecef`: Cartesian ECEF site positions, length 1 or the batch length. Units: (*m*)
+/// - `x_sez`: Relative positions in the local SEZ frame, length 1 or the batch length. Units: (*m*)
+/// - `conversion_type`: Ellipsoidal conversion used to orient the local frame
+///
+/// # Returns
+/// - Cartesian ECEF positions in input order. Units: (*m*)
+/// - Error if the lengths do not satisfy the broadcast rule
+///
+/// # Examples
+/// ```
+/// use brahe::constants::{AngleFormat, R_EARTH};
+/// use brahe::coordinates::{EllipsoidalConversionType, position_geodetic_to_ecef, relative_positions_sez_to_ecef};
+/// use nalgebra::Vector3;
+///
+/// let station = position_geodetic_to_ecef(Vector3::new(-122.4, 37.8, 0.0), AngleFormat::Degrees).unwrap();
+/// let targets = vec![Vector3::new(R_EARTH + 500e3, 0.0, 0.0), Vector3::new(0.0, R_EARTH + 500e3, 0.0)];
+/// let out = relative_positions_sez_to_ecef(&[station], &targets, EllipsoidalConversionType::Geodetic).unwrap();
+/// assert_eq!(out.len(), 2);
+/// ```
+pub fn relative_positions_sez_to_ecef(
+    location_ecef: &[Vector3<f64>],
+    x_sez: &[Vector3<f64>],
+    conversion_type: EllipsoidalConversionType,
+) -> Result<Vec<Vector3<f64>>, BraheError> {
+    if location_ecef.len() == 1 {
+        let rot = sez_inverse_rotation_at(location_ecef[0], conversion_type);
+        return Ok(batch_map(x_sez, |x| {
+            apply_relative_local_to_ecef(&rot, &location_ecef[0], x)
+        }));
+    }
+    batch_zip(location_ecef, x_sez, |loc, x| {
+        relative_position_sez_to_ecef(*loc, *x, conversion_type)
+    })
+}
+
+/// Converts a batch of ENZ relative positions to azimuth/elevation/range.
+///
+/// Batch form of [`position_enz_to_azel`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// # Arguments
+/// - `x_enz`: Relative positions in the ENZ frame. Units: (*m*)
+/// - `angle_format`: Format of the returned angles
+///
+/// # Returns
+/// - `[az, el, range]` in input order. Units: (angles per `angle_format`, *m*)
+///
+/// # Examples
+/// ```
+/// use brahe::constants::AngleFormat;
+/// use brahe::coordinates::positions_enz_to_azel;
+/// use nalgebra::Vector3;
+///
+/// let rel = vec![Vector3::new(1.0e3, 2.0e3, 3.0e3), Vector3::new(-1.0e3, 0.5e3, 2.0e3)];
+/// let azel = positions_enz_to_azel(&rel, AngleFormat::Degrees);
+/// assert_eq!(azel.len(), 2);
+/// ```
+pub fn positions_enz_to_azel(
+    x_enz: &[Vector3<f64>],
+    angle_format: AngleFormat,
+) -> Vec<Vector3<f64>> {
+    batch_map(x_enz, |x| position_enz_to_azel(*x, angle_format))
+}
+
+/// Converts a batch of SEZ relative positions to azimuth/elevation/range.
+///
+/// Batch form of [`position_sez_to_azel`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// # Arguments
+/// - `x_sez`: Relative positions in the SEZ frame. Units: (*m*)
+/// - `angle_format`: Format of the returned angles
+///
+/// # Returns
+/// - `[az, el, range]` in input order. Units: (angles per `angle_format`, *m*)
+///
+/// # Examples
+/// ```
+/// use brahe::constants::AngleFormat;
+/// use brahe::coordinates::positions_sez_to_azel;
+/// use nalgebra::Vector3;
+///
+/// let rel = vec![Vector3::new(1.0e3, 2.0e3, 3.0e3), Vector3::new(-1.0e3, 0.5e3, 2.0e3)];
+/// let azel = positions_sez_to_azel(&rel, AngleFormat::Degrees);
+/// assert_eq!(azel.len(), 2);
+/// ```
+pub fn positions_sez_to_azel(
+    x_sez: &[Vector3<f64>],
+    angle_format: AngleFormat,
+) -> Vec<Vector3<f64>> {
+    batch_map(x_sez, |x| position_sez_to_azel(*x, angle_format))
+}
+
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use approx::assert_abs_diff_eq;
+    use serial_test::parallel;
 
     use crate::constants::DEGREES;
     use crate::{R_EARTH, position_geocentric_to_ecef, position_geodetic_to_ecef};
@@ -858,5 +1261,111 @@ mod tests {
         assert_abs_diff_eq!(x_azel[0], 315.0, epsilon = tol);
         assert_abs_diff_eq!(x_azel[1], 0.0, epsilon = tol);
         assert_abs_diff_eq!(x_azel[2], 100.0 * 2.0_f64.sqrt(), epsilon = tol);
+    }
+
+    #[test]
+    #[parallel]
+    fn test_batch_topocentric_match_scalar() {
+        let sites = vec![
+            Vector3::new(-122.4, 37.8, 0.0),
+            Vector3::new(151.2, -33.9, 100.0),
+            Vector3::new(0.0, 0.0, 10.0),
+        ];
+        let stations: Vec<Vector3<f64>> = sites
+            .iter()
+            .map(|s| position_geodetic_to_ecef(*s, DEGREES).unwrap())
+            .collect();
+        let targets: Vec<Vector3<f64>> = (0..3)
+            .map(|i| Vector3::new(R_EARTH + 500e3 + 1e3 * i as f64, 1e5 * i as f64, 2e5))
+            .collect();
+
+        for i in 0..3 {
+            assert_eq!(
+                rotations_ellipsoid_to_enz(&sites, DEGREES)[i],
+                rotation_ellipsoid_to_enz(sites[i], DEGREES)
+            );
+            assert_eq!(
+                rotations_enz_to_ellipsoid(&sites, DEGREES)[i],
+                rotation_enz_to_ellipsoid(sites[i], DEGREES)
+            );
+            assert_eq!(
+                rotations_ellipsoid_to_sez(&sites, DEGREES)[i],
+                rotation_ellipsoid_to_sez(sites[i], DEGREES)
+            );
+            assert_eq!(
+                rotations_sez_to_ellipsoid(&sites, DEGREES)[i],
+                rotation_sez_to_ellipsoid(sites[i], DEGREES)
+            );
+        }
+
+        for ct in [
+            EllipsoidalConversionType::Geodetic,
+            EllipsoidalConversionType::Geocentric,
+        ] {
+            let enz = relative_positions_ecef_to_enz(&stations, &targets, ct).unwrap();
+            let enz1 = relative_positions_ecef_to_enz(&stations[..1], &targets, ct).unwrap();
+            let enz_one_target =
+                relative_positions_ecef_to_enz(&stations, &targets[..1], ct).unwrap();
+            let ecef = relative_positions_enz_to_ecef(&stations, &enz, ct).unwrap();
+            let ecef1 = relative_positions_enz_to_ecef(&stations[..1], &enz1, ct).unwrap();
+            let sez = relative_positions_ecef_to_sez(&stations, &targets, ct).unwrap();
+            let sez1 = relative_positions_ecef_to_sez(&stations[..1], &targets, ct).unwrap();
+            let ecef_s = relative_positions_sez_to_ecef(&stations, &sez, ct).unwrap();
+            let ecef_s1 = relative_positions_sez_to_ecef(&stations[..1], &sez1, ct).unwrap();
+            for i in 0..3 {
+                assert_eq!(
+                    enz[i],
+                    relative_position_ecef_to_enz(stations[i], targets[i], ct)
+                );
+                assert_eq!(
+                    enz1[i],
+                    relative_position_ecef_to_enz(stations[0], targets[i], ct)
+                );
+                assert_eq!(
+                    enz_one_target[i],
+                    relative_position_ecef_to_enz(stations[i], targets[0], ct)
+                );
+                assert_eq!(
+                    ecef[i],
+                    relative_position_enz_to_ecef(stations[i], enz[i], ct)
+                );
+                assert_eq!(
+                    ecef1[i],
+                    relative_position_enz_to_ecef(stations[0], enz1[i], ct)
+                );
+                assert_eq!(
+                    sez[i],
+                    relative_position_ecef_to_sez(stations[i], targets[i], ct)
+                );
+                assert_eq!(
+                    sez1[i],
+                    relative_position_ecef_to_sez(stations[0], targets[i], ct)
+                );
+                assert_eq!(
+                    ecef_s[i],
+                    relative_position_sez_to_ecef(stations[i], sez[i], ct)
+                );
+                assert_eq!(
+                    ecef_s1[i],
+                    relative_position_sez_to_ecef(stations[0], sez1[i], ct)
+                );
+                for k in 0..3 {
+                    assert_abs_diff_eq!(ecef[i][k], targets[i][k], epsilon = 1e-6);
+                    assert_abs_diff_eq!(ecef_s[i][k], targets[i][k], epsilon = 1e-6);
+                }
+            }
+            let azel = positions_enz_to_azel(&enz, DEGREES);
+            let azel_s = positions_sez_to_azel(&sez, DEGREES);
+            for i in 0..3 {
+                assert_eq!(azel[i], position_enz_to_azel(enz[i], DEGREES));
+                assert_eq!(azel_s[i], position_sez_to_azel(sez[i], DEGREES));
+            }
+            assert!(relative_positions_ecef_to_enz(&stations[..2], &targets, ct).is_err());
+            assert!(
+                relative_positions_ecef_to_enz(&stations[..1], &[], ct)
+                    .unwrap()
+                    .is_empty()
+            );
+        }
     }
 }

--- a/src/coordinates/topocentric.rs
+++ b/src/coordinates/topocentric.rs
@@ -85,6 +85,23 @@ pub fn rotation_enz_to_ellipsoid(x_ellipsoid: Vector3<f64>, angle_format: AngleF
 }
 
 /// Rotation matrix from ECEF axes to the ENZ frame of `location_ecef`.
+///
+/// # Arguments
+/// - `location_ecef`: Cartesian ECEF site position. Units: (*m*)
+/// - `conversion_type`: Ellipsoidal conversion used to orient the local frame
+///
+/// # Returns
+/// - Rotation matrix transforming ECEF -> ENZ at the site
+///
+/// # Examples
+///
+/// ```ignore
+/// use brahe::constants::R_EARTH;
+/// use brahe::coordinates::EllipsoidalConversionType;
+/// use nalgebra::Vector3;
+///
+/// let e = enz_rotation_at(Vector3::new(R_EARTH, 0.0, 0.0), EllipsoidalConversionType::Geodetic);
+/// ```
 fn enz_rotation_at(
     location_ecef: Vector3<f64>,
     conversion_type: EllipsoidalConversionType,
@@ -102,6 +119,23 @@ fn enz_rotation_at(
 }
 
 /// Rotation matrix from the ENZ frame of `location_ecef` to ECEF axes.
+///
+/// # Arguments
+/// - `location_ecef`: Cartesian ECEF site position. Units: (*m*)
+/// - `conversion_type`: Ellipsoidal conversion used to orient the local frame
+///
+/// # Returns
+/// - Rotation matrix transforming ENZ -> ECEF at the site
+///
+/// # Examples
+///
+/// ```ignore
+/// use brahe::constants::R_EARTH;
+/// use brahe::coordinates::EllipsoidalConversionType;
+/// use nalgebra::Vector3;
+///
+/// let et = enz_inverse_rotation_at(Vector3::new(R_EARTH, 0.0, 0.0), EllipsoidalConversionType::Geodetic);
+/// ```
 fn enz_inverse_rotation_at(
     location_ecef: Vector3<f64>,
     conversion_type: EllipsoidalConversionType,
@@ -119,6 +153,23 @@ fn enz_inverse_rotation_at(
 }
 
 /// Rotation matrix from ECEF axes to the SEZ frame of `location_ecef`.
+///
+/// # Arguments
+/// - `location_ecef`: Cartesian ECEF site position. Units: (*m*)
+/// - `conversion_type`: Ellipsoidal conversion used to orient the local frame
+///
+/// # Returns
+/// - Rotation matrix transforming ECEF -> SEZ at the site
+///
+/// # Examples
+///
+/// ```ignore
+/// use brahe::constants::R_EARTH;
+/// use brahe::coordinates::EllipsoidalConversionType;
+/// use nalgebra::Vector3;
+///
+/// let e = sez_rotation_at(Vector3::new(R_EARTH, 0.0, 0.0), EllipsoidalConversionType::Geodetic);
+/// ```
 fn sez_rotation_at(
     location_ecef: Vector3<f64>,
     conversion_type: EllipsoidalConversionType,
@@ -136,6 +187,23 @@ fn sez_rotation_at(
 }
 
 /// Rotation matrix from the SEZ frame of `location_ecef` to ECEF axes.
+///
+/// # Arguments
+/// - `location_ecef`: Cartesian ECEF site position. Units: (*m*)
+/// - `conversion_type`: Ellipsoidal conversion used to orient the local frame
+///
+/// # Returns
+/// - Rotation matrix transforming SEZ -> ECEF at the site
+///
+/// # Examples
+///
+/// ```ignore
+/// use brahe::constants::R_EARTH;
+/// use brahe::coordinates::EllipsoidalConversionType;
+/// use nalgebra::Vector3;
+///
+/// let et = sez_inverse_rotation_at(Vector3::new(R_EARTH, 0.0, 0.0), EllipsoidalConversionType::Geodetic);
+/// ```
 fn sez_inverse_rotation_at(
     location_ecef: Vector3<f64>,
     conversion_type: EllipsoidalConversionType,
@@ -154,6 +222,26 @@ fn sez_inverse_rotation_at(
 
 /// Express `r_ecef` relative to `location_ecef` in the local frame given by
 /// `rot` (ECEF -> local).
+///
+/// # Arguments
+/// - `rot`: Rotation matrix transforming ECEF -> local (ENZ or SEZ)
+/// - `location_ecef`: Cartesian ECEF site position. Units: (*m*)
+/// - `r_ecef`: Cartesian ECEF position to express relative to the site. Units: (*m*)
+///
+/// # Returns
+/// - Relative position in the local frame. Units: (*m*)
+///
+/// # Examples
+///
+/// ```ignore
+/// use brahe::constants::R_EARTH;
+/// use brahe::coordinates::EllipsoidalConversionType;
+/// use nalgebra::Vector3;
+///
+/// let site = Vector3::new(R_EARTH, 0.0, 0.0);
+/// let rot = enz_rotation_at(site, EllipsoidalConversionType::Geodetic);
+/// let enz = apply_relative_ecef_to_local(&rot, &site, &Vector3::new(R_EARTH + 500e3, 0.0, 0.0));
+/// ```
 fn apply_relative_ecef_to_local(
     rot: &SMatrix3,
     location_ecef: &Vector3<f64>,
@@ -165,6 +253,26 @@ fn apply_relative_ecef_to_local(
 
 /// Express a local-frame relative position as an ECEF position, given `rot`
 /// (local -> ECEF).
+///
+/// # Arguments
+/// - `rot`: Rotation matrix transforming local (ENZ or SEZ) -> ECEF
+/// - `location_ecef`: Cartesian ECEF site position. Units: (*m*)
+/// - `r_local`: Relative position in the local frame. Units: (*m*)
+///
+/// # Returns
+/// - Cartesian ECEF position. Units: (*m*)
+///
+/// # Examples
+///
+/// ```ignore
+/// use brahe::constants::R_EARTH;
+/// use brahe::coordinates::EllipsoidalConversionType;
+/// use nalgebra::Vector3;
+///
+/// let site = Vector3::new(R_EARTH, 0.0, 0.0);
+/// let rot = enz_inverse_rotation_at(site, EllipsoidalConversionType::Geodetic);
+/// let ecef = apply_relative_local_to_ecef(&rot, &site, &Vector3::new(0.0, 0.0, 500e3));
+/// ```
 fn apply_relative_local_to_ecef(
     rot: &SMatrix3,
     location_ecef: &Vector3<f64>,

--- a/src/coordinates/topocentric.rs
+++ b/src/coordinates/topocentric.rs
@@ -614,7 +614,7 @@ pub fn rotations_ellipsoid_to_enz(
     x_ellipsoid: &[Vector3<f64>],
     angle_format: AngleFormat,
 ) -> Vec<SMatrix3> {
-    batch_map(x_ellipsoid, |x| rotation_ellipsoid_to_enz(*x, angle_format))
+    batch_map(|x| rotation_ellipsoid_to_enz(*x, angle_format), x_ellipsoid)
 }
 
 /// Computes the ENZ-to-ellipsoidal rotation matrix for each site in `x_ellipsoid`.
@@ -643,7 +643,7 @@ pub fn rotations_enz_to_ellipsoid(
     x_ellipsoid: &[Vector3<f64>],
     angle_format: AngleFormat,
 ) -> Vec<SMatrix3> {
-    batch_map(x_ellipsoid, |x| rotation_enz_to_ellipsoid(*x, angle_format))
+    batch_map(|x| rotation_enz_to_ellipsoid(*x, angle_format), x_ellipsoid)
 }
 
 /// Computes the ellipsoidal-to-SEZ rotation matrix for each site in `x_ellipsoid`.
@@ -672,7 +672,7 @@ pub fn rotations_ellipsoid_to_sez(
     x_ellipsoid: &[Vector3<f64>],
     angle_format: AngleFormat,
 ) -> Vec<SMatrix3> {
-    batch_map(x_ellipsoid, |x| rotation_ellipsoid_to_sez(*x, angle_format))
+    batch_map(|x| rotation_ellipsoid_to_sez(*x, angle_format), x_ellipsoid)
 }
 
 /// Computes the SEZ-to-ellipsoidal rotation matrix for each site in `x_ellipsoid`.
@@ -701,7 +701,7 @@ pub fn rotations_sez_to_ellipsoid(
     x_ellipsoid: &[Vector3<f64>],
     angle_format: AngleFormat,
 ) -> Vec<SMatrix3> {
-    batch_map(x_ellipsoid, |x| rotation_sez_to_ellipsoid(*x, angle_format))
+    batch_map(|x| rotation_sez_to_ellipsoid(*x, angle_format), x_ellipsoid)
 }
 
 /// Transforms a batch of positions between ECEF and the local ENZ frame of one or more sites.
@@ -740,13 +740,16 @@ pub fn relative_positions_ecef_to_enz(
 ) -> Result<Vec<Vector3<f64>>, BraheError> {
     if location_ecef.len() == 1 {
         let rot = enz_rotation_at(location_ecef[0], conversion_type);
-        return Ok(batch_map(r_ecef, |x| {
-            apply_relative_ecef_to_local(&rot, &location_ecef[0], x)
-        }));
+        return Ok(batch_map(
+            |x| apply_relative_ecef_to_local(&rot, &location_ecef[0], x),
+            r_ecef,
+        ));
     }
-    batch_zip(location_ecef, r_ecef, |loc, x| {
-        relative_position_ecef_to_enz(*loc, *x, conversion_type)
-    })
+    batch_zip(
+        |loc, x| relative_position_ecef_to_enz(*loc, *x, conversion_type),
+        location_ecef,
+        r_ecef,
+    )
 }
 
 /// Transforms a batch of positions between ECEF and the local ENZ frame of one or more sites.
@@ -785,13 +788,16 @@ pub fn relative_positions_enz_to_ecef(
 ) -> Result<Vec<Vector3<f64>>, BraheError> {
     if location_ecef.len() == 1 {
         let rot = enz_inverse_rotation_at(location_ecef[0], conversion_type);
-        return Ok(batch_map(r_enz, |x| {
-            apply_relative_local_to_ecef(&rot, &location_ecef[0], x)
-        }));
+        return Ok(batch_map(
+            |x| apply_relative_local_to_ecef(&rot, &location_ecef[0], x),
+            r_enz,
+        ));
     }
-    batch_zip(location_ecef, r_enz, |loc, x| {
-        relative_position_enz_to_ecef(*loc, *x, conversion_type)
-    })
+    batch_zip(
+        |loc, x| relative_position_enz_to_ecef(*loc, *x, conversion_type),
+        location_ecef,
+        r_enz,
+    )
 }
 
 /// Transforms a batch of positions between ECEF and the local SEZ frame of one or more sites.
@@ -830,13 +836,16 @@ pub fn relative_positions_ecef_to_sez(
 ) -> Result<Vec<Vector3<f64>>, BraheError> {
     if location_ecef.len() == 1 {
         let rot = sez_rotation_at(location_ecef[0], conversion_type);
-        return Ok(batch_map(r_ecef, |x| {
-            apply_relative_ecef_to_local(&rot, &location_ecef[0], x)
-        }));
+        return Ok(batch_map(
+            |x| apply_relative_ecef_to_local(&rot, &location_ecef[0], x),
+            r_ecef,
+        ));
     }
-    batch_zip(location_ecef, r_ecef, |loc, x| {
-        relative_position_ecef_to_sez(*loc, *x, conversion_type)
-    })
+    batch_zip(
+        |loc, x| relative_position_ecef_to_sez(*loc, *x, conversion_type),
+        location_ecef,
+        r_ecef,
+    )
 }
 
 /// Transforms a batch of positions between ECEF and the local SEZ frame of one or more sites.
@@ -875,13 +884,16 @@ pub fn relative_positions_sez_to_ecef(
 ) -> Result<Vec<Vector3<f64>>, BraheError> {
     if location_ecef.len() == 1 {
         let rot = sez_inverse_rotation_at(location_ecef[0], conversion_type);
-        return Ok(batch_map(x_sez, |x| {
-            apply_relative_local_to_ecef(&rot, &location_ecef[0], x)
-        }));
+        return Ok(batch_map(
+            |x| apply_relative_local_to_ecef(&rot, &location_ecef[0], x),
+            x_sez,
+        ));
     }
-    batch_zip(location_ecef, x_sez, |loc, x| {
-        relative_position_sez_to_ecef(*loc, *x, conversion_type)
-    })
+    batch_zip(
+        |loc, x| relative_position_sez_to_ecef(*loc, *x, conversion_type),
+        location_ecef,
+        x_sez,
+    )
 }
 
 /// Converts a batch of ENZ relative positions to azimuth/elevation/range.
@@ -910,7 +922,7 @@ pub fn positions_enz_to_azel(
     x_enz: &[Vector3<f64>],
     angle_format: AngleFormat,
 ) -> Vec<Vector3<f64>> {
-    batch_map(x_enz, |x| position_enz_to_azel(*x, angle_format))
+    batch_map(|x| position_enz_to_azel(*x, angle_format), x_enz)
 }
 
 /// Converts a batch of SEZ relative positions to azimuth/elevation/range.
@@ -939,7 +951,7 @@ pub fn positions_sez_to_azel(
     x_sez: &[Vector3<f64>],
     angle_format: AngleFormat,
 ) -> Vec<Vector3<f64>> {
-    batch_map(x_sez, |x| position_sez_to_azel(*x, angle_format))
+    batch_map(|x| position_sez_to_azel(*x, angle_format), x_sez)
 }
 
 #[cfg(test)]

--- a/src/utils/batch.rs
+++ b/src/utils/batch.rs
@@ -153,7 +153,6 @@ pub(crate) fn batch_map<T: Sync, U: Send>(f: impl Fn(&T) -> U + Sync, inputs: &[
 /// let sums = batch_zip(|a, b| a + b, &[10.0], &[1.0, 2.0]).unwrap();
 /// assert_eq!(sums, vec![11.0, 12.0]);
 /// ```
-#[allow(dead_code)]
 pub(crate) fn batch_zip<A: Sync, B: Sync, U: Send>(
     f: impl Fn(&A, &B) -> U + Sync,
     a: &[A],

--- a/tests/coordinates/test_cartesian.py
+++ b/tests/coordinates/test_cartesian.py
@@ -180,3 +180,57 @@ def test_state_koe_to_inertial_for_body_errors(eop):
     no_frame = brahe.CentralBody.Custom("Rogue", -99, 1.0e10, radius=1.0e5)
     with pytest.raises(RuntimeError):
         brahe.state_koe_to_inertial_for_body(osc, no_frame, AngleFormat.DEGREES)
+
+
+def test_batch_koe_eci():
+    elements = np.array(
+        [
+            [brahe.R_EARTH + 500e3 + 1e3 * i, 0.01, 97.8, 15.0 + i, 30.0, 45.0]
+            for i in range(3)
+        ]
+    )
+    states = brahe.state_koe_to_eci(elements, AngleFormat.DEGREES)
+    assert states.shape == (3, 6)
+    back = brahe.state_eci_to_koe(states, AngleFormat.DEGREES)
+    for i in range(3):
+        np.testing.assert_array_equal(
+            states[i], brahe.state_koe_to_eci(elements[i], AngleFormat.DEGREES)
+        )
+        np.testing.assert_array_equal(
+            back[i], brahe.state_eci_to_koe(states[i], AngleFormat.DEGREES)
+        )
+    np.testing.assert_array_equal(
+        brahe.state_koe_to_eci(elements.T, AngleFormat.DEGREES, axis=0), states.T
+    )
+    np.testing.assert_array_equal(
+        brahe.state_koe_to_eci(elements.tolist(), AngleFormat.DEGREES), states
+    )
+    np.testing.assert_allclose(back, elements, atol=1e-6)
+
+
+def test_batch_koe_inertial_for_body():
+    elements = np.array(
+        [
+            [brahe.R_MOON + 100e3 + 1e3 * i, 0.01, 30.0, 0.0, 0.0, 10.0 * i]
+            for i in range(3)
+        ]
+    )
+    body = brahe.CentralBody.Moon
+    states = brahe.state_koe_to_inertial_for_body(elements, body, AngleFormat.DEGREES)
+    back = brahe.state_inertial_to_koe_for_body(states, body, AngleFormat.DEGREES)
+    assert states.shape == (3, 6)
+    for i in range(3):
+        np.testing.assert_array_equal(
+            states[i],
+            brahe.state_koe_to_inertial_for_body(
+                elements[i], body, AngleFormat.DEGREES
+            ),
+        )
+        np.testing.assert_array_equal(
+            back[i],
+            brahe.state_inertial_to_koe_for_body(states[i], body, AngleFormat.DEGREES),
+        )
+    with pytest.raises(ValueError):
+        brahe.state_koe_to_inertial_for_body(
+            np.zeros((3, 5)), body, AngleFormat.DEGREES
+        )

--- a/tests/coordinates/test_geocentric.py
+++ b/tests/coordinates/test_geocentric.py
@@ -85,3 +85,30 @@ def test_geocentric_failure(eop, lat):
         brahe.position_geocentric_to_ecef(
             np.array([0.0, lat, 0.0]), brahe.AngleFormat.DEGREES
         )
+
+
+def test_batch_geocentric_ecef():
+    sites = np.array(
+        [
+            [-122.4, 37.8, brahe.R_EARTH],
+            [151.2, -33.9, brahe.R_EARTH + 100.0],
+            [0.0, 0.0, brahe.R_EARTH + 500e3],
+        ]
+    )
+    ecef = brahe.position_geocentric_to_ecef(sites, brahe.AngleFormat.DEGREES)
+    back = brahe.position_ecef_to_geocentric(ecef, brahe.AngleFormat.DEGREES)
+    assert ecef.shape == (3, 3)
+    for i in range(3):
+        np.testing.assert_array_equal(
+            ecef[i],
+            brahe.position_geocentric_to_ecef(sites[i], brahe.AngleFormat.DEGREES),
+        )
+        np.testing.assert_array_equal(
+            back[i],
+            brahe.position_ecef_to_geocentric(ecef[i], brahe.AngleFormat.DEGREES),
+        )
+    np.testing.assert_allclose(back, sites, atol=1e-6)
+    with pytest.raises(ValueError):
+        brahe.position_geocentric_to_ecef(
+            np.array([[0.0, 95.0, 0.0]]), brahe.AngleFormat.DEGREES
+        )

--- a/tests/coordinates/test_geodetic.py
+++ b/tests/coordinates/test_geodetic.py
@@ -84,3 +84,27 @@ def test_geodetic_failure(eop, lat):
         brahe.position_geodetic_to_ecef(
             np.array([0.0, lat, 0.0]), brahe.AngleFormat.DEGREES
         )
+
+
+def test_batch_geodetic_ecef():
+    sites = np.array([[-122.4, 37.8, 0.0], [151.2, -33.9, 100.0], [0.0, 0.0, 500e3]])
+    ecef = brahe.position_geodetic_to_ecef(sites, brahe.AngleFormat.DEGREES)
+    back = brahe.position_ecef_to_geodetic(ecef, brahe.AngleFormat.DEGREES)
+    assert ecef.shape == (3, 3)
+    for i in range(3):
+        np.testing.assert_array_equal(
+            ecef[i],
+            brahe.position_geodetic_to_ecef(sites[i], brahe.AngleFormat.DEGREES),
+        )
+        np.testing.assert_array_equal(
+            back[i], brahe.position_ecef_to_geodetic(ecef[i], brahe.AngleFormat.DEGREES)
+        )
+    np.testing.assert_allclose(back, sites, atol=1e-6)
+    np.testing.assert_array_equal(
+        brahe.position_ecef_to_geodetic(ecef.T, brahe.AngleFormat.DEGREES, axis=0),
+        back.T,
+    )
+    with pytest.raises(ValueError):
+        brahe.position_geodetic_to_ecef(
+            np.array([[0.0, 95.0, 0.0]]), brahe.AngleFormat.DEGREES
+        )

--- a/tests/coordinates/test_radec.py
+++ b/tests/coordinates/test_radec.py
@@ -350,3 +350,59 @@ def test_position_radec_to_inertial_input_types():
     for x in ([0.0, 0.0, 1.0], (0.0, 0.0, 1.0), np.array([0.0, 0.0, 1.0])):
         r = bh.position_radec_to_inertial(x, AngleFormat.DEGREES)
         assert r == pytest.approx([1.0, 0.0, 0.0], abs=1e-12)
+
+
+def test_batch_radec_inertial():
+    radec = np.array([[30.0, 10.0, 1.0e6], [200.0, -45.0, 2.0e6], [359.0, 80.0, 3.0e6]])
+    out = bh.position_radec_to_inertial(radec, AngleFormat.DEGREES)
+    back = bh.position_inertial_to_radec(out, AngleFormat.DEGREES)
+    radec6 = np.hstack([radec, np.tile([0.01, -0.02, 5.0], (3, 1))])
+    out6 = bh.state_radec_to_inertial(radec6, AngleFormat.DEGREES)
+    back6 = bh.state_inertial_to_radec(out6, AngleFormat.DEGREES)
+    assert out.shape == (3, 3) and out6.shape == (3, 6)
+    for i in range(3):
+        np.testing.assert_array_equal(
+            out[i], bh.position_radec_to_inertial(radec[i], AngleFormat.DEGREES)
+        )
+        np.testing.assert_array_equal(
+            back[i], bh.position_inertial_to_radec(out[i], AngleFormat.DEGREES)
+        )
+        np.testing.assert_array_equal(
+            out6[i], bh.state_radec_to_inertial(radec6[i], AngleFormat.DEGREES)
+        )
+        np.testing.assert_array_equal(
+            back6[i], bh.state_inertial_to_radec(out6[i], AngleFormat.DEGREES)
+        )
+    np.testing.assert_allclose(back, radec, atol=1e-6)
+
+
+def test_batch_radec_azel(eop):
+    epc0 = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.UTC)
+    epochs = [epc0 + 600.0 * i for i in range(3)]
+    site = np.array([-122.4, 37.8, 0.0])
+    radec = np.array([[30.0, 10.0, 1.0e6], [200.0, -45.0, 2.0e6], [359.0, 80.0, 3.0e6]])
+    azel = bh.position_radec_to_azel(radec, site, epochs, AngleFormat.DEGREES)
+    azel_shared = bh.position_radec_to_azel(radec, site, epochs[0], AngleFormat.DEGREES)
+    back = bh.position_azel_to_radec(azel, site, epochs, AngleFormat.DEGREES)
+    one = bh.position_radec_to_azel(radec[0], site, epochs, AngleFormat.DEGREES)
+    assert azel.shape == (3, 3) and one.shape == (3, 3)
+    for i in range(3):
+        np.testing.assert_array_equal(
+            azel[i],
+            bh.position_radec_to_azel(radec[i], site, epochs[i], AngleFormat.DEGREES),
+        )
+        np.testing.assert_array_equal(
+            azel_shared[i],
+            bh.position_radec_to_azel(radec[i], site, epochs[0], AngleFormat.DEGREES),
+        )
+        np.testing.assert_array_equal(
+            back[i],
+            bh.position_azel_to_radec(azel[i], site, epochs[i], AngleFormat.DEGREES),
+        )
+        np.testing.assert_array_equal(
+            one[i],
+            bh.position_radec_to_azel(radec[0], site, epochs[i], AngleFormat.DEGREES),
+        )
+    np.testing.assert_allclose(back[:, 2], radec[:, 2], atol=1e-6)
+    with pytest.raises(ValueError):
+        bh.position_radec_to_azel(radec, site, epochs[:2], AngleFormat.DEGREES)

--- a/tests/coordinates/test_topocentric.py
+++ b/tests/coordinates/test_topocentric.py
@@ -1,6 +1,7 @@
 import math
 
 import numpy as np
+import pytest
 from pytest import approx
 
 import brahe
@@ -423,3 +424,72 @@ def test_position_sez_to_azel():
     assert x_azel[0] == approx(315.0, abs=tol)
     assert x_azel[1] == approx(0.0, abs=tol)
     assert x_azel[2] == approx(100.0 * math.sqrt(2.0), abs=tol)
+
+
+def test_batch_topocentric():
+    sites = np.array([[-122.4, 37.8, 0.0], [151.2, -33.9, 100.0], [0.0, 0.0, 10.0]])
+    stations = brahe.position_geodetic_to_ecef(sites, AngleFormat.DEGREES)
+    targets = np.array(
+        [[brahe.R_EARTH + 500e3 + 1e3 * i, 1e5 * i, 2e5] for i in range(3)]
+    )
+
+    for f in (
+        brahe.rotation_ellipsoid_to_enz,
+        brahe.rotation_enz_to_ellipsoid,
+        brahe.rotation_ellipsoid_to_sez,
+        brahe.rotation_sez_to_ellipsoid,
+    ):
+        R = f(sites, AngleFormat.DEGREES)
+        assert R.shape == (3, 3, 3)
+        for i in range(3):
+            np.testing.assert_array_equal(R[i], f(sites[i], AngleFormat.DEGREES))
+        assert f(sites[0], AngleFormat.DEGREES).shape == (3, 3)
+
+    for ct in (
+        EllipsoidalConversionType.GEODETIC,
+        EllipsoidalConversionType.GEOCENTRIC,
+    ):
+        for fwd, inv, to_azel in (
+            (
+                brahe.relative_position_ecef_to_enz,
+                brahe.relative_position_enz_to_ecef,
+                brahe.position_enz_to_azel,
+            ),
+            (
+                brahe.relative_position_ecef_to_sez,
+                brahe.relative_position_sez_to_ecef,
+                brahe.position_sez_to_azel,
+            ),
+        ):
+            local = fwd(stations, targets, ct)
+            local1 = fwd(stations[0], targets, ct)
+            one_target = fwd(stations, targets[0], ct)
+            back = inv(stations, local, ct)
+            back1 = inv(stations[0], local1, ct)
+            azel = to_azel(local, AngleFormat.DEGREES)
+            assert (
+                local.shape == (3, 3)
+                and local1.shape == (3, 3)
+                and one_target.shape == (3, 3)
+            )
+            for i in range(3):
+                np.testing.assert_array_equal(
+                    local[i], fwd(stations[i], targets[i], ct)
+                )
+                np.testing.assert_array_equal(
+                    local1[i], fwd(stations[0], targets[i], ct)
+                )
+                np.testing.assert_array_equal(
+                    one_target[i], fwd(stations[i], targets[0], ct)
+                )
+                np.testing.assert_array_equal(back[i], inv(stations[i], local[i], ct))
+                np.testing.assert_array_equal(back1[i], inv(stations[0], local1[i], ct))
+                np.testing.assert_array_equal(
+                    azel[i], to_azel(local[i], AngleFormat.DEGREES)
+                )
+            np.testing.assert_allclose(back, targets, atol=1e-6)
+            np.testing.assert_array_equal(
+                fwd(stations[0], targets.T, ct, axis=0), local1.T
+            )
+            with pytest.raises(ValueError):
+                fwd(stations[:2], targets, ct)

--- a/tests/coordinates/test_topocentric.py
+++ b/tests/coordinates/test_topocentric.py
@@ -493,3 +493,25 @@ def test_batch_topocentric():
             )
             with pytest.raises(ValueError):
                 fwd(stations[:2], targets, ct)
+
+
+def test_batch_topocentric_length_one_broadcast():
+    stations = brahe.position_geodetic_to_ecef(
+        np.array([[-122.4, 37.8, 0.0], [151.2, -33.9, 100.0], [0.0, 0.0, 10.0]]),
+        AngleFormat.DEGREES,
+    )
+    targets = np.array(
+        [[brahe.R_EARTH + 500e3 + 1e3 * i, 1e5 * i, 2e5] for i in range(3)]
+    )
+    ct = EllipsoidalConversionType.GEODETIC
+    local = brahe.relative_position_ecef_to_enz(stations[:1], targets, ct)
+    assert local.shape == (3, 3)
+    for i in range(3):
+        np.testing.assert_array_equal(
+            local[i], brahe.relative_position_ecef_to_enz(stations[0], targets[i], ct)
+        )
+    local_b = brahe.relative_position_ecef_to_enz(stations, targets[:1], ct)
+    for i in range(3):
+        np.testing.assert_array_equal(
+            local_b[i], brahe.relative_position_ecef_to_enz(stations[i], targets[0], ct)
+        )


### PR DESCRIPTION
# Pull Request

## Description

Vectorizes the coordinates module: Keplerian/Cartesian (including `_for_body`), geodetic, geocentric, right ascension/declination (including the epoch-dependent radec/azel pair), topocentric (rotations, relative positions, ENZ/SEZ to az/el), and `points_in_polygon` (Rust only; `point_in_polygon` has no Python binding). Topocentric relative-position functions hoist the site rotation when one location is paired with many positions; the radec/azel pair hoists the ECI-to-ECEF and site rotations per epoch. Python bindings gain `try_dispatch_vec`, `dispatch_vec_rotation`, and `dispatch_vec_pair` helpers so each function keeps its existing error mapping.

## Changelog

### Added
- Batch coordinate transformations in Rust: `states_koe_to_eci`/`states_eci_to_koe` (+ `_for_body`), `positions_{geodetic,geocentric}_to_ecef` and inverses, `positions_/states_{radec_to_inertial,inertial_to_radec}`, `positions_{radec_to_azel,azel_to_radec}`, `rotations_ellipsoid_to_{enz,sez}` and inverses, `relative_positions_{ecef_to_enz,enz_to_ecef,ecef_to_sez,sez_to_ecef}`, `positions_{enz,sez}_to_azel`, `points_in_polygon`.
- Python coordinate functions accept batches with the `axis` keyword; relative-position functions broadcast a single site across a batch of positions (and vice versa); `position_radec_to_azel`/`position_azel_to_radec` accept epoch sequences.

## Note to Reviewers
`relative_position_*` scalars are expressed as `rotation-at-location` + apply, unchanged numerically. Rust and Python tests assert exact equality against scalar loops for every function, both broadcast directions, and error cases.
