### PR TITLE
Vectorize relative-motion transformations

### DIFF
--- a/crates/brahe-py/src/relative_motion.rs
+++ b/crates/brahe-py/src/relative_motion.rs
@@ -11,8 +11,10 @@
 /// Args:
 ///     x_eci (numpy.ndarray or list): 6D state vector in the ECI frame [x, y, z, vx, vy, vz] (m, m/s), shape (6,), or a batch of
 ///         vectors with the 6 components along `axis` (for example shape (n, 6)).
-///     axis (int, optional): Axis holding the vector components for batched input.
-///         Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis along which the 6 components of a single vector
+///         lie; the remaining axes enumerate the batch. For a batch of shape (n, 6)
+///         the components lie along the last axis, so the default `-1` applies; a
+///         (6, n) column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: 3x3 rotation matrix transforming from RTN to ECI frame, shape (3, 3), or the batch dimensions
@@ -57,8 +59,10 @@ fn py_rotation_rtn_to_eci<'py>(
 /// Args:
 ///     x_eci (numpy.ndarray or list): 6D state vector in the ECI frame [x, y, z, vx, vy, vz] (m, m/s), shape (6,), or a batch of
 ///         vectors with the 6 components along `axis` (for example shape (n, 6)).
-///     axis (int, optional): Axis holding the vector components for batched input.
-///         Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis along which the 6 components of a single vector
+///         lie; the remaining axes enumerate the batch. For a batch of shape (n, 6)
+///         the components lie along the last axis, so the default `-1` applies; a
+///         (6, n) column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: 3x3 rotation matrix transforming from ECI to RTN frame, shape (3, 3), or the batch dimensions
@@ -104,8 +108,10 @@ fn py_rotation_eci_to_rtn<'py>(
 ///         vectors with the 6 components along `axis` (for example shape (n, 6)).
 ///     x_deputy (numpy.ndarray or list): 6D state vector of the deputy satellite in the ECI frame [x, y, z, vx, vy, vz] (m, m/s), shape (6,), or a batch of
 ///         vectors with the 6 components along `axis` (for example shape (n, 6)).
-///     axis (int, optional): Axis holding the vector components for batched input.
-///         Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis along which the 6 components of a single vector
+///         lie; the remaining axes enumerate the batch. For a batch of shape (n, 6)
+///         the components lie along the last axis, so the default `-1` applies; a
+///         (6, n) column layout uses `axis=0`.
 ///         A single vector in one argument is broadcast across a batch in the other.
 ///
 /// Returns:
@@ -160,8 +166,10 @@ fn py_state_eci_to_rtn<'py>(
 ///         vectors with the 6 components along `axis` (for example shape (n, 6)).
 ///     x_rel_rtn (numpy.ndarray or list): 6D relative state vector of the deputy with respect to the chief in the RTN frame [ρ_R, ρ_T, ρ_N, ρ̇_R, ρ̇_T, ρ̇_N] (m, m/s), shape (6,), or a batch of
 ///         vectors with the 6 components along `axis` (for example shape (n, 6)).
-///     axis (int, optional): Axis holding the vector components for batched input.
-///         Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis along which the 6 components of a single vector
+///         lie; the remaining axes enumerate the batch. For a batch of shape (n, 6)
+///         the components lie along the last axis, so the default `-1` applies; a
+///         (6, n) column layout uses `axis=0`.
 ///         A single vector in one argument is broadcast across a batch in the other.
 ///
 /// Returns:
@@ -223,8 +231,10 @@ fn py_state_rtn_to_eci<'py>(
 ///     oe_deputy (numpy.ndarray or list): Deputy satellite orbital elements [a, e, i, Ω, ω, M] shape (6,), or a batch of
 ///         vectors with the 6 components along `axis` (for example shape (n, 6)).
 ///     angle_format (AngleFormat): Format of angular elements (DEGREES or RADIANS)
-///     axis (int, optional): Axis holding the vector components for batched input.
-///         Defaults to `-1` (the last axis). A single vector in one argument is
+///     axis (int, optional): The axis along which the 6 components of a single vector
+///         lie; the remaining axes enumerate the batch. For a batch of shape (n, 6)
+///         the components lie along the last axis, so the default `-1` applies; a
+///         (6, n) column layout uses `axis=0`. A single vector in one argument is
 ///         broadcast across a batch in the other.
 ///
 /// Returns:
@@ -279,8 +289,10 @@ fn py_state_oe_to_roe<'py>(
 ///     roe (numpy.ndarray or list): Relative orbital elements [da, dλ, dex, dey, dix, diy] shape (6,), or a batch of
 ///         vectors with the 6 components along `axis` (for example shape (n, 6)).
 ///     angle_format (AngleFormat): Format of angular elements (DEGREES or RADIANS)
-///     axis (int, optional): Axis holding the vector components for batched input.
-///         Defaults to `-1` (the last axis). A single vector in one argument is
+///     axis (int, optional): The axis along which the 6 components of a single vector
+///         lie; the remaining axes enumerate the batch. For a batch of shape (n, 6)
+///         the components lie along the last axis, so the default `-1` applies; a
+///         (6, n) column layout uses `axis=0`. A single vector in one argument is
 ///         broadcast across a batch in the other.
 ///
 /// Returns:
@@ -343,8 +355,10 @@ fn py_state_roe_to_oe<'py>(
 ///     x_deputy (numpy.ndarray or list): 6D ECI state vector of the deputy satellite [x, y, z, vx, vy, vz] (m, m/s), shape (6,), or a batch of
 ///         vectors with the 6 components along `axis` (for example shape (n, 6)).
 ///     angle_format (AngleFormat): Format of angular elements in output (DEGREES or RADIANS)
-///     axis (int, optional): Axis holding the vector components for batched input.
-///         Defaults to `-1` (the last axis). A single vector in one argument is
+///     axis (int, optional): The axis along which the 6 components of a single vector
+///         lie; the remaining axes enumerate the batch. For a batch of shape (n, 6)
+///         the components lie along the last axis, so the default `-1` applies; a
+///         (6, n) column layout uses `axis=0`. A single vector in one argument is
 ///         broadcast across a batch in the other.
 ///
 /// Returns:
@@ -405,8 +419,10 @@ fn py_state_eci_to_roe<'py>(
 ///     roe (numpy.ndarray or list): Relative orbital elements [da, dλ, dex, dey, dix, diy] shape (6,), or a batch of
 ///         vectors with the 6 components along `axis` (for example shape (n, 6)).
 ///     angle_format (AngleFormat): Format of angular elements in input ROE (DEGREES or RADIANS)
-///     axis (int, optional): Axis holding the vector components for batched input.
-///         Defaults to `-1` (the last axis). A single vector in one argument is
+///     axis (int, optional): The axis along which the 6 components of a single vector
+///         lie; the remaining axes enumerate the batch. For a batch of shape (n, 6)
+///         the components lie along the last axis, so the default `-1` applies; a
+///         (6, n) column layout uses `axis=0`. A single vector in one argument is
 ///         broadcast across a batch in the other.
 ///
 /// Returns:

--- a/crates/brahe-py/src/relative_motion.rs
+++ b/crates/brahe-py/src/relative_motion.rs
@@ -9,10 +9,14 @@
 /// - T (Along-Track): Completes the right-handed coordinate system, lying in the orbital plane and perpendicular to R and N.
 ///
 /// Args:
-///     x_eci (numpy.ndarray or list): 6D state vector in the ECI frame [x, y, z, vx, vy, vz] (m, m/s), shape (6,)
+///     x_eci (numpy.ndarray or list): 6D state vector in the ECI frame [x, y, z, vx, vy, vz] (m, m/s), shape (6,), or a batch of
+///         vectors with the 6 components along `axis` (for example shape (n, 6)).
+///     axis (int, optional): Axis holding the vector components for batched input.
+///         Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: 3x3 rotation matrix transforming from RTN to ECI frame, shape (3, 3)
+///     numpy.ndarray: 3x3 rotation matrix transforming from RTN to ECI frame, shape (3, 3), or the batch dimensions
+///         followed by (3, 3) for batched input.
 ///
 /// Example:
 ///     ```python
@@ -28,14 +32,21 @@
 ///     print(f"RTN to ECI rotation matrix:\n{R}")
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(x_eci)")]
+#[pyo3(signature = (x_eci, axis=-1))]
+#[pyo3(text_signature = "(x_eci, axis=-1)")]
 #[pyo3(name = "rotation_rtn_to_eci")]
-unsafe fn py_rotation_rtn_to_eci<'py>(
+fn py_rotation_rtn_to_eci<'py>(
     py: Python<'py>,
-    x_eci: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix2>>> {
-    let mat = relative_motion::rotation_rtn_to_eci(pyany_to_svector::<6>(&x_eci)?);
-    Ok(matrix_to_numpy!(py, mat, 3, 3, f64))
+    x_eci: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_vec_rotation::<6>(
+        py,
+        x_eci,
+        axis,
+        relative_motion::rotation_rtn_to_eci,
+        relative_motion::rotations_rtn_to_eci,
+    )
 }
 
 /// Computes the rotation matrix transforming a vector in the Earth-Centered Inertial (ECI)
@@ -44,10 +55,14 @@ unsafe fn py_rotation_rtn_to_eci<'py>(
 /// This is the transpose (inverse) of the RTN-to-ECI rotation matrix.
 ///
 /// Args:
-///     x_eci (numpy.ndarray or list): 6D state vector in the ECI frame [x, y, z, vx, vy, vz] (m, m/s), shape (6,)
+///     x_eci (numpy.ndarray or list): 6D state vector in the ECI frame [x, y, z, vx, vy, vz] (m, m/s), shape (6,), or a batch of
+///         vectors with the 6 components along `axis` (for example shape (n, 6)).
+///     axis (int, optional): Axis holding the vector components for batched input.
+///         Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     numpy.ndarray: 3x3 rotation matrix transforming from ECI to RTN frame, shape (3, 3)
+///     numpy.ndarray: 3x3 rotation matrix transforming from ECI to RTN frame, shape (3, 3), or the batch dimensions
+///         followed by (3, 3) for batched input.
 ///
 /// Example:
 ///     ```python
@@ -63,14 +78,21 @@ unsafe fn py_rotation_rtn_to_eci<'py>(
 ///     print(f"ECI to RTN rotation matrix:\n{R}")
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(x_eci)")]
+#[pyo3(signature = (x_eci, axis=-1))]
+#[pyo3(text_signature = "(x_eci, axis=-1)")]
 #[pyo3(name = "rotation_eci_to_rtn")]
-unsafe fn py_rotation_eci_to_rtn<'py>(
+fn py_rotation_eci_to_rtn<'py>(
     py: Python<'py>,
-    x_eci: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix2>>> {
-    let mat = relative_motion::rotation_eci_to_rtn(pyany_to_svector::<6>(&x_eci)?);
-    Ok(matrix_to_numpy!(py, mat, 3, 3, f64))
+    x_eci: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_vec_rotation::<6>(
+        py,
+        x_eci,
+        axis,
+        relative_motion::rotation_eci_to_rtn,
+        relative_motion::rotations_eci_to_rtn,
+    )
 }
 
 /// Transforms the absolute states of a chief and deputy satellite from the Earth-Centered Inertial (ECI)
@@ -78,11 +100,17 @@ unsafe fn py_rotation_eci_to_rtn<'py>(
 /// Radial, Along-Track, Cross-Track (RTN) frame.
 ///
 /// Args:
-///     x_chief (numpy.ndarray or list): 6D state vector of the chief satellite in the ECI frame [x, y, z, vx, vy, vz] (m, m/s), shape (6,)
-///     x_deputy (numpy.ndarray or list): 6D state vector of the deputy satellite in the ECI frame [x, y, z, vx, vy, vz] (m, m/s), shape (6,)
+///     x_chief (numpy.ndarray or list): 6D state vector of the chief satellite in the ECI frame [x, y, z, vx, vy, vz] (m, m/s), shape (6,), or a batch of
+///         vectors with the 6 components along `axis` (for example shape (n, 6)).
+///     x_deputy (numpy.ndarray or list): 6D state vector of the deputy satellite in the ECI frame [x, y, z, vx, vy, vz] (m, m/s), shape (6,), or a batch of
+///         vectors with the 6 components along `axis` (for example shape (n, 6)).
+///     axis (int, optional): Axis holding the vector components for batched input.
+///         Defaults to `-1` (the last axis).
+///         A single vector in one argument is broadcast across a batch in the other.
 ///
 /// Returns:
-///     numpy.ndarray: 6D relative state vector of the deputy with respect to the chief in the RTN frame [ρ_R, ρ_T, ρ_N, ρ̇_R, ρ̇_T, ρ̇_N] (m, m/s), shape (6,)
+///     numpy.ndarray: 6D relative state vector of the deputy with respect to the chief in the RTN frame [ρ_R, ρ_T, ρ_N, ρ̇_R, ρ̇_T, ρ̇_N] (m, m/s), shape (6,), or the layout of the batched
+///         argument for batched input.
 ///
 /// Example:
 ///     ```python
@@ -104,18 +132,23 @@ unsafe fn py_rotation_eci_to_rtn<'py>(
 ///     print(f"Relative state in RTN: {x_rel_rtn}")
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(x_chief, x_deputy)")]
+#[pyo3(signature = (x_chief, x_deputy, axis=-1))]
+#[pyo3(text_signature = "(x_chief, x_deputy, axis=-1)")]
 #[pyo3(name = "state_eci_to_rtn")]
-unsafe fn py_state_eci_to_rtn<'py>(
+fn py_state_eci_to_rtn<'py>(
     py: Python<'py>,
-    x_chief: Bound<'py, PyAny>,
-    x_deputy: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let result = relative_motion::state_eci_to_rtn(
-        pyany_to_svector::<6>(&x_chief)?,
-        pyany_to_svector::<6>(&x_deputy)?,
-    );
-    Ok(vector_to_numpy!(py, result, 6, f64))
+    x_chief: &Bound<'py, PyAny>,
+    x_deputy: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_vec_pair::<6>(
+        py,
+        x_chief,
+        x_deputy,
+        axis,
+        relative_motion::state_eci_to_rtn,
+        relative_motion::states_eci_to_rtn,
+    )
 }
 
 /// Transforms the relative state of a deputy satellite with respect to a chief satellite
@@ -123,11 +156,17 @@ unsafe fn py_state_eci_to_rtn<'py>(
 /// of the deputy in the Earth-Centered Inertial (ECI) frame.
 ///
 /// Args:
-///     x_chief (numpy.ndarray or list): 6D state vector of the chief satellite in the ECI frame [x, y, z, vx, vy, vz] (m, m/s), shape (6,)
-///     x_rel_rtn (numpy.ndarray or list): 6D relative state vector of the deputy with respect to the chief in the RTN frame [ρ_R, ρ_T, ρ_N, ρ̇_R, ρ̇_T, ρ̇_N] (m, m/s), shape (6,)
+///     x_chief (numpy.ndarray or list): 6D state vector of the chief satellite in the ECI frame [x, y, z, vx, vy, vz] (m, m/s), shape (6,), or a batch of
+///         vectors with the 6 components along `axis` (for example shape (n, 6)).
+///     x_rel_rtn (numpy.ndarray or list): 6D relative state vector of the deputy with respect to the chief in the RTN frame [ρ_R, ρ_T, ρ_N, ρ̇_R, ρ̇_T, ρ̇_N] (m, m/s), shape (6,), or a batch of
+///         vectors with the 6 components along `axis` (for example shape (n, 6)).
+///     axis (int, optional): Axis holding the vector components for batched input.
+///         Defaults to `-1` (the last axis).
+///         A single vector in one argument is broadcast across a batch in the other.
 ///
 /// Returns:
-///     numpy.ndarray: 6D state vector of the deputy satellite in the ECI frame [x, y, z, vx, vy, vz] (m, m/s), shape (6,)
+///     numpy.ndarray: 6D state vector of the deputy satellite in the ECI frame [x, y, z, vx, vy, vz] (m, m/s), shape (6,), or the layout of the batched
+///         argument for batched input.
 ///
 /// Example:
 ///     ```python
@@ -148,18 +187,23 @@ unsafe fn py_state_eci_to_rtn<'py>(
 ///     print(f"Deputy state in ECI: {x_deputy}")
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(x_chief, x_rel_rtn)")]
+#[pyo3(signature = (x_chief, x_rel_rtn, axis=-1))]
+#[pyo3(text_signature = "(x_chief, x_rel_rtn, axis=-1)")]
 #[pyo3(name = "state_rtn_to_eci")]
-unsafe fn py_state_rtn_to_eci<'py>(
+fn py_state_rtn_to_eci<'py>(
     py: Python<'py>,
-    x_chief: Bound<'py, PyAny>,
-    x_rel_rtn: Bound<'py, PyAny>,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let result = relative_motion::state_rtn_to_eci(
-        pyany_to_svector::<6>(&x_chief)?,
-        pyany_to_svector::<6>(&x_rel_rtn)?,
-    );
-    Ok(vector_to_numpy!(py, result, 6, f64))
+    x_chief: &Bound<'py, PyAny>,
+    x_rel_rtn: &Bound<'py, PyAny>,
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_vec_pair::<6>(
+        py,
+        x_chief,
+        x_rel_rtn,
+        axis,
+        relative_motion::state_rtn_to_eci,
+        relative_motion::states_rtn_to_eci,
+    )
 }
 
 /// Converts chief and deputy satellite orbital elements (OE) to quasi-nonsingular relative orbital elements (ROE).
@@ -174,12 +218,18 @@ unsafe fn py_state_rtn_to_eci<'py>(
 /// - diy: y-component of relative inclination vector (degrees or radians)
 ///
 /// Args:
-///     oe_chief (numpy.ndarray or list): Chief satellite orbital elements [a, e, i, Ω, ω, M] shape (6,)
-///     oe_deputy (numpy.ndarray or list): Deputy satellite orbital elements [a, e, i, Ω, ω, M] shape (6,)
+///     oe_chief (numpy.ndarray or list): Chief satellite orbital elements [a, e, i, Ω, ω, M] shape (6,), or a batch of
+///         vectors with the 6 components along `axis` (for example shape (n, 6)).
+///     oe_deputy (numpy.ndarray or list): Deputy satellite orbital elements [a, e, i, Ω, ω, M] shape (6,), or a batch of
+///         vectors with the 6 components along `axis` (for example shape (n, 6)).
 ///     angle_format (AngleFormat): Format of angular elements (DEGREES or RADIANS)
+///     axis (int, optional): Axis holding the vector components for batched input.
+///         Defaults to `-1` (the last axis). A single vector in one argument is
+///         broadcast across a batch in the other.
 ///
 /// Returns:
-///     numpy.ndarray: Relative orbital elements [da, dλ, dex, dey, dix, diy] shape (6,)
+///     numpy.ndarray: Relative orbital elements [da, dλ, dex, dey, dix, diy] shape (6,), or the layout of the batched
+///         argument for batched input.
 ///
 /// Example:
 ///     ```python
@@ -196,20 +246,25 @@ unsafe fn py_state_rtn_to_eci<'py>(
 ///     # Relative orbital elements: [1.413e-4, 9.321e-2, 4.324e-4, 2.511e-4, 5.0e-2, 4.954e-2]
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(oe_chief, oe_deputy, angle_format)")]
+#[pyo3(signature = (oe_chief, oe_deputy, angle_format, axis=-1))]
+#[pyo3(text_signature = "(oe_chief, oe_deputy, angle_format, axis=-1)")]
 #[pyo3(name = "state_oe_to_roe")]
-unsafe fn py_state_oe_to_roe<'py>(
+fn py_state_oe_to_roe<'py>(
     py: Python<'py>,
-    oe_chief: Bound<'py, PyAny>,
-    oe_deputy: Bound<'py, PyAny>,
+    oe_chief: &Bound<'py, PyAny>,
+    oe_deputy: &Bound<'py, PyAny>,
     angle_format: &PyAngleFormat,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let result = relative_motion::state_oe_to_roe(
-        pyany_to_svector::<6>(&oe_chief)?,
-        pyany_to_svector::<6>(&oe_deputy)?,
-        angle_format.value,
-    );
-    Ok(vector_to_numpy!(py, result, 6, f64))
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    let af = angle_format.value;
+    dispatch_vec_pair::<6>(
+        py,
+        oe_chief,
+        oe_deputy,
+        axis,
+        |c, d| relative_motion::state_oe_to_roe(c, d, af),
+        |cs, ds| relative_motion::states_oe_to_roe(cs, ds, af),
+    )
 }
 
 /// Converts chief satellite orbital elements (OE) and quasi-nonsingular relative orbital elements (ROE)
@@ -219,12 +274,18 @@ unsafe fn py_state_oe_to_roe<'py>(
 /// back to classical orbital elements for the deputy satellite.
 ///
 /// Args:
-///     oe_chief (numpy.ndarray or list): Chief satellite orbital elements [a, e, i, Ω, ω, M] shape (6,)
-///     roe (numpy.ndarray or list): Relative orbital elements [da, dλ, dex, dey, dix, diy] shape (6,)
+///     oe_chief (numpy.ndarray or list): Chief satellite orbital elements [a, e, i, Ω, ω, M] shape (6,), or a batch of
+///         vectors with the 6 components along `axis` (for example shape (n, 6)).
+///     roe (numpy.ndarray or list): Relative orbital elements [da, dλ, dex, dey, dix, diy] shape (6,), or a batch of
+///         vectors with the 6 components along `axis` (for example shape (n, 6)).
 ///     angle_format (AngleFormat): Format of angular elements (DEGREES or RADIANS)
+///     axis (int, optional): Axis holding the vector components for batched input.
+///         Defaults to `-1` (the last axis). A single vector in one argument is
+///         broadcast across a batch in the other.
 ///
 /// Returns:
-///     numpy.ndarray: Deputy satellite orbital elements [a, e, i, Ω, ω, M] shape (6,)
+///     numpy.ndarray: Deputy satellite orbital elements [a, e, i, Ω, ω, M] shape (6,), or the layout of the batched
+///         argument for batched input.
 ///
 /// Example:
 ///     ```python
@@ -241,20 +302,25 @@ unsafe fn py_state_oe_to_roe<'py>(
 ///     # Deputy orbital elements: [7.079e6, 1.5e-3, 97.85, 15.05, 30.05, 45.05]
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(oe_chief, roe, angle_format)")]
+#[pyo3(signature = (oe_chief, roe, angle_format, axis=-1))]
+#[pyo3(text_signature = "(oe_chief, roe, angle_format, axis=-1)")]
 #[pyo3(name = "state_roe_to_oe")]
-unsafe fn py_state_roe_to_oe<'py>(
+fn py_state_roe_to_oe<'py>(
     py: Python<'py>,
-    oe_chief: Bound<'py, PyAny>,
-    roe: Bound<'py, PyAny>,
+    oe_chief: &Bound<'py, PyAny>,
+    roe: &Bound<'py, PyAny>,
     angle_format: &PyAngleFormat,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let result = relative_motion::state_roe_to_oe(
-        pyany_to_svector::<6>(&oe_chief)?,
-        pyany_to_svector::<6>(&roe)?,
-        angle_format.value,
-    );
-    Ok(vector_to_numpy!(py, result, 6, f64))
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    let af = angle_format.value;
+    dispatch_vec_pair::<6>(
+        py,
+        oe_chief,
+        roe,
+        axis,
+        |c, d| relative_motion::state_roe_to_oe(c, d, af),
+        |cs, ds| relative_motion::states_roe_to_oe(cs, ds, af),
+    )
 }
 
 /// Converts chief and deputy satellite ECI state vectors to quasi-nonsingular Relative Orbital Elements (ROE).
@@ -272,12 +338,18 @@ unsafe fn py_state_roe_to_oe<'py>(
 /// - diy: y-component of relative inclination vector (degrees or radians)
 ///
 /// Args:
-///     x_chief (numpy.ndarray or list): 6D ECI state vector of the chief satellite [x, y, z, vx, vy, vz] (m, m/s), shape (6,)
-///     x_deputy (numpy.ndarray or list): 6D ECI state vector of the deputy satellite [x, y, z, vx, vy, vz] (m, m/s), shape (6,)
+///     x_chief (numpy.ndarray or list): 6D ECI state vector of the chief satellite [x, y, z, vx, vy, vz] (m, m/s), shape (6,), or a batch of
+///         vectors with the 6 components along `axis` (for example shape (n, 6)).
+///     x_deputy (numpy.ndarray or list): 6D ECI state vector of the deputy satellite [x, y, z, vx, vy, vz] (m, m/s), shape (6,), or a batch of
+///         vectors with the 6 components along `axis` (for example shape (n, 6)).
 ///     angle_format (AngleFormat): Format of angular elements in output (DEGREES or RADIANS)
+///     axis (int, optional): Axis holding the vector components for batched input.
+///         Defaults to `-1` (the last axis). A single vector in one argument is
+///         broadcast across a batch in the other.
 ///
 /// Returns:
-///     numpy.ndarray: Relative orbital elements [da, dλ, dex, dey, dix, diy] shape (6,)
+///     numpy.ndarray: Relative orbital elements [da, dλ, dex, dey, dix, diy] shape (6,), or the layout of the batched
+///         argument for batched input.
 ///
 /// Example:
 ///     ```python
@@ -300,20 +372,25 @@ unsafe fn py_state_roe_to_oe<'py>(
 ///     # Relative orbital elements: [1.413e-4, 9.321e-2, 4.324e-4, 2.511e-4, 5.0e-2, 4.954e-2]
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(x_chief, x_deputy, angle_format)")]
+#[pyo3(signature = (x_chief, x_deputy, angle_format, axis=-1))]
+#[pyo3(text_signature = "(x_chief, x_deputy, angle_format, axis=-1)")]
 #[pyo3(name = "state_eci_to_roe")]
-unsafe fn py_state_eci_to_roe<'py>(
+fn py_state_eci_to_roe<'py>(
     py: Python<'py>,
-    x_chief: Bound<'py, PyAny>,
-    x_deputy: Bound<'py, PyAny>,
+    x_chief: &Bound<'py, PyAny>,
+    x_deputy: &Bound<'py, PyAny>,
     angle_format: &PyAngleFormat,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let result = relative_motion::state_eci_to_roe(
-        pyany_to_svector::<6>(&x_chief)?,
-        pyany_to_svector::<6>(&x_deputy)?,
-        angle_format.value,
-    );
-    Ok(vector_to_numpy!(py, result, 6, f64))
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    let af = angle_format.value;
+    dispatch_vec_pair::<6>(
+        py,
+        x_chief,
+        x_deputy,
+        axis,
+        |c, d| relative_motion::state_eci_to_roe(c, d, af),
+        |cs, ds| relative_motion::states_eci_to_roe(cs, ds, af),
+    )
 }
 
 /// Converts chief satellite ECI state and quasi-nonsingular Relative Orbital Elements (ROE)
@@ -323,12 +400,18 @@ unsafe fn py_state_eci_to_roe<'py>(
 /// the ROE to obtain deputy orbital elements, then converts back to ECI state.
 ///
 /// Args:
-///     x_chief (numpy.ndarray or list): 6D ECI state vector of the chief satellite [x, y, z, vx, vy, vz] (m, m/s), shape (6,)
-///     roe (numpy.ndarray or list): Relative orbital elements [da, dλ, dex, dey, dix, diy] shape (6,)
+///     x_chief (numpy.ndarray or list): 6D ECI state vector of the chief satellite [x, y, z, vx, vy, vz] (m, m/s), shape (6,), or a batch of
+///         vectors with the 6 components along `axis` (for example shape (n, 6)).
+///     roe (numpy.ndarray or list): Relative orbital elements [da, dλ, dex, dey, dix, diy] shape (6,), or a batch of
+///         vectors with the 6 components along `axis` (for example shape (n, 6)).
 ///     angle_format (AngleFormat): Format of angular elements in input ROE (DEGREES or RADIANS)
+///     axis (int, optional): Axis holding the vector components for batched input.
+///         Defaults to `-1` (the last axis). A single vector in one argument is
+///         broadcast across a batch in the other.
 ///
 /// Returns:
-///     numpy.ndarray: 6D ECI state vector of the deputy satellite [x, y, z, vx, vy, vz] (m, m/s), shape (6,)
+///     numpy.ndarray: 6D ECI state vector of the deputy satellite [x, y, z, vx, vy, vz] (m, m/s), shape (6,), or the layout of the batched
+///         argument for batched input.
 ///
 /// Example:
 ///     ```python
@@ -349,18 +432,23 @@ unsafe fn py_state_eci_to_roe<'py>(
 ///     print(f"Deputy ECI state: {x_deputy}")
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(x_chief, roe, angle_format)")]
+#[pyo3(signature = (x_chief, roe, angle_format, axis=-1))]
+#[pyo3(text_signature = "(x_chief, roe, angle_format, axis=-1)")]
 #[pyo3(name = "state_roe_to_eci")]
-unsafe fn py_state_roe_to_eci<'py>(
+fn py_state_roe_to_eci<'py>(
     py: Python<'py>,
-    x_chief: Bound<'py, PyAny>,
-    roe: Bound<'py, PyAny>,
+    x_chief: &Bound<'py, PyAny>,
+    roe: &Bound<'py, PyAny>,
     angle_format: &PyAngleFormat,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let result = relative_motion::state_roe_to_eci(
-        pyany_to_svector::<6>(&x_chief)?,
-        pyany_to_svector::<6>(&roe)?,
-        angle_format.value,
-    );
-    Ok(vector_to_numpy!(py, result, 6, f64))
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    let af = angle_format.value;
+    dispatch_vec_pair::<6>(
+        py,
+        x_chief,
+        roe,
+        axis,
+        |c, d| relative_motion::state_roe_to_eci(c, d, af),
+        |cs, ds| relative_motion::states_roe_to_eci(cs, ds, af),
+    )
 }

--- a/docs/learn/relative_motion/index.md
+++ b/docs/learn/relative_motion/index.md
@@ -3,6 +3,8 @@
 The relative motion module provides tools for working with satellite state representations,
 relative motion frames, and relative dynamics models. 
 
+Every relative-motion function accepts batches: passing `(n, 6)` arrays for the chief and deputy transforms each pair, and a single chief (or single deputy) broadcasts across the batch. The `axis` keyword (default `-1`) names the dimension holding the vector components, following the rules described in [Vectorized Transformations](../frames/vectorized.md).
+
 ### See Also
 
 - [RTN Transformations API Reference](../../library_api/relative_motion/rtn_transformations.md) - Detailed API documentation

--- a/src/relative_motion/eci_roe.rs
+++ b/src/relative_motion/eci_roe.rs
@@ -10,6 +10,8 @@ use crate::AngleFormat;
 use crate::coordinates::{state_eci_to_koe, state_koe_to_eci};
 use crate::math::SVector6;
 use crate::relative_motion::{state_oe_to_roe, state_roe_to_oe};
+use crate::utils::BraheError;
+use crate::utils::batch::batch_zip;
 
 /// Compute the Relative Orbital Elements (ROE) from the Chief and Deputy ECI state vectors.
 ///
@@ -110,6 +112,84 @@ pub fn state_roe_to_eci(x_chief: SVector6, roe: SVector6, angle_format: AngleFor
     state_koe_to_eci(oe_deputy, angle_format)
 }
 
+/// Computes relative orbital elements for each chief/deputy pair of ECI states.
+///
+/// Batch form of [`state_eci_to_roe`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// The chief and deputy arguments follow the broadcast rule: each has length 1
+/// or the common batch length, so one chief may be paired with many deputies
+/// and vice versa.
+///
+/// # Arguments
+/// - `x_chief`: Chief Cartesian ECI states, length 1 or the batch length. Units: (*m*; *m/s*)
+/// - `x_deputy`: Deputy Cartesian ECI states, length 1 or the batch length. Units: (*m*; *m/s*)
+/// - `angle_format`: Format of the angular relative elements
+///
+/// # Returns
+/// - Relative orbital elements `[da, dλ, dex, dey, dix, diy]` in input order
+/// - Error if the lengths do not satisfy the broadcast rule
+///
+/// # Examples
+/// ```
+/// use brahe::constants::{R_EARTH, AngleFormat};
+/// use brahe::coordinates::state_koe_to_eci;
+/// use brahe::relative_motion::states_eci_to_roe;
+/// use brahe::vector6_from_array;
+///
+/// let chief = state_koe_to_eci(vector6_from_array([R_EARTH + 700e3, 0.001, 97.8, 15.0, 30.0, 45.0]), AngleFormat::Degrees);
+/// let deputies = vec![state_koe_to_eci(vector6_from_array([R_EARTH + 701e3, 0.0015, 97.85, 15.05, 30.05, 45.05]), AngleFormat::Degrees); 2];
+/// let roe = states_eci_to_roe(&[chief], &deputies, AngleFormat::Degrees).unwrap();
+/// assert_eq!(roe.len(), 2);
+/// ```
+pub fn states_eci_to_roe(
+    x_chief: &[SVector6],
+    x_deputy: &[SVector6],
+    angle_format: AngleFormat,
+) -> Result<Vec<SVector6>, BraheError> {
+    batch_zip(x_chief, x_deputy, |c, d| {
+        state_eci_to_roe(*c, *d, angle_format)
+    })
+}
+
+/// Computes deputy ECI states from each chief/relative-orbital-element pair.
+///
+/// Batch form of [`state_roe_to_eci`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// The chief and deputy arguments follow the broadcast rule: each has length 1
+/// or the common batch length, so one chief may be paired with many deputies
+/// and vice versa.
+///
+/// # Arguments
+/// - `x_chief`: Chief Cartesian ECI states, length 1 or the batch length. Units: (*m*; *m/s*)
+/// - `roe`: Relative orbital elements `[da, dλ, dex, dey, dix, diy]`, length 1 or the batch length
+/// - `angle_format`: Format of the angular relative elements
+///
+/// # Returns
+/// - Deputy Cartesian ECI states in input order. Units: (*m*; *m/s*)
+/// - Error if the lengths do not satisfy the broadcast rule
+///
+/// # Examples
+/// ```
+/// use brahe::constants::{R_EARTH, AngleFormat};
+/// use brahe::coordinates::state_koe_to_eci;
+/// use brahe::relative_motion::states_roe_to_eci;
+/// use brahe::vector6_from_array;
+///
+/// let chief = state_koe_to_eci(vector6_from_array([R_EARTH + 700e3, 0.001, 97.8, 15.0, 30.0, 45.0]), AngleFormat::Degrees);
+/// let roe = vec![vector6_from_array([1.413e-4, 9.321e-2, 4.324e-4, 2.511e-4, 5.0e-2, 4.954e-2]); 2];
+/// let deputies = states_roe_to_eci(&[chief], &roe, AngleFormat::Degrees).unwrap();
+/// assert_eq!(deputies.len(), 2);
+/// ```
+pub fn states_roe_to_eci(
+    x_chief: &[SVector6],
+    roe: &[SVector6],
+    angle_format: AngleFormat,
+) -> Result<Vec<SVector6>, BraheError> {
+    batch_zip(x_chief, roe, |c, r| state_roe_to_eci(*c, *r, angle_format))
+}
+
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
@@ -118,6 +198,7 @@ mod tests {
     use crate::coordinates::state_koe_to_eci;
     use crate::relative_motion::state_oe_to_roe;
     use approx::assert_abs_diff_eq;
+    use serial_test::parallel;
 
     #[test]
     fn test_state_eci_to_roe_degrees() {
@@ -268,5 +349,66 @@ mod tests {
         assert_abs_diff_eq!(x_deputy_recovered[3], x_deputy_orig[3], epsilon = 1e-6);
         assert_abs_diff_eq!(x_deputy_recovered[4], x_deputy_orig[4], epsilon = 1e-6);
         assert_abs_diff_eq!(x_deputy_recovered[5], x_deputy_orig[5], epsilon = 1e-6);
+    }
+
+    #[test]
+    #[parallel]
+    fn test_batch_eci_roe_match_scalar() {
+        let chiefs: Vec<SVector6> = (0..3)
+            .map(|i| {
+                state_koe_to_eci(
+                    SVector6::new(
+                        R_EARTH + 700e3 + 1e3 * i as f64,
+                        0.001,
+                        97.8,
+                        15.0,
+                        30.0,
+                        45.0 + i as f64,
+                    ),
+                    AngleFormat::Degrees,
+                )
+            })
+            .collect();
+        let deputies: Vec<SVector6> = (0..3)
+            .map(|i| {
+                state_koe_to_eci(
+                    SVector6::new(
+                        R_EARTH + 701e3 + 1e3 * i as f64,
+                        0.0015,
+                        97.85,
+                        15.05,
+                        30.05,
+                        45.05 + i as f64,
+                    ),
+                    AngleFormat::Degrees,
+                )
+            })
+            .collect();
+        let roe = states_eci_to_roe(&chiefs, &deputies, AngleFormat::Degrees).unwrap();
+        let roe_one = states_eci_to_roe(&chiefs[..1], &deputies, AngleFormat::Degrees).unwrap();
+        let back = states_roe_to_eci(&chiefs, &roe, AngleFormat::Degrees).unwrap();
+        let back_one = states_roe_to_eci(&chiefs[..1], &roe_one, AngleFormat::Degrees).unwrap();
+        for i in 0..3 {
+            assert_eq!(
+                roe[i],
+                state_eci_to_roe(chiefs[i], deputies[i], AngleFormat::Degrees)
+            );
+            assert_eq!(
+                roe_one[i],
+                state_eci_to_roe(chiefs[0], deputies[i], AngleFormat::Degrees)
+            );
+            assert_eq!(
+                back[i],
+                state_roe_to_eci(chiefs[i], roe[i], AngleFormat::Degrees)
+            );
+            assert_eq!(
+                back_one[i],
+                state_roe_to_eci(chiefs[0], roe_one[i], AngleFormat::Degrees)
+            );
+            for k in 0..3 {
+                assert_abs_diff_eq!(back[i][k], deputies[i][k], epsilon = 1e-3);
+            }
+        }
+        assert!(states_eci_to_roe(&chiefs[..2], &deputies, AngleFormat::Degrees).is_err());
     }
 }

--- a/src/relative_motion/eci_roe.rs
+++ b/src/relative_motion/eci_roe.rs
@@ -147,9 +147,11 @@ pub fn states_eci_to_roe(
     x_deputy: &[SVector6],
     angle_format: AngleFormat,
 ) -> Result<Vec<SVector6>, BraheError> {
-    batch_zip(x_chief, x_deputy, |c, d| {
-        state_eci_to_roe(*c, *d, angle_format)
-    })
+    batch_zip(
+        |c, d| state_eci_to_roe(*c, *d, angle_format),
+        x_chief,
+        x_deputy,
+    )
 }
 
 /// Computes deputy ECI states from each chief/relative-orbital-element pair.
@@ -187,7 +189,7 @@ pub fn states_roe_to_eci(
     roe: &[SVector6],
     angle_format: AngleFormat,
 ) -> Result<Vec<SVector6>, BraheError> {
-    batch_zip(x_chief, roe, |c, r| state_roe_to_eci(*c, *r, angle_format))
+    batch_zip(|c, r| state_roe_to_eci(*c, *r, angle_format), x_chief, roe)
 }
 
 #[cfg(test)]

--- a/src/relative_motion/eci_rtn.rs
+++ b/src/relative_motion/eci_rtn.rs
@@ -228,7 +228,7 @@ pub fn state_rtn_to_eci(x_chief: SVector6, x_rel_rtn: SVector6) -> SVector6 {
 /// assert_eq!(r.len(), 2);
 /// ```
 pub fn rotations_rtn_to_eci(x_eci: &[SVector6]) -> Vec<SMatrix3> {
-    batch_map(x_eci, |x| rotation_rtn_to_eci(*x))
+    batch_map(|x| rotation_rtn_to_eci(*x), x_eci)
 }
 
 /// Computes the ECI-to-RTN rotation matrix for each state in `x_eci`.
@@ -254,7 +254,7 @@ pub fn rotations_rtn_to_eci(x_eci: &[SVector6]) -> Vec<SMatrix3> {
 /// assert_eq!(r.len(), 2);
 /// ```
 pub fn rotations_eci_to_rtn(x_eci: &[SVector6]) -> Vec<SMatrix3> {
-    batch_map(x_eci, |x| rotation_eci_to_rtn(*x))
+    batch_map(|x| rotation_eci_to_rtn(*x), x_eci)
 }
 
 /// Computes the RTN relative state of each deputy with respect to its chief.
@@ -293,7 +293,7 @@ pub fn states_eci_to_rtn(
     x_chief: &[SVector6],
     x_deputy: &[SVector6],
 ) -> Result<Vec<SVector6>, BraheError> {
-    batch_zip(x_chief, x_deputy, |c, d| state_eci_to_rtn(*c, *d))
+    batch_zip(|c, d| state_eci_to_rtn(*c, *d), x_chief, x_deputy)
 }
 
 /// Computes the ECI state of each deputy from its RTN relative state and chief.
@@ -329,7 +329,7 @@ pub fn states_rtn_to_eci(
     x_chief: &[SVector6],
     x_rel_rtn: &[SVector6],
 ) -> Result<Vec<SVector6>, BraheError> {
-    batch_zip(x_chief, x_rel_rtn, |c, r| state_rtn_to_eci(*c, *r))
+    batch_zip(|c, r| state_rtn_to_eci(*c, *r), x_chief, x_rel_rtn)
 }
 
 #[cfg(test)]

--- a/src/relative_motion/eci_rtn.rs
+++ b/src/relative_motion/eci_rtn.rs
@@ -5,6 +5,9 @@
 use crate::math::{SMatrix3, SVector6};
 use nalgebra::Vector3;
 
+use crate::utils::BraheError;
+use crate::utils::batch::{batch_map, batch_zip};
+
 /// Computes the rotation matrix transforming a vector in the radial, along-track, cross-track (RTN)
 /// frame to the Earth-Centered Inertial (ECI) frame at a given epoch.
 ///
@@ -202,6 +205,133 @@ pub fn state_rtn_to_eci(x_chief: SVector6, x_rel_rtn: SVector6) -> SVector6 {
     )
 }
 
+/// Computes the RTN-to-ECI rotation matrix for each state in `x_eci`.
+///
+/// Batch form of [`rotation_rtn_to_eci`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// # Arguments
+/// - `x_eci`: Cartesian ECI states (position, velocity). Units: (*m*; *m/s*)
+///
+/// # Returns
+/// - Rotation matrices transforming RTN -> ECI, one per state, in input order
+///
+/// # Examples
+/// ```
+/// use brahe::constants::{R_EARTH, AngleFormat};
+/// use brahe::coordinates::state_koe_to_eci;
+/// use brahe::relative_motion::rotations_rtn_to_eci;
+/// use brahe::vector6_from_array;
+///
+/// let x = state_koe_to_eci(vector6_from_array([R_EARTH + 700e3, 0.001, 97.8, 15.0, 30.0, 45.0]), AngleFormat::Degrees);
+/// let r = rotations_rtn_to_eci(&[x, x]);
+/// assert_eq!(r.len(), 2);
+/// ```
+pub fn rotations_rtn_to_eci(x_eci: &[SVector6]) -> Vec<SMatrix3> {
+    batch_map(x_eci, |x| rotation_rtn_to_eci(*x))
+}
+
+/// Computes the ECI-to-RTN rotation matrix for each state in `x_eci`.
+///
+/// Batch form of [`rotation_eci_to_rtn`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// # Arguments
+/// - `x_eci`: Cartesian ECI states (position, velocity). Units: (*m*; *m/s*)
+///
+/// # Returns
+/// - Rotation matrices transforming ECI -> RTN, one per state, in input order
+///
+/// # Examples
+/// ```
+/// use brahe::constants::{R_EARTH, AngleFormat};
+/// use brahe::coordinates::state_koe_to_eci;
+/// use brahe::relative_motion::rotations_eci_to_rtn;
+/// use brahe::vector6_from_array;
+///
+/// let x = state_koe_to_eci(vector6_from_array([R_EARTH + 700e3, 0.001, 97.8, 15.0, 30.0, 45.0]), AngleFormat::Degrees);
+/// let r = rotations_eci_to_rtn(&[x, x]);
+/// assert_eq!(r.len(), 2);
+/// ```
+pub fn rotations_eci_to_rtn(x_eci: &[SVector6]) -> Vec<SMatrix3> {
+    batch_map(x_eci, |x| rotation_eci_to_rtn(*x))
+}
+
+/// Computes the RTN relative state of each deputy with respect to its chief.
+///
+/// Batch form of [`state_eci_to_rtn`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// The chief and deputy arguments follow the broadcast rule: each has length 1
+/// or the common batch length, so one chief may be paired with many deputies
+/// and vice versa.
+///
+/// # Arguments
+/// - `x_chief`: Chief Cartesian ECI states, length 1 or the batch length. Units: (*m*; *m/s*)
+/// - `x_deputy`: Deputy Cartesian ECI states, length 1 or the batch length. Units: (*m*; *m/s*)
+///
+/// # Returns
+/// - Deputy relative states in the chief RTN frame, in input order. Units: (*m*; *m/s*)
+/// - Error if the lengths do not satisfy the broadcast rule
+///
+/// # Examples
+/// ```
+/// use brahe::constants::{R_EARTH, AngleFormat};
+/// use brahe::coordinates::state_koe_to_eci;
+/// use brahe::relative_motion::states_eci_to_rtn;
+/// use brahe::vector6_from_array;
+///
+/// let chief = state_koe_to_eci(vector6_from_array([R_EARTH + 700e3, 0.001, 97.8, 15.0, 30.0, 45.0]), AngleFormat::Degrees);
+/// let deputies = vec![
+///     state_koe_to_eci(vector6_from_array([R_EARTH + 701e3, 0.0015, 97.85, 15.05, 30.05, 45.05]), AngleFormat::Degrees),
+///     state_koe_to_eci(vector6_from_array([R_EARTH + 702e3, 0.0012, 97.82, 15.02, 30.02, 45.02]), AngleFormat::Degrees),
+/// ];
+/// let rel = states_eci_to_rtn(&[chief], &deputies).unwrap();
+/// assert_eq!(rel.len(), 2);
+/// ```
+pub fn states_eci_to_rtn(
+    x_chief: &[SVector6],
+    x_deputy: &[SVector6],
+) -> Result<Vec<SVector6>, BraheError> {
+    batch_zip(x_chief, x_deputy, |c, d| state_eci_to_rtn(*c, *d))
+}
+
+/// Computes the ECI state of each deputy from its RTN relative state and chief.
+///
+/// Batch form of [`state_rtn_to_eci`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// The chief and deputy arguments follow the broadcast rule: each has length 1
+/// or the common batch length, so one chief may be paired with many deputies
+/// and vice versa.
+///
+/// # Arguments
+/// - `x_chief`: Chief Cartesian ECI states, length 1 or the batch length. Units: (*m*; *m/s*)
+/// - `x_rel_rtn`: Deputy relative states in the chief RTN frame, length 1 or the batch length. Units: (*m*; *m/s*)
+///
+/// # Returns
+/// - Deputy Cartesian ECI states, in input order. Units: (*m*; *m/s*)
+/// - Error if the lengths do not satisfy the broadcast rule
+///
+/// # Examples
+/// ```
+/// use brahe::constants::{R_EARTH, AngleFormat};
+/// use brahe::coordinates::state_koe_to_eci;
+/// use brahe::relative_motion::states_rtn_to_eci;
+/// use brahe::vector6_from_array;
+///
+/// let chief = state_koe_to_eci(vector6_from_array([R_EARTH + 700e3, 0.001, 97.8, 15.0, 30.0, 45.0]), AngleFormat::Degrees);
+/// let rel = vec![vector6_from_array([1000.0, 500.0, -300.0, 0.0, 0.0, 0.0]); 2];
+/// let deputies = states_rtn_to_eci(&[chief], &rel).unwrap();
+/// assert_eq!(deputies.len(), 2);
+/// ```
+pub fn states_rtn_to_eci(
+    x_chief: &[SVector6],
+    x_rel_rtn: &[SVector6],
+) -> Result<Vec<SVector6>, BraheError> {
+    batch_zip(x_chief, x_rel_rtn, |c, r| state_rtn_to_eci(*c, *r))
+}
+
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
@@ -209,8 +339,10 @@ mod tests {
     use crate::AngleFormat;
     use crate::R_EARTH;
     use crate::coordinates::state_koe_to_eci;
+    use crate::math::vector6_from_array;
     use crate::orbits::perigee_velocity;
     use crate::utils::testing::setup_global_test_eop;
+    use serial_test::parallel;
 
     fn get_test_state() -> SVector6 {
         let sma = R_EARTH + 700e3; // Semi-major axis in meters
@@ -299,5 +431,62 @@ mod tests {
 
         assert!(pos_err < 1e-8, "Position round-trip error: {pos_err} m");
         assert!(vel_err < 1e-8, "Velocity round-trip error: {vel_err} m/s");
+    }
+
+    #[test]
+    #[parallel]
+    fn test_batch_rtn_match_scalar() {
+        let chiefs: Vec<SVector6> = (0..3)
+            .map(|i| {
+                state_koe_to_eci(
+                    vector6_from_array([
+                        R_EARTH + 700e3 + 1e3 * i as f64,
+                        0.001,
+                        97.8,
+                        15.0,
+                        30.0,
+                        45.0 + i as f64,
+                    ]),
+                    AngleFormat::Degrees,
+                )
+            })
+            .collect();
+        let deputies: Vec<SVector6> = (0..3)
+            .map(|i| {
+                state_koe_to_eci(
+                    vector6_from_array([
+                        R_EARTH + 701e3 + 1e3 * i as f64,
+                        0.0015,
+                        97.85,
+                        15.05,
+                        30.05,
+                        45.05 + i as f64,
+                    ]),
+                    AngleFormat::Degrees,
+                )
+            })
+            .collect();
+
+        let rot = rotations_rtn_to_eci(&chiefs);
+        let rot_inv = rotations_eci_to_rtn(&chiefs);
+        let rel = states_eci_to_rtn(&chiefs, &deputies).unwrap();
+        let rel_one_chief = states_eci_to_rtn(&chiefs[..1], &deputies).unwrap();
+        let rel_one_deputy = states_eci_to_rtn(&chiefs, &deputies[..1]).unwrap();
+        let back = states_rtn_to_eci(&chiefs, &rel).unwrap();
+        let back_one = states_rtn_to_eci(&chiefs[..1], &rel_one_chief).unwrap();
+        for i in 0..3 {
+            assert_eq!(rot[i], rotation_rtn_to_eci(chiefs[i]));
+            assert_eq!(rot_inv[i], rotation_eci_to_rtn(chiefs[i]));
+            assert_eq!(rel[i], state_eci_to_rtn(chiefs[i], deputies[i]));
+            assert_eq!(rel_one_chief[i], state_eci_to_rtn(chiefs[0], deputies[i]));
+            assert_eq!(rel_one_deputy[i], state_eci_to_rtn(chiefs[i], deputies[0]));
+            assert_eq!(back[i], state_rtn_to_eci(chiefs[i], rel[i]));
+            assert_eq!(back_one[i], state_rtn_to_eci(chiefs[0], rel_one_chief[i]));
+            for k in 0..3 {
+                assert!((back[i][k] - deputies[i][k]).abs() < 1e-6);
+            }
+        }
+        assert!(states_eci_to_rtn(&chiefs[..2], &deputies).is_err());
+        assert!(rotations_rtn_to_eci(&[]).is_empty());
     }
 }

--- a/src/relative_motion/oe_roe.rs
+++ b/src/relative_motion/oe_roe.rs
@@ -197,9 +197,11 @@ pub fn states_oe_to_roe(
     oe_deputy: &[SVector6],
     angle_format: AngleFormat,
 ) -> Result<Vec<SVector6>, BraheError> {
-    batch_zip(oe_chief, oe_deputy, |c, d| {
-        state_oe_to_roe(*c, *d, angle_format)
-    })
+    batch_zip(
+        |c, d| state_oe_to_roe(*c, *d, angle_format),
+        oe_chief,
+        oe_deputy,
+    )
 }
 
 /// Computes deputy Keplerian elements from each chief/relative-orbital-element pair.
@@ -236,7 +238,7 @@ pub fn states_roe_to_oe(
     roe: &[SVector6],
     angle_format: AngleFormat,
 ) -> Result<Vec<SVector6>, BraheError> {
-    batch_zip(oe_chief, roe, |c, r| state_roe_to_oe(*c, *r, angle_format))
+    batch_zip(|c, r| state_roe_to_oe(*c, *r, angle_format), oe_chief, roe)
 }
 
 #[cfg(test)]

--- a/src/relative_motion/oe_roe.rs
+++ b/src/relative_motion/oe_roe.rs
@@ -3,6 +3,8 @@
  */
 
 use crate::math::{SVector6, oe_to_radians, wrap_to_2pi};
+use crate::utils::BraheError;
+use crate::utils::batch::batch_zip;
 use crate::{AngleFormat, DEG2RAD, RAD2DEG};
 
 /// Compute the Relative Orbital Elements (ROE) from the Chief and Deputy Orbital Elements (OE).
@@ -161,12 +163,89 @@ pub fn state_roe_to_oe(oe_chief: SVector6, roe: SVector6, angle_format: AngleFor
     }
 }
 
+/// Computes relative orbital elements for each chief/deputy pair of Keplerian elements.
+///
+/// Batch form of [`state_oe_to_roe`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// The chief and deputy arguments follow the broadcast rule: each has length 1
+/// or the common batch length, so one chief may be paired with many deputies
+/// and vice versa.
+///
+/// # Arguments
+/// - `oe_chief`: Chief Keplerian elements `[a, e, i, Ω, ω, M]`, length 1 or the batch length
+/// - `oe_deputy`: Deputy Keplerian elements, length 1 or the batch length
+/// - `angle_format`: Format of the angular elements
+///
+/// # Returns
+/// - Relative orbital elements `[da, dλ, dex, dey, dix, diy]` in input order
+/// - Error if the lengths do not satisfy the broadcast rule
+///
+/// # Examples
+/// ```
+/// use brahe::constants::{R_EARTH, AngleFormat};
+/// use brahe::relative_motion::states_oe_to_roe;
+/// use brahe::vector6_from_array;
+///
+/// let chief = vector6_from_array([R_EARTH + 700e3, 0.001, 97.8, 15.0, 30.0, 45.0]);
+/// let deputies = vec![vector6_from_array([R_EARTH + 701e3, 0.0015, 97.85, 15.05, 30.05, 45.05]); 2];
+/// let roe = states_oe_to_roe(&[chief], &deputies, AngleFormat::Degrees).unwrap();
+/// assert_eq!(roe.len(), 2);
+/// ```
+pub fn states_oe_to_roe(
+    oe_chief: &[SVector6],
+    oe_deputy: &[SVector6],
+    angle_format: AngleFormat,
+) -> Result<Vec<SVector6>, BraheError> {
+    batch_zip(oe_chief, oe_deputy, |c, d| {
+        state_oe_to_roe(*c, *d, angle_format)
+    })
+}
+
+/// Computes deputy Keplerian elements from each chief/relative-orbital-element pair.
+///
+/// Batch form of [`state_roe_to_oe`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// The chief and deputy arguments follow the broadcast rule: each has length 1
+/// or the common batch length, so one chief may be paired with many deputies
+/// and vice versa.
+///
+/// # Arguments
+/// - `oe_chief`: Chief Keplerian elements `[a, e, i, Ω, ω, M]`, length 1 or the batch length
+/// - `roe`: Relative orbital elements `[da, dλ, dex, dey, dix, diy]`, length 1 or the batch length
+/// - `angle_format`: Format of the angular elements
+///
+/// # Returns
+/// - Deputy Keplerian elements in input order
+/// - Error if the lengths do not satisfy the broadcast rule
+///
+/// # Examples
+/// ```
+/// use brahe::constants::{R_EARTH, AngleFormat};
+/// use brahe::relative_motion::states_roe_to_oe;
+/// use brahe::vector6_from_array;
+///
+/// let chief = vector6_from_array([R_EARTH + 700e3, 0.001, 97.8, 15.0, 30.0, 45.0]);
+/// let roe = vec![vector6_from_array([1.413e-4, 9.321e-2, 4.324e-4, 2.511e-4, 5.0e-2, 4.954e-2]); 2];
+/// let deputies = states_roe_to_oe(&[chief], &roe, AngleFormat::Degrees).unwrap();
+/// assert_eq!(deputies.len(), 2);
+/// ```
+pub fn states_roe_to_oe(
+    oe_chief: &[SVector6],
+    roe: &[SVector6],
+    angle_format: AngleFormat,
+) -> Result<Vec<SVector6>, BraheError> {
+    batch_zip(oe_chief, roe, |c, r| state_roe_to_oe(*c, *r, angle_format))
+}
+
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use crate::constants::R_EARTH;
     use approx::assert_abs_diff_eq;
+    use serial_test::parallel;
 
     #[test]
     fn test_state_oe_to_roe() {
@@ -271,5 +350,65 @@ mod tests {
         assert_abs_diff_eq!(oe_deputy[3], 15.05 * DEG2RAD, epsilon = 1e-6);
         assert_abs_diff_eq!(oe_deputy[4], 30.05 * DEG2RAD, epsilon = 1e-6);
         assert_abs_diff_eq!(oe_deputy[5], 45.05 * DEG2RAD, epsilon = 1e-6);
+    }
+
+    #[test]
+    #[parallel]
+    fn test_batch_oe_roe_match_scalar() {
+        let chiefs: Vec<SVector6> = (0..3)
+            .map(|i| {
+                SVector6::new(
+                    R_EARTH + 700e3 + 1e3 * i as f64,
+                    0.001,
+                    97.8,
+                    15.0,
+                    30.0,
+                    45.0 + i as f64,
+                )
+            })
+            .collect();
+        let deputies: Vec<SVector6> = (0..3)
+            .map(|i| {
+                SVector6::new(
+                    R_EARTH + 701e3 + 1e3 * i as f64,
+                    0.0015,
+                    97.85,
+                    15.05,
+                    30.05,
+                    45.05 + i as f64,
+                )
+            })
+            .collect();
+        let roe = states_oe_to_roe(&chiefs, &deputies, AngleFormat::Degrees).unwrap();
+        let roe_one = states_oe_to_roe(&chiefs[..1], &deputies, AngleFormat::Degrees).unwrap();
+        let back = states_roe_to_oe(&chiefs, &roe, AngleFormat::Degrees).unwrap();
+        let back_one = states_roe_to_oe(&chiefs[..1], &roe_one, AngleFormat::Degrees).unwrap();
+        for i in 0..3 {
+            assert_eq!(
+                roe[i],
+                state_oe_to_roe(chiefs[i], deputies[i], AngleFormat::Degrees)
+            );
+            assert_eq!(
+                roe_one[i],
+                state_oe_to_roe(chiefs[0], deputies[i], AngleFormat::Degrees)
+            );
+            assert_eq!(
+                back[i],
+                state_roe_to_oe(chiefs[i], roe[i], AngleFormat::Degrees)
+            );
+            assert_eq!(
+                back_one[i],
+                state_roe_to_oe(chiefs[0], roe_one[i], AngleFormat::Degrees)
+            );
+            for k in 0..6 {
+                assert_abs_diff_eq!(back[i][k], deputies[i][k], epsilon = 1e-6);
+            }
+        }
+        assert!(states_oe_to_roe(&chiefs[..2], &deputies, AngleFormat::Degrees).is_err());
+        assert!(
+            states_roe_to_oe(&chiefs[..1], &[], AngleFormat::Degrees)
+                .unwrap()
+                .is_empty()
+        );
     }
 }

--- a/tests/relative_motion/test_eci_roe.py
+++ b/tests/relative_motion/test_eci_roe.py
@@ -183,3 +183,58 @@ def test_state_eci_roe_roundtrip_radians(eop):
     assert x_deputy_recovered[3] == approx(x_deputy_orig[3], abs=1e-6)
     assert x_deputy_recovered[4] == approx(x_deputy_orig[4], abs=1e-6)
     assert x_deputy_recovered[5] == approx(x_deputy_orig[5], abs=1e-6)
+
+
+def test_batch_eci_roe():
+    chiefs = np.array(
+        [
+            brahe.state_koe_to_eci(
+                np.array(
+                    [brahe.R_EARTH + 700e3 + 1e3 * i, 0.001, 97.8, 15.0, 30.0, 45.0 + i]
+                ),
+                brahe.AngleFormat.DEGREES,
+            )
+            for i in range(3)
+        ]
+    )
+    deputies = np.array(
+        [
+            brahe.state_koe_to_eci(
+                np.array(
+                    [
+                        brahe.R_EARTH + 701e3 + 1e3 * i,
+                        0.0015,
+                        97.85,
+                        15.05,
+                        30.05,
+                        45.05 + i,
+                    ]
+                ),
+                brahe.AngleFormat.DEGREES,
+            )
+            for i in range(3)
+        ]
+    )
+    roe = brahe.state_eci_to_roe(chiefs, deputies, brahe.AngleFormat.DEGREES)
+    roe_one = brahe.state_eci_to_roe(chiefs[0], deputies, brahe.AngleFormat.DEGREES)
+    back = brahe.state_roe_to_eci(chiefs, roe, brahe.AngleFormat.DEGREES)
+    back_one = brahe.state_roe_to_eci(chiefs[0], roe_one, brahe.AngleFormat.DEGREES)
+    assert roe.shape == (3, 6)
+    for i in range(3):
+        np.testing.assert_array_equal(
+            roe[i],
+            brahe.state_eci_to_roe(chiefs[i], deputies[i], brahe.AngleFormat.DEGREES),
+        )
+        np.testing.assert_array_equal(
+            roe_one[i],
+            brahe.state_eci_to_roe(chiefs[0], deputies[i], brahe.AngleFormat.DEGREES),
+        )
+        np.testing.assert_array_equal(
+            back[i],
+            brahe.state_roe_to_eci(chiefs[i], roe[i], brahe.AngleFormat.DEGREES),
+        )
+        np.testing.assert_array_equal(
+            back_one[i],
+            brahe.state_roe_to_eci(chiefs[0], roe_one[i], brahe.AngleFormat.DEGREES),
+        )
+    np.testing.assert_allclose(back[:, :3], deputies[:, :3], atol=1e-3)

--- a/tests/relative_motion/test_eci_rtn.py
+++ b/tests/relative_motion/test_eci_rtn.py
@@ -5,6 +5,7 @@ These tests mirror the Rust tests in src/relative_motion/eci_rtn.rs
 """
 
 import numpy as np
+import pytest
 from pytest import approx
 
 import brahe
@@ -179,3 +180,70 @@ def test_state_rtn_to_eci_and_back_non_aligned_orbit(eop):
 
     assert pos_err == approx(0.0, abs=1e-8)
     assert vel_err == approx(0.0, abs=1e-8)
+
+
+def test_batch_rtn(eop):
+    chiefs = np.array(
+        [
+            brahe.state_koe_to_eci(
+                np.array(
+                    [brahe.R_EARTH + 700e3 + 1e3 * i, 0.001, 97.8, 15.0, 30.0, 45.0 + i]
+                ),
+                brahe.AngleFormat.DEGREES,
+            )
+            for i in range(3)
+        ]
+    )
+    deputies = np.array(
+        [
+            brahe.state_koe_to_eci(
+                np.array(
+                    [
+                        brahe.R_EARTH + 701e3 + 1e3 * i,
+                        0.0015,
+                        97.85,
+                        15.05,
+                        30.05,
+                        45.05 + i,
+                    ]
+                ),
+                brahe.AngleFormat.DEGREES,
+            )
+            for i in range(3)
+        ]
+    )
+    R = brahe.rotation_rtn_to_eci(chiefs)
+    Rt = brahe.rotation_eci_to_rtn(chiefs)
+    assert R.shape == (3, 3, 3)
+    rel = brahe.state_eci_to_rtn(chiefs, deputies)
+    rel_one = brahe.state_eci_to_rtn(chiefs[0], deputies)
+    rel_one_dep = brahe.state_eci_to_rtn(chiefs, deputies[0])
+    back = brahe.state_rtn_to_eci(chiefs, rel)
+    back_one = brahe.state_rtn_to_eci(chiefs[0], rel_one)
+    assert (
+        rel.shape == (3, 6) and rel_one.shape == (3, 6) and rel_one_dep.shape == (3, 6)
+    )
+    for i in range(3):
+        np.testing.assert_array_equal(R[i], brahe.rotation_rtn_to_eci(chiefs[i]))
+        np.testing.assert_array_equal(Rt[i], brahe.rotation_eci_to_rtn(chiefs[i]))
+        np.testing.assert_array_equal(
+            rel[i], brahe.state_eci_to_rtn(chiefs[i], deputies[i])
+        )
+        np.testing.assert_array_equal(
+            rel_one[i], brahe.state_eci_to_rtn(chiefs[0], deputies[i])
+        )
+        np.testing.assert_array_equal(
+            rel_one_dep[i], brahe.state_eci_to_rtn(chiefs[i], deputies[0])
+        )
+        np.testing.assert_array_equal(
+            back[i], brahe.state_rtn_to_eci(chiefs[i], rel[i])
+        )
+        np.testing.assert_array_equal(
+            back_one[i], brahe.state_rtn_to_eci(chiefs[0], rel_one[i])
+        )
+    np.testing.assert_allclose(back, deputies, atol=1e-6)
+    np.testing.assert_array_equal(
+        brahe.state_eci_to_rtn(chiefs.T, deputies.T, axis=0), rel.T
+    )
+    with pytest.raises(ValueError):
+        brahe.state_eci_to_rtn(chiefs[:2], deputies)

--- a/tests/relative_motion/test_eci_rtn.py
+++ b/tests/relative_motion/test_eci_rtn.py
@@ -247,3 +247,32 @@ def test_batch_rtn(eop):
     )
     with pytest.raises(ValueError):
         brahe.state_eci_to_rtn(chiefs[:2], deputies)
+
+
+def test_batch_rtn_length_one_broadcast(eop):
+    chiefs = np.array(
+        [
+            brahe.state_koe_to_eci(
+                np.array(
+                    [brahe.R_EARTH + 700e3 + 1e3 * i, 0.001, 97.8, 15.0, 30.0, 45.0 + i]
+                ),
+                brahe.AngleFormat.DEGREES,
+            )
+            for i in range(3)
+        ]
+    )
+    deputies = chiefs + np.array([1000.0, 500.0, -300.0, 0.0, 0.0, 0.0])
+    rel = brahe.state_eci_to_rtn(chiefs[:1], deputies)
+    assert rel.shape == (3, 6)
+    for i in range(3):
+        np.testing.assert_array_equal(
+            rel[i], brahe.state_eci_to_rtn(chiefs[0], deputies[i])
+        )
+    rel_b = brahe.state_eci_to_rtn(chiefs, deputies[:1])
+    for i in range(3):
+        np.testing.assert_array_equal(
+            rel_b[i], brahe.state_eci_to_rtn(chiefs[i], deputies[0])
+        )
+    np.testing.assert_array_equal(
+        brahe.state_eci_to_rtn(chiefs[:1].T, deputies.T, axis=0), rel.T
+    )

--- a/tests/relative_motion/test_oe_roe.py
+++ b/tests/relative_motion/test_oe_roe.py
@@ -135,3 +135,40 @@ def test_state_roe_to_oe_radians(eop):
     assert oe_deputy[3] == approx(15.05 * brahe.DEG2RAD, abs=1e-6)
     assert oe_deputy[4] == approx(30.05 * brahe.DEG2RAD, abs=1e-6)
     assert oe_deputy[5] == approx(45.05 * brahe.DEG2RAD, abs=1e-6)
+
+
+def test_batch_oe_roe():
+    chiefs = np.array(
+        [
+            [brahe.R_EARTH + 700e3 + 1e3 * i, 0.001, 97.8, 15.0, 30.0, 45.0 + i]
+            for i in range(3)
+        ]
+    )
+    deputies = np.array(
+        [
+            [brahe.R_EARTH + 701e3 + 1e3 * i, 0.0015, 97.85, 15.05, 30.05, 45.05 + i]
+            for i in range(3)
+        ]
+    )
+    roe = brahe.state_oe_to_roe(chiefs, deputies, brahe.AngleFormat.DEGREES)
+    roe_one = brahe.state_oe_to_roe(chiefs[0], deputies, brahe.AngleFormat.DEGREES)
+    back = brahe.state_roe_to_oe(chiefs, roe, brahe.AngleFormat.DEGREES)
+    back_one = brahe.state_roe_to_oe(chiefs[0], roe_one, brahe.AngleFormat.DEGREES)
+    assert roe.shape == (3, 6)
+    for i in range(3):
+        np.testing.assert_array_equal(
+            roe[i],
+            brahe.state_oe_to_roe(chiefs[i], deputies[i], brahe.AngleFormat.DEGREES),
+        )
+        np.testing.assert_array_equal(
+            roe_one[i],
+            brahe.state_oe_to_roe(chiefs[0], deputies[i], brahe.AngleFormat.DEGREES),
+        )
+        np.testing.assert_array_equal(
+            back[i], brahe.state_roe_to_oe(chiefs[i], roe[i], brahe.AngleFormat.DEGREES)
+        )
+        np.testing.assert_array_equal(
+            back_one[i],
+            brahe.state_roe_to_oe(chiefs[0], roe_one[i], brahe.AngleFormat.DEGREES),
+        )
+    np.testing.assert_allclose(back, deputies, atol=1e-6)


### PR DESCRIPTION
# Pull Request

## Description

Vectorizes the relative-motion module: `rotations_{rtn_to_eci,eci_to_rtn}`, `states_{eci_to_rtn,rtn_to_eci}`, `states_{oe_to_roe,roe_to_oe}`, and `states_{eci_to_roe,roe_to_eci}`. Chief and deputy arguments follow the broadcast rule so one chief pairs with many deputies (or one deputy with many chiefs). Python functions accept batches with the `axis` keyword.

## Changelog

### Added
- Batch relative-motion transformations in Rust (`rotations_/states_*` for RTN, ROE, and Keplerian-pair conversions) with chief/deputy broadcasting.
- Python relative-motion functions accept batches with the `axis` keyword; a single chief or deputy broadcasts across the other argument's batch.

## Note to Reviewers
Plurals map or zip the untouched scalars; tests assert exact equality against scalar loops in both broadcast directions.
