### PR TITLE
Vectorize orbits functions and rename mean-element batch functions

### DIFF
--- a/brahe/orbits.py
+++ b/brahe/orbits.py
@@ -46,8 +46,6 @@ from brahe._brahe import (
     apoapsis_velocity,
     apogee_altitude,
     apogee_velocity,
-    batch_state_koe_mean_to_osc,
-    batch_state_koe_osc_to_mean,
     calculate_tle_line_checksum,
     create_tle_lines,
     epoch_from_tle,
@@ -81,6 +79,8 @@ from brahe._brahe import (
     state_koe_osc_to_mean,
     # Equinoctial element conversions
     state_koe_to_equinoctial,
+    states_koe_mean_to_osc,
+    states_koe_osc_to_mean,
     # Special orbits
     sun_synchronous_inclination,
     validate_tle_line,
@@ -110,8 +110,6 @@ __all__ = [
     "apoapsis_velocity",
     "apogee_altitude",
     "apogee_velocity",
-    "batch_state_koe_mean_to_osc",
-    "batch_state_koe_osc_to_mean",
     "calculate_tle_line_checksum",
     "create_tle_lines",
     "epoch_from_tle",
@@ -145,6 +143,8 @@ __all__ = [
     "state_koe_osc_to_mean",
     # Equinoctial element conversions
     "state_koe_to_equinoctial",
+    "states_koe_mean_to_osc",
+    "states_koe_osc_to_mean",
     # Special orbits
     "sun_synchronous_inclination",
     "validate_tle_line",

--- a/crates/brahe-py/src/batch.rs
+++ b/crates/brahe-py/src/batch.rs
@@ -448,3 +448,189 @@ fn dispatch_vec_pair<'py, const N: usize>(
     let out = py.detach(|| batch(&a_vecs, &b_vecs))?;
     vecs_to_numpy(py, &layout, axis, out)
 }
+
+/// A numeric argument parsed from Python: a scalar or an array of any shape.
+enum NumArg {
+    Scalar(f64),
+    Array(ndarray::ArrayD<f64>),
+}
+
+/// Parse a Python float/int or array-like into a `NumArg`.
+fn parse_num_arg(obj: &Bound<'_, PyAny>) -> PyResult<NumArg> {
+    if let Ok(v) = obj.extract::<f64>() {
+        return Ok(NumArg::Scalar(v));
+    }
+    let py = obj.py();
+    let np = py
+        .import("numpy")
+        .map_err(|_| exceptions::PyImportError::new_err("Failed to import numpy"))?;
+    let float64 = np.getattr("float64")?;
+    let arr = np
+        .call_method1("asarray", (obj, float64))
+        .map_err(|_| exceptions::PyTypeError::new_err("Expected a number or an array of numbers"))?;
+    let arr = arr
+        .cast::<PyArrayDyn<f64>>()
+        .map_err(|_| exceptions::PyTypeError::new_err("Expected a number or an array of numbers"))?;
+    Ok(NumArg::Array(arr.readonly().as_array().to_owned()))
+}
+
+/// Broadcast numeric arguments against each other with numpy rules and return
+/// the common shape plus each argument flattened to that shape (C order).
+fn broadcast_num_args(py: Python<'_>, args: &[&NumArg]) -> PyResult<(Vec<usize>, Vec<Vec<f64>>)> {
+    let np = py
+        .import("numpy")
+        .map_err(|_| exceptions::PyImportError::new_err("Failed to import numpy"))?;
+    let py_args: Vec<Bound<'_, PyAny>> = args
+        .iter()
+        .map(|a| match a {
+            NumArg::Scalar(v) => np.call_method1("asarray", (*v,)),
+            NumArg::Array(arr) => Ok(arr.to_pyarray(py).into_any()),
+        })
+        .collect::<PyResult<Vec<_>>>()?;
+    let broadcast = np
+        .call_method1("broadcast_arrays", pyo3::types::PyTuple::new(py, &py_args)?)
+        .map_err(|_| {
+            exceptions::PyValueError::new_err("Arguments could not be broadcast to a common shape")
+        })?;
+    let mut shape: Vec<usize> = Vec::new();
+    let mut flats: Vec<Vec<f64>> = Vec::new();
+    for item in broadcast.try_iter()? {
+        let arr = item?.cast_into::<PyArrayDyn<f64>>().map_err(|_| {
+            exceptions::PyTypeError::new_err("Expected a number or an array of numbers")
+        })?;
+        let ro = arr.readonly();
+        let view = ro.as_array();
+        shape = view.shape().to_vec();
+        flats.push(view.iter().copied().collect());
+    }
+    Ok((shape, flats))
+}
+
+/// Evaluate a scalar kernel over numeric arguments with numpy broadcasting.
+/// All-scalar arguments return a Python float; otherwise an array of the
+/// broadcast shape.
+fn ufunc<'py>(
+    py: Python<'py>,
+    args: &[&Bound<'py, PyAny>],
+    f: impl Fn(&[f64]) -> PyResult<f64>,
+) -> PyResult<Bound<'py, PyAny>> {
+    let parsed: Vec<NumArg> = args
+        .iter()
+        .map(|a| parse_num_arg(a))
+        .collect::<PyResult<Vec<_>>>()?;
+    if parsed.iter().all(|a| matches!(a, NumArg::Scalar(_))) {
+        let vals: Vec<f64> = parsed
+            .iter()
+            .map(|a| match a {
+                NumArg::Scalar(v) => *v,
+                NumArg::Array(_) => unreachable!(),
+            })
+            .collect();
+        return Ok(f(&vals)?.into_pyobject(py)?.into_any());
+    }
+    let refs: Vec<&NumArg> = parsed.iter().collect();
+    let (shape, flats) = broadcast_num_args(py, &refs)?;
+    let n = flats.first().map(|v| v.len()).unwrap_or(0);
+    let mut out = Vec::with_capacity(n);
+    let mut vals = vec![0.0; flats.len()];
+    for i in 0..n {
+        for (k, flat) in flats.iter().enumerate() {
+            vals[k] = flat[i];
+        }
+        out.push(f(&vals)?);
+    }
+    let arr = ndarray::ArrayD::from_shape_vec(ndarray::IxDyn(&shape), out)
+        .map_err(|e| exceptions::PyValueError::new_err(e.to_string()))?;
+    Ok(arr.into_pyarray(py).into_any())
+}
+
+/// Dispatch a Keplerian scalar function whose first argument is either a
+/// value (with an optional second numeric argument `e`) or an element set.
+///
+/// - scalar first argument with no `e` or a scalar `e`: `elem_fn(x, e)`
+/// - `(6,)` array with no `e`: `oe_fn(elements)`
+/// - `(n, 6)` array with no `e`: `oe_fn` per row, returning `(n,)`
+/// - any other array with no `e`: `ValueError`
+/// - array `e`, or array first argument with `e` given: element-wise
+///   `elem_fn` with numpy broadcasting
+fn dispatch_oe_or_scalar<'py>(
+    py: Python<'py>,
+    x: &Bound<'py, PyAny>,
+    e: Option<&Bound<'py, PyAny>>,
+    oe_fn: impl Fn(&[f64]) -> PyResult<f64>,
+    elem_fn: impl Fn(f64, Option<f64>) -> PyResult<f64>,
+) -> PyResult<Bound<'py, PyAny>> {
+    let x_arg = parse_num_arg(x)?;
+    let e_arg = e.map(parse_num_arg).transpose()?;
+    match (&x_arg, &e_arg) {
+        (NumArg::Scalar(v), None) => Ok(elem_fn(*v, None)?.into_pyobject(py)?.into_any()),
+        (NumArg::Scalar(v), Some(NumArg::Scalar(ecc))) => {
+            Ok(elem_fn(*v, Some(*ecc))?.into_pyobject(py)?.into_any())
+        }
+        (NumArg::Array(arr), None) if arr.ndim() == 1 && arr.len() == 6 => {
+            let oe: Vec<f64> = arr.iter().copied().collect();
+            Ok(oe_fn(&oe)?.into_pyobject(py)?.into_any())
+        }
+        (NumArg::Array(arr), None) if arr.ndim() == 2 && arr.shape()[1] == 6 => {
+            let out: Vec<f64> = arr
+                .rows()
+                .into_iter()
+                .map(|row| {
+                    let oe: Vec<f64> = row.iter().copied().collect();
+                    oe_fn(&oe)
+                })
+                .collect::<PyResult<Vec<_>>>()?;
+            Ok(out.into_pyarray(py).into_any())
+        }
+        (NumArg::Array(arr), None) => {
+            if arr.ndim() == 1 {
+                return Err(exceptions::PyValueError::new_err(format!(
+                    "Expected array or list of length 6, got {}",
+                    arr.len()
+                )));
+            }
+            Err(exceptions::PyValueError::new_err(format!(
+                "Expected an element set of shape (6,) or a batch of shape (n, 6), got shape {:?}",
+                arr.shape()
+            )))
+        }
+        (_, Some(ea)) => {
+            let refs: Vec<&NumArg> = vec![&x_arg, ea];
+            let (shape, flats) = broadcast_num_args(py, &refs)?;
+            let out: Vec<f64> = flats[0]
+                .iter()
+                .zip(flats[1].iter())
+                .map(|(x, ecc)| elem_fn(*x, Some(*ecc)))
+                .collect::<PyResult<Vec<_>>>()?;
+            let arr = ndarray::ArrayD::from_shape_vec(ndarray::IxDyn(&shape), out)
+                .map_err(|err| exceptions::PyValueError::new_err(err.to_string()))?;
+            Ok(arr.into_pyarray(py).into_any())
+        }
+    }
+}
+
+/// Dispatch a vector-to-scalar function on a single vector or a batch. A batch
+/// returns an array of the batch dimensions.
+fn dispatch_vec_to_scalar<'py, const N: usize>(
+    py: Python<'py>,
+    x: &Bound<'py, PyAny>,
+    axis: isize,
+    f: impl Fn(SVector<f64, N>) -> f64,
+) -> PyResult<Bound<'py, PyAny>> {
+    match parse_vec_arg::<N>(x, axis)? {
+        VecArg::Single(v) => Ok(f(v).into_pyobject(py)?.into_any()),
+        VecArg::Batch { vecs, layout } => {
+            let shape: Vec<usize> = layout
+                .shape
+                .iter()
+                .enumerate()
+                .filter(|(i, _)| *i != layout.axis)
+                .map(|(_, d)| *d)
+                .collect();
+            let out: Vec<f64> = vecs.iter().map(|v| f(*v)).collect();
+            let arr = ndarray::ArrayD::from_shape_vec(ndarray::IxDyn(&shape), out)
+                .map_err(|e| exceptions::PyValueError::new_err(e.to_string()))?;
+            Ok(arr.into_pyarray(py).into_any())
+        }
+    }
+}

--- a/crates/brahe-py/src/batch.rs
+++ b/crates/brahe-py/src/batch.rs
@@ -545,14 +545,14 @@ fn ufunc<'py>(
 }
 
 /// Dispatch a Keplerian scalar function whose first argument is either a
-/// value (with an optional second numeric argument `e`) or an element set.
+/// value (with an optional second numeric argument `e`) or a batch of
+/// element sets.
 ///
-/// - scalar first argument with no `e` or a scalar `e`: `elem_fn(x, e)`
-/// - `(6,)` array: `oe_fn(elements)`; `e` is ignored
-/// - `(n, 6)` array: `oe_fn` per row, returning `(n,)`; `e` is ignored
-/// - any other array with no `e`: `ValueError`
-/// - array `e` with a scalar first argument, or any other array first
-///   argument with `e` given: element-wise `elem_fn` with numpy broadcasting
+/// - scalar first argument: `elem_fn(x, e)` (`e` scalar, or broadcast if an
+///   array)
+/// - `(n, 6)` array with no `e`: `oe_fn` per row, returning `(n,)`
+/// - any other array (any shape, including 1-D of length 6): element-wise
+///   `elem_fn` with numpy broadcasting against `e`
 fn dispatch_oe_or_scalar<'py>(
     py: Python<'py>,
     x: &Bound<'py, PyAny>,
@@ -567,11 +567,7 @@ fn dispatch_oe_or_scalar<'py>(
         (NumArg::Scalar(v), Some(NumArg::Scalar(ecc))) => {
             Ok(elem_fn(*v, Some(*ecc))?.into_pyobject(py)?.into_any())
         }
-        (NumArg::Array(arr), _) if arr.ndim() == 1 && arr.len() == 6 => {
-            let oe: Vec<f64> = arr.iter().copied().collect();
-            Ok(oe_fn(&oe)?.into_pyobject(py)?.into_any())
-        }
-        (NumArg::Array(arr), _) if arr.ndim() == 2 && arr.shape()[1] == 6 => {
+        (NumArg::Array(arr), None) if arr.ndim() == 2 && arr.shape()[1] == 6 => {
             let out: Vec<f64> = arr
                 .rows()
                 .into_iter()
@@ -582,17 +578,15 @@ fn dispatch_oe_or_scalar<'py>(
                 .collect::<PyResult<Vec<_>>>()?;
             Ok(out.into_pyarray(py).into_any())
         }
-        (NumArg::Array(arr), None) => {
-            if arr.ndim() == 1 {
-                return Err(exceptions::PyValueError::new_err(format!(
-                    "Expected array or list of length 6, got {}",
-                    arr.len()
-                )));
-            }
-            Err(exceptions::PyValueError::new_err(format!(
-                "Expected an element set of shape (6,) or a batch of shape (n, 6), got shape {:?}",
-                arr.shape()
-            )))
+        (_, None) => {
+            let (shape, flats) = broadcast_num_args(py, &[&x_arg])?;
+            let out: Vec<f64> = flats[0]
+                .iter()
+                .map(|x| elem_fn(*x, None))
+                .collect::<PyResult<Vec<_>>>()?;
+            let arr = ndarray::ArrayD::from_shape_vec(ndarray::IxDyn(&shape), out)
+                .map_err(|err| exceptions::PyValueError::new_err(err.to_string()))?;
+            Ok(arr.into_pyarray(py).into_any())
         }
         (_, Some(ea)) => {
             let refs: Vec<&NumArg> = vec![&x_arg, ea];

--- a/crates/brahe-py/src/batch.rs
+++ b/crates/brahe-py/src/batch.rs
@@ -548,11 +548,11 @@ fn ufunc<'py>(
 /// value (with an optional second numeric argument `e`) or an element set.
 ///
 /// - scalar first argument with no `e` or a scalar `e`: `elem_fn(x, e)`
-/// - `(6,)` array with no `e`: `oe_fn(elements)`
-/// - `(n, 6)` array with no `e`: `oe_fn` per row, returning `(n,)`
+/// - `(6,)` array: `oe_fn(elements)`; `e` is ignored
+/// - `(n, 6)` array: `oe_fn` per row, returning `(n,)`; `e` is ignored
 /// - any other array with no `e`: `ValueError`
-/// - array `e`, or array first argument with `e` given: element-wise
-///   `elem_fn` with numpy broadcasting
+/// - array `e` with a scalar first argument, or any other array first
+///   argument with `e` given: element-wise `elem_fn` with numpy broadcasting
 fn dispatch_oe_or_scalar<'py>(
     py: Python<'py>,
     x: &Bound<'py, PyAny>,
@@ -567,11 +567,11 @@ fn dispatch_oe_or_scalar<'py>(
         (NumArg::Scalar(v), Some(NumArg::Scalar(ecc))) => {
             Ok(elem_fn(*v, Some(*ecc))?.into_pyobject(py)?.into_any())
         }
-        (NumArg::Array(arr), None) if arr.ndim() == 1 && arr.len() == 6 => {
+        (NumArg::Array(arr), _) if arr.ndim() == 1 && arr.len() == 6 => {
             let oe: Vec<f64> = arr.iter().copied().collect();
             Ok(oe_fn(&oe)?.into_pyobject(py)?.into_any())
         }
-        (NumArg::Array(arr), None) if arr.ndim() == 2 && arr.shape()[1] == 6 => {
+        (NumArg::Array(arr), _) if arr.ndim() == 2 && arr.shape()[1] == 6 => {
             let out: Vec<f64> = arr
                 .rows()
                 .into_iter()

--- a/crates/brahe-py/src/coordinates.rs
+++ b/crates/brahe-py/src/coordinates.rs
@@ -1281,6 +1281,8 @@ fn py_state_inertial_to_radec<'py>(
 ///     import brahe as bh
 ///     import numpy as np
 ///
+///     bh.initialize_eop()
+///
 ///     epc = bh.Epoch.from_datetime(2024, 3, 20, 12, 0, 0.0, 0.0, bh.UTC)
 ///     site = np.array([-122.17, 37.43, 100.0])  # Stanford, deg/deg/m
 ///     x_radec = np.array([101.28, -16.72, 1.0])
@@ -1355,6 +1357,8 @@ fn py_position_radec_to_azel<'py>(
 ///     ```python
 ///     import brahe as bh
 ///     import numpy as np
+///
+///     bh.initialize_eop()
 ///
 ///     epc = bh.Epoch.from_datetime(2024, 3, 20, 12, 0, 0.0, 0.0, bh.UTC)
 ///     site = np.array([-122.17, 37.43, 100.0])  # Stanford, deg/deg/m

--- a/crates/brahe-py/src/frames.rs
+++ b/crates/brahe-py/src/frames.rs
@@ -91,6 +91,8 @@ unsafe fn py_polar_motion<'py>(py: Python<'py>, epc: &PyEpoch) -> Bound<'py, PyA
 ///     import brahe as bh
 ///     import numpy as np
 ///
+///     bh.initialize_eop()
+///
 ///     # Create epoch
 ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
 ///
@@ -126,6 +128,8 @@ fn py_rotation_gcrf_to_itrf<'py>(py: Python<'py>, epc: &Bound<'py, PyAny>) -> Py
 ///     ```python
 ///     import brahe as bh
 ///     import numpy as np
+///
+///     bh.initialize_eop()
 ///
 ///     # Create epoch
 ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
@@ -166,6 +170,8 @@ fn py_rotation_eci_to_ecef<'py>(py: Python<'py>, epc: &Bound<'py, PyAny>) -> PyR
 ///     ```python
 ///     import brahe as bh
 ///
+///     bh.initialize_eop()
+///
 ///     # Create epoch
 ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
 ///
@@ -199,6 +205,8 @@ fn py_rotation_itrf_to_gcrf<'py>(py: Python<'py>, epc: &Bound<'py, PyAny>) -> Py
 /// Example:
 ///     ```python
 ///     import brahe as bh
+///
+///     bh.initialize_eop()
 ///
 ///     # Create epoch
 ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
@@ -240,6 +248,8 @@ fn py_rotation_ecef_to_eci<'py>(py: Python<'py>, epc: &Bound<'py, PyAny>) -> PyR
 ///     ```python
 ///     import brahe as bh
 ///     import numpy as np
+///
+///     bh.initialize_eop()
 ///
 ///     # Create epoch
 ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
@@ -299,6 +309,8 @@ fn py_position_gcrf_to_itrf<'py>(
 ///     import brahe as bh
 ///     import numpy as np
 ///
+///     bh.initialize_eop()
+///
 ///     # Create epoch
 ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
 ///
@@ -349,6 +361,8 @@ fn py_position_eci_to_ecef<'py>(
 ///     import brahe as bh
 ///     import numpy as np
 ///
+///     bh.initialize_eop()
+///
 ///     # Create epoch
 ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
 ///
@@ -398,6 +412,8 @@ fn py_position_itrf_to_gcrf<'py>(
 ///     ```python
 ///     import brahe as bh
 ///     import numpy as np
+///
+///     bh.initialize_eop()
 ///
 ///     # Create epoch
 ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
@@ -450,6 +466,8 @@ fn py_position_ecef_to_eci<'py>(
 ///     import brahe as bh
 ///     import numpy as np
 ///
+///     bh.initialize_eop()
+///
 ///     # Create epoch
 ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
 ///
@@ -500,6 +518,8 @@ fn py_state_gcrf_to_itrf<'py>(
 ///     ```python
 ///     import brahe as bh
 ///     import numpy as np
+///
+///     bh.initialize_eop()
 ///
 ///     # Create epoch
 ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
@@ -559,6 +579,8 @@ fn py_state_eci_to_ecef<'py>(
 ///     import brahe as bh
 ///     import numpy as np
 ///
+///     bh.initialize_eop()
+///
 ///     # Create epoch
 ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
 ///
@@ -609,6 +631,8 @@ fn py_state_itrf_to_gcrf<'py>(
 ///     ```python
 ///     import brahe as bh
 ///     import numpy as np
+///
+///     bh.initialize_eop()
 ///
 ///     # Create epoch
 ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
@@ -3416,6 +3440,8 @@ fn py_unregister_custom_frame(key: u32) -> bool {
 /// Example:
 ///     ```python
 ///     import brahe as bh
+///
+///     bh.initialize_eop()
 ///
 ///     epc = bh.Epoch.from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, bh.UTC)
 ///     x_gcrf = [bh.R_EARTH + 500e3, 0.0, 0.0]

--- a/crates/brahe-py/src/lib.rs
+++ b/crates/brahe-py/src/lib.rs
@@ -1095,8 +1095,8 @@ pub fn _brahe(py: Python<'_>, module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_class::<PyMeanElementInverseConfig>()?;
     module.add_function(wrap_pyfunction!(py_state_koe_osc_to_mean, module)?)?;
     module.add_function(wrap_pyfunction!(py_state_koe_mean_to_osc, module)?)?;
-    module.add_function(wrap_pyfunction!(py_batch_state_koe_osc_to_mean, module)?)?;
-    module.add_function(wrap_pyfunction!(py_batch_state_koe_mean_to_osc, module)?)?;
+    module.add_function(wrap_pyfunction!(py_states_koe_osc_to_mean, module)?)?;
+    module.add_function(wrap_pyfunction!(py_states_koe_mean_to_osc, module)?)?;
 
     // Equinoctial element conversions
     module.add_function(wrap_pyfunction!(py_state_koe_to_equinoctial, module)?)?;

--- a/crates/brahe-py/src/orbits.rs
+++ b/crates/brahe-py/src/orbits.rs
@@ -1953,14 +1953,14 @@ fn pairs_to_py<'py>(py: Python<'py>, pairs: Vec<(time::Epoch, SVector<f64, 6>)>)
 ///     s = np.array([bh.R_EARTH + 500e3, 0.01, 45.0, 30.0, 60.0, 90.0])
 ///     states = np.vstack([s, s, s])
 ///
-///     out_epochs, out_states = bh.batch_state_koe_osc_to_mean(
+///     out_epochs, out_states = bh.states_koe_osc_to_mean(
 ///         epochs, states, bh.MeanElementMethod.BROUWER_LYDDANE, bh.AngleFormat.DEGREES
 ///     )
 ///     ```
 #[pyfunction]
 #[pyo3(text_signature = "(epochs, states, method, angle_format)")]
-#[pyo3(name = "batch_state_koe_osc_to_mean")]
-fn py_batch_state_koe_osc_to_mean<'py>(
+#[pyo3(name = "states_koe_osc_to_mean")]
+fn py_states_koe_osc_to_mean<'py>(
     py: Python<'py>,
     epochs: Vec<PyRef<'_, PyEpoch>>,
     states: PyReadonlyArray2<f64>,
@@ -1969,7 +1969,7 @@ fn py_batch_state_koe_osc_to_mean<'py>(
 ) -> PyResult<BatchKoeResult<'py>> {
     let epochs_vec: Vec<time::Epoch> = epochs.iter().map(|e| e.obj).collect();
     let states_vec = states_array2_to_svec6(&states)?;
-    let pairs = orbits::batch_state_koe_osc_to_mean(
+    let pairs = orbits::states_koe_osc_to_mean(
         &epochs_vec,
         &states_vec,
         method.method.clone(),
@@ -2020,14 +2020,14 @@ fn py_batch_state_koe_osc_to_mean<'py>(
 ///     s = np.array([bh.R_EARTH + 500e3, 0.01, 45.0, 30.0, 60.0, 90.0])
 ///     states = np.vstack([s, s, s])
 ///
-///     out_epochs, out_states = bh.batch_state_koe_mean_to_osc(
+///     out_epochs, out_states = bh.states_koe_mean_to_osc(
 ///         epochs, states, bh.MeanElementMethod.BROUWER_LYDDANE, bh.AngleFormat.DEGREES
 ///     )
 ///     ```
 #[pyfunction]
 #[pyo3(text_signature = "(epochs, states, method, angle_format)")]
-#[pyo3(name = "batch_state_koe_mean_to_osc")]
-fn py_batch_state_koe_mean_to_osc<'py>(
+#[pyo3(name = "states_koe_mean_to_osc")]
+fn py_states_koe_mean_to_osc<'py>(
     py: Python<'py>,
     epochs: Vec<PyRef<'_, PyEpoch>>,
     states: PyReadonlyArray2<f64>,
@@ -2036,7 +2036,7 @@ fn py_batch_state_koe_mean_to_osc<'py>(
 ) -> PyResult<BatchKoeResult<'py>> {
     let epochs_vec: Vec<time::Epoch> = epochs.iter().map(|e| e.obj).collect();
     let states_vec = states_array2_to_svec6(&states)?;
-    let pairs = orbits::batch_state_koe_mean_to_osc(
+    let pairs = orbits::states_koe_mean_to_osc(
         &epochs_vec,
         &states_vec,
         method.method.clone(),

--- a/crates/brahe-py/src/orbits.rs
+++ b/crates/brahe-py/src/orbits.rs
@@ -3,13 +3,14 @@
 /// Uses rastro.constants.GM_EARTH as the standard gravitational parameter for the calculation.
 ///
 /// Args:
-///     a_or_oe (float or array): Either the semi-major axis in meters, or a 6-element
-///         Keplerian elements array [a, e, i, Ω, ω, ν] from which `a` will be extracted.
-///         A 2-D array of shape `(n, 6)` is treated as `n` element sets.
+///     a_or_oe (float or array): The semi-major axis in meters, as a scalar or an array
+///         evaluated element-wise; or a 2-D array of shape `(n, 6)` of Keplerian element
+///         sets [a, e, i, Ω, ω, ν] from which `a` is taken row by row.
 ///
 /// Returns:
 ///     float or numpy.ndarray: The orbital period of the astronomical object in seconds.
-///         An array of shape `(n,)` is returned for a batch of `n` element sets.
+///         An array is returned for array input: shape `(n,)` for `n` element sets, or the
+///         input shape for element-wise input.
 ///
 /// Example:
 ///     ```python
@@ -21,9 +22,9 @@
 ///     period = bh.orbital_period(a)
 ///     print(f"Orbital period: {period/60:.2f} minutes")
 ///
-///     # Using Keplerian elements vector
+///     # Using a batch of Keplerian element sets, one result per row
 ///     oe = [bh.R_EARTH + 400e3, 0.001, np.radians(51.6), 0, 0, 0]
-///     period = bh.orbital_period(oe)
+///     period = bh.orbital_period(np.array([oe, oe]))
 ///     print(f"Orbital period: {period/60:.2f} minutes")
 ///     ```
 #[pyfunction]
@@ -45,14 +46,15 @@ fn py_orbital_period<'py>(
 /// Computes the orbital period of an astronomical object around a general body.
 ///
 /// Args:
-///     a_or_oe (float or array): Either the semi-major axis in meters, or a 6-element
-///         Keplerian elements array [a, e, i, Ω, ω, ν] from which `a` will be extracted.
-///         A 2-D array of shape `(n, 6)` is treated as `n` element sets.
+///     a_or_oe (float or array): The semi-major axis in meters, as a scalar or an array
+///         evaluated element-wise; or a 2-D array of shape `(n, 6)` of Keplerian element
+///         sets [a, e, i, Ω, ω, ν] from which `a` is taken row by row.
 ///     gm (float): (keyword-only) The standard gravitational parameter of primary body in m³/s².
 ///
 /// Returns:
 ///     float or numpy.ndarray: The orbital period of the astronomical object in seconds.
-///         An array of shape `(n,)` is returned for a batch of `n` element sets.
+///         An array is returned for array input: shape `(n,)` for `n` element sets, or the
+///         input shape for element-wise input.
 ///
 /// Example:
 ///     ```python
@@ -64,9 +66,9 @@ fn py_orbital_period<'py>(
 ///     period = bh.orbital_period_general(a, bh.GM_MOON)
 ///     print(f"Lunar orbital period: {period/3600:.2f} hours")
 ///
-///     # Using Keplerian elements vector
+///     # Using a batch of Keplerian element sets, one result per row
 ///     oe = [1900000.0, 0.01, np.radians(45), 0, 0, 0]
-///     period = bh.orbital_period_general(oe, bh.GM_MOON)
+///     period = bh.orbital_period_general(np.array([oe, oe]), bh.GM_MOON)
 ///     print(f"Lunar orbital period: {period/3600:.2f} hours")
 ///     ```
 #[pyfunction]
@@ -141,14 +143,15 @@ fn py_orbital_period_from_state<'py>(
 /// Computes the mean motion of an astronomical object around Earth.
 ///
 /// Args:
-///     a_or_oe (float or array): Either the semi-major axis in meters, or a 6-element
-///         Keplerian elements array [a, e, i, Ω, ω, ν] from which `a` will be extracted.
-///         A 2-D array of shape `(n, 6)` is treated as `n` element sets.
+///     a_or_oe (float or array): The semi-major axis in meters, as a scalar or an array
+///         evaluated element-wise; or a 2-D array of shape `(n, 6)` of Keplerian element
+///         sets [a, e, i, Ω, ω, ν] from which `a` is taken row by row.
 ///     angle_format (AngleFormat): (keyword-only) Return output in AngleFormat.DEGREES or AngleFormat.RADIANS.
 ///
 /// Returns:
 ///     float or numpy.ndarray: The mean motion of the astronomical object in radians or degrees.
-///         An array of shape `(n,)` is returned for a batch of `n` element sets.
+///         An array is returned for array input: shape `(n,)` for `n` element sets, or the
+///         input shape for element-wise input.
 ///
 /// Example:
 ///     ```python
@@ -160,9 +163,9 @@ fn py_orbital_period_from_state<'py>(
 ///     n = bh.mean_motion(a, bh.AngleFormat.DEGREES)
 ///     print(f"Mean motion: {n:.6f} deg/s")
 ///
-///     # Using Keplerian elements vector
+///     # Using a batch of Keplerian element sets, one result per row
 ///     oe = [bh.R_EARTH + 35786e3, 0.001, np.radians(0), 0, 0, 0]
-///     n = bh.mean_motion(oe, bh.AngleFormat.DEGREES)
+///     n = bh.mean_motion(np.array([oe, oe]), bh.AngleFormat.DEGREES)
 ///     print(f"Mean motion: {n:.6f} deg/s")
 ///     ```
 #[pyfunction]
@@ -187,15 +190,16 @@ fn py_mean_motion<'py>(
 /// given a semi-major axis.
 ///
 /// Args:
-///     a_or_oe (float or array): Either the semi-major axis in meters, or a 6-element
-///         Keplerian elements array [a, e, i, Ω, ω, ν] from which `a` will be extracted.
-///         A 2-D array of shape `(n, 6)` is treated as `n` element sets.
+///     a_or_oe (float or array): The semi-major axis in meters, as a scalar or an array
+///         evaluated element-wise; or a 2-D array of shape `(n, 6)` of Keplerian element
+///         sets [a, e, i, Ω, ω, ν] from which `a` is taken row by row.
 ///     gm (float): (keyword-only) The standard gravitational parameter of primary body in m³/s².
 ///     angle_format (AngleFormat): (keyword-only) Return output in AngleFormat.DEGREES or AngleFormat.RADIANS.
 ///
 /// Returns:
 ///     float or numpy.ndarray: The mean motion of the astronomical object in radians or degrees.
-///         An array of shape `(n,)` is returned for a batch of `n` element sets.
+///         An array is returned for array input: shape `(n,)` for `n` element sets, or the
+///         input shape for element-wise input.
 ///
 /// Example:
 ///     ```python
@@ -207,9 +211,9 @@ fn py_mean_motion<'py>(
 ///     n = bh.mean_motion_general(a, bh.GM_MARS, bh.AngleFormat.RADIANS)
 ///     print(f"Mean motion: {n:.6f} rad/s")
 ///
-///     # Using Keplerian elements vector
+///     # Using a batch of Keplerian element sets, one result per row
 ///     oe = [4000000.0, 0.01, np.radians(30), 0, 0, 0]
-///     n = bh.mean_motion_general(oe, bh.GM_MARS, bh.AngleFormat.RADIANS)
+///     n = bh.mean_motion_general(np.array([oe, oe]), bh.GM_MARS, bh.AngleFormat.RADIANS)
 ///     print(f"Mean motion: {n:.6f} rad/s")
 ///     ```
 #[pyfunction]
@@ -362,18 +366,17 @@ fn py_semimajor_axis_from_orbital_period<'py>(
 /// Computes the perigee velocity of an astronomical object around Earth.
 ///
 /// Args:
-///     a_or_oe (float or array): Either the semi-major axis in meters, or a 6-element
-///         Keplerian elements array [a, e, i, Ω, ω, ν] from which `a` and `e` will be extracted.
-///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
-///         arrays of any shape are evaluated element-wise (broadcast against `e`).
-///     e (float or array, optional): The eccentricity. Required if `a_or_oe` is a scalar, ignored if vector.
-///         Ignored when `a_or_oe` is an element set; otherwise broadcast against `a_or_oe` when
-///         either is an array.
+///     a_or_oe (float or array): The semi-major axis in meters, as a scalar or an array
+///         evaluated element-wise (broadcast against `e`); or, when `e` is omitted, a 2-D
+///         array of shape `(n, 6)` of Keplerian element sets [a, e, i, Ω, ω, ν] from which
+///         `a` and `e` are taken row by row.
+///     e (float or array, optional): The eccentricity, broadcast against `a_or_oe` when either is
+///         an array. Required unless `a_or_oe` is a 2-D element-set batch, where it is ignored.
 ///
 /// Returns:
 ///     float or numpy.ndarray: The magnitude of velocity of the object at perigee in m/s.
-///         An array is returned for array input, with shape `(n,)` for `n` element
-///         sets or the broadcast shape for element-wise input.
+///         An array is returned for array input: shape `(n,)` for `n` element sets, or the
+///         broadcast shape for element-wise input.
 ///
 /// Example:
 ///     ```python
@@ -386,9 +389,9 @@ fn py_semimajor_axis_from_orbital_period<'py>(
 ///     v_peri = bh.perigee_velocity(a, e)
 ///     print(f"Perigee velocity: {v_peri:.2f} m/s")
 ///
-///     # Using Keplerian elements vector
+///     # Using a batch of Keplerian element sets, one result per row
 ///     oe = [26554000.0, 0.72, np.radians(63.4), 0, 0, 0]
-///     v_peri = bh.perigee_velocity(oe)
+///     v_peri = bh.perigee_velocity(np.array([oe, oe]))
 ///     print(f"Perigee velocity: {v_peri:.2f} m/s")
 ///     ```
 #[pyfunction]
@@ -407,7 +410,7 @@ fn py_perigee_velocity<'py>(
         |v, e| {
             let ecc = e.ok_or_else(|| {
                 exceptions::PyValueError::new_err(
-                    "Parameter 'e' is required when 'a_or_oe' is a scalar",
+                    "Parameter 'e' is required when 'a_or_oe' is a scalar or an array of values",
                 )
             })?;
             Ok(orbits::perigee_velocity(v, ecc))
@@ -418,19 +421,18 @@ fn py_perigee_velocity<'py>(
 /// Computes the periapsis velocity of an astronomical object around a general body.
 ///
 /// Args:
-///     a_or_oe (float or array): Either the semi-major axis in meters, or a 6-element
-///         Keplerian elements array [a, e, i, Ω, ω, ν] from which `a` and `e` will be extracted.
-///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
-///         arrays of any shape are evaluated element-wise (broadcast against `e`).
-///     e (float or array, optional): The eccentricity. Required if `a_or_oe` is a scalar, ignored if vector.
-///         Ignored when `a_or_oe` is an element set; otherwise broadcast against `a_or_oe` when
-///         either is an array.
+///     a_or_oe (float or array): The semi-major axis in meters, as a scalar or an array
+///         evaluated element-wise (broadcast against `e`); or, when `e` is omitted, a 2-D
+///         array of shape `(n, 6)` of Keplerian element sets [a, e, i, Ω, ω, ν] from which
+///         `a` and `e` are taken row by row.
+///     e (float or array, optional): The eccentricity, broadcast against `a_or_oe` when either is
+///         an array. Required unless `a_or_oe` is a 2-D element-set batch, where it is ignored.
 ///     gm (float): (keyword-only) The standard gravitational parameter of primary body in m³/s².
 ///
 /// Returns:
 ///     float or numpy.ndarray: The magnitude of velocity of the object at periapsis in m/s.
-///         An array is returned for array input, with shape `(n,)` for `n` element
-///         sets or the broadcast shape for element-wise input.
+///         An array is returned for array input: shape `(n,)` for `n` element sets, or the
+///         broadcast shape for element-wise input.
 ///
 /// Example:
 ///     ```python
@@ -443,9 +445,9 @@ fn py_perigee_velocity<'py>(
 ///     v_peri = bh.periapsis_velocity(a, e, bh.GM_SUN)
 ///     print(f"Periapsis velocity: {v_peri/1000:.2f} km/s")
 ///
-///     # Using Keplerian elements vector
+///     # Using a batch of Keplerian element sets, one result per row
 ///     oe = [5e11, 0.95, np.radians(10), 0, 0, 0]
-///     v_peri = bh.periapsis_velocity(oe, gm=bh.GM_SUN)
+///     v_peri = bh.periapsis_velocity(np.array([oe, oe]), gm=bh.GM_SUN)
 ///     print(f"Periapsis velocity: {v_peri/1000:.2f} km/s")
 ///     ```
 #[pyfunction]
@@ -465,7 +467,7 @@ fn py_periapsis_velocity<'py>(
         |v, e| {
             let ecc = e.ok_or_else(|| {
                 exceptions::PyValueError::new_err(
-                    "Parameter 'e' is required when 'a_or_oe' is a scalar",
+                    "Parameter 'e' is required when 'a_or_oe' is a scalar or an array of values",
                 )
             })?;
             Ok(orbits::periapsis_velocity(v, ecc, gm))
@@ -476,18 +478,17 @@ fn py_periapsis_velocity<'py>(
 /// Calculate the distance of an object at its periapsis.
 ///
 /// Args:
-///     a_or_oe (float or array): Either the semi-major axis in meters, or a 6-element
-///         Keplerian elements array [a, e, i, Ω, ω, ν] from which `a` and `e` will be extracted.
-///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
-///         arrays of any shape are evaluated element-wise (broadcast against `e`).
-///     e (float or array, optional): The eccentricity. Required if `a_or_oe` is a scalar, ignored if vector.
-///         Ignored when `a_or_oe` is an element set; otherwise broadcast against `a_or_oe` when
-///         either is an array.
+///     a_or_oe (float or array): The semi-major axis in meters, as a scalar or an array
+///         evaluated element-wise (broadcast against `e`); or, when `e` is omitted, a 2-D
+///         array of shape `(n, 6)` of Keplerian element sets [a, e, i, Ω, ω, ν] from which
+///         `a` and `e` are taken row by row.
+///     e (float or array, optional): The eccentricity, broadcast against `a_or_oe` when either is
+///         an array. Required unless `a_or_oe` is a 2-D element-set batch, where it is ignored.
 ///
 /// Returns:
 ///     float or numpy.ndarray: The distance of the object at periapsis in meters.
-///         An array is returned for array input, with shape `(n,)` for `n` element
-///         sets or the broadcast shape for element-wise input.
+///         An array is returned for array input: shape `(n,)` for `n` element sets, or the
+///         broadcast shape for element-wise input.
 ///
 /// Example:
 ///     ```python
@@ -500,9 +501,9 @@ fn py_periapsis_velocity<'py>(
 ///     r_peri = bh.periapsis_distance(a, e)
 ///     print(f"Periapsis distance: {r_peri/1000:.2f} km")
 ///
-///     # Using Keplerian elements vector
+///     # Using a batch of Keplerian element sets, one result per row
 ///     oe = [8000000.0, 0.2, np.radians(45), 0, 0, 0]
-///     r_peri = bh.periapsis_distance(oe)
+///     r_peri = bh.periapsis_distance(np.array([oe, oe]))
 ///     print(f"Periapsis distance: {r_peri/1000:.2f} km")
 ///     ```
 #[pyfunction]
@@ -521,7 +522,7 @@ fn py_periapsis_distance<'py>(
         |v, e| {
             let ecc = e.ok_or_else(|| {
                 exceptions::PyValueError::new_err(
-                    "Parameter 'e' is required when 'a_or_oe' is a scalar",
+                    "Parameter 'e' is required when 'a_or_oe' is a scalar or an array of values",
                 )
             })?;
             Ok(orbits::periapsis_distance(v, ecc))
@@ -532,18 +533,17 @@ fn py_periapsis_distance<'py>(
 /// Computes the apogee velocity of an astronomical object around Earth.
 ///
 /// Args:
-///     a_or_oe (float or array): Either the semi-major axis in meters, or a 6-element
-///         Keplerian elements array [a, e, i, Ω, ω, ν] from which `a` and `e` will be extracted.
-///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
-///         arrays of any shape are evaluated element-wise (broadcast against `e`).
-///     e (float or array, optional): The eccentricity. Required if `a_or_oe` is a scalar, ignored if vector.
-///         Ignored when `a_or_oe` is an element set; otherwise broadcast against `a_or_oe` when
-///         either is an array.
+///     a_or_oe (float or array): The semi-major axis in meters, as a scalar or an array
+///         evaluated element-wise (broadcast against `e`); or, when `e` is omitted, a 2-D
+///         array of shape `(n, 6)` of Keplerian element sets [a, e, i, Ω, ω, ν] from which
+///         `a` and `e` are taken row by row.
+///     e (float or array, optional): The eccentricity, broadcast against `a_or_oe` when either is
+///         an array. Required unless `a_or_oe` is a 2-D element-set batch, where it is ignored.
 ///
 /// Returns:
 ///     float or numpy.ndarray: The magnitude of velocity of the object at apogee in m/s.
-///         An array is returned for array input, with shape `(n,)` for `n` element
-///         sets or the broadcast shape for element-wise input.
+///         An array is returned for array input: shape `(n,)` for `n` element sets, or the
+///         broadcast shape for element-wise input.
 ///
 /// Example:
 ///     ```python
@@ -556,9 +556,9 @@ fn py_periapsis_distance<'py>(
 ///     v_apo = bh.apogee_velocity(a, e)
 ///     print(f"Apogee velocity: {v_apo:.2f} m/s")
 ///
-///     # Using Keplerian elements vector
+///     # Using a batch of Keplerian element sets, one result per row
 ///     oe = [24400000.0, 0.73, np.radians(7), 0, 0, 0]
-///     v_apo = bh.apogee_velocity(oe)
+///     v_apo = bh.apogee_velocity(np.array([oe, oe]))
 ///     print(f"Apogee velocity: {v_apo:.2f} m/s")
 ///     ```
 #[pyfunction]
@@ -577,7 +577,7 @@ fn py_apogee_velocity<'py>(
         |v, e| {
             let ecc = e.ok_or_else(|| {
                 exceptions::PyValueError::new_err(
-                    "Parameter 'e' is required when 'a_or_oe' is a scalar",
+                    "Parameter 'e' is required when 'a_or_oe' is a scalar or an array of values",
                 )
             })?;
             Ok(orbits::apogee_velocity(v, ecc))
@@ -588,19 +588,18 @@ fn py_apogee_velocity<'py>(
 /// Computes the apoapsis velocity of an astronomical object around a general body.
 ///
 /// Args:
-///     a_or_oe (float or array): Either the semi-major axis in meters, or a 6-element
-///         Keplerian elements array [a, e, i, Ω, ω, ν] from which `a` and `e` will be extracted.
-///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
-///         arrays of any shape are evaluated element-wise (broadcast against `e`).
-///     e (float or array, optional): The eccentricity. Required if `a_or_oe` is a scalar, ignored if vector.
-///         Ignored when `a_or_oe` is an element set; otherwise broadcast against `a_or_oe` when
-///         either is an array.
+///     a_or_oe (float or array): The semi-major axis in meters, as a scalar or an array
+///         evaluated element-wise (broadcast against `e`); or, when `e` is omitted, a 2-D
+///         array of shape `(n, 6)` of Keplerian element sets [a, e, i, Ω, ω, ν] from which
+///         `a` and `e` are taken row by row.
+///     e (float or array, optional): The eccentricity, broadcast against `a_or_oe` when either is
+///         an array. Required unless `a_or_oe` is a 2-D element-set batch, where it is ignored.
 ///     gm (float): (keyword-only) The standard gravitational parameter of primary body in m³/s².
 ///
 /// Returns:
 ///     float or numpy.ndarray: The magnitude of velocity of the object at apoapsis in m/s.
-///         An array is returned for array input, with shape `(n,)` for `n` element
-///         sets or the broadcast shape for element-wise input.
+///         An array is returned for array input: shape `(n,)` for `n` element sets, or the
+///         broadcast shape for element-wise input.
 ///
 /// Example:
 ///     ```python
@@ -613,9 +612,9 @@ fn py_apogee_velocity<'py>(
 ///     v_apo = bh.apoapsis_velocity(a, e, bh.GM_MARS)
 ///     print(f"Apoapsis velocity: {v_apo/1000:.2f} km/s")
 ///
-///     # Using Keplerian elements vector
+///     # Using a batch of Keplerian element sets, one result per row
 ///     oe = [10000000.0, 0.3, np.radians(30), 0, 0, 0]
-///     v_apo = bh.apoapsis_velocity(oe, gm=bh.GM_MARS)
+///     v_apo = bh.apoapsis_velocity(np.array([oe, oe]), gm=bh.GM_MARS)
 ///     print(f"Apoapsis velocity: {v_apo/1000:.2f} km/s")
 ///     ```
 #[pyfunction]
@@ -635,7 +634,7 @@ fn py_apoapsis_velocity<'py>(
         |v, e| {
             let ecc = e.ok_or_else(|| {
                 exceptions::PyValueError::new_err(
-                    "Parameter 'e' is required when 'a_or_oe' is a scalar",
+                    "Parameter 'e' is required when 'a_or_oe' is a scalar or an array of values",
                 )
             })?;
             Ok(orbits::apoapsis_velocity(v, ecc, gm))
@@ -646,18 +645,17 @@ fn py_apoapsis_velocity<'py>(
 /// Calculate the distance of an object at its apoapsis.
 ///
 /// Args:
-///     a_or_oe (float or array): Either the semi-major axis in meters, or a 6-element
-///         Keplerian elements array [a, e, i, Ω, ω, ν] from which `a` and `e` will be extracted.
-///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
-///         arrays of any shape are evaluated element-wise (broadcast against `e`).
-///     e (float or array, optional): The eccentricity. Required if `a_or_oe` is a scalar, ignored if vector.
-///         Ignored when `a_or_oe` is an element set; otherwise broadcast against `a_or_oe` when
-///         either is an array.
+///     a_or_oe (float or array): The semi-major axis in meters, as a scalar or an array
+///         evaluated element-wise (broadcast against `e`); or, when `e` is omitted, a 2-D
+///         array of shape `(n, 6)` of Keplerian element sets [a, e, i, Ω, ω, ν] from which
+///         `a` and `e` are taken row by row.
+///     e (float or array, optional): The eccentricity, broadcast against `a_or_oe` when either is
+///         an array. Required unless `a_or_oe` is a 2-D element-set batch, where it is ignored.
 ///
 /// Returns:
 ///     float or numpy.ndarray: The distance of the object at apoapsis in meters.
-///         An array is returned for array input, with shape `(n,)` for `n` element
-///         sets or the broadcast shape for element-wise input.
+///         An array is returned for array input: shape `(n,)` for `n` element sets, or the
+///         broadcast shape for element-wise input.
 ///
 /// Example:
 ///     ```python
@@ -670,9 +668,9 @@ fn py_apoapsis_velocity<'py>(
 ///     r_apo = bh.apoapsis_distance(a, e)
 ///     print(f"Apoapsis distance: {r_apo/1000:.2f} km")
 ///
-///     # Using Keplerian elements vector
+///     # Using a batch of Keplerian element sets, one result per row
 ///     oe = [8000000.0, 0.2, np.radians(45), 0, 0, 0]
-///     r_apo = bh.apoapsis_distance(oe)
+///     r_apo = bh.apoapsis_distance(np.array([oe, oe]))
 ///     print(f"Apoapsis distance: {r_apo/1000:.2f} km")
 ///     ```
 #[pyfunction]
@@ -691,7 +689,7 @@ fn py_apoapsis_distance<'py>(
         |v, e| {
             let ecc = e.ok_or_else(|| {
                 exceptions::PyValueError::new_err(
-                    "Parameter 'e' is required when 'a_or_oe' is a scalar",
+                    "Parameter 'e' is required when 'a_or_oe' is a scalar or an array of values",
                 )
             })?;
             Ok(orbits::apoapsis_distance(v, ecc))
@@ -702,19 +700,18 @@ fn py_apoapsis_distance<'py>(
 /// Calculate the altitude above a body's surface at periapsis.
 ///
 /// Args:
-///     a_or_oe (float or array): Either the semi-major axis in meters, or a 6-element
-///         Keplerian elements array [a, e, i, Ω, ω, ν] from which `a` and `e` will be extracted.
-///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
-///         arrays of any shape are evaluated element-wise (broadcast against `e`).
-///     e (float or array, optional): The eccentricity. Required if `a_or_oe` is a scalar, ignored if vector.
-///         Ignored when `a_or_oe` is an element set; otherwise broadcast against `a_or_oe` when
-///         either is an array.
+///     a_or_oe (float or array): The semi-major axis in meters, as a scalar or an array
+///         evaluated element-wise (broadcast against `e`); or, when `e` is omitted, a 2-D
+///         array of shape `(n, 6)` of Keplerian element sets [a, e, i, Ω, ω, ν] from which
+///         `a` and `e` are taken row by row.
+///     e (float or array, optional): The eccentricity, broadcast against `a_or_oe` when either is
+///         an array. Required unless `a_or_oe` is a 2-D element-set batch, where it is ignored.
 ///     r_body (float): (keyword-only) The radius of the central body in meters.
 ///
 /// Returns:
 ///     float or numpy.ndarray: The altitude above the body's surface at periapsis in meters.
-///         An array is returned for array input, with shape `(n,)` for `n` element
-///         sets or the broadcast shape for element-wise input.
+///         An array is returned for array input: shape `(n,)` for `n` element sets, or the
+///         broadcast shape for element-wise input.
 ///
 /// Example:
 ///     ```python
@@ -727,9 +724,9 @@ fn py_apoapsis_distance<'py>(
 ///     alt_peri = bh.periapsis_altitude(a, e, bh.R_EARTH)
 ///     print(f"Periapsis altitude: {alt_peri/1000:.2f} km")
 ///
-///     # Using Keplerian elements vector
+///     # Using a batch of Keplerian element sets, one result per row
 ///     oe = [bh.R_EARTH + 500e3, 0.01, np.radians(45), 0, 0, 0]
-///     alt_peri = bh.periapsis_altitude(oe, r_body=bh.R_EARTH)
+///     alt_peri = bh.periapsis_altitude(np.array([oe, oe]), r_body=bh.R_EARTH)
 ///     print(f"Periapsis altitude: {alt_peri/1000:.2f} km")
 ///     ```
 #[pyfunction]
@@ -749,7 +746,7 @@ fn py_periapsis_altitude<'py>(
         |v, e| {
             let ecc = e.ok_or_else(|| {
                 exceptions::PyValueError::new_err(
-                    "Parameter 'e' is required when 'a_or_oe' is a scalar",
+                    "Parameter 'e' is required when 'a_or_oe' is a scalar or an array of values",
                 )
             })?;
             Ok(orbits::periapsis_altitude(v, ecc, r_body))
@@ -760,18 +757,17 @@ fn py_periapsis_altitude<'py>(
 /// Calculate the altitude above Earth's surface at perigee.
 ///
 /// Args:
-///     a_or_oe (float or array): Either the semi-major axis in meters, or a 6-element
-///         Keplerian elements array [a, e, i, Ω, ω, ν] from which `a` and `e` will be extracted.
-///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
-///         arrays of any shape are evaluated element-wise (broadcast against `e`).
-///     e (float or array, optional): The eccentricity. Required if `a_or_oe` is a scalar, ignored if vector.
-///         Ignored when `a_or_oe` is an element set; otherwise broadcast against `a_or_oe` when
-///         either is an array.
+///     a_or_oe (float or array): The semi-major axis in meters, as a scalar or an array
+///         evaluated element-wise (broadcast against `e`); or, when `e` is omitted, a 2-D
+///         array of shape `(n, 6)` of Keplerian element sets [a, e, i, Ω, ω, ν] from which
+///         `a` and `e` are taken row by row.
+///     e (float or array, optional): The eccentricity, broadcast against `a_or_oe` when either is
+///         an array. Required unless `a_or_oe` is a 2-D element-set batch, where it is ignored.
 ///
 /// Returns:
 ///     float or numpy.ndarray: The altitude above Earth's surface at perigee in meters.
-///         An array is returned for array input, with shape `(n,)` for `n` element
-///         sets or the broadcast shape for element-wise input.
+///         An array is returned for array input: shape `(n,)` for `n` element sets, or the
+///         broadcast shape for element-wise input.
 ///
 /// Example:
 ///     ```python
@@ -784,9 +780,9 @@ fn py_periapsis_altitude<'py>(
 ///     alt = bh.perigee_altitude(a, e)
 ///     print(f"Perigee altitude: {alt/1000:.2f} km")
 ///
-///     # Using Keplerian elements vector
+///     # Using a batch of Keplerian element sets, one result per row
 ///     oe = [bh.R_EARTH + 420e3, 0.0005, np.radians(51.6), 0, 0, 0]
-///     alt = bh.perigee_altitude(oe)
+///     alt = bh.perigee_altitude(np.array([oe, oe]))
 ///     print(f"Perigee altitude: {alt/1000:.2f} km")
 ///     ```
 #[pyfunction]
@@ -805,7 +801,7 @@ fn py_perigee_altitude<'py>(
         |v, e| {
             let ecc = e.ok_or_else(|| {
                 exceptions::PyValueError::new_err(
-                    "Parameter 'e' is required when 'a_or_oe' is a scalar",
+                    "Parameter 'e' is required when 'a_or_oe' is a scalar or an array of values",
                 )
             })?;
             Ok(orbits::perigee_altitude(v, ecc))
@@ -816,19 +812,18 @@ fn py_perigee_altitude<'py>(
 /// Calculate the altitude above a body's surface at apoapsis.
 ///
 /// Args:
-///     a_or_oe (float or array): Either the semi-major axis in meters, or a 6-element
-///         Keplerian elements array [a, e, i, Ω, ω, ν] from which `a` and `e` will be extracted.
-///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
-///         arrays of any shape are evaluated element-wise (broadcast against `e`).
-///     e (float or array, optional): The eccentricity. Required if `a_or_oe` is a scalar, ignored if vector.
-///         Ignored when `a_or_oe` is an element set; otherwise broadcast against `a_or_oe` when
-///         either is an array.
+///     a_or_oe (float or array): The semi-major axis in meters, as a scalar or an array
+///         evaluated element-wise (broadcast against `e`); or, when `e` is omitted, a 2-D
+///         array of shape `(n, 6)` of Keplerian element sets [a, e, i, Ω, ω, ν] from which
+///         `a` and `e` are taken row by row.
+///     e (float or array, optional): The eccentricity, broadcast against `a_or_oe` when either is
+///         an array. Required unless `a_or_oe` is a 2-D element-set batch, where it is ignored.
 ///     r_body (float): (keyword-only) The radius of the central body in meters.
 ///
 /// Returns:
 ///     float or numpy.ndarray: The altitude above the body's surface at apoapsis in meters.
-///         An array is returned for array input, with shape `(n,)` for `n` element
-///         sets or the broadcast shape for element-wise input.
+///         An array is returned for array input: shape `(n,)` for `n` element sets, or the
+///         broadcast shape for element-wise input.
 ///
 /// Example:
 ///     ```python
@@ -841,9 +836,9 @@ fn py_perigee_altitude<'py>(
 ///     alt_apo = bh.apoapsis_altitude(a, e, bh.R_MOON)
 ///     print(f"Apoapsis altitude: {alt_apo/1000:.2f} km")
 ///
-///     # Using Keplerian elements vector
+///     # Using a batch of Keplerian element sets, one result per row
 ///     oe = [bh.R_MOON + 100e3, 0.05, np.radians(30), 0, 0, 0]
-///     alt_apo = bh.apoapsis_altitude(oe, r_body=bh.R_MOON)
+///     alt_apo = bh.apoapsis_altitude(np.array([oe, oe]), r_body=bh.R_MOON)
 ///     print(f"Apoapsis altitude: {alt_apo/1000:.2f} km")
 ///     ```
 #[pyfunction]
@@ -863,7 +858,7 @@ fn py_apoapsis_altitude<'py>(
         |v, e| {
             let ecc = e.ok_or_else(|| {
                 exceptions::PyValueError::new_err(
-                    "Parameter 'e' is required when 'a_or_oe' is a scalar",
+                    "Parameter 'e' is required when 'a_or_oe' is a scalar or an array of values",
                 )
             })?;
             Ok(orbits::apoapsis_altitude(v, ecc, r_body))
@@ -874,18 +869,17 @@ fn py_apoapsis_altitude<'py>(
 /// Calculate the altitude above Earth's surface at apogee.
 ///
 /// Args:
-///     a_or_oe (float or array): Either the semi-major axis in meters, or a 6-element
-///         Keplerian elements array [a, e, i, Ω, ω, ν] from which `a` and `e` will be extracted.
-///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
-///         arrays of any shape are evaluated element-wise (broadcast against `e`).
-///     e (float or array, optional): The eccentricity. Required if `a_or_oe` is a scalar, ignored if vector.
-///         Ignored when `a_or_oe` is an element set; otherwise broadcast against `a_or_oe` when
-///         either is an array.
+///     a_or_oe (float or array): The semi-major axis in meters, as a scalar or an array
+///         evaluated element-wise (broadcast against `e`); or, when `e` is omitted, a 2-D
+///         array of shape `(n, 6)` of Keplerian element sets [a, e, i, Ω, ω, ν] from which
+///         `a` and `e` are taken row by row.
+///     e (float or array, optional): The eccentricity, broadcast against `a_or_oe` when either is
+///         an array. Required unless `a_or_oe` is a 2-D element-set batch, where it is ignored.
 ///
 /// Returns:
 ///     float or numpy.ndarray: The altitude above Earth's surface at apogee in meters.
-///         An array is returned for array input, with shape `(n,)` for `n` element
-///         sets or the broadcast shape for element-wise input.
+///         An array is returned for array input: shape `(n,)` for `n` element sets, or the
+///         broadcast shape for element-wise input.
 ///
 /// Example:
 ///     ```python
@@ -898,9 +892,9 @@ fn py_apoapsis_altitude<'py>(
 ///     alt = bh.apogee_altitude(a, e)
 ///     print(f"Apogee altitude: {alt/1000:.2f} km")
 ///
-///     # Using Keplerian elements vector
+///     # Using a batch of Keplerian element sets, one result per row
 ///     oe = [26554000.0, 0.7, np.radians(63.4), 0, 0, 0]
-///     alt = bh.apogee_altitude(oe)
+///     alt = bh.apogee_altitude(np.array([oe, oe]))
 ///     print(f"Apogee altitude: {alt/1000:.2f} km")
 ///     ```
 #[pyfunction]
@@ -919,7 +913,7 @@ fn py_apogee_altitude<'py>(
         |v, e| {
             let ecc = e.ok_or_else(|| {
                 exceptions::PyValueError::new_err(
-                    "Parameter 'e' is required when 'a_or_oe' is a scalar",
+                    "Parameter 'e' is required when 'a_or_oe' is a scalar or an array of values",
                 )
             })?;
             Ok(orbits::apogee_altitude(v, ecc))
@@ -931,19 +925,18 @@ fn py_apogee_altitude<'py>(
 /// the J2 gravitational perturbation.
 ///
 /// Args:
-///     a_or_oe (float or array): Either the semi-major axis in meters, or a 6-element
-///         Keplerian elements array [a, e, i, Ω, ω, ν] from which `a` and `e` will be extracted.
-///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
-///         arrays of any shape are evaluated element-wise (broadcast against `e`).
-///     e (float or array, optional): The eccentricity. Required if `a_or_oe` is a scalar, ignored if vector.
-///         Ignored when `a_or_oe` is an element set; otherwise broadcast against `a_or_oe` when
-///         either is an array.
+///     a_or_oe (float or array): The semi-major axis in meters, as a scalar or an array
+///         evaluated element-wise (broadcast against `e`); or, when `e` is omitted, a 2-D
+///         array of shape `(n, 6)` of Keplerian element sets [a, e, i, Ω, ω, ν] from which
+///         `a` and `e` are taken row by row.
+///     e (float or array, optional): The eccentricity, broadcast against `a_or_oe` when either is
+///         an array. Required unless `a_or_oe` is a 2-D element-set batch, where it is ignored.
 ///     angle_format (AngleFormat): (keyword-only) Return output in AngleFormat.DEGREES or AngleFormat.RADIANS.
 ///
 /// Returns:
 ///     float or numpy.ndarray: Inclination for a Sun synchronous orbit in degrees or radians.
-///         An array is returned for array input, with shape `(n,)` for `n` element
-///         sets or the broadcast shape for element-wise input.
+///         An array is returned for array input: shape `(n,)` for `n` element sets, or the
+///         broadcast shape for element-wise input.
 ///
 /// Example:
 ///     ```python
@@ -956,9 +949,9 @@ fn py_apogee_altitude<'py>(
 ///     inc = bh.sun_synchronous_inclination(a, e, bh.AngleFormat.DEGREES)
 ///     print(f"Sun-synchronous inclination: {inc:.2f} degrees")
 ///
-///     # Using Keplerian elements vector
+///     # Using a batch of Keplerian element sets, one result per row
 ///     oe = [bh.R_EARTH + 600e3, 0.001, np.radians(97.8), 0, 0, 0]
-///     inc = bh.sun_synchronous_inclination(oe, angle_format=bh.AngleFormat.DEGREES)
+///     inc = bh.sun_synchronous_inclination(np.array([oe, oe]), angle_format=bh.AngleFormat.DEGREES)
 ///     print(f"Sun-synchronous inclination: {inc:.2f} degrees")
 ///     ```
 #[pyfunction]
@@ -979,7 +972,7 @@ fn py_sun_synchronous_inclination<'py>(
         |v, e| {
             let ecc = e.ok_or_else(|| {
                 exceptions::PyValueError::new_err(
-                    "Parameter 'e' is required when 'a_or_oe' is a scalar",
+                    "Parameter 'e' is required when 'a_or_oe' is a scalar or an array of values",
                 )
             })?;
             Ok(orbits::sun_synchronous_inclination(v, ecc, af))
@@ -1008,20 +1001,18 @@ fn py_geo_sma() -> PyResult<f64> {
 /// Converts eccentric anomaly into mean anomaly.
 ///
 /// Args:
-///     anm_ecc_or_oe (float or array): Either the eccentric anomaly, or a 6-element
-///         Keplerian elements array [a, e, i, Ω, ω, E] from which `e` and `E` will be extracted.
-///         The anomaly in the vector should match the `angle_format`.
-///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
-///         arrays of any shape are evaluated element-wise (broadcast against `e`).
-///     e (float or array, optional): The eccentricity. Required if `anm_ecc_or_oe` is a scalar, ignored if vector.
-///         Ignored when `anm_ecc_or_oe` is an element set; otherwise broadcast against `anm_ecc_or_oe` when
-///         either is an array.
+///     anm_ecc_or_oe (float or array): The eccentric anomaly, as a scalar or an array evaluated
+///         element-wise (broadcast against `e`); or, when `e` is omitted, a 2-D array of
+///         shape `(n, 6)` of Keplerian element sets [a, e, i, Ω, ω, M] from which `e` and the
+///         anomaly (index 5) are taken row by row. The anomaly must match the `angle_format`.
+///     e (float or array, optional): The eccentricity, broadcast against `anm_ecc_or_oe` when either is
+///         an array. Required unless `anm_ecc_or_oe` is a 2-D element-set batch, where it is ignored.
 ///     angle_format (AngleFormat): (keyword-only) Interprets input and returns output in AngleFormat.DEGREES or AngleFormat.RADIANS.
 ///
 /// Returns:
 ///     float or numpy.ndarray: Mean anomaly in radians or degrees.
-///         An array is returned for array input, with shape `(n,)` for `n` element
-///         sets or the broadcast shape for element-wise input.
+///         An array is returned for array input: shape `(n,)` for `n` element sets, or the
+///         broadcast shape for element-wise input.
 ///
 /// Example:
 ///     ```python
@@ -1034,9 +1025,9 @@ fn py_geo_sma() -> PyResult<f64> {
 ///     M = bh.anomaly_eccentric_to_mean(E, e, bh.AngleFormat.RADIANS)
 ///     print(f"Mean anomaly: {M:.4f} radians")
 ///
-///     # Using Keplerian elements vector (with eccentric anomaly at index 5)
+///     # Using a batch of Keplerian element sets (eccentric anomaly at index 5), one result per row
 ///     oe = [bh.R_EARTH + 500e3, 0.1, np.radians(45), 0, 0, np.pi/4]
-///     M = bh.anomaly_eccentric_to_mean(oe, angle_format=bh.AngleFormat.RADIANS)
+///     M = bh.anomaly_eccentric_to_mean(np.array([oe, oe]), angle_format=bh.AngleFormat.RADIANS)
 ///     print(f"Mean anomaly: {M:.4f} radians")
 ///     ```
 #[pyfunction]
@@ -1057,7 +1048,7 @@ fn py_anomaly_eccentric_to_mean<'py>(
         |v, e| {
             let ecc = e.ok_or_else(|| {
                 exceptions::PyValueError::new_err(
-                    "Parameter 'e' is required when 'anm_ecc_or_oe' is a scalar",
+                    "Parameter 'e' is required when 'anm_ecc_or_oe' is a scalar or an array of values",
                 )
             })?;
             Ok(orbits::anomaly_eccentric_to_mean(v, ecc, af))
@@ -1068,20 +1059,18 @@ fn py_anomaly_eccentric_to_mean<'py>(
 /// Converts mean anomaly into eccentric anomaly.
 ///
 /// Args:
-///     anm_mean_or_oe (float or array): Either the mean anomaly, or a 6-element
-///         Keplerian elements array [a, e, i, Ω, ω, M] from which `e` and `M` will be extracted.
-///         The anomaly in the vector should match the `angle_format`.
-///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
-///         arrays of any shape are evaluated element-wise (broadcast against `e`).
-///     e (float or array, optional): The eccentricity. Required if `anm_mean_or_oe` is a scalar, ignored if vector.
-///         Ignored when `anm_mean_or_oe` is an element set; otherwise broadcast against `anm_mean_or_oe` when
-///         either is an array.
+///     anm_mean_or_oe (float or array): The mean anomaly, as a scalar or an array evaluated
+///         element-wise (broadcast against `e`); or, when `e` is omitted, a 2-D array of
+///         shape `(n, 6)` of Keplerian element sets [a, e, i, Ω, ω, M] from which `e` and the
+///         anomaly (index 5) are taken row by row. The anomaly must match the `angle_format`.
+///     e (float or array, optional): The eccentricity, broadcast against `anm_mean_or_oe` when either is
+///         an array. Required unless `anm_mean_or_oe` is a 2-D element-set batch, where it is ignored.
 ///     angle_format (AngleFormat): (keyword-only) Interprets input and returns output in AngleFormat.DEGREES or AngleFormat.RADIANS.
 ///
 /// Returns:
 ///     float or numpy.ndarray: Eccentric anomaly in radians or degrees.
-///         An array is returned for array input, with shape `(n,)` for `n` element
-///         sets or the broadcast shape for element-wise input.
+///         An array is returned for array input: shape `(n,)` for `n` element sets, or the
+///         broadcast shape for element-wise input.
 ///
 /// Example:
 ///     ```python
@@ -1094,9 +1083,9 @@ fn py_anomaly_eccentric_to_mean<'py>(
 ///     E = bh.anomaly_mean_to_eccentric(M, e, bh.AngleFormat.RADIANS)
 ///     print(f"Eccentric anomaly: {E:.4f} radians")
 ///
-///     # Using Keplerian elements vector (with mean anomaly at index 5)
+///     # Using a batch of Keplerian element sets (mean anomaly at index 5), one result per row
 ///     oe = [bh.R_EARTH + 500e3, 0.3, np.radians(45), 0, 0, 1.5]
-///     E = bh.anomaly_mean_to_eccentric(oe, angle_format=bh.AngleFormat.RADIANS)
+///     E = bh.anomaly_mean_to_eccentric(np.array([oe, oe]), angle_format=bh.AngleFormat.RADIANS)
 ///     print(f"Eccentric anomaly: {E:.4f} radians")
 ///     ```
 #[pyfunction]
@@ -1117,7 +1106,7 @@ fn py_anomaly_mean_to_eccentric<'py>(
         |v, e| {
             let ecc = e.ok_or_else(|| {
                 exceptions::PyValueError::new_err(
-                    "Parameter 'e' is required when 'anm_mean_or_oe' is a scalar",
+                    "Parameter 'e' is required when 'anm_mean_or_oe' is a scalar or an array of values",
                 )
             })?;
             orbits::anomaly_mean_to_eccentric(v, ecc, af).map_err(exceptions::PyRuntimeError::new_err)
@@ -1128,20 +1117,18 @@ fn py_anomaly_mean_to_eccentric<'py>(
 /// Converts true anomaly into eccentric anomaly.
 ///
 /// Args:
-///     anm_true_or_oe (float or array): Either the true anomaly, or a 6-element
-///         Keplerian elements array [a, e, i, Ω, ω, ν] from which `e` and `ν` will be extracted.
-///         The anomaly in the vector should match the `angle_format`.
-///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
-///         arrays of any shape are evaluated element-wise (broadcast against `e`).
-///     e (float or array, optional): The eccentricity. Required if `anm_true_or_oe` is a scalar, ignored if vector.
-///         Ignored when `anm_true_or_oe` is an element set; otherwise broadcast against `anm_true_or_oe` when
-///         either is an array.
+///     anm_true_or_oe (float or array): The true anomaly, as a scalar or an array evaluated
+///         element-wise (broadcast against `e`); or, when `e` is omitted, a 2-D array of
+///         shape `(n, 6)` of Keplerian element sets [a, e, i, Ω, ω, M] from which `e` and the
+///         anomaly (index 5) are taken row by row. The anomaly must match the `angle_format`.
+///     e (float or array, optional): The eccentricity, broadcast against `anm_true_or_oe` when either is
+///         an array. Required unless `anm_true_or_oe` is a 2-D element-set batch, where it is ignored.
 ///     angle_format (AngleFormat): (keyword-only) Interprets input and returns output in AngleFormat.DEGREES or AngleFormat.RADIANS.
 ///
 /// Returns:
 ///     float or numpy.ndarray: Eccentric anomaly in radians or degrees.
-///         An array is returned for array input, with shape `(n,)` for `n` element
-///         sets or the broadcast shape for element-wise input.
+///         An array is returned for array input: shape `(n,)` for `n` element sets, or the
+///         broadcast shape for element-wise input.
 ///
 /// Example:
 ///     ```python
@@ -1154,9 +1141,9 @@ fn py_anomaly_mean_to_eccentric<'py>(
 ///     E = bh.anomaly_true_to_eccentric(nu, e, bh.AngleFormat.RADIANS)
 ///     print(f"Eccentric anomaly: {E:.4f} radians")
 ///
-///     # Using Keplerian elements vector (with true anomaly at index 5)
+///     # Using a batch of Keplerian element sets (true anomaly at index 5), one result per row
 ///     oe = [bh.R_EARTH + 500e3, 0.2, np.radians(45), 0, 0, np.pi/3]
-///     E = bh.anomaly_true_to_eccentric(oe, angle_format=bh.AngleFormat.RADIANS)
+///     E = bh.anomaly_true_to_eccentric(np.array([oe, oe]), angle_format=bh.AngleFormat.RADIANS)
 ///     print(f"Eccentric anomaly: {E:.4f} radians")
 ///     ```
 #[pyfunction]
@@ -1177,7 +1164,7 @@ fn py_anomaly_true_to_eccentric<'py>(
         |v, e| {
             let ecc = e.ok_or_else(|| {
                 exceptions::PyValueError::new_err(
-                    "Parameter 'e' is required when 'anm_true_or_oe' is a scalar",
+                    "Parameter 'e' is required when 'anm_true_or_oe' is a scalar or an array of values",
                 )
             })?;
             Ok(orbits::anomaly_true_to_eccentric(v, ecc, af))
@@ -1188,20 +1175,18 @@ fn py_anomaly_true_to_eccentric<'py>(
 /// Converts eccentric anomaly into true anomaly.
 ///
 /// Args:
-///     anm_ecc_or_oe (float or array): Either the eccentric anomaly, or a 6-element
-///         Keplerian elements array [a, e, i, Ω, ω, E] from which `e` and `E` will be extracted.
-///         The anomaly in the vector should match the `angle_format`.
-///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
-///         arrays of any shape are evaluated element-wise (broadcast against `e`).
-///     e (float or array, optional): The eccentricity. Required if `anm_ecc_or_oe` is a scalar, ignored if vector.
-///         Ignored when `anm_ecc_or_oe` is an element set; otherwise broadcast against `anm_ecc_or_oe` when
-///         either is an array.
+///     anm_ecc_or_oe (float or array): The eccentric anomaly, as a scalar or an array evaluated
+///         element-wise (broadcast against `e`); or, when `e` is omitted, a 2-D array of
+///         shape `(n, 6)` of Keplerian element sets [a, e, i, Ω, ω, M] from which `e` and the
+///         anomaly (index 5) are taken row by row. The anomaly must match the `angle_format`.
+///     e (float or array, optional): The eccentricity, broadcast against `anm_ecc_or_oe` when either is
+///         an array. Required unless `anm_ecc_or_oe` is a 2-D element-set batch, where it is ignored.
 ///     angle_format (AngleFormat): (keyword-only) Interprets input and returns output in AngleFormat.DEGREES or AngleFormat.RADIANS.
 ///
 /// Returns:
 ///     float or numpy.ndarray: True anomaly in radians or degrees.
-///         An array is returned for array input, with shape `(n,)` for `n` element
-///         sets or the broadcast shape for element-wise input.
+///         An array is returned for array input: shape `(n,)` for `n` element sets, or the
+///         broadcast shape for element-wise input.
 ///
 /// Example:
 ///     ```python
@@ -1214,9 +1199,9 @@ fn py_anomaly_true_to_eccentric<'py>(
 ///     nu = bh.anomaly_eccentric_to_true(E, e, bh.AngleFormat.RADIANS)
 ///     print(f"True anomaly: {nu:.4f} radians")
 ///
-///     # Using Keplerian elements vector (with eccentric anomaly at index 5)
+///     # Using a batch of Keplerian element sets (eccentric anomaly at index 5), one result per row
 ///     oe = [bh.R_EARTH + 500e3, 0.4, np.radians(45), 0, 0, np.pi/4]
-///     nu = bh.anomaly_eccentric_to_true(oe, angle_format=bh.AngleFormat.RADIANS)
+///     nu = bh.anomaly_eccentric_to_true(np.array([oe, oe]), angle_format=bh.AngleFormat.RADIANS)
 ///     print(f"True anomaly: {nu:.4f} radians")
 ///     ```
 #[pyfunction]
@@ -1237,7 +1222,7 @@ fn py_anomaly_eccentric_to_true<'py>(
         |v, e| {
             let ecc = e.ok_or_else(|| {
                 exceptions::PyValueError::new_err(
-                    "Parameter 'e' is required when 'anm_ecc_or_oe' is a scalar",
+                    "Parameter 'e' is required when 'anm_ecc_or_oe' is a scalar or an array of values",
                 )
             })?;
             Ok(orbits::anomaly_eccentric_to_true(v, ecc, af))
@@ -1248,20 +1233,18 @@ fn py_anomaly_eccentric_to_true<'py>(
 /// Converts true anomaly into mean anomaly.
 ///
 /// Args:
-///     anm_true_or_oe (float or array): Either the true anomaly, or a 6-element
-///         Keplerian elements array [a, e, i, Ω, ω, ν] from which `e` and `ν` will be extracted.
-///         The anomaly in the vector should match the `angle_format`.
-///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
-///         arrays of any shape are evaluated element-wise (broadcast against `e`).
-///     e (float or array, optional): The eccentricity. Required if `anm_true_or_oe` is a scalar, ignored if vector.
-///         Ignored when `anm_true_or_oe` is an element set; otherwise broadcast against `anm_true_or_oe` when
-///         either is an array.
+///     anm_true_or_oe (float or array): The true anomaly, as a scalar or an array evaluated
+///         element-wise (broadcast against `e`); or, when `e` is omitted, a 2-D array of
+///         shape `(n, 6)` of Keplerian element sets [a, e, i, Ω, ω, M] from which `e` and the
+///         anomaly (index 5) are taken row by row. The anomaly must match the `angle_format`.
+///     e (float or array, optional): The eccentricity, broadcast against `anm_true_or_oe` when either is
+///         an array. Required unless `anm_true_or_oe` is a 2-D element-set batch, where it is ignored.
 ///     angle_format (AngleFormat): (keyword-only) Interprets input and returns output in AngleFormat.DEGREES or AngleFormat.RADIANS.
 ///
 /// Returns:
 ///     float or numpy.ndarray: Mean anomaly in radians or degrees.
-///         An array is returned for array input, with shape `(n,)` for `n` element
-///         sets or the broadcast shape for element-wise input.
+///         An array is returned for array input: shape `(n,)` for `n` element sets, or the
+///         broadcast shape for element-wise input.
 ///
 /// Example:
 ///     ```python
@@ -1274,9 +1257,9 @@ fn py_anomaly_eccentric_to_true<'py>(
 ///     M = bh.anomaly_true_to_mean(nu, e, bh.AngleFormat.RADIANS)
 ///     print(f"Mean anomaly: {M:.4f} radians")
 ///
-///     # Using Keplerian elements vector (with true anomaly at index 5)
+///     # Using a batch of Keplerian element sets (true anomaly at index 5), one result per row
 ///     oe = [bh.R_EARTH + 500e3, 0.15, np.radians(45), 0, 0, np.pi/2]
-///     M = bh.anomaly_true_to_mean(oe, angle_format=bh.AngleFormat.RADIANS)
+///     M = bh.anomaly_true_to_mean(np.array([oe, oe]), angle_format=bh.AngleFormat.RADIANS)
 ///     print(f"Mean anomaly: {M:.4f} radians")
 ///     ```
 #[pyfunction]
@@ -1297,7 +1280,7 @@ fn py_anomaly_true_to_mean<'py>(
         |v, e| {
             let ecc = e.ok_or_else(|| {
                 exceptions::PyValueError::new_err(
-                    "Parameter 'e' is required when 'anm_true_or_oe' is a scalar",
+                    "Parameter 'e' is required when 'anm_true_or_oe' is a scalar or an array of values",
                 )
             })?;
             Ok(orbits::anomaly_true_to_mean(v, ecc, af))
@@ -1308,20 +1291,18 @@ fn py_anomaly_true_to_mean<'py>(
 /// Converts mean anomaly into true anomaly.
 ///
 /// Args:
-///     anm_mean_or_oe (float or array): Either the mean anomaly, or a 6-element
-///         Keplerian elements array [a, e, i, Ω, ω, M] from which `e` and `M` will be extracted.
-///         The anomaly in the vector should match the `angle_format`.
-///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
-///         arrays of any shape are evaluated element-wise (broadcast against `e`).
-///     e (float or array, optional): The eccentricity. Required if `anm_mean_or_oe` is a scalar, ignored if vector.
-///         Ignored when `anm_mean_or_oe` is an element set; otherwise broadcast against `anm_mean_or_oe` when
-///         either is an array.
+///     anm_mean_or_oe (float or array): The mean anomaly, as a scalar or an array evaluated
+///         element-wise (broadcast against `e`); or, when `e` is omitted, a 2-D array of
+///         shape `(n, 6)` of Keplerian element sets [a, e, i, Ω, ω, M] from which `e` and the
+///         anomaly (index 5) are taken row by row. The anomaly must match the `angle_format`.
+///     e (float or array, optional): The eccentricity, broadcast against `anm_mean_or_oe` when either is
+///         an array. Required unless `anm_mean_or_oe` is a 2-D element-set batch, where it is ignored.
 ///     angle_format (AngleFormat): (keyword-only) Interprets input and returns output in AngleFormat.DEGREES or AngleFormat.RADIANS.
 ///
 /// Returns:
 ///     float or numpy.ndarray: True anomaly in radians or degrees.
-///         An array is returned for array input, with shape `(n,)` for `n` element
-///         sets or the broadcast shape for element-wise input.
+///         An array is returned for array input: shape `(n,)` for `n` element sets, or the
+///         broadcast shape for element-wise input.
 ///
 /// Example:
 ///     ```python
@@ -1334,9 +1315,9 @@ fn py_anomaly_true_to_mean<'py>(
 ///     nu = bh.anomaly_mean_to_true(M, e, bh.AngleFormat.RADIANS)
 ///     print(f"True anomaly: {nu:.4f} radians")
 ///
-///     # Using Keplerian elements vector (with mean anomaly at index 5)
+///     # Using a batch of Keplerian element sets (mean anomaly at index 5), one result per row
 ///     oe = [bh.R_EARTH + 500e3, 0.25, np.radians(45), 0, 0, 2.0]
-///     nu = bh.anomaly_mean_to_true(oe, angle_format=bh.AngleFormat.RADIANS)
+///     nu = bh.anomaly_mean_to_true(np.array([oe, oe]), angle_format=bh.AngleFormat.RADIANS)
 ///     print(f"True anomaly: {nu:.4f} radians")
 ///     ```
 #[pyfunction]
@@ -1357,7 +1338,7 @@ fn py_anomaly_mean_to_true<'py>(
         |v, e| {
             let ecc = e.ok_or_else(|| {
                 exceptions::PyValueError::new_err(
-                    "Parameter 'e' is required when 'anm_mean_or_oe' is a scalar",
+                    "Parameter 'e' is required when 'anm_mean_or_oe' is a scalar or an array of values",
                 )
             })?;
             orbits::anomaly_mean_to_true(v, ecc, af).map_err(exceptions::PyRuntimeError::new_err)

--- a/crates/brahe-py/src/orbits.rs
+++ b/crates/brahe-py/src/orbits.rs
@@ -5,9 +5,12 @@
 /// Args:
 ///     a_or_oe (float or array): Either the semi-major axis in meters, or a 6-element
 ///         Keplerian elements array [a, e, i, Ω, ω, ν] from which `a` will be extracted.
+///         A 2-D array of shape `(n, 6)` is treated as `n` element sets.
 ///
 /// Returns:
-///     float: The orbital period of the astronomical object in seconds.
+///     float or numpy.ndarray: The orbital period of the astronomical object in seconds.
+///         An array is returned for array input, with shape `(n,)` for `n` element
+///         sets or the broadcast shape for element-wise input.
 ///
 /// Example:
 ///     ```python
@@ -25,17 +28,19 @@
 ///     print(f"Orbital period: {period/60:.2f} minutes")
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(a_or_oe)")]
+#[pyo3(signature = (a_or_oe), text_signature = "(a_or_oe)")]
 #[pyo3(name = "orbital_period")]
-fn py_orbital_period(a_or_oe: &Bound<'_, PyAny>) -> PyResult<f64> {
-    // Try to extract as scalar first
-    if let Ok(a) = a_or_oe.extract::<f64>() {
-        return Ok(orbits::orbital_period(a));
-    }
-
-    // Try to extract as vector (Keplerian elements)
-    let oe = pyany_to_f64_array1(a_or_oe, Some(6))?;
-    Ok(orbits::orbital_period(oe[0]))
+fn py_orbital_period<'py>(
+    py: Python<'py>,
+    a_or_oe: &Bound<'py, PyAny>,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_oe_or_scalar(
+        py,
+        a_or_oe,
+        None,
+        |oe| Ok(orbits::orbital_period(oe[0])),
+        |v, _| Ok(orbits::orbital_period(v)),
+    )
 }
 
 /// Computes the orbital period of an astronomical object around a general body.
@@ -43,10 +48,13 @@ fn py_orbital_period(a_or_oe: &Bound<'_, PyAny>) -> PyResult<f64> {
 /// Args:
 ///     a_or_oe (float or array): Either the semi-major axis in meters, or a 6-element
 ///         Keplerian elements array [a, e, i, Ω, ω, ν] from which `a` will be extracted.
+///         A 2-D array of shape `(n, 6)` is treated as `n` element sets.
 ///     gm (float): (keyword-only) The standard gravitational parameter of primary body in m³/s².
 ///
 /// Returns:
-///     float: The orbital period of the astronomical object in seconds.
+///     float or numpy.ndarray: The orbital period of the astronomical object in seconds.
+///         An array is returned for array input, with shape `(n,)` for `n` element
+///         sets or the broadcast shape for element-wise input.
 ///
 /// Example:
 ///     ```python
@@ -64,17 +72,20 @@ fn py_orbital_period(a_or_oe: &Bound<'_, PyAny>) -> PyResult<f64> {
 ///     print(f"Lunar orbital period: {period/3600:.2f} hours")
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(a_or_oe, gm)")]
+#[pyo3(signature = (a_or_oe, gm), text_signature = "(a_or_oe, gm)")]
 #[pyo3(name = "orbital_period_general")]
-fn py_orbital_period_general(a_or_oe: &Bound<'_, PyAny>, gm: f64) -> PyResult<f64> {
-    // Try to extract as scalar first
-    if let Ok(a) = a_or_oe.extract::<f64>() {
-        return Ok(orbits::orbital_period_general(a, gm));
-    }
-
-    // Try to extract as vector (Keplerian elements)
-    let oe = pyany_to_f64_array1(a_or_oe, Some(6))?;
-    Ok(orbits::orbital_period_general(oe[0], gm))
+fn py_orbital_period_general<'py>(
+    py: Python<'py>,
+    a_or_oe: &Bound<'py, PyAny>,
+    gm: f64,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_oe_or_scalar(
+        py,
+        a_or_oe,
+        None,
+        |oe| Ok(orbits::orbital_period_general(oe[0], gm)),
+        |v, _| Ok(orbits::orbital_period_general(v, gm)),
+    )
 }
 
 /// Computes orbital period from an ECI state vector using the vis-viva equation.
@@ -83,11 +94,16 @@ fn py_orbital_period_general(a_or_oe: &Bound<'_, PyAny>, gm: f64) -> PyResult<f6
 /// position and velocity, then calculates the orbital period.
 ///
 /// Args:
-///     state_eci (np.ndarray): ECI state vector [x, y, z, vx, vy, vz] in meters and meters/second.
+///     state_eci (numpy.ndarray or list): ECI state vector [x, y, z, vx, vy, vz] in meters and meters/second.
+///         Also accepts a batch of states with the 6 components along `axis`
+///         (for example shape `(n, 6)`).
 ///     gm (float): Gravitational parameter in m³/s². Use GM_EARTH for Earth orbits.
+///     axis (int, optional): Axis of `state_eci` holding the state components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
-///     float: Orbital period in seconds.
+///     float or numpy.ndarray: Orbital period in seconds.
+///         An array of the batch dimensions is returned for batched input.
 ///
 /// Example:
 ///     ```python
@@ -104,22 +120,24 @@ fn py_orbital_period_general(a_or_oe: &Bound<'_, PyAny>, gm: f64) -> PyResult<f6
 ///     print(f"Period: {period/60:.2f} minutes")
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(state_eci, gm)")]
+#[pyo3(signature = (state_eci, gm, axis=-1), text_signature = "(state_eci, gm, axis=-1)")]
 #[pyo3(name = "orbital_period_from_state")]
-fn py_orbital_period_from_state(
-    _py: Python,
-    state_eci: PyReadonlyArray1<f64>,
+fn py_orbital_period_from_state<'py>(
+    py: Python<'py>,
+    state_eci: &Bound<'py, PyAny>,
     gm: f64,
-) -> PyResult<f64> {
-    let state = state_eci.as_array();
-    if state.len() != 6 {
-        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    if let Ok(v) = state_eci.extract::<Vec<f64>>()
+        && v.len() != 6
+    {
+        return Err(exceptions::PyValueError::new_err(
             "state_eci must be a 6-element array [x, y, z, vx, vy, vz]",
         ));
     }
-
-    let state_vec = nalgebra::Vector6::from_iterator(state.iter().copied());
-    Ok(orbits::orbital_period_from_state(&state_vec, gm))
+    dispatch_vec_to_scalar::<6>(py, state_eci, axis, |s| {
+        orbits::orbital_period_from_state(&s, gm)
+    })
 }
 
 /// Computes the mean motion of an astronomical object around Earth.
@@ -127,10 +145,13 @@ fn py_orbital_period_from_state(
 /// Args:
 ///     a_or_oe (float or array): Either the semi-major axis in meters, or a 6-element
 ///         Keplerian elements array [a, e, i, Ω, ω, ν] from which `a` will be extracted.
+///         A 2-D array of shape `(n, 6)` is treated as `n` element sets.
 ///     angle_format (AngleFormat): (keyword-only) Return output in AngleFormat.DEGREES or AngleFormat.RADIANS.
 ///
 /// Returns:
-///     float: The mean motion of the astronomical object in radians or degrees.
+///     float or numpy.ndarray: The mean motion of the astronomical object in radians or degrees.
+///         An array is returned for array input, with shape `(n,)` for `n` element
+///         sets or the broadcast shape for element-wise input.
 ///
 /// Example:
 ///     ```python
@@ -148,17 +169,21 @@ fn py_orbital_period_from_state(
 ///     print(f"Mean motion: {n:.6f} deg/s")
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(a_or_oe, angle_format)")]
+#[pyo3(signature = (a_or_oe, angle_format), text_signature = "(a_or_oe, angle_format)")]
 #[pyo3(name = "mean_motion")]
-fn py_mean_motion(a_or_oe: &Bound<'_, PyAny>, angle_format: &PyAngleFormat) -> PyResult<f64> {
-    // Try to extract as scalar first
-    if let Ok(a) = a_or_oe.extract::<f64>() {
-        return Ok(orbits::mean_motion(a, angle_format.value));
-    }
-
-    // Try to extract as vector (Keplerian elements)
-    let oe = pyany_to_f64_array1(a_or_oe, Some(6))?;
-    Ok(orbits::mean_motion(oe[0], angle_format.value))
+fn py_mean_motion<'py>(
+    py: Python<'py>,
+    a_or_oe: &Bound<'py, PyAny>,
+    angle_format: &PyAngleFormat,
+) -> PyResult<Bound<'py, PyAny>> {
+    let af = angle_format.value;
+    dispatch_oe_or_scalar(
+        py,
+        a_or_oe,
+        None,
+        |oe| Ok(orbits::mean_motion(oe[0], af)),
+        |v, _| Ok(orbits::mean_motion(v, af)),
+    )
 }
 
 /// Computes the mean motion of an astronomical object around a general body
@@ -167,11 +192,14 @@ fn py_mean_motion(a_or_oe: &Bound<'_, PyAny>, angle_format: &PyAngleFormat) -> P
 /// Args:
 ///     a_or_oe (float or array): Either the semi-major axis in meters, or a 6-element
 ///         Keplerian elements array [a, e, i, Ω, ω, ν] from which `a` will be extracted.
+///         A 2-D array of shape `(n, 6)` is treated as `n` element sets.
 ///     gm (float): (keyword-only) The standard gravitational parameter of primary body in m³/s².
 ///     angle_format (AngleFormat): (keyword-only) Return output in AngleFormat.DEGREES or AngleFormat.RADIANS.
 ///
 /// Returns:
-///     float: The mean motion of the astronomical object in radians or degrees.
+///     float or numpy.ndarray: The mean motion of the astronomical object in radians or degrees.
+///         An array is returned for array input, with shape `(n,)` for `n` element
+///         sets or the broadcast shape for element-wise input.
 ///
 /// Example:
 ///     ```python
@@ -189,28 +217,35 @@ fn py_mean_motion(a_or_oe: &Bound<'_, PyAny>, angle_format: &PyAngleFormat) -> P
 ///     print(f"Mean motion: {n:.6f} rad/s")
 ///     ```
 #[pyfunction]
-#[pyo3(text_signature = "(a_or_oe, gm, angle_format)")]
+#[pyo3(signature = (a_or_oe, gm, angle_format), text_signature = "(a_or_oe, gm, angle_format)")]
 #[pyo3(name = "mean_motion_general")]
-fn py_mean_motion_general(a_or_oe: &Bound<'_, PyAny>, gm: f64, angle_format: &PyAngleFormat) -> PyResult<f64> {
-    // Try to extract as scalar first
-    if let Ok(a) = a_or_oe.extract::<f64>() {
-        return Ok(orbits::mean_motion_general(a, gm, angle_format.value));
-    }
-
-    // Try to extract as vector (Keplerian elements)
-    let oe = pyany_to_f64_array1(a_or_oe, Some(6))?;
-    Ok(orbits::mean_motion_general(oe[0], gm, angle_format.value))
+fn py_mean_motion_general<'py>(
+    py: Python<'py>,
+    a_or_oe: &Bound<'py, PyAny>,
+    gm: f64,
+    angle_format: &PyAngleFormat,
+) -> PyResult<Bound<'py, PyAny>> {
+    let af = angle_format.value;
+    dispatch_oe_or_scalar(
+        py,
+        a_or_oe,
+        None,
+        |oe| Ok(orbits::mean_motion_general(oe[0], gm, af)),
+        |v, _| Ok(orbits::mean_motion_general(v, gm, af)),
+    )
 }
 
 /// Computes the semi-major axis of an astronomical object from Earth
 /// given the object's mean motion.
 ///
 /// Args:
-///     n (float): The mean motion of the astronomical object in radians or degrees.
+///     n (float or array): The mean motion of the astronomical object in radians or degrees.
+///         An array is evaluated element-wise.
 ///     angle_format (AngleFormat): Interpret mean motion as AngleFormat.DEGREES or AngleFormat.RADIANS.
 ///
 /// Returns:
-///     float: The semi-major axis of the astronomical object in meters.
+///     float or numpy.ndarray: The semi-major axis of the astronomical object in meters.
+///         An array of the input shape is returned for array input.
 ///
 /// Example:
 ///     ```python
@@ -224,20 +259,27 @@ fn py_mean_motion_general(a_or_oe: &Bound<'_, PyAny>, gm: f64, angle_format: &Py
 #[pyfunction]
 #[pyo3(text_signature = "(n, angle_format)")]
 #[pyo3(name = "semimajor_axis")]
-fn py_semimajor_axis(n: f64, angle_format: &PyAngleFormat) -> PyResult<f64> {
-    Ok(orbits::semimajor_axis(n, angle_format.value))
+fn py_semimajor_axis<'py>(
+    py: Python<'py>,
+    n: &Bound<'py, PyAny>,
+    angle_format: &PyAngleFormat,
+) -> PyResult<Bound<'py, PyAny>> {
+    let af = angle_format.value;
+    ufunc(py, &[n], |v| Ok(orbits::semimajor_axis(v[0], af)))
 }
 
 /// Computes the semi-major axis of an astronomical object from a general body
 /// given the object's mean motion.
 ///
 /// Args:
-///     n (float): The mean motion of the astronomical object in radians or degrees.
+///     n (float or array): The mean motion of the astronomical object in radians or degrees.
+///         An array is evaluated element-wise.
 ///     gm (float): (keyword-only) The standard gravitational parameter of primary body in m³/s².
 ///     angle_format (AngleFormat): Interpret mean motion as AngleFormat.DEGREES or AngleFormat.RADIANS.
 ///
 /// Returns:
-///     float: The semi-major axis of the astronomical object in meters.
+///     float or numpy.ndarray: The semi-major axis of the astronomical object in meters.
+///         An array of the input shape is returned for array input.
 ///
 /// Example:
 ///     ```python
@@ -251,18 +293,26 @@ fn py_semimajor_axis(n: f64, angle_format: &PyAngleFormat) -> PyResult<f64> {
 #[pyfunction]
 #[pyo3(text_signature = "(n, gm, angle_format)")]
 #[pyo3(name = "semimajor_axis_general")]
-fn py_semimajor_axis_general(n: f64, gm: f64, angle_format: &PyAngleFormat) -> PyResult<f64> {
-    Ok(orbits::semimajor_axis_general(n, gm, angle_format.value))
+fn py_semimajor_axis_general<'py>(
+    py: Python<'py>,
+    n: &Bound<'py, PyAny>,
+    gm: f64,
+    angle_format: &PyAngleFormat,
+) -> PyResult<Bound<'py, PyAny>> {
+    let af = angle_format.value;
+    ufunc(py, &[n], |v| Ok(orbits::semimajor_axis_general(v[0], gm, af)))
 }
 
 /// Computes the semi-major axis from orbital period for a general body.
 ///
 /// Args:
-///     period (float): The orbital period in seconds.
+///     period (float or array): The orbital period in seconds.
+///         An array is evaluated element-wise.
 ///     gm (float): (keyword-only) The standard gravitational parameter of primary body in m³/s².
 ///
 /// Returns:
-///     float: The semi-major axis in meters.
+///     float or numpy.ndarray: The semi-major axis in meters.
+///         An array of the input shape is returned for array input.
 ///
 /// Example:
 ///     ```python
@@ -276,17 +326,23 @@ fn py_semimajor_axis_general(n: f64, gm: f64, angle_format: &PyAngleFormat) -> P
 #[pyfunction]
 #[pyo3(text_signature = "(period, gm)")]
 #[pyo3(name = "semimajor_axis_from_orbital_period_general")]
-fn py_semimajor_axis_from_orbital_period_general(period: f64, gm: f64) -> PyResult<f64> {
-    Ok(orbits::semimajor_axis_from_orbital_period_general(period, gm))
+fn py_semimajor_axis_from_orbital_period_general<'py>(
+    py: Python<'py>,
+    period: &Bound<'py, PyAny>,
+    gm: f64,
+) -> PyResult<Bound<'py, PyAny>> {
+    ufunc(py, &[period], |v| Ok(orbits::semimajor_axis_from_orbital_period_general(v[0], gm)))
 }
 
 /// Computes the semi-major axis from orbital period around Earth.
 ///
 /// Args:
-///     period (float): The orbital period in seconds.
+///     period (float or array): The orbital period in seconds.
+///         An array is evaluated element-wise.
 ///
 /// Returns:
-///     float: The semi-major axis in meters.
+///     float or numpy.ndarray: The semi-major axis in meters.
+///         An array of the input shape is returned for array input.
 ///
 /// Example:
 ///     ```python
@@ -300,8 +356,11 @@ fn py_semimajor_axis_from_orbital_period_general(period: f64, gm: f64) -> PyResu
 #[pyfunction]
 #[pyo3(text_signature = "(period)")]
 #[pyo3(name = "semimajor_axis_from_orbital_period")]
-fn py_semimajor_axis_from_orbital_period(period: f64) -> PyResult<f64> {
-    Ok(orbits::semimajor_axis_from_orbital_period(period))
+fn py_semimajor_axis_from_orbital_period<'py>(
+    py: Python<'py>,
+    period: &Bound<'py, PyAny>,
+) -> PyResult<Bound<'py, PyAny>> {
+    ufunc(py, &[period], |v| Ok(orbits::semimajor_axis_from_orbital_period(v[0])))
 }
 
 /// Computes the perigee velocity of an astronomical object around Earth.
@@ -309,10 +368,15 @@ fn py_semimajor_axis_from_orbital_period(period: f64) -> PyResult<f64> {
 /// Args:
 ///     a_or_oe (float or array): Either the semi-major axis in meters, or a 6-element
 ///         Keplerian elements array [a, e, i, Ω, ω, ν] from which `a` and `e` will be extracted.
-///     e (float, optional): The eccentricity. Required if `a_or_oe` is a scalar, ignored if vector.
+///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
+///         arrays of any shape are evaluated element-wise (broadcast against `e`).
+///     e (float or array, optional): The eccentricity. Required if `a_or_oe` is a scalar, ignored if vector.
+///         Broadcast against `a_or_oe` when either is an array.
 ///
 /// Returns:
-///     float: The magnitude of velocity of the object at perigee in m/s.
+///     float or numpy.ndarray: The magnitude of velocity of the object at perigee in m/s.
+///         An array is returned for array input, with shape `(n,)` for `n` element
+///         sets or the broadcast shape for element-wise input.
 ///
 /// Example:
 ///     ```python
@@ -333,18 +397,25 @@ fn py_semimajor_axis_from_orbital_period(period: f64) -> PyResult<f64> {
 #[pyfunction]
 #[pyo3(signature = (a_or_oe, e=None), text_signature = "(a_or_oe, e=None)")]
 #[pyo3(name = "perigee_velocity")]
-fn py_perigee_velocity(a_or_oe: &Bound<'_, PyAny>, e: Option<f64>) -> PyResult<f64> {
-    // Try to extract as scalar first
-    if let Ok(a) = a_or_oe.extract::<f64>() {
-        let ecc = e.ok_or_else(|| exceptions::PyValueError::new_err(
-            "Parameter 'e' is required when 'a_or_oe' is a scalar"
-        ))?;
-        return Ok(orbits::perigee_velocity(a, ecc));
-    }
-
-    // Try to extract as vector (Keplerian elements)
-    let oe = pyany_to_f64_array1(a_or_oe, Some(6))?;
-    Ok(orbits::perigee_velocity(oe[0], oe[1]))
+fn py_perigee_velocity<'py>(
+    py: Python<'py>,
+    a_or_oe: &Bound<'py, PyAny>,
+    e: Option<&Bound<'py, PyAny>>,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_oe_or_scalar(
+        py,
+        a_or_oe,
+        e,
+        |oe| Ok(orbits::perigee_velocity(oe[0], oe[1])),
+        |v, e| {
+            let ecc = e.ok_or_else(|| {
+                exceptions::PyValueError::new_err(
+                    "Parameter 'e' is required when 'a_or_oe' is a scalar",
+                )
+            })?;
+            Ok(orbits::perigee_velocity(v, ecc))
+        },
+    )
 }
 
 /// Computes the periapsis velocity of an astronomical object around a general body.
@@ -352,11 +423,16 @@ fn py_perigee_velocity(a_or_oe: &Bound<'_, PyAny>, e: Option<f64>) -> PyResult<f
 /// Args:
 ///     a_or_oe (float or array): Either the semi-major axis in meters, or a 6-element
 ///         Keplerian elements array [a, e, i, Ω, ω, ν] from which `a` and `e` will be extracted.
-///     e (float, optional): The eccentricity. Required if `a_or_oe` is a scalar, ignored if vector.
+///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
+///         arrays of any shape are evaluated element-wise (broadcast against `e`).
+///     e (float or array, optional): The eccentricity. Required if `a_or_oe` is a scalar, ignored if vector.
+///         Broadcast against `a_or_oe` when either is an array.
 ///     gm (float): (keyword-only) The standard gravitational parameter of primary body in m³/s².
 ///
 /// Returns:
-///     float: The magnitude of velocity of the object at periapsis in m/s.
+///     float or numpy.ndarray: The magnitude of velocity of the object at periapsis in m/s.
+///         An array is returned for array input, with shape `(n,)` for `n` element
+///         sets or the broadcast shape for element-wise input.
 ///
 /// Example:
 ///     ```python
@@ -377,18 +453,26 @@ fn py_perigee_velocity(a_or_oe: &Bound<'_, PyAny>, e: Option<f64>) -> PyResult<f
 #[pyfunction]
 #[pyo3(signature = (a_or_oe, e=None, *, gm), text_signature = "(a_or_oe, e=None, *, gm)")]
 #[pyo3(name = "periapsis_velocity")]
-fn py_periapsis_velocity(a_or_oe: &Bound<'_, PyAny>, e: Option<f64>, gm: f64) -> PyResult<f64> {
-    // Try to extract as scalar first
-    if let Ok(a) = a_or_oe.extract::<f64>() {
-        let ecc = e.ok_or_else(|| exceptions::PyValueError::new_err(
-            "Parameter 'e' is required when 'a_or_oe' is a scalar"
-        ))?;
-        return Ok(orbits::periapsis_velocity(a, ecc, gm));
-    }
-
-    // Try to extract as vector (Keplerian elements)
-    let oe = pyany_to_f64_array1(a_or_oe, Some(6))?;
-    Ok(orbits::periapsis_velocity(oe[0], oe[1], gm))
+fn py_periapsis_velocity<'py>(
+    py: Python<'py>,
+    a_or_oe: &Bound<'py, PyAny>,
+    e: Option<&Bound<'py, PyAny>>,
+    gm: f64,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_oe_or_scalar(
+        py,
+        a_or_oe,
+        e,
+        |oe| Ok(orbits::periapsis_velocity(oe[0], oe[1], gm)),
+        |v, e| {
+            let ecc = e.ok_or_else(|| {
+                exceptions::PyValueError::new_err(
+                    "Parameter 'e' is required when 'a_or_oe' is a scalar",
+                )
+            })?;
+            Ok(orbits::periapsis_velocity(v, ecc, gm))
+        },
+    )
 }
 
 /// Calculate the distance of an object at its periapsis.
@@ -396,10 +480,15 @@ fn py_periapsis_velocity(a_or_oe: &Bound<'_, PyAny>, e: Option<f64>, gm: f64) ->
 /// Args:
 ///     a_or_oe (float or array): Either the semi-major axis in meters, or a 6-element
 ///         Keplerian elements array [a, e, i, Ω, ω, ν] from which `a` and `e` will be extracted.
-///     e (float, optional): The eccentricity. Required if `a_or_oe` is a scalar, ignored if vector.
+///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
+///         arrays of any shape are evaluated element-wise (broadcast against `e`).
+///     e (float or array, optional): The eccentricity. Required if `a_or_oe` is a scalar, ignored if vector.
+///         Broadcast against `a_or_oe` when either is an array.
 ///
 /// Returns:
-///     float: The distance of the object at periapsis in meters.
+///     float or numpy.ndarray: The distance of the object at periapsis in meters.
+///         An array is returned for array input, with shape `(n,)` for `n` element
+///         sets or the broadcast shape for element-wise input.
 ///
 /// Example:
 ///     ```python
@@ -420,18 +509,25 @@ fn py_periapsis_velocity(a_or_oe: &Bound<'_, PyAny>, e: Option<f64>, gm: f64) ->
 #[pyfunction]
 #[pyo3(signature = (a_or_oe, e=None), text_signature = "(a_or_oe, e=None)")]
 #[pyo3(name = "periapsis_distance")]
-fn py_periapsis_distance(a_or_oe: &Bound<'_, PyAny>, e: Option<f64>) -> PyResult<f64> {
-    // Try to extract as scalar first
-    if let Ok(a) = a_or_oe.extract::<f64>() {
-        let ecc = e.ok_or_else(|| exceptions::PyValueError::new_err(
-            "Parameter 'e' is required when 'a_or_oe' is a scalar"
-        ))?;
-        return Ok(orbits::periapsis_distance(a, ecc));
-    }
-
-    // Try to extract as vector (Keplerian elements)
-    let oe = pyany_to_f64_array1(a_or_oe, Some(6))?;
-    Ok(orbits::periapsis_distance(oe[0], oe[1]))
+fn py_periapsis_distance<'py>(
+    py: Python<'py>,
+    a_or_oe: &Bound<'py, PyAny>,
+    e: Option<&Bound<'py, PyAny>>,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_oe_or_scalar(
+        py,
+        a_or_oe,
+        e,
+        |oe| Ok(orbits::periapsis_distance(oe[0], oe[1])),
+        |v, e| {
+            let ecc = e.ok_or_else(|| {
+                exceptions::PyValueError::new_err(
+                    "Parameter 'e' is required when 'a_or_oe' is a scalar",
+                )
+            })?;
+            Ok(orbits::periapsis_distance(v, ecc))
+        },
+    )
 }
 
 /// Computes the apogee velocity of an astronomical object around Earth.
@@ -439,10 +535,15 @@ fn py_periapsis_distance(a_or_oe: &Bound<'_, PyAny>, e: Option<f64>) -> PyResult
 /// Args:
 ///     a_or_oe (float or array): Either the semi-major axis in meters, or a 6-element
 ///         Keplerian elements array [a, e, i, Ω, ω, ν] from which `a` and `e` will be extracted.
-///     e (float, optional): The eccentricity. Required if `a_or_oe` is a scalar, ignored if vector.
+///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
+///         arrays of any shape are evaluated element-wise (broadcast against `e`).
+///     e (float or array, optional): The eccentricity. Required if `a_or_oe` is a scalar, ignored if vector.
+///         Broadcast against `a_or_oe` when either is an array.
 ///
 /// Returns:
-///     float: The magnitude of velocity of the object at apogee in m/s.
+///     float or numpy.ndarray: The magnitude of velocity of the object at apogee in m/s.
+///         An array is returned for array input, with shape `(n,)` for `n` element
+///         sets or the broadcast shape for element-wise input.
 ///
 /// Example:
 ///     ```python
@@ -463,18 +564,25 @@ fn py_periapsis_distance(a_or_oe: &Bound<'_, PyAny>, e: Option<f64>) -> PyResult
 #[pyfunction]
 #[pyo3(signature = (a_or_oe, e=None), text_signature = "(a_or_oe, e=None)")]
 #[pyo3(name = "apogee_velocity")]
-fn py_apogee_velocity(a_or_oe: &Bound<'_, PyAny>, e: Option<f64>) -> PyResult<f64> {
-    // Try to extract as scalar first
-    if let Ok(a) = a_or_oe.extract::<f64>() {
-        let ecc = e.ok_or_else(|| exceptions::PyValueError::new_err(
-            "Parameter 'e' is required when 'a_or_oe' is a scalar"
-        ))?;
-        return Ok(orbits::apogee_velocity(a, ecc));
-    }
-
-    // Try to extract as vector (Keplerian elements)
-    let oe = pyany_to_f64_array1(a_or_oe, Some(6))?;
-    Ok(orbits::apogee_velocity(oe[0], oe[1]))
+fn py_apogee_velocity<'py>(
+    py: Python<'py>,
+    a_or_oe: &Bound<'py, PyAny>,
+    e: Option<&Bound<'py, PyAny>>,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_oe_or_scalar(
+        py,
+        a_or_oe,
+        e,
+        |oe| Ok(orbits::apogee_velocity(oe[0], oe[1])),
+        |v, e| {
+            let ecc = e.ok_or_else(|| {
+                exceptions::PyValueError::new_err(
+                    "Parameter 'e' is required when 'a_or_oe' is a scalar",
+                )
+            })?;
+            Ok(orbits::apogee_velocity(v, ecc))
+        },
+    )
 }
 
 /// Computes the apoapsis velocity of an astronomical object around a general body.
@@ -482,11 +590,16 @@ fn py_apogee_velocity(a_or_oe: &Bound<'_, PyAny>, e: Option<f64>) -> PyResult<f6
 /// Args:
 ///     a_or_oe (float or array): Either the semi-major axis in meters, or a 6-element
 ///         Keplerian elements array [a, e, i, Ω, ω, ν] from which `a` and `e` will be extracted.
-///     e (float, optional): The eccentricity. Required if `a_or_oe` is a scalar, ignored if vector.
+///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
+///         arrays of any shape are evaluated element-wise (broadcast against `e`).
+///     e (float or array, optional): The eccentricity. Required if `a_or_oe` is a scalar, ignored if vector.
+///         Broadcast against `a_or_oe` when either is an array.
 ///     gm (float): (keyword-only) The standard gravitational parameter of primary body in m³/s².
 ///
 /// Returns:
-///     float: The magnitude of velocity of the object at apoapsis in m/s.
+///     float or numpy.ndarray: The magnitude of velocity of the object at apoapsis in m/s.
+///         An array is returned for array input, with shape `(n,)` for `n` element
+///         sets or the broadcast shape for element-wise input.
 ///
 /// Example:
 ///     ```python
@@ -507,18 +620,26 @@ fn py_apogee_velocity(a_or_oe: &Bound<'_, PyAny>, e: Option<f64>) -> PyResult<f6
 #[pyfunction]
 #[pyo3(signature = (a_or_oe, e=None, *, gm), text_signature = "(a_or_oe, e=None, *, gm)")]
 #[pyo3(name = "apoapsis_velocity")]
-fn py_apoapsis_velocity(a_or_oe: &Bound<'_, PyAny>, e: Option<f64>, gm: f64) -> PyResult<f64> {
-    // Try to extract as scalar first
-    if let Ok(a) = a_or_oe.extract::<f64>() {
-        let ecc = e.ok_or_else(|| exceptions::PyValueError::new_err(
-            "Parameter 'e' is required when 'a_or_oe' is a scalar"
-        ))?;
-        return Ok(orbits::apoapsis_velocity(a, ecc, gm));
-    }
-
-    // Try to extract as vector (Keplerian elements)
-    let oe = pyany_to_f64_array1(a_or_oe, Some(6))?;
-    Ok(orbits::apoapsis_velocity(oe[0], oe[1], gm))
+fn py_apoapsis_velocity<'py>(
+    py: Python<'py>,
+    a_or_oe: &Bound<'py, PyAny>,
+    e: Option<&Bound<'py, PyAny>>,
+    gm: f64,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_oe_or_scalar(
+        py,
+        a_or_oe,
+        e,
+        |oe| Ok(orbits::apoapsis_velocity(oe[0], oe[1], gm)),
+        |v, e| {
+            let ecc = e.ok_or_else(|| {
+                exceptions::PyValueError::new_err(
+                    "Parameter 'e' is required when 'a_or_oe' is a scalar",
+                )
+            })?;
+            Ok(orbits::apoapsis_velocity(v, ecc, gm))
+        },
+    )
 }
 
 /// Calculate the distance of an object at its apoapsis.
@@ -526,10 +647,15 @@ fn py_apoapsis_velocity(a_or_oe: &Bound<'_, PyAny>, e: Option<f64>, gm: f64) -> 
 /// Args:
 ///     a_or_oe (float or array): Either the semi-major axis in meters, or a 6-element
 ///         Keplerian elements array [a, e, i, Ω, ω, ν] from which `a` and `e` will be extracted.
-///     e (float, optional): The eccentricity. Required if `a_or_oe` is a scalar, ignored if vector.
+///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
+///         arrays of any shape are evaluated element-wise (broadcast against `e`).
+///     e (float or array, optional): The eccentricity. Required if `a_or_oe` is a scalar, ignored if vector.
+///         Broadcast against `a_or_oe` when either is an array.
 ///
 /// Returns:
-///     float: The distance of the object at apoapsis in meters.
+///     float or numpy.ndarray: The distance of the object at apoapsis in meters.
+///         An array is returned for array input, with shape `(n,)` for `n` element
+///         sets or the broadcast shape for element-wise input.
 ///
 /// Example:
 ///     ```python
@@ -550,18 +676,25 @@ fn py_apoapsis_velocity(a_or_oe: &Bound<'_, PyAny>, e: Option<f64>, gm: f64) -> 
 #[pyfunction]
 #[pyo3(signature = (a_or_oe, e=None), text_signature = "(a_or_oe, e=None)")]
 #[pyo3(name = "apoapsis_distance")]
-fn py_apoapsis_distance(a_or_oe: &Bound<'_, PyAny>, e: Option<f64>) -> PyResult<f64> {
-    // Try to extract as scalar first
-    if let Ok(a) = a_or_oe.extract::<f64>() {
-        let ecc = e.ok_or_else(|| exceptions::PyValueError::new_err(
-            "Parameter 'e' is required when 'a_or_oe' is a scalar"
-        ))?;
-        return Ok(orbits::apoapsis_distance(a, ecc));
-    }
-
-    // Try to extract as vector (Keplerian elements)
-    let oe = pyany_to_f64_array1(a_or_oe, Some(6))?;
-    Ok(orbits::apoapsis_distance(oe[0], oe[1]))
+fn py_apoapsis_distance<'py>(
+    py: Python<'py>,
+    a_or_oe: &Bound<'py, PyAny>,
+    e: Option<&Bound<'py, PyAny>>,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_oe_or_scalar(
+        py,
+        a_or_oe,
+        e,
+        |oe| Ok(orbits::apoapsis_distance(oe[0], oe[1])),
+        |v, e| {
+            let ecc = e.ok_or_else(|| {
+                exceptions::PyValueError::new_err(
+                    "Parameter 'e' is required when 'a_or_oe' is a scalar",
+                )
+            })?;
+            Ok(orbits::apoapsis_distance(v, ecc))
+        },
+    )
 }
 
 /// Calculate the altitude above a body's surface at periapsis.
@@ -569,11 +702,16 @@ fn py_apoapsis_distance(a_or_oe: &Bound<'_, PyAny>, e: Option<f64>) -> PyResult<
 /// Args:
 ///     a_or_oe (float or array): Either the semi-major axis in meters, or a 6-element
 ///         Keplerian elements array [a, e, i, Ω, ω, ν] from which `a` and `e` will be extracted.
-///     e (float, optional): The eccentricity. Required if `a_or_oe` is a scalar, ignored if vector.
+///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
+///         arrays of any shape are evaluated element-wise (broadcast against `e`).
+///     e (float or array, optional): The eccentricity. Required if `a_or_oe` is a scalar, ignored if vector.
+///         Broadcast against `a_or_oe` when either is an array.
 ///     r_body (float): (keyword-only) The radius of the central body in meters.
 ///
 /// Returns:
-///     float: The altitude above the body's surface at periapsis in meters.
+///     float or numpy.ndarray: The altitude above the body's surface at periapsis in meters.
+///         An array is returned for array input, with shape `(n,)` for `n` element
+///         sets or the broadcast shape for element-wise input.
 ///
 /// Example:
 ///     ```python
@@ -594,18 +732,26 @@ fn py_apoapsis_distance(a_or_oe: &Bound<'_, PyAny>, e: Option<f64>) -> PyResult<
 #[pyfunction]
 #[pyo3(signature = (a_or_oe, e=None, *, r_body), text_signature = "(a_or_oe, e=None, *, r_body)")]
 #[pyo3(name = "periapsis_altitude")]
-fn py_periapsis_altitude(a_or_oe: &Bound<'_, PyAny>, e: Option<f64>, r_body: f64) -> PyResult<f64> {
-    // Try to extract as scalar first
-    if let Ok(a) = a_or_oe.extract::<f64>() {
-        let ecc = e.ok_or_else(|| exceptions::PyValueError::new_err(
-            "Parameter 'e' is required when 'a_or_oe' is a scalar"
-        ))?;
-        return Ok(orbits::periapsis_altitude(a, ecc, r_body));
-    }
-
-    // Try to extract as vector (Keplerian elements)
-    let oe = pyany_to_f64_array1(a_or_oe, Some(6))?;
-    Ok(orbits::periapsis_altitude(oe[0], oe[1], r_body))
+fn py_periapsis_altitude<'py>(
+    py: Python<'py>,
+    a_or_oe: &Bound<'py, PyAny>,
+    e: Option<&Bound<'py, PyAny>>,
+    r_body: f64,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_oe_or_scalar(
+        py,
+        a_or_oe,
+        e,
+        |oe| Ok(orbits::periapsis_altitude(oe[0], oe[1], r_body)),
+        |v, e| {
+            let ecc = e.ok_or_else(|| {
+                exceptions::PyValueError::new_err(
+                    "Parameter 'e' is required when 'a_or_oe' is a scalar",
+                )
+            })?;
+            Ok(orbits::periapsis_altitude(v, ecc, r_body))
+        },
+    )
 }
 
 /// Calculate the altitude above Earth's surface at perigee.
@@ -613,10 +759,15 @@ fn py_periapsis_altitude(a_or_oe: &Bound<'_, PyAny>, e: Option<f64>, r_body: f64
 /// Args:
 ///     a_or_oe (float or array): Either the semi-major axis in meters, or a 6-element
 ///         Keplerian elements array [a, e, i, Ω, ω, ν] from which `a` and `e` will be extracted.
-///     e (float, optional): The eccentricity. Required if `a_or_oe` is a scalar, ignored if vector.
+///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
+///         arrays of any shape are evaluated element-wise (broadcast against `e`).
+///     e (float or array, optional): The eccentricity. Required if `a_or_oe` is a scalar, ignored if vector.
+///         Broadcast against `a_or_oe` when either is an array.
 ///
 /// Returns:
-///     float: The altitude above Earth's surface at perigee in meters.
+///     float or numpy.ndarray: The altitude above Earth's surface at perigee in meters.
+///         An array is returned for array input, with shape `(n,)` for `n` element
+///         sets or the broadcast shape for element-wise input.
 ///
 /// Example:
 ///     ```python
@@ -637,18 +788,25 @@ fn py_periapsis_altitude(a_or_oe: &Bound<'_, PyAny>, e: Option<f64>, r_body: f64
 #[pyfunction]
 #[pyo3(signature = (a_or_oe, e=None), text_signature = "(a_or_oe, e=None)")]
 #[pyo3(name = "perigee_altitude")]
-fn py_perigee_altitude(a_or_oe: &Bound<'_, PyAny>, e: Option<f64>) -> PyResult<f64> {
-    // Try to extract as scalar first
-    if let Ok(a) = a_or_oe.extract::<f64>() {
-        let ecc = e.ok_or_else(|| exceptions::PyValueError::new_err(
-            "Parameter 'e' is required when 'a_or_oe' is a scalar"
-        ))?;
-        return Ok(orbits::perigee_altitude(a, ecc));
-    }
-
-    // Try to extract as vector (Keplerian elements)
-    let oe = pyany_to_f64_array1(a_or_oe, Some(6))?;
-    Ok(orbits::perigee_altitude(oe[0], oe[1]))
+fn py_perigee_altitude<'py>(
+    py: Python<'py>,
+    a_or_oe: &Bound<'py, PyAny>,
+    e: Option<&Bound<'py, PyAny>>,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_oe_or_scalar(
+        py,
+        a_or_oe,
+        e,
+        |oe| Ok(orbits::perigee_altitude(oe[0], oe[1])),
+        |v, e| {
+            let ecc = e.ok_or_else(|| {
+                exceptions::PyValueError::new_err(
+                    "Parameter 'e' is required when 'a_or_oe' is a scalar",
+                )
+            })?;
+            Ok(orbits::perigee_altitude(v, ecc))
+        },
+    )
 }
 
 /// Calculate the altitude above a body's surface at apoapsis.
@@ -656,11 +814,16 @@ fn py_perigee_altitude(a_or_oe: &Bound<'_, PyAny>, e: Option<f64>) -> PyResult<f
 /// Args:
 ///     a_or_oe (float or array): Either the semi-major axis in meters, or a 6-element
 ///         Keplerian elements array [a, e, i, Ω, ω, ν] from which `a` and `e` will be extracted.
-///     e (float, optional): The eccentricity. Required if `a_or_oe` is a scalar, ignored if vector.
+///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
+///         arrays of any shape are evaluated element-wise (broadcast against `e`).
+///     e (float or array, optional): The eccentricity. Required if `a_or_oe` is a scalar, ignored if vector.
+///         Broadcast against `a_or_oe` when either is an array.
 ///     r_body (float): (keyword-only) The radius of the central body in meters.
 ///
 /// Returns:
-///     float: The altitude above the body's surface at apoapsis in meters.
+///     float or numpy.ndarray: The altitude above the body's surface at apoapsis in meters.
+///         An array is returned for array input, with shape `(n,)` for `n` element
+///         sets or the broadcast shape for element-wise input.
 ///
 /// Example:
 ///     ```python
@@ -681,18 +844,26 @@ fn py_perigee_altitude(a_or_oe: &Bound<'_, PyAny>, e: Option<f64>) -> PyResult<f
 #[pyfunction]
 #[pyo3(signature = (a_or_oe, e=None, *, r_body), text_signature = "(a_or_oe, e=None, *, r_body)")]
 #[pyo3(name = "apoapsis_altitude")]
-fn py_apoapsis_altitude(a_or_oe: &Bound<'_, PyAny>, e: Option<f64>, r_body: f64) -> PyResult<f64> {
-    // Try to extract as scalar first
-    if let Ok(a) = a_or_oe.extract::<f64>() {
-        let ecc = e.ok_or_else(|| exceptions::PyValueError::new_err(
-            "Parameter 'e' is required when 'a_or_oe' is a scalar"
-        ))?;
-        return Ok(orbits::apoapsis_altitude(a, ecc, r_body));
-    }
-
-    // Try to extract as vector (Keplerian elements)
-    let oe = pyany_to_f64_array1(a_or_oe, Some(6))?;
-    Ok(orbits::apoapsis_altitude(oe[0], oe[1], r_body))
+fn py_apoapsis_altitude<'py>(
+    py: Python<'py>,
+    a_or_oe: &Bound<'py, PyAny>,
+    e: Option<&Bound<'py, PyAny>>,
+    r_body: f64,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_oe_or_scalar(
+        py,
+        a_or_oe,
+        e,
+        |oe| Ok(orbits::apoapsis_altitude(oe[0], oe[1], r_body)),
+        |v, e| {
+            let ecc = e.ok_or_else(|| {
+                exceptions::PyValueError::new_err(
+                    "Parameter 'e' is required when 'a_or_oe' is a scalar",
+                )
+            })?;
+            Ok(orbits::apoapsis_altitude(v, ecc, r_body))
+        },
+    )
 }
 
 /// Calculate the altitude above Earth's surface at apogee.
@@ -700,10 +871,15 @@ fn py_apoapsis_altitude(a_or_oe: &Bound<'_, PyAny>, e: Option<f64>, r_body: f64)
 /// Args:
 ///     a_or_oe (float or array): Either the semi-major axis in meters, or a 6-element
 ///         Keplerian elements array [a, e, i, Ω, ω, ν] from which `a` and `e` will be extracted.
-///     e (float, optional): The eccentricity. Required if `a_or_oe` is a scalar, ignored if vector.
+///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
+///         arrays of any shape are evaluated element-wise (broadcast against `e`).
+///     e (float or array, optional): The eccentricity. Required if `a_or_oe` is a scalar, ignored if vector.
+///         Broadcast against `a_or_oe` when either is an array.
 ///
 /// Returns:
-///     float: The altitude above Earth's surface at apogee in meters.
+///     float or numpy.ndarray: The altitude above Earth's surface at apogee in meters.
+///         An array is returned for array input, with shape `(n,)` for `n` element
+///         sets or the broadcast shape for element-wise input.
 ///
 /// Example:
 ///     ```python
@@ -724,18 +900,25 @@ fn py_apoapsis_altitude(a_or_oe: &Bound<'_, PyAny>, e: Option<f64>, r_body: f64)
 #[pyfunction]
 #[pyo3(signature = (a_or_oe, e=None), text_signature = "(a_or_oe, e=None)")]
 #[pyo3(name = "apogee_altitude")]
-fn py_apogee_altitude(a_or_oe: &Bound<'_, PyAny>, e: Option<f64>) -> PyResult<f64> {
-    // Try to extract as scalar first
-    if let Ok(a) = a_or_oe.extract::<f64>() {
-        let ecc = e.ok_or_else(|| exceptions::PyValueError::new_err(
-            "Parameter 'e' is required when 'a_or_oe' is a scalar"
-        ))?;
-        return Ok(orbits::apogee_altitude(a, ecc));
-    }
-
-    // Try to extract as vector (Keplerian elements)
-    let oe = pyany_to_f64_array1(a_or_oe, Some(6))?;
-    Ok(orbits::apogee_altitude(oe[0], oe[1]))
+fn py_apogee_altitude<'py>(
+    py: Python<'py>,
+    a_or_oe: &Bound<'py, PyAny>,
+    e: Option<&Bound<'py, PyAny>>,
+) -> PyResult<Bound<'py, PyAny>> {
+    dispatch_oe_or_scalar(
+        py,
+        a_or_oe,
+        e,
+        |oe| Ok(orbits::apogee_altitude(oe[0], oe[1])),
+        |v, e| {
+            let ecc = e.ok_or_else(|| {
+                exceptions::PyValueError::new_err(
+                    "Parameter 'e' is required when 'a_or_oe' is a scalar",
+                )
+            })?;
+            Ok(orbits::apogee_altitude(v, ecc))
+        },
+    )
 }
 
 /// Computes the inclination for a Sun-synchronous orbit around Earth based on
@@ -744,11 +927,16 @@ fn py_apogee_altitude(a_or_oe: &Bound<'_, PyAny>, e: Option<f64>) -> PyResult<f6
 /// Args:
 ///     a_or_oe (float or array): Either the semi-major axis in meters, or a 6-element
 ///         Keplerian elements array [a, e, i, Ω, ω, ν] from which `a` and `e` will be extracted.
-///     e (float, optional): The eccentricity. Required if `a_or_oe` is a scalar, ignored if vector.
+///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
+///         arrays of any shape are evaluated element-wise (broadcast against `e`).
+///     e (float or array, optional): The eccentricity. Required if `a_or_oe` is a scalar, ignored if vector.
+///         Broadcast against `a_or_oe` when either is an array.
 ///     angle_format (AngleFormat): (keyword-only) Return output in AngleFormat.DEGREES or AngleFormat.RADIANS.
 ///
 /// Returns:
-///     float: Inclination for a Sun synchronous orbit in degrees or radians.
+///     float or numpy.ndarray: Inclination for a Sun synchronous orbit in degrees or radians.
+///         An array is returned for array input, with shape `(n,)` for `n` element
+///         sets or the broadcast shape for element-wise input.
 ///
 /// Example:
 ///     ```python
@@ -769,18 +957,27 @@ fn py_apogee_altitude(a_or_oe: &Bound<'_, PyAny>, e: Option<f64>) -> PyResult<f6
 #[pyfunction]
 #[pyo3(signature = (a_or_oe, e=None, *, angle_format), text_signature = "(a_or_oe, e=None, *, angle_format)")]
 #[pyo3(name = "sun_synchronous_inclination")]
-fn py_sun_synchronous_inclination(a_or_oe: &Bound<'_, PyAny>, e: Option<f64>, angle_format: &PyAngleFormat) -> PyResult<f64> {
-    // Try to extract as scalar first
-    if let Ok(a) = a_or_oe.extract::<f64>() {
-        let ecc = e.ok_or_else(|| exceptions::PyValueError::new_err(
-            "Parameter 'e' is required when 'a_or_oe' is a scalar"
-        ))?;
-        return Ok(orbits::sun_synchronous_inclination(a, ecc, angle_format.value));
-    }
-
-    // Try to extract as vector (Keplerian elements)
-    let oe = pyany_to_f64_array1(a_or_oe, Some(6))?;
-    Ok(orbits::sun_synchronous_inclination(oe[0], oe[1], angle_format.value))
+fn py_sun_synchronous_inclination<'py>(
+    py: Python<'py>,
+    a_or_oe: &Bound<'py, PyAny>,
+    e: Option<&Bound<'py, PyAny>>,
+    angle_format: &PyAngleFormat,
+) -> PyResult<Bound<'py, PyAny>> {
+    let af = angle_format.value;
+    dispatch_oe_or_scalar(
+        py,
+        a_or_oe,
+        e,
+        |oe| Ok(orbits::sun_synchronous_inclination(oe[0], oe[1], af)),
+        |v, e| {
+            let ecc = e.ok_or_else(|| {
+                exceptions::PyValueError::new_err(
+                    "Parameter 'e' is required when 'a_or_oe' is a scalar",
+                )
+            })?;
+            Ok(orbits::sun_synchronous_inclination(v, ecc, af))
+        },
+    )
 }
 
 /// Returns the geostationary orbit semi-major axis around Earth.
@@ -807,11 +1004,16 @@ fn py_geo_sma() -> PyResult<f64> {
 ///     anm_ecc_or_oe (float or array): Either the eccentric anomaly, or a 6-element
 ///         Keplerian elements array [a, e, i, Ω, ω, E] from which `e` and `E` will be extracted.
 ///         The anomaly in the vector should match the `angle_format`.
-///     e (float, optional): The eccentricity. Required if `anm_ecc_or_oe` is a scalar, ignored if vector.
+///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
+///         arrays of any shape are evaluated element-wise (broadcast against `e`).
+///     e (float or array, optional): The eccentricity. Required if `anm_ecc_or_oe` is a scalar, ignored if vector.
+///         Broadcast against `anm_ecc_or_oe` when either is an array.
 ///     angle_format (AngleFormat): (keyword-only) Interprets input and returns output in AngleFormat.DEGREES or AngleFormat.RADIANS.
 ///
 /// Returns:
-///     float: Mean anomaly in radians or degrees.
+///     float or numpy.ndarray: Mean anomaly in radians or degrees.
+///         An array is returned for array input, with shape `(n,)` for `n` element
+///         sets or the broadcast shape for element-wise input.
 ///
 /// Example:
 ///     ```python
@@ -832,18 +1034,27 @@ fn py_geo_sma() -> PyResult<f64> {
 #[pyfunction]
 #[pyo3(signature = (anm_ecc_or_oe, e=None, *, angle_format), text_signature = "(anm_ecc_or_oe, e=None, *, angle_format)")]
 #[pyo3(name = "anomaly_eccentric_to_mean")]
-fn py_anomaly_eccentric_to_mean(anm_ecc_or_oe: &Bound<'_, PyAny>, e: Option<f64>, angle_format: &PyAngleFormat) -> PyResult<f64> {
-    // Try to extract as scalar first
-    if let Ok(anm_ecc) = anm_ecc_or_oe.extract::<f64>() {
-        let ecc = e.ok_or_else(|| exceptions::PyValueError::new_err(
-            "Parameter 'e' is required when 'anm_ecc_or_oe' is a scalar"
-        ))?;
-        return Ok(orbits::anomaly_eccentric_to_mean(anm_ecc, ecc, angle_format.value));
-    }
-
-    // Try to extract as vector (Keplerian elements)
-    let oe = pyany_to_f64_array1(anm_ecc_or_oe, Some(6))?;
-    Ok(orbits::anomaly_eccentric_to_mean(oe[5], oe[1], angle_format.value))
+fn py_anomaly_eccentric_to_mean<'py>(
+    py: Python<'py>,
+    anm_ecc_or_oe: &Bound<'py, PyAny>,
+    e: Option<&Bound<'py, PyAny>>,
+    angle_format: &PyAngleFormat,
+) -> PyResult<Bound<'py, PyAny>> {
+    let af = angle_format.value;
+    dispatch_oe_or_scalar(
+        py,
+        anm_ecc_or_oe,
+        e,
+        |oe| Ok(orbits::anomaly_eccentric_to_mean(oe[5], oe[1], af)),
+        |v, e| {
+            let ecc = e.ok_or_else(|| {
+                exceptions::PyValueError::new_err(
+                    "Parameter 'e' is required when 'anm_ecc_or_oe' is a scalar",
+                )
+            })?;
+            Ok(orbits::anomaly_eccentric_to_mean(v, ecc, af))
+        },
+    )
 }
 
 /// Converts mean anomaly into eccentric anomaly.
@@ -852,11 +1063,16 @@ fn py_anomaly_eccentric_to_mean(anm_ecc_or_oe: &Bound<'_, PyAny>, e: Option<f64>
 ///     anm_mean_or_oe (float or array): Either the mean anomaly, or a 6-element
 ///         Keplerian elements array [a, e, i, Ω, ω, M] from which `e` and `M` will be extracted.
 ///         The anomaly in the vector should match the `angle_format`.
-///     e (float, optional): The eccentricity. Required if `anm_mean_or_oe` is a scalar, ignored if vector.
+///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
+///         arrays of any shape are evaluated element-wise (broadcast against `e`).
+///     e (float or array, optional): The eccentricity. Required if `anm_mean_or_oe` is a scalar, ignored if vector.
+///         Broadcast against `anm_mean_or_oe` when either is an array.
 ///     angle_format (AngleFormat): (keyword-only) Interprets input and returns output in AngleFormat.DEGREES or AngleFormat.RADIANS.
 ///
 /// Returns:
-///     float: Eccentric anomaly in radians or degrees.
+///     float or numpy.ndarray: Eccentric anomaly in radians or degrees.
+///         An array is returned for array input, with shape `(n,)` for `n` element
+///         sets or the broadcast shape for element-wise input.
 ///
 /// Example:
 ///     ```python
@@ -877,24 +1093,27 @@ fn py_anomaly_eccentric_to_mean(anm_ecc_or_oe: &Bound<'_, PyAny>, e: Option<f64>
 #[pyfunction]
 #[pyo3(signature = (anm_mean_or_oe, e=None, *, angle_format), text_signature = "(anm_mean_or_oe, e=None, *, angle_format)")]
 #[pyo3(name = "anomaly_mean_to_eccentric")]
-fn py_anomaly_mean_to_eccentric(anm_mean_or_oe: &Bound<'_, PyAny>, e: Option<f64>, angle_format: &PyAngleFormat) -> PyResult<f64> {
-    // Try to extract as scalar first
-    if let Ok(anm_mean) = anm_mean_or_oe.extract::<f64>() {
-        let ecc = e.ok_or_else(|| exceptions::PyValueError::new_err(
-            "Parameter 'e' is required when 'anm_mean_or_oe' is a scalar"
-        ))?;
-        return match orbits::anomaly_mean_to_eccentric(anm_mean, ecc, angle_format.value) {
-            Ok(value) => Ok(value),
-            Err(err) => Err(exceptions::PyRuntimeError::new_err(err)),
-        };
-    }
-
-    // Try to extract as vector (Keplerian elements)
-    let oe = pyany_to_f64_array1(anm_mean_or_oe, Some(6))?;
-    match orbits::anomaly_mean_to_eccentric(oe[5], oe[1], angle_format.value) {
-        Ok(value) => Ok(value),
-        Err(err) => Err(exceptions::PyRuntimeError::new_err(err)),
-    }
+fn py_anomaly_mean_to_eccentric<'py>(
+    py: Python<'py>,
+    anm_mean_or_oe: &Bound<'py, PyAny>,
+    e: Option<&Bound<'py, PyAny>>,
+    angle_format: &PyAngleFormat,
+) -> PyResult<Bound<'py, PyAny>> {
+    let af = angle_format.value;
+    dispatch_oe_or_scalar(
+        py,
+        anm_mean_or_oe,
+        e,
+        |oe| orbits::anomaly_mean_to_eccentric(oe[5], oe[1], af).map_err(exceptions::PyRuntimeError::new_err),
+        |v, e| {
+            let ecc = e.ok_or_else(|| {
+                exceptions::PyValueError::new_err(
+                    "Parameter 'e' is required when 'anm_mean_or_oe' is a scalar",
+                )
+            })?;
+            orbits::anomaly_mean_to_eccentric(v, ecc, af).map_err(exceptions::PyRuntimeError::new_err)
+        },
+    )
 }
 
 /// Converts true anomaly into eccentric anomaly.
@@ -903,11 +1122,16 @@ fn py_anomaly_mean_to_eccentric(anm_mean_or_oe: &Bound<'_, PyAny>, e: Option<f64
 ///     anm_true_or_oe (float or array): Either the true anomaly, or a 6-element
 ///         Keplerian elements array [a, e, i, Ω, ω, ν] from which `e` and `ν` will be extracted.
 ///         The anomaly in the vector should match the `angle_format`.
-///     e (float, optional): The eccentricity. Required if `anm_true_or_oe` is a scalar, ignored if vector.
+///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
+///         arrays of any shape are evaluated element-wise (broadcast against `e`).
+///     e (float or array, optional): The eccentricity. Required if `anm_true_or_oe` is a scalar, ignored if vector.
+///         Broadcast against `anm_true_or_oe` when either is an array.
 ///     angle_format (AngleFormat): (keyword-only) Interprets input and returns output in AngleFormat.DEGREES or AngleFormat.RADIANS.
 ///
 /// Returns:
-///     float: Eccentric anomaly in radians or degrees.
+///     float or numpy.ndarray: Eccentric anomaly in radians or degrees.
+///         An array is returned for array input, with shape `(n,)` for `n` element
+///         sets or the broadcast shape for element-wise input.
 ///
 /// Example:
 ///     ```python
@@ -928,18 +1152,27 @@ fn py_anomaly_mean_to_eccentric(anm_mean_or_oe: &Bound<'_, PyAny>, e: Option<f64
 #[pyfunction]
 #[pyo3(signature = (anm_true_or_oe, e=None, *, angle_format), text_signature = "(anm_true_or_oe, e=None, *, angle_format)")]
 #[pyo3(name = "anomaly_true_to_eccentric")]
-fn py_anomaly_true_to_eccentric(anm_true_or_oe: &Bound<'_, PyAny>, e: Option<f64>, angle_format: &PyAngleFormat) -> PyResult<f64> {
-    // Try to extract as scalar first
-    if let Ok(anm_true) = anm_true_or_oe.extract::<f64>() {
-        let ecc = e.ok_or_else(|| exceptions::PyValueError::new_err(
-            "Parameter 'e' is required when 'anm_true_or_oe' is a scalar"
-        ))?;
-        return Ok(orbits::anomaly_true_to_eccentric(anm_true, ecc, angle_format.value));
-    }
-
-    // Try to extract as vector (Keplerian elements)
-    let oe = pyany_to_f64_array1(anm_true_or_oe, Some(6))?;
-    Ok(orbits::anomaly_true_to_eccentric(oe[5], oe[1], angle_format.value))
+fn py_anomaly_true_to_eccentric<'py>(
+    py: Python<'py>,
+    anm_true_or_oe: &Bound<'py, PyAny>,
+    e: Option<&Bound<'py, PyAny>>,
+    angle_format: &PyAngleFormat,
+) -> PyResult<Bound<'py, PyAny>> {
+    let af = angle_format.value;
+    dispatch_oe_or_scalar(
+        py,
+        anm_true_or_oe,
+        e,
+        |oe| Ok(orbits::anomaly_true_to_eccentric(oe[5], oe[1], af)),
+        |v, e| {
+            let ecc = e.ok_or_else(|| {
+                exceptions::PyValueError::new_err(
+                    "Parameter 'e' is required when 'anm_true_or_oe' is a scalar",
+                )
+            })?;
+            Ok(orbits::anomaly_true_to_eccentric(v, ecc, af))
+        },
+    )
 }
 
 /// Converts eccentric anomaly into true anomaly.
@@ -948,11 +1181,16 @@ fn py_anomaly_true_to_eccentric(anm_true_or_oe: &Bound<'_, PyAny>, e: Option<f64
 ///     anm_ecc_or_oe (float or array): Either the eccentric anomaly, or a 6-element
 ///         Keplerian elements array [a, e, i, Ω, ω, E] from which `e` and `E` will be extracted.
 ///         The anomaly in the vector should match the `angle_format`.
-///     e (float, optional): The eccentricity. Required if `anm_ecc_or_oe` is a scalar, ignored if vector.
+///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
+///         arrays of any shape are evaluated element-wise (broadcast against `e`).
+///     e (float or array, optional): The eccentricity. Required if `anm_ecc_or_oe` is a scalar, ignored if vector.
+///         Broadcast against `anm_ecc_or_oe` when either is an array.
 ///     angle_format (AngleFormat): (keyword-only) Interprets input and returns output in AngleFormat.DEGREES or AngleFormat.RADIANS.
 ///
 /// Returns:
-///     float: True anomaly in radians or degrees.
+///     float or numpy.ndarray: True anomaly in radians or degrees.
+///         An array is returned for array input, with shape `(n,)` for `n` element
+///         sets or the broadcast shape for element-wise input.
 ///
 /// Example:
 ///     ```python
@@ -973,18 +1211,27 @@ fn py_anomaly_true_to_eccentric(anm_true_or_oe: &Bound<'_, PyAny>, e: Option<f64
 #[pyfunction]
 #[pyo3(signature = (anm_ecc_or_oe, e=None, *, angle_format), text_signature = "(anm_ecc_or_oe, e=None, *, angle_format)")]
 #[pyo3(name = "anomaly_eccentric_to_true")]
-fn py_anomaly_eccentric_to_true(anm_ecc_or_oe: &Bound<'_, PyAny>, e: Option<f64>, angle_format: &PyAngleFormat) -> PyResult<f64> {
-    // Try to extract as scalar first
-    if let Ok(anm_ecc) = anm_ecc_or_oe.extract::<f64>() {
-        let ecc = e.ok_or_else(|| exceptions::PyValueError::new_err(
-            "Parameter 'e' is required when 'anm_ecc_or_oe' is a scalar"
-        ))?;
-        return Ok(orbits::anomaly_eccentric_to_true(anm_ecc, ecc, angle_format.value));
-    }
-
-    // Try to extract as vector (Keplerian elements)
-    let oe = pyany_to_f64_array1(anm_ecc_or_oe, Some(6))?;
-    Ok(orbits::anomaly_eccentric_to_true(oe[5], oe[1], angle_format.value))
+fn py_anomaly_eccentric_to_true<'py>(
+    py: Python<'py>,
+    anm_ecc_or_oe: &Bound<'py, PyAny>,
+    e: Option<&Bound<'py, PyAny>>,
+    angle_format: &PyAngleFormat,
+) -> PyResult<Bound<'py, PyAny>> {
+    let af = angle_format.value;
+    dispatch_oe_or_scalar(
+        py,
+        anm_ecc_or_oe,
+        e,
+        |oe| Ok(orbits::anomaly_eccentric_to_true(oe[5], oe[1], af)),
+        |v, e| {
+            let ecc = e.ok_or_else(|| {
+                exceptions::PyValueError::new_err(
+                    "Parameter 'e' is required when 'anm_ecc_or_oe' is a scalar",
+                )
+            })?;
+            Ok(orbits::anomaly_eccentric_to_true(v, ecc, af))
+        },
+    )
 }
 
 /// Converts true anomaly into mean anomaly.
@@ -993,11 +1240,16 @@ fn py_anomaly_eccentric_to_true(anm_ecc_or_oe: &Bound<'_, PyAny>, e: Option<f64>
 ///     anm_true_or_oe (float or array): Either the true anomaly, or a 6-element
 ///         Keplerian elements array [a, e, i, Ω, ω, ν] from which `e` and `ν` will be extracted.
 ///         The anomaly in the vector should match the `angle_format`.
-///     e (float, optional): The eccentricity. Required if `anm_true_or_oe` is a scalar, ignored if vector.
+///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
+///         arrays of any shape are evaluated element-wise (broadcast against `e`).
+///     e (float or array, optional): The eccentricity. Required if `anm_true_or_oe` is a scalar, ignored if vector.
+///         Broadcast against `anm_true_or_oe` when either is an array.
 ///     angle_format (AngleFormat): (keyword-only) Interprets input and returns output in AngleFormat.DEGREES or AngleFormat.RADIANS.
 ///
 /// Returns:
-///     float: Mean anomaly in radians or degrees.
+///     float or numpy.ndarray: Mean anomaly in radians or degrees.
+///         An array is returned for array input, with shape `(n,)` for `n` element
+///         sets or the broadcast shape for element-wise input.
 ///
 /// Example:
 ///     ```python
@@ -1018,18 +1270,27 @@ fn py_anomaly_eccentric_to_true(anm_ecc_or_oe: &Bound<'_, PyAny>, e: Option<f64>
 #[pyfunction]
 #[pyo3(signature = (anm_true_or_oe, e=None, *, angle_format), text_signature = "(anm_true_or_oe, e=None, *, angle_format)")]
 #[pyo3(name = "anomaly_true_to_mean")]
-fn py_anomaly_true_to_mean(anm_true_or_oe: &Bound<'_, PyAny>, e: Option<f64>, angle_format: &PyAngleFormat) -> PyResult<f64> {
-    // Try to extract as scalar first
-    if let Ok(anm_true) = anm_true_or_oe.extract::<f64>() {
-        let ecc = e.ok_or_else(|| exceptions::PyValueError::new_err(
-            "Parameter 'e' is required when 'anm_true_or_oe' is a scalar"
-        ))?;
-        return Ok(orbits::anomaly_true_to_mean(anm_true, ecc, angle_format.value));
-    }
-
-    // Try to extract as vector (Keplerian elements)
-    let oe = pyany_to_f64_array1(anm_true_or_oe, Some(6))?;
-    Ok(orbits::anomaly_true_to_mean(oe[5], oe[1], angle_format.value))
+fn py_anomaly_true_to_mean<'py>(
+    py: Python<'py>,
+    anm_true_or_oe: &Bound<'py, PyAny>,
+    e: Option<&Bound<'py, PyAny>>,
+    angle_format: &PyAngleFormat,
+) -> PyResult<Bound<'py, PyAny>> {
+    let af = angle_format.value;
+    dispatch_oe_or_scalar(
+        py,
+        anm_true_or_oe,
+        e,
+        |oe| Ok(orbits::anomaly_true_to_mean(oe[5], oe[1], af)),
+        |v, e| {
+            let ecc = e.ok_or_else(|| {
+                exceptions::PyValueError::new_err(
+                    "Parameter 'e' is required when 'anm_true_or_oe' is a scalar",
+                )
+            })?;
+            Ok(orbits::anomaly_true_to_mean(v, ecc, af))
+        },
+    )
 }
 
 /// Converts mean anomaly into true anomaly.
@@ -1038,11 +1299,16 @@ fn py_anomaly_true_to_mean(anm_true_or_oe: &Bound<'_, PyAny>, e: Option<f64>, an
 ///     anm_mean_or_oe (float or array): Either the mean anomaly, or a 6-element
 ///         Keplerian elements array [a, e, i, Ω, ω, M] from which `e` and `M` will be extracted.
 ///         The anomaly in the vector should match the `angle_format`.
-///     e (float, optional): The eccentricity. Required if `anm_mean_or_oe` is a scalar, ignored if vector.
+///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
+///         arrays of any shape are evaluated element-wise (broadcast against `e`).
+///     e (float or array, optional): The eccentricity. Required if `anm_mean_or_oe` is a scalar, ignored if vector.
+///         Broadcast against `anm_mean_or_oe` when either is an array.
 ///     angle_format (AngleFormat): (keyword-only) Interprets input and returns output in AngleFormat.DEGREES or AngleFormat.RADIANS.
 ///
 /// Returns:
-///     float: True anomaly in radians or degrees.
+///     float or numpy.ndarray: True anomaly in radians or degrees.
+///         An array is returned for array input, with shape `(n,)` for `n` element
+///         sets or the broadcast shape for element-wise input.
 ///
 /// Example:
 ///     ```python
@@ -1063,24 +1329,27 @@ fn py_anomaly_true_to_mean(anm_true_or_oe: &Bound<'_, PyAny>, e: Option<f64>, an
 #[pyfunction]
 #[pyo3(signature = (anm_mean_or_oe, e=None, *, angle_format), text_signature = "(anm_mean_or_oe, e=None, *, angle_format)")]
 #[pyo3(name = "anomaly_mean_to_true")]
-fn py_anomaly_mean_to_true(anm_mean_or_oe: &Bound<'_, PyAny>, e: Option<f64>, angle_format: &PyAngleFormat) -> PyResult<f64> {
-    // Try to extract as scalar first
-    if let Ok(anm_mean) = anm_mean_or_oe.extract::<f64>() {
-        let ecc = e.ok_or_else(|| exceptions::PyValueError::new_err(
-            "Parameter 'e' is required when 'anm_mean_or_oe' is a scalar"
-        ))?;
-        return match orbits::anomaly_mean_to_true(anm_mean, ecc, angle_format.value) {
-            Ok(value) => Ok(value),
-            Err(err) => Err(exceptions::PyRuntimeError::new_err(err)),
-        };
-    }
-
-    // Try to extract as vector (Keplerian elements)
-    let oe = pyany_to_f64_array1(anm_mean_or_oe, Some(6))?;
-    match orbits::anomaly_mean_to_true(oe[5], oe[1], angle_format.value) {
-        Ok(value) => Ok(value),
-        Err(err) => Err(exceptions::PyRuntimeError::new_err(err)),
-    }
+fn py_anomaly_mean_to_true<'py>(
+    py: Python<'py>,
+    anm_mean_or_oe: &Bound<'py, PyAny>,
+    e: Option<&Bound<'py, PyAny>>,
+    angle_format: &PyAngleFormat,
+) -> PyResult<Bound<'py, PyAny>> {
+    let af = angle_format.value;
+    dispatch_oe_or_scalar(
+        py,
+        anm_mean_or_oe,
+        e,
+        |oe| orbits::anomaly_mean_to_true(oe[5], oe[1], af).map_err(exceptions::PyRuntimeError::new_err),
+        |v, e| {
+            let ecc = e.ok_or_else(|| {
+                exceptions::PyValueError::new_err(
+                    "Parameter 'e' is required when 'anm_mean_or_oe' is a scalar",
+                )
+            })?;
+            orbits::anomaly_mean_to_true(v, ecc, af).map_err(exceptions::PyRuntimeError::new_err)
+        },
+    )
 }
 
 // New propagator implementations
@@ -2048,12 +2317,17 @@ fn py_states_koe_mean_to_osc<'py>(
 /// Convert Keplerian elements to equinoctial elements (Vallado 2-99).
 ///
 /// Args:
-///     koe (numpy.ndarray): Keplerian `[a, e, i, Ω, ω, M]` (a in meters; angles per angle_format).
+///     koe (numpy.ndarray or list): Keplerian `[a, e, i, Ω, ω, M]` (a in meters; angles per angle_format).
+///         Also accepts a batch of element sets with the 6 components along `axis`
+///         (for example shape `(n, 6)`).
 ///     angle_format (AngleFormat): Format of angular inputs/outputs.
 ///     fr (int): Retrograde factor, +1 for direct orbits, -1 for near-retrograde. Defaults to 1.
+///     axis (int, optional): Axis of `koe` holding the element components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
 ///     numpy.ndarray: Equinoctial `[a, h, k, p, q, l]` (a in meters; l per angle_format).
+///         For batched input the output takes the batch layout of `koe`.
 ///
 /// Example:
 ///     ```python
@@ -2062,29 +2336,39 @@ fn py_states_koe_mean_to_osc<'py>(
 ///     eqn = bh.state_koe_to_equinoctial(koe, bh.AngleFormat.DEGREES)
 ///     ```
 #[pyfunction]
-#[pyo3(signature = (koe, angle_format, fr=1), text_signature = "(koe, angle_format, fr=1)")]
+#[pyo3(signature = (koe, angle_format, fr=1, axis=-1), text_signature = "(koe, angle_format, fr=1, axis=-1)")]
 #[pyo3(name = "state_koe_to_equinoctial")]
 fn py_state_koe_to_equinoctial<'py>(
     py: Python<'py>,
-    koe: &Bound<'_, PyAny>,
+    koe: &Bound<'py, PyAny>,
     angle_format: &PyAngleFormat,
     fr: i8,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let koe_vec = pyany_to_f64_array1(koe, Some(6))?;
-    let koe_svec = SVector::<f64, 6>::from_row_slice(&koe_vec);
-    let eqn = orbits::state_koe_to_equinoctial(&koe_svec, angle_format.value, fr);
-    Ok(eqn.as_slice().to_pyarray(py))
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    let af = angle_format.value;
+    dispatch_vec::<6>(
+        py,
+        koe,
+        axis,
+        |v| orbits::state_koe_to_equinoctial(&v, af, fr),
+        |vs| orbits::states_koe_to_equinoctial(vs, af, fr),
+    )
 }
 
 /// Convert equinoctial elements to Keplerian elements (Vallado 2-99).
 ///
 /// Args:
-///     eqn (numpy.ndarray): Equinoctial `[a, h, k, p, q, l]` (a in meters; l per angle_format).
+///     eqn (numpy.ndarray or list): Equinoctial `[a, h, k, p, q, l]` (a in meters; l per angle_format).
+///         Also accepts a batch of element sets with the 6 components along `axis`
+///         (for example shape `(n, 6)`).
 ///     angle_format (AngleFormat): Format of angular input/outputs.
 ///     fr (int): Retrograde factor matching the forward conversion. Defaults to 1.
+///     axis (int, optional): Axis of `eqn` holding the element components for batched
+///         input. Defaults to `-1` (the last axis).
 ///
 /// Returns:
 ///     numpy.ndarray: Keplerian `[a, e, i, Ω, ω, M]` (a in meters; angles per angle_format).
+///         For batched input the output takes the batch layout of `eqn`.
 ///
 /// Example:
 ///     ```python
@@ -2094,18 +2378,23 @@ fn py_state_koe_to_equinoctial<'py>(
 ///     back = bh.state_equinoctial_to_koe(eqn, bh.AngleFormat.DEGREES)
 ///     ```
 #[pyfunction]
-#[pyo3(signature = (eqn, angle_format, fr=1), text_signature = "(eqn, angle_format, fr=1)")]
+#[pyo3(signature = (eqn, angle_format, fr=1, axis=-1), text_signature = "(eqn, angle_format, fr=1, axis=-1)")]
 #[pyo3(name = "state_equinoctial_to_koe")]
 fn py_state_equinoctial_to_koe<'py>(
     py: Python<'py>,
-    eqn: &Bound<'_, PyAny>,
+    eqn: &Bound<'py, PyAny>,
     angle_format: &PyAngleFormat,
     fr: i8,
-) -> PyResult<Bound<'py, PyArray<f64, Ix1>>> {
-    let eqn_vec = pyany_to_f64_array1(eqn, Some(6))?;
-    let eqn_svec = SVector::<f64, 6>::from_row_slice(&eqn_vec);
-    let koe = orbits::state_equinoctial_to_koe(&eqn_svec, angle_format.value, fr);
-    Ok(koe.as_slice().to_pyarray(py))
+    axis: isize,
+) -> PyResult<Bound<'py, PyAny>> {
+    let af = angle_format.value;
+    dispatch_vec::<6>(
+        py,
+        eqn,
+        axis,
+        |v| orbits::state_equinoctial_to_koe(&v, af, fr),
+        |vs| orbits::states_equinoctial_to_koe(vs, af, fr),
+    )
 }
 
 // ============================================================================

--- a/crates/brahe-py/src/orbits.rs
+++ b/crates/brahe-py/src/orbits.rs
@@ -24,8 +24,8 @@
 ///
 ///     # Using a batch of Keplerian element sets, one result per row
 ///     oe = [bh.R_EARTH + 400e3, 0.001, np.radians(51.6), 0, 0, 0]
-///     period = bh.orbital_period(np.array([oe, oe]))
-///     print(f"Orbital period: {period/60:.2f} minutes")
+///     period_rows = bh.orbital_period(np.array([oe, oe]))
+///     print(f"Orbital period: (first row) {period_rows[0]/60:.2f} minutes")
 ///     ```
 #[pyfunction]
 #[pyo3(signature = (a_or_oe), text_signature = "(a_or_oe)")]
@@ -68,8 +68,8 @@ fn py_orbital_period<'py>(
 ///
 ///     # Using a batch of Keplerian element sets, one result per row
 ///     oe = [1900000.0, 0.01, np.radians(45), 0, 0, 0]
-///     period = bh.orbital_period_general(np.array([oe, oe]), bh.GM_MOON)
-///     print(f"Lunar orbital period: {period/3600:.2f} hours")
+///     period_rows = bh.orbital_period_general(np.array([oe, oe]), bh.GM_MOON)
+///     print(f"Lunar orbital period: (first row) {period_rows[0]/3600:.2f} hours")
 ///     ```
 #[pyfunction]
 #[pyo3(signature = (a_or_oe, gm), text_signature = "(a_or_oe, gm)")]
@@ -165,8 +165,8 @@ fn py_orbital_period_from_state<'py>(
 ///
 ///     # Using a batch of Keplerian element sets, one result per row
 ///     oe = [bh.R_EARTH + 35786e3, 0.001, np.radians(0), 0, 0, 0]
-///     n = bh.mean_motion(np.array([oe, oe]), bh.AngleFormat.DEGREES)
-///     print(f"Mean motion: {n:.6f} deg/s")
+///     n_rows = bh.mean_motion(np.array([oe, oe]), bh.AngleFormat.DEGREES)
+///     print(f"Mean motion: (first row) {n_rows[0]:.6f} deg/s")
 ///     ```
 #[pyfunction]
 #[pyo3(signature = (a_or_oe, angle_format), text_signature = "(a_or_oe, angle_format)")]
@@ -213,8 +213,8 @@ fn py_mean_motion<'py>(
 ///
 ///     # Using a batch of Keplerian element sets, one result per row
 ///     oe = [4000000.0, 0.01, np.radians(30), 0, 0, 0]
-///     n = bh.mean_motion_general(np.array([oe, oe]), bh.GM_MARS, bh.AngleFormat.RADIANS)
-///     print(f"Mean motion: {n:.6f} rad/s")
+///     n_rows = bh.mean_motion_general(np.array([oe, oe]), bh.GM_MARS, bh.AngleFormat.RADIANS)
+///     print(f"Mean motion: (first row) {n_rows[0]:.6f} rad/s")
 ///     ```
 #[pyfunction]
 #[pyo3(signature = (a_or_oe, gm, angle_format), text_signature = "(a_or_oe, gm, angle_format)")]
@@ -391,8 +391,8 @@ fn py_semimajor_axis_from_orbital_period<'py>(
 ///
 ///     # Using a batch of Keplerian element sets, one result per row
 ///     oe = [26554000.0, 0.72, np.radians(63.4), 0, 0, 0]
-///     v_peri = bh.perigee_velocity(np.array([oe, oe]))
-///     print(f"Perigee velocity: {v_peri:.2f} m/s")
+///     v_peri_rows = bh.perigee_velocity(np.array([oe, oe]))
+///     print(f"Perigee velocity: (first row) {v_peri_rows[0]:.2f} m/s")
 ///     ```
 #[pyfunction]
 #[pyo3(signature = (a_or_oe, e=None), text_signature = "(a_or_oe, e=None)")]
@@ -442,13 +442,13 @@ fn py_perigee_velocity<'py>(
 ///     # Using scalar parameters
 ///     a = 5e11  # 5 AU semi-major axis (meters)
 ///     e = 0.95  # highly elliptical
-///     v_peri = bh.periapsis_velocity(a, e, bh.GM_SUN)
+///     v_peri = bh.periapsis_velocity(a, e, gm=bh.GM_SUN)
 ///     print(f"Periapsis velocity: {v_peri/1000:.2f} km/s")
 ///
 ///     # Using a batch of Keplerian element sets, one result per row
 ///     oe = [5e11, 0.95, np.radians(10), 0, 0, 0]
-///     v_peri = bh.periapsis_velocity(np.array([oe, oe]), gm=bh.GM_SUN)
-///     print(f"Periapsis velocity: {v_peri/1000:.2f} km/s")
+///     v_peri_rows = bh.periapsis_velocity(np.array([oe, oe]), gm=bh.GM_SUN)
+///     print(f"Periapsis velocity: (first row) {v_peri_rows[0]/1000:.2f} km/s")
 ///     ```
 #[pyfunction]
 #[pyo3(signature = (a_or_oe, e=None, *, gm), text_signature = "(a_or_oe, e=None, *, gm)")]
@@ -503,8 +503,8 @@ fn py_periapsis_velocity<'py>(
 ///
 ///     # Using a batch of Keplerian element sets, one result per row
 ///     oe = [8000000.0, 0.2, np.radians(45), 0, 0, 0]
-///     r_peri = bh.periapsis_distance(np.array([oe, oe]))
-///     print(f"Periapsis distance: {r_peri/1000:.2f} km")
+///     r_peri_rows = bh.periapsis_distance(np.array([oe, oe]))
+///     print(f"Periapsis distance: (first row) {r_peri_rows[0]/1000:.2f} km")
 ///     ```
 #[pyfunction]
 #[pyo3(signature = (a_or_oe, e=None), text_signature = "(a_or_oe, e=None)")]
@@ -558,8 +558,8 @@ fn py_periapsis_distance<'py>(
 ///
 ///     # Using a batch of Keplerian element sets, one result per row
 ///     oe = [24400000.0, 0.73, np.radians(7), 0, 0, 0]
-///     v_apo = bh.apogee_velocity(np.array([oe, oe]))
-///     print(f"Apogee velocity: {v_apo:.2f} m/s")
+///     v_apo_rows = bh.apogee_velocity(np.array([oe, oe]))
+///     print(f"Apogee velocity: (first row) {v_apo_rows[0]:.2f} m/s")
 ///     ```
 #[pyfunction]
 #[pyo3(signature = (a_or_oe, e=None), text_signature = "(a_or_oe, e=None)")]
@@ -609,13 +609,13 @@ fn py_apogee_velocity<'py>(
 ///     # Using scalar parameters
 ///     a = 10000000.0  # 10000 km semi-major axis
 ///     e = 0.3
-///     v_apo = bh.apoapsis_velocity(a, e, bh.GM_MARS)
+///     v_apo = bh.apoapsis_velocity(a, e, gm=bh.GM_MARS)
 ///     print(f"Apoapsis velocity: {v_apo/1000:.2f} km/s")
 ///
 ///     # Using a batch of Keplerian element sets, one result per row
 ///     oe = [10000000.0, 0.3, np.radians(30), 0, 0, 0]
-///     v_apo = bh.apoapsis_velocity(np.array([oe, oe]), gm=bh.GM_MARS)
-///     print(f"Apoapsis velocity: {v_apo/1000:.2f} km/s")
+///     v_apo_rows = bh.apoapsis_velocity(np.array([oe, oe]), gm=bh.GM_MARS)
+///     print(f"Apoapsis velocity: (first row) {v_apo_rows[0]/1000:.2f} km/s")
 ///     ```
 #[pyfunction]
 #[pyo3(signature = (a_or_oe, e=None, *, gm), text_signature = "(a_or_oe, e=None, *, gm)")]
@@ -670,8 +670,8 @@ fn py_apoapsis_velocity<'py>(
 ///
 ///     # Using a batch of Keplerian element sets, one result per row
 ///     oe = [8000000.0, 0.2, np.radians(45), 0, 0, 0]
-///     r_apo = bh.apoapsis_distance(np.array([oe, oe]))
-///     print(f"Apoapsis distance: {r_apo/1000:.2f} km")
+///     r_apo_rows = bh.apoapsis_distance(np.array([oe, oe]))
+///     print(f"Apoapsis distance: (first row) {r_apo_rows[0]/1000:.2f} km")
 ///     ```
 #[pyfunction]
 #[pyo3(signature = (a_or_oe, e=None), text_signature = "(a_or_oe, e=None)")]
@@ -721,13 +721,13 @@ fn py_apoapsis_distance<'py>(
 ///     # Using scalar parameters
 ///     a = bh.R_EARTH + 500e3  # 500 km mean altitude
 ///     e = 0.01  # slight eccentricity
-///     alt_peri = bh.periapsis_altitude(a, e, bh.R_EARTH)
+///     alt_peri = bh.periapsis_altitude(a, e, r_body=bh.R_EARTH)
 ///     print(f"Periapsis altitude: {alt_peri/1000:.2f} km")
 ///
 ///     # Using a batch of Keplerian element sets, one result per row
 ///     oe = [bh.R_EARTH + 500e3, 0.01, np.radians(45), 0, 0, 0]
-///     alt_peri = bh.periapsis_altitude(np.array([oe, oe]), r_body=bh.R_EARTH)
-///     print(f"Periapsis altitude: {alt_peri/1000:.2f} km")
+///     alt_peri_rows = bh.periapsis_altitude(np.array([oe, oe]), r_body=bh.R_EARTH)
+///     print(f"Periapsis altitude: (first row) {alt_peri_rows[0]/1000:.2f} km")
 ///     ```
 #[pyfunction]
 #[pyo3(signature = (a_or_oe, e=None, *, r_body), text_signature = "(a_or_oe, e=None, *, r_body)")]
@@ -782,8 +782,8 @@ fn py_periapsis_altitude<'py>(
 ///
 ///     # Using a batch of Keplerian element sets, one result per row
 ///     oe = [bh.R_EARTH + 420e3, 0.0005, np.radians(51.6), 0, 0, 0]
-///     alt = bh.perigee_altitude(np.array([oe, oe]))
-///     print(f"Perigee altitude: {alt/1000:.2f} km")
+///     alt_rows = bh.perigee_altitude(np.array([oe, oe]))
+///     print(f"Perigee altitude: (first row) {alt_rows[0]/1000:.2f} km")
 ///     ```
 #[pyfunction]
 #[pyo3(signature = (a_or_oe, e=None), text_signature = "(a_or_oe, e=None)")]
@@ -833,13 +833,13 @@ fn py_perigee_altitude<'py>(
 ///     # Using scalar parameters
 ///     a = bh.R_MOON + 100e3  # 100 km mean altitude
 ///     e = 0.05  # moderate eccentricity
-///     alt_apo = bh.apoapsis_altitude(a, e, bh.R_MOON)
+///     alt_apo = bh.apoapsis_altitude(a, e, r_body=bh.R_MOON)
 ///     print(f"Apoapsis altitude: {alt_apo/1000:.2f} km")
 ///
 ///     # Using a batch of Keplerian element sets, one result per row
 ///     oe = [bh.R_MOON + 100e3, 0.05, np.radians(30), 0, 0, 0]
-///     alt_apo = bh.apoapsis_altitude(np.array([oe, oe]), r_body=bh.R_MOON)
-///     print(f"Apoapsis altitude: {alt_apo/1000:.2f} km")
+///     alt_apo_rows = bh.apoapsis_altitude(np.array([oe, oe]), r_body=bh.R_MOON)
+///     print(f"Apoapsis altitude: (first row) {alt_apo_rows[0]/1000:.2f} km")
 ///     ```
 #[pyfunction]
 #[pyo3(signature = (a_or_oe, e=None, *, r_body), text_signature = "(a_or_oe, e=None, *, r_body)")]
@@ -894,8 +894,8 @@ fn py_apoapsis_altitude<'py>(
 ///
 ///     # Using a batch of Keplerian element sets, one result per row
 ///     oe = [26554000.0, 0.7, np.radians(63.4), 0, 0, 0]
-///     alt = bh.apogee_altitude(np.array([oe, oe]))
-///     print(f"Apogee altitude: {alt/1000:.2f} km")
+///     alt_rows = bh.apogee_altitude(np.array([oe, oe]))
+///     print(f"Apogee altitude: (first row) {alt_rows[0]/1000:.2f} km")
 ///     ```
 #[pyfunction]
 #[pyo3(signature = (a_or_oe, e=None), text_signature = "(a_or_oe, e=None)")]
@@ -946,13 +946,13 @@ fn py_apogee_altitude<'py>(
 ///     # Using scalar parameters
 ///     a = bh.R_EARTH + 600e3
 ///     e = 0.001  # nearly circular
-///     inc = bh.sun_synchronous_inclination(a, e, bh.AngleFormat.DEGREES)
+///     inc = bh.sun_synchronous_inclination(a, e, angle_format=bh.AngleFormat.DEGREES)
 ///     print(f"Sun-synchronous inclination: {inc:.2f} degrees")
 ///
 ///     # Using a batch of Keplerian element sets, one result per row
 ///     oe = [bh.R_EARTH + 600e3, 0.001, np.radians(97.8), 0, 0, 0]
-///     inc = bh.sun_synchronous_inclination(np.array([oe, oe]), angle_format=bh.AngleFormat.DEGREES)
-///     print(f"Sun-synchronous inclination: {inc:.2f} degrees")
+///     inc_rows = bh.sun_synchronous_inclination(np.array([oe, oe]), angle_format=bh.AngleFormat.DEGREES)
+///     print(f"Sun-synchronous inclination: (first row) {inc_rows[0]:.2f} degrees")
 ///     ```
 #[pyfunction]
 #[pyo3(signature = (a_or_oe, e=None, *, angle_format), text_signature = "(a_or_oe, e=None, *, angle_format)")]
@@ -1022,13 +1022,13 @@ fn py_geo_sma() -> PyResult<f64> {
 ///     # Using scalar parameters
 ///     E = np.pi / 4  # 45 degrees eccentric anomaly
 ///     e = 0.1  # eccentricity
-///     M = bh.anomaly_eccentric_to_mean(E, e, bh.AngleFormat.RADIANS)
+///     M = bh.anomaly_eccentric_to_mean(E, e, angle_format=bh.AngleFormat.RADIANS)
 ///     print(f"Mean anomaly: {M:.4f} radians")
 ///
 ///     # Using a batch of Keplerian element sets (eccentric anomaly at index 5), one result per row
 ///     oe = [bh.R_EARTH + 500e3, 0.1, np.radians(45), 0, 0, np.pi/4]
-///     M = bh.anomaly_eccentric_to_mean(np.array([oe, oe]), angle_format=bh.AngleFormat.RADIANS)
-///     print(f"Mean anomaly: {M:.4f} radians")
+///     M_rows = bh.anomaly_eccentric_to_mean(np.array([oe, oe]), angle_format=bh.AngleFormat.RADIANS)
+///     print(f"Mean anomaly: (first row) {M_rows[0]:.4f} radians")
 ///     ```
 #[pyfunction]
 #[pyo3(signature = (anm_ecc_or_oe, e=None, *, angle_format), text_signature = "(anm_ecc_or_oe, e=None, *, angle_format)")]
@@ -1080,13 +1080,13 @@ fn py_anomaly_eccentric_to_mean<'py>(
 ///     # Using scalar parameters
 ///     M = 1.5  # mean anomaly in radians
 ///     e = 0.3  # eccentricity
-///     E = bh.anomaly_mean_to_eccentric(M, e, bh.AngleFormat.RADIANS)
+///     E = bh.anomaly_mean_to_eccentric(M, e, angle_format=bh.AngleFormat.RADIANS)
 ///     print(f"Eccentric anomaly: {E:.4f} radians")
 ///
 ///     # Using a batch of Keplerian element sets (mean anomaly at index 5), one result per row
 ///     oe = [bh.R_EARTH + 500e3, 0.3, np.radians(45), 0, 0, 1.5]
-///     E = bh.anomaly_mean_to_eccentric(np.array([oe, oe]), angle_format=bh.AngleFormat.RADIANS)
-///     print(f"Eccentric anomaly: {E:.4f} radians")
+///     E_rows = bh.anomaly_mean_to_eccentric(np.array([oe, oe]), angle_format=bh.AngleFormat.RADIANS)
+///     print(f"Eccentric anomaly: (first row) {E_rows[0]:.4f} radians")
 ///     ```
 #[pyfunction]
 #[pyo3(signature = (anm_mean_or_oe, e=None, *, angle_format), text_signature = "(anm_mean_or_oe, e=None, *, angle_format)")]
@@ -1138,13 +1138,13 @@ fn py_anomaly_mean_to_eccentric<'py>(
 ///     # Using scalar parameters
 ///     nu = np.pi / 3  # 60 degrees true anomaly
 ///     e = 0.2  # eccentricity
-///     E = bh.anomaly_true_to_eccentric(nu, e, bh.AngleFormat.RADIANS)
+///     E = bh.anomaly_true_to_eccentric(nu, e, angle_format=bh.AngleFormat.RADIANS)
 ///     print(f"Eccentric anomaly: {E:.4f} radians")
 ///
 ///     # Using a batch of Keplerian element sets (true anomaly at index 5), one result per row
 ///     oe = [bh.R_EARTH + 500e3, 0.2, np.radians(45), 0, 0, np.pi/3]
-///     E = bh.anomaly_true_to_eccentric(np.array([oe, oe]), angle_format=bh.AngleFormat.RADIANS)
-///     print(f"Eccentric anomaly: {E:.4f} radians")
+///     E_rows = bh.anomaly_true_to_eccentric(np.array([oe, oe]), angle_format=bh.AngleFormat.RADIANS)
+///     print(f"Eccentric anomaly: (first row) {E_rows[0]:.4f} radians")
 ///     ```
 #[pyfunction]
 #[pyo3(signature = (anm_true_or_oe, e=None, *, angle_format), text_signature = "(anm_true_or_oe, e=None, *, angle_format)")]
@@ -1196,13 +1196,13 @@ fn py_anomaly_true_to_eccentric<'py>(
 ///     # Using scalar parameters
 ///     E = np.pi / 4  # 45 degrees eccentric anomaly
 ///     e = 0.4  # eccentricity
-///     nu = bh.anomaly_eccentric_to_true(E, e, bh.AngleFormat.RADIANS)
+///     nu = bh.anomaly_eccentric_to_true(E, e, angle_format=bh.AngleFormat.RADIANS)
 ///     print(f"True anomaly: {nu:.4f} radians")
 ///
 ///     # Using a batch of Keplerian element sets (eccentric anomaly at index 5), one result per row
 ///     oe = [bh.R_EARTH + 500e3, 0.4, np.radians(45), 0, 0, np.pi/4]
-///     nu = bh.anomaly_eccentric_to_true(np.array([oe, oe]), angle_format=bh.AngleFormat.RADIANS)
-///     print(f"True anomaly: {nu:.4f} radians")
+///     nu_rows = bh.anomaly_eccentric_to_true(np.array([oe, oe]), angle_format=bh.AngleFormat.RADIANS)
+///     print(f"True anomaly: (first row) {nu_rows[0]:.4f} radians")
 ///     ```
 #[pyfunction]
 #[pyo3(signature = (anm_ecc_or_oe, e=None, *, angle_format), text_signature = "(anm_ecc_or_oe, e=None, *, angle_format)")]
@@ -1254,13 +1254,13 @@ fn py_anomaly_eccentric_to_true<'py>(
 ///     # Using scalar parameters
 ///     nu = np.pi / 2  # 90 degrees true anomaly
 ///     e = 0.15  # eccentricity
-///     M = bh.anomaly_true_to_mean(nu, e, bh.AngleFormat.RADIANS)
+///     M = bh.anomaly_true_to_mean(nu, e, angle_format=bh.AngleFormat.RADIANS)
 ///     print(f"Mean anomaly: {M:.4f} radians")
 ///
 ///     # Using a batch of Keplerian element sets (true anomaly at index 5), one result per row
 ///     oe = [bh.R_EARTH + 500e3, 0.15, np.radians(45), 0, 0, np.pi/2]
-///     M = bh.anomaly_true_to_mean(np.array([oe, oe]), angle_format=bh.AngleFormat.RADIANS)
-///     print(f"Mean anomaly: {M:.4f} radians")
+///     M_rows = bh.anomaly_true_to_mean(np.array([oe, oe]), angle_format=bh.AngleFormat.RADIANS)
+///     print(f"Mean anomaly: (first row) {M_rows[0]:.4f} radians")
 ///     ```
 #[pyfunction]
 #[pyo3(signature = (anm_true_or_oe, e=None, *, angle_format), text_signature = "(anm_true_or_oe, e=None, *, angle_format)")]
@@ -1312,13 +1312,13 @@ fn py_anomaly_true_to_mean<'py>(
 ///     # Using scalar parameters
 ///     M = 2.0  # mean anomaly in radians
 ///     e = 0.25  # eccentricity
-///     nu = bh.anomaly_mean_to_true(M, e, bh.AngleFormat.RADIANS)
+///     nu = bh.anomaly_mean_to_true(M, e, angle_format=bh.AngleFormat.RADIANS)
 ///     print(f"True anomaly: {nu:.4f} radians")
 ///
 ///     # Using a batch of Keplerian element sets (mean anomaly at index 5), one result per row
 ///     oe = [bh.R_EARTH + 500e3, 0.25, np.radians(45), 0, 0, 2.0]
-///     nu = bh.anomaly_mean_to_true(np.array([oe, oe]), angle_format=bh.AngleFormat.RADIANS)
-///     print(f"True anomaly: {nu:.4f} radians")
+///     nu_rows = bh.anomaly_mean_to_true(np.array([oe, oe]), angle_format=bh.AngleFormat.RADIANS)
+///     print(f"True anomaly: (first row) {nu_rows[0]:.4f} radians")
 ///     ```
 #[pyfunction]
 #[pyo3(signature = (anm_mean_or_oe, e=None, *, angle_format), text_signature = "(anm_mean_or_oe, e=None, *, angle_format)")]
@@ -1596,8 +1596,10 @@ fn py_norad_id_alpha5_to_numeric(alpha5_id: String) -> PyResult<u32> {
 ///
 /// Examples:
 ///     ```python
+///     import brahe as bh
+///
 ///     line1 = "1 25544U 98067A   21001.50000000  .00001764  00000-0  40967-4 0  9997"
-///     epoch = epoch_from_tle(line1)
+///     epoch = bh.epoch_from_tle(line1)
 ///     epoch.year()
 ///     ```
 #[pyfunction]

--- a/crates/brahe-py/src/orbits.rs
+++ b/crates/brahe-py/src/orbits.rs
@@ -98,8 +98,10 @@ fn py_orbital_period_general<'py>(
 ///         Also accepts a batch of states with the 6 components along `axis`
 ///         (for example shape `(n, 6)`).
 ///     gm (float): Gravitational parameter in m³/s². Use GM_EARTH for Earth orbits.
-///     axis (int, optional): Axis of `state_eci` holding the state components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `state_eci` along which the 6 state components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 6)` the components lie along the last axis, so the default `-1`
+///         applies; a `(6, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     float or numpy.ndarray: Orbital period in seconds.
@@ -2318,8 +2320,10 @@ fn py_states_koe_mean_to_osc<'py>(
 ///         (for example shape `(n, 6)`).
 ///     angle_format (AngleFormat): Format of angular inputs/outputs.
 ///     fr (int): Retrograde factor, +1 for direct orbits, -1 for near-retrograde. Defaults to 1.
-///     axis (int, optional): Axis of `koe` holding the element components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `koe` along which the 6 element components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 6)` the components lie along the last axis, so the default `-1`
+///         applies; a `(6, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Equinoctial `[a, h, k, p, q, l]` (a in meters; l per angle_format).
@@ -2359,8 +2363,10 @@ fn py_state_koe_to_equinoctial<'py>(
 ///         (for example shape `(n, 6)`).
 ///     angle_format (AngleFormat): Format of angular input/outputs.
 ///     fr (int): Retrograde factor matching the forward conversion. Defaults to 1.
-///     axis (int, optional): Axis of `eqn` holding the element components for batched
-///         input. Defaults to `-1` (the last axis).
+///     axis (int, optional): The axis of `eqn` along which the 6 element components of a
+///         single vector lie; the remaining axes enumerate the batch. For a batch of
+///         shape `(n, 6)` the components lie along the last axis, so the default `-1`
+///         applies; a `(6, n)` column layout uses `axis=0`.
 ///
 /// Returns:
 ///     numpy.ndarray: Keplerian `[a, e, i, Ω, ω, M]` (a in meters; angles per angle_format).

--- a/crates/brahe-py/src/orbits.rs
+++ b/crates/brahe-py/src/orbits.rs
@@ -9,8 +9,7 @@
 ///
 /// Returns:
 ///     float or numpy.ndarray: The orbital period of the astronomical object in seconds.
-///         An array is returned for array input, with shape `(n,)` for `n` element
-///         sets or the broadcast shape for element-wise input.
+///         An array of shape `(n,)` is returned for a batch of `n` element sets.
 ///
 /// Example:
 ///     ```python
@@ -53,8 +52,7 @@ fn py_orbital_period<'py>(
 ///
 /// Returns:
 ///     float or numpy.ndarray: The orbital period of the astronomical object in seconds.
-///         An array is returned for array input, with shape `(n,)` for `n` element
-///         sets or the broadcast shape for element-wise input.
+///         An array of shape `(n,)` is returned for a batch of `n` element sets.
 ///
 /// Example:
 ///     ```python
@@ -150,8 +148,7 @@ fn py_orbital_period_from_state<'py>(
 ///
 /// Returns:
 ///     float or numpy.ndarray: The mean motion of the astronomical object in radians or degrees.
-///         An array is returned for array input, with shape `(n,)` for `n` element
-///         sets or the broadcast shape for element-wise input.
+///         An array of shape `(n,)` is returned for a batch of `n` element sets.
 ///
 /// Example:
 ///     ```python
@@ -198,8 +195,7 @@ fn py_mean_motion<'py>(
 ///
 /// Returns:
 ///     float or numpy.ndarray: The mean motion of the astronomical object in radians or degrees.
-///         An array is returned for array input, with shape `(n,)` for `n` element
-///         sets or the broadcast shape for element-wise input.
+///         An array of shape `(n,)` is returned for a batch of `n` element sets.
 ///
 /// Example:
 ///     ```python
@@ -371,7 +367,8 @@ fn py_semimajor_axis_from_orbital_period<'py>(
 ///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
 ///         arrays of any shape are evaluated element-wise (broadcast against `e`).
 ///     e (float or array, optional): The eccentricity. Required if `a_or_oe` is a scalar, ignored if vector.
-///         Broadcast against `a_or_oe` when either is an array.
+///         Ignored when `a_or_oe` is an element set; otherwise broadcast against `a_or_oe` when
+///         either is an array.
 ///
 /// Returns:
 ///     float or numpy.ndarray: The magnitude of velocity of the object at perigee in m/s.
@@ -426,7 +423,8 @@ fn py_perigee_velocity<'py>(
 ///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
 ///         arrays of any shape are evaluated element-wise (broadcast against `e`).
 ///     e (float or array, optional): The eccentricity. Required if `a_or_oe` is a scalar, ignored if vector.
-///         Broadcast against `a_or_oe` when either is an array.
+///         Ignored when `a_or_oe` is an element set; otherwise broadcast against `a_or_oe` when
+///         either is an array.
 ///     gm (float): (keyword-only) The standard gravitational parameter of primary body in m³/s².
 ///
 /// Returns:
@@ -483,7 +481,8 @@ fn py_periapsis_velocity<'py>(
 ///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
 ///         arrays of any shape are evaluated element-wise (broadcast against `e`).
 ///     e (float or array, optional): The eccentricity. Required if `a_or_oe` is a scalar, ignored if vector.
-///         Broadcast against `a_or_oe` when either is an array.
+///         Ignored when `a_or_oe` is an element set; otherwise broadcast against `a_or_oe` when
+///         either is an array.
 ///
 /// Returns:
 ///     float or numpy.ndarray: The distance of the object at periapsis in meters.
@@ -538,7 +537,8 @@ fn py_periapsis_distance<'py>(
 ///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
 ///         arrays of any shape are evaluated element-wise (broadcast against `e`).
 ///     e (float or array, optional): The eccentricity. Required if `a_or_oe` is a scalar, ignored if vector.
-///         Broadcast against `a_or_oe` when either is an array.
+///         Ignored when `a_or_oe` is an element set; otherwise broadcast against `a_or_oe` when
+///         either is an array.
 ///
 /// Returns:
 ///     float or numpy.ndarray: The magnitude of velocity of the object at apogee in m/s.
@@ -593,7 +593,8 @@ fn py_apogee_velocity<'py>(
 ///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
 ///         arrays of any shape are evaluated element-wise (broadcast against `e`).
 ///     e (float or array, optional): The eccentricity. Required if `a_or_oe` is a scalar, ignored if vector.
-///         Broadcast against `a_or_oe` when either is an array.
+///         Ignored when `a_or_oe` is an element set; otherwise broadcast against `a_or_oe` when
+///         either is an array.
 ///     gm (float): (keyword-only) The standard gravitational parameter of primary body in m³/s².
 ///
 /// Returns:
@@ -650,7 +651,8 @@ fn py_apoapsis_velocity<'py>(
 ///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
 ///         arrays of any shape are evaluated element-wise (broadcast against `e`).
 ///     e (float or array, optional): The eccentricity. Required if `a_or_oe` is a scalar, ignored if vector.
-///         Broadcast against `a_or_oe` when either is an array.
+///         Ignored when `a_or_oe` is an element set; otherwise broadcast against `a_or_oe` when
+///         either is an array.
 ///
 /// Returns:
 ///     float or numpy.ndarray: The distance of the object at apoapsis in meters.
@@ -705,7 +707,8 @@ fn py_apoapsis_distance<'py>(
 ///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
 ///         arrays of any shape are evaluated element-wise (broadcast against `e`).
 ///     e (float or array, optional): The eccentricity. Required if `a_or_oe` is a scalar, ignored if vector.
-///         Broadcast against `a_or_oe` when either is an array.
+///         Ignored when `a_or_oe` is an element set; otherwise broadcast against `a_or_oe` when
+///         either is an array.
 ///     r_body (float): (keyword-only) The radius of the central body in meters.
 ///
 /// Returns:
@@ -762,7 +765,8 @@ fn py_periapsis_altitude<'py>(
 ///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
 ///         arrays of any shape are evaluated element-wise (broadcast against `e`).
 ///     e (float or array, optional): The eccentricity. Required if `a_or_oe` is a scalar, ignored if vector.
-///         Broadcast against `a_or_oe` when either is an array.
+///         Ignored when `a_or_oe` is an element set; otherwise broadcast against `a_or_oe` when
+///         either is an array.
 ///
 /// Returns:
 ///     float or numpy.ndarray: The altitude above Earth's surface at perigee in meters.
@@ -817,7 +821,8 @@ fn py_perigee_altitude<'py>(
 ///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
 ///         arrays of any shape are evaluated element-wise (broadcast against `e`).
 ///     e (float or array, optional): The eccentricity. Required if `a_or_oe` is a scalar, ignored if vector.
-///         Broadcast against `a_or_oe` when either is an array.
+///         Ignored when `a_or_oe` is an element set; otherwise broadcast against `a_or_oe` when
+///         either is an array.
 ///     r_body (float): (keyword-only) The radius of the central body in meters.
 ///
 /// Returns:
@@ -874,7 +879,8 @@ fn py_apoapsis_altitude<'py>(
 ///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
 ///         arrays of any shape are evaluated element-wise (broadcast against `e`).
 ///     e (float or array, optional): The eccentricity. Required if `a_or_oe` is a scalar, ignored if vector.
-///         Broadcast against `a_or_oe` when either is an array.
+///         Ignored when `a_or_oe` is an element set; otherwise broadcast against `a_or_oe` when
+///         either is an array.
 ///
 /// Returns:
 ///     float or numpy.ndarray: The altitude above Earth's surface at apogee in meters.
@@ -930,7 +936,8 @@ fn py_apogee_altitude<'py>(
 ///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
 ///         arrays of any shape are evaluated element-wise (broadcast against `e`).
 ///     e (float or array, optional): The eccentricity. Required if `a_or_oe` is a scalar, ignored if vector.
-///         Broadcast against `a_or_oe` when either is an array.
+///         Ignored when `a_or_oe` is an element set; otherwise broadcast against `a_or_oe` when
+///         either is an array.
 ///     angle_format (AngleFormat): (keyword-only) Return output in AngleFormat.DEGREES or AngleFormat.RADIANS.
 ///
 /// Returns:
@@ -1007,7 +1014,8 @@ fn py_geo_sma() -> PyResult<f64> {
 ///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
 ///         arrays of any shape are evaluated element-wise (broadcast against `e`).
 ///     e (float or array, optional): The eccentricity. Required if `anm_ecc_or_oe` is a scalar, ignored if vector.
-///         Broadcast against `anm_ecc_or_oe` when either is an array.
+///         Ignored when `anm_ecc_or_oe` is an element set; otherwise broadcast against `anm_ecc_or_oe` when
+///         either is an array.
 ///     angle_format (AngleFormat): (keyword-only) Interprets input and returns output in AngleFormat.DEGREES or AngleFormat.RADIANS.
 ///
 /// Returns:
@@ -1066,7 +1074,8 @@ fn py_anomaly_eccentric_to_mean<'py>(
 ///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
 ///         arrays of any shape are evaluated element-wise (broadcast against `e`).
 ///     e (float or array, optional): The eccentricity. Required if `anm_mean_or_oe` is a scalar, ignored if vector.
-///         Broadcast against `anm_mean_or_oe` when either is an array.
+///         Ignored when `anm_mean_or_oe` is an element set; otherwise broadcast against `anm_mean_or_oe` when
+///         either is an array.
 ///     angle_format (AngleFormat): (keyword-only) Interprets input and returns output in AngleFormat.DEGREES or AngleFormat.RADIANS.
 ///
 /// Returns:
@@ -1125,7 +1134,8 @@ fn py_anomaly_mean_to_eccentric<'py>(
 ///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
 ///         arrays of any shape are evaluated element-wise (broadcast against `e`).
 ///     e (float or array, optional): The eccentricity. Required if `anm_true_or_oe` is a scalar, ignored if vector.
-///         Broadcast against `anm_true_or_oe` when either is an array.
+///         Ignored when `anm_true_or_oe` is an element set; otherwise broadcast against `anm_true_or_oe` when
+///         either is an array.
 ///     angle_format (AngleFormat): (keyword-only) Interprets input and returns output in AngleFormat.DEGREES or AngleFormat.RADIANS.
 ///
 /// Returns:
@@ -1184,7 +1194,8 @@ fn py_anomaly_true_to_eccentric<'py>(
 ///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
 ///         arrays of any shape are evaluated element-wise (broadcast against `e`).
 ///     e (float or array, optional): The eccentricity. Required if `anm_ecc_or_oe` is a scalar, ignored if vector.
-///         Broadcast against `anm_ecc_or_oe` when either is an array.
+///         Ignored when `anm_ecc_or_oe` is an element set; otherwise broadcast against `anm_ecc_or_oe` when
+///         either is an array.
 ///     angle_format (AngleFormat): (keyword-only) Interprets input and returns output in AngleFormat.DEGREES or AngleFormat.RADIANS.
 ///
 /// Returns:
@@ -1243,7 +1254,8 @@ fn py_anomaly_eccentric_to_true<'py>(
 ///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
 ///         arrays of any shape are evaluated element-wise (broadcast against `e`).
 ///     e (float or array, optional): The eccentricity. Required if `anm_true_or_oe` is a scalar, ignored if vector.
-///         Broadcast against `anm_true_or_oe` when either is an array.
+///         Ignored when `anm_true_or_oe` is an element set; otherwise broadcast against `anm_true_or_oe` when
+///         either is an array.
 ///     angle_format (AngleFormat): (keyword-only) Interprets input and returns output in AngleFormat.DEGREES or AngleFormat.RADIANS.
 ///
 /// Returns:
@@ -1302,7 +1314,8 @@ fn py_anomaly_true_to_mean<'py>(
 ///         A 2-D array of shape `(n, 6)` is treated as `n` element sets. When `e` is given,
 ///         arrays of any shape are evaluated element-wise (broadcast against `e`).
 ///     e (float or array, optional): The eccentricity. Required if `anm_mean_or_oe` is a scalar, ignored if vector.
-///         Broadcast against `anm_mean_or_oe` when either is an array.
+///         Ignored when `anm_mean_or_oe` is an element set; otherwise broadcast against `anm_mean_or_oe` when
+///         either is an array.
 ///     angle_format (AngleFormat): (keyword-only) Interprets input and returns output in AngleFormat.DEGREES or AngleFormat.RADIANS.
 ///
 /// Returns:

--- a/docs/learn/orbits/index.md
+++ b/docs/learn/orbits/index.md
@@ -42,7 +42,7 @@ These functions are found in the [coordinates module](../coordinates/cartesian_t
 
 ## Batch Input
 
-The orbital-property and anomaly functions accept arrays as well as scalars. A `(n, 6)` array of Keplerian element sets evaluates one result per row, and when the eccentricity is passed explicitly, the first argument and `e` may be arrays of any shape and are broadcast against each other with numpy rules; the pure numeric functions such as `semimajor_axis` evaluate arrays element-wise. `state_koe_to_equinoctial`, `state_equinoctial_to_koe`, and `orbital_period_from_state` accept batches of element sets or states with the `axis` keyword, following the rules in [Vectorized Transformations](../frames/vectorized.md).
+The orbital-property and anomaly functions accept arrays as well as scalars, following one rule: a 2-D array of shape `(n, 6)` passed without an explicit eccentricity is a batch of Keplerian element sets and evaluates one result per row (`orbital_period(oes)`, `anomaly_mean_to_true(oes, angle_format=...)`); every other array, including a 1-D array of any length, is a set of values evaluated element-wise, and the first argument and `e` are broadcast against each other with numpy rules (`perigee_velocity(oes[:, 0], oes[:, 1])`). The pure numeric functions such as `semimajor_axis` evaluate arrays element-wise. `state_koe_to_equinoctial`, `state_equinoctial_to_koe`, and `orbital_period_from_state` accept batches of element sets or states with the `axis` keyword, following the rules in [Vectorized Transformations](../frames/vectorized.md).
 
 ## Topics in This Section
 

--- a/docs/learn/orbits/index.md
+++ b/docs/learn/orbits/index.md
@@ -40,6 +40,10 @@ Brahe provides functions to convert between Keplerian elements and Cartesian sta
 
 These functions are found in the [coordinates module](../coordinates/cartesian_transformations.md) but are essential for working with orbits.
 
+## Batch Input
+
+The orbital-property and anomaly functions accept arrays as well as scalars. A `(n, 6)` array of Keplerian element sets evaluates one result per row, and when the eccentricity is passed explicitly, the first argument and `e` may be arrays of any shape and are broadcast against each other with numpy rules; the pure numeric functions such as `semimajor_axis` evaluate arrays element-wise. `state_koe_to_equinoctial`, `state_equinoctial_to_koe`, and `orbital_period_from_state` accept batches of element sets or states with the `axis` keyword, following the rules in [Vectorized Transformations](../frames/vectorized.md).
+
 ## Topics in This Section
 
 ### [Orbital Properties](properties.md)

--- a/docs/learn/orbits/mean_elements.md
+++ b/docs/learn/orbits/mean_elements.md
@@ -57,7 +57,7 @@ the truncated higher-order terms of the series remains, growing with eccentricit
 
 ## Numerical (Windowed Averaging)
 
-`batch_state_koe_osc_to_mean` and `batch_state_koe_mean_to_osc`, given
+`states_koe_osc_to_mean` and `states_koe_mean_to_osc`, given
 `MeanElementMethod.numerical(config)`, average an osculating trajectory over a moving window to
 produce mean elements that reflect whatever dynamics were used to generate the input trajectory —
 not just $J_2$. This is the appropriate method when higher-fidelity perturbations (drag, third-body,
@@ -207,8 +207,8 @@ average over the window, so the result is independent of input sampling cadence 
 |---|---|---|
 | Osculating → mean | Single state | [`state_koe_osc_to_mean`](../../library_api/orbits/mean_elements.md#brahe.orbits.state_koe_osc_to_mean) |
 | Mean → osculating | Single state | [`state_koe_mean_to_osc`](../../library_api/orbits/mean_elements.md#brahe.orbits.state_koe_mean_to_osc) |
-| Osculating → mean | Batch | [`batch_state_koe_osc_to_mean`](../../library_api/orbits/mean_elements.md#brahe.orbits.batch_state_koe_osc_to_mean) |
-| Mean → osculating | Batch | [`batch_state_koe_mean_to_osc`](../../library_api/orbits/mean_elements.md#brahe.orbits.batch_state_koe_mean_to_osc) |
+| Osculating → mean | Batch | [`states_koe_osc_to_mean`](../../library_api/orbits/mean_elements.md#brahe.orbits.states_koe_osc_to_mean) |
+| Mean → osculating | Batch | [`states_koe_mean_to_osc`](../../library_api/orbits/mean_elements.md#brahe.orbits.states_koe_mean_to_osc) |
 
 All functions operate on Keplerian elements `[a, e, i, Ω, ω, anomaly]` in SI units (`a` in meters)
 with angles in the format specified by `AngleFormat`.

--- a/docs/library_api/orbits/mean_elements.md
+++ b/docs/library_api/orbits/mean_elements.md
@@ -14,9 +14,9 @@ first-order Brouwer-Lyddane theory or numerical windowed averaging.
 
 ## Batch Conversions
 
-::: brahe.orbits.batch_state_koe_osc_to_mean
+::: brahe.orbits.states_koe_osc_to_mean
 
-::: brahe.orbits.batch_state_koe_mean_to_osc
+::: brahe.orbits.states_koe_mean_to_osc
 
 ## Methods and Configuration
 

--- a/examples/orbits/mean_osculating_inverse.py
+++ b/examples/orbits/mean_osculating_inverse.py
@@ -36,7 +36,7 @@ config = bh.MeanElementNumericalMethodConfig(
 method = bh.MeanElementMethod.numerical(config)
 
 epoch = bh.Epoch.from_gps_seconds(0.0)
-out_epochs, out_states = bh.batch_state_koe_mean_to_osc(
+out_epochs, out_states = bh.states_koe_mean_to_osc(
     [epoch], mean.reshape(1, 6), method, bh.AngleFormat.DEGREES
 )
 osc = out_states[0]

--- a/examples/orbits/mean_osculating_inverse.rs
+++ b/examples/orbits/mean_osculating_inverse.rs
@@ -35,7 +35,7 @@ fn main() {
     let method = bh::orbits::MeanElementMethod::Numerical(config);
 
     let epoch = bh::time::Epoch::from_gps_seconds(0.0);
-    let out = bh::orbits::batch_state_koe_mean_to_osc(
+    let out = bh::orbits::states_koe_mean_to_osc(
         &[epoch],
         &[mean],
         method,

--- a/examples/orbits/mean_osculating_numerical.py
+++ b/examples/orbits/mean_osculating_numerical.py
@@ -47,7 +47,7 @@ config = bh.MeanElementNumericalMethodConfig(
 )
 method_numerical = bh.MeanElementMethod.numerical(config)
 
-out_epochs, out_states = bh.batch_state_koe_osc_to_mean(
+out_epochs, out_states = bh.states_koe_osc_to_mean(
     epochs, osc_states, method_numerical, bh.AngleFormat.DEGREES
 )
 

--- a/examples/orbits/mean_osculating_numerical.rs
+++ b/examples/orbits/mean_osculating_numerical.rs
@@ -55,7 +55,7 @@ fn main() {
     };
     let method_numerical = bh::orbits::MeanElementMethod::Numerical(config);
 
-    let out = bh::orbits::batch_state_koe_osc_to_mean(
+    let out = bh::orbits::states_koe_osc_to_mean(
         &epochs,
         &osc_states,
         method_numerical,

--- a/scripts/add_stub_annotations.py
+++ b/scripts/add_stub_annotations.py
@@ -21,7 +21,9 @@ def parse_return_type_from_docstring(doc: str) -> str:
 
     # Look for Returns: section - match type including dots for numpy.ndarray, etc.
     returns_match = re.search(
-        r"Returns:\s*\n\s*([\w.]+(?:\[[\w\[\], ]+\])?)", doc, re.MULTILINE
+        r"Returns:\s*\n\s*([\w.]+(?:\[[\w\[\], ]+\])?(?: or [\w.]+)*)(?=:)",
+        doc,
+        re.MULTILINE,
     )
     if returns_match:
         type_str = returns_match.group(1).strip()

--- a/src/orbits/equinoctial.rs
+++ b/src/orbits/equinoctial.rs
@@ -8,6 +8,7 @@
 
 use crate::constants::AngleFormat;
 use crate::math::angles::{oe_to_degrees, oe_to_radians, wrap_to_2pi};
+use crate::utils::batch::batch_map;
 use nalgebra::SVector;
 
 /// Convert Keplerian elements to equinoctial elements.
@@ -109,6 +110,68 @@ pub fn state_equinoctial_to_koe(
     }
 }
 
+/// Converts a batch of Keplerian element sets to equinoctial elements.
+///
+/// Batch form of [`state_koe_to_equinoctial`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// # Arguments
+/// - `koe`: Keplerian element sets `[a, e, i, Ω, ω, M]`. Units: (*m*, dimensionless, angles per `angle_format`)
+/// - `angle_format`: Format of the angular elements
+/// - `fr`: Retrograde factor, `+1` for prograde or `-1` for retrograde
+///
+/// # Returns
+/// - Equinoctial element sets `[a, h, k, p, q, l]` in input order
+///
+/// # Examples
+/// ```
+/// use brahe::constants::{R_EARTH, AngleFormat};
+/// use brahe::orbits::states_koe_to_equinoctial;
+/// use nalgebra::SVector;
+///
+/// let koe = vec![SVector::<f64, 6>::new(R_EARTH + 500e3, 0.01, 45.0, 30.0, 60.0, 90.0); 3];
+/// let eqn = states_koe_to_equinoctial(&koe, AngleFormat::Degrees, 1);
+/// assert_eq!(eqn.len(), 3);
+/// ```
+pub fn states_koe_to_equinoctial(
+    koe: &[SVector<f64, 6>],
+    angle_format: AngleFormat,
+    fr: i8,
+) -> Vec<SVector<f64, 6>> {
+    batch_map(koe, |x| state_koe_to_equinoctial(x, angle_format, fr))
+}
+
+/// Converts a batch of equinoctial element sets to Keplerian elements.
+///
+/// Batch form of [`state_equinoctial_to_koe`]. Evaluation runs on the global thread pool for
+/// large inputs.
+///
+/// # Arguments
+/// - `eqn`: Equinoctial element sets `[a, h, k, p, q, l]`
+/// - `angle_format`: Format of the returned angular elements
+/// - `fr`: Retrograde factor, `+1` for prograde or `-1` for retrograde
+///
+/// # Returns
+/// - Keplerian element sets `[a, e, i, Ω, ω, M]` in input order. Units: (*m*, dimensionless, angles per `angle_format`)
+///
+/// # Examples
+/// ```
+/// use brahe::constants::{R_EARTH, AngleFormat};
+/// use brahe::orbits::{state_koe_to_equinoctial, states_equinoctial_to_koe};
+/// use nalgebra::SVector;
+///
+/// let eqn = state_koe_to_equinoctial(&SVector::<f64, 6>::new(R_EARTH + 500e3, 0.01, 45.0, 30.0, 60.0, 90.0), AngleFormat::Degrees, 1);
+/// let koe = states_equinoctial_to_koe(&[eqn, eqn], AngleFormat::Degrees, 1);
+/// assert_eq!(koe.len(), 2);
+/// ```
+pub fn states_equinoctial_to_koe(
+    eqn: &[SVector<f64, 6>],
+    angle_format: AngleFormat,
+    fr: i8,
+) -> Vec<SVector<f64, 6>> {
+    batch_map(eqn, |x| state_equinoctial_to_koe(x, angle_format, fr))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -154,5 +217,38 @@ mod tests {
         let eqn = state_koe_to_equinoctial(&koe, AngleFormat::Degrees, -1);
         let back = state_equinoctial_to_koe(&eqn, AngleFormat::Degrees, -1);
         assert_koe_close(&koe, &back);
+    }
+
+    #[test]
+    #[parallel]
+    fn test_batch_equinoctial_match_scalar() {
+        let koe: Vec<SVector<f64, 6>> = (0..3)
+            .map(|i| {
+                SVector::<f64, 6>::new(
+                    R_EARTH + 500e3 + 1e3 * i as f64,
+                    0.01,
+                    45.0,
+                    30.0 + i as f64,
+                    60.0,
+                    90.0,
+                )
+            })
+            .collect();
+        for fr in [1i8, -1i8] {
+            let eqn = states_koe_to_equinoctial(&koe, AngleFormat::Degrees, fr);
+            let back = states_equinoctial_to_koe(&eqn, AngleFormat::Degrees, fr);
+            for i in 0..3 {
+                assert_eq!(
+                    eqn[i],
+                    state_koe_to_equinoctial(&koe[i], AngleFormat::Degrees, fr)
+                );
+                assert_eq!(
+                    back[i],
+                    state_equinoctial_to_koe(&eqn[i], AngleFormat::Degrees, fr)
+                );
+                assert_koe_close(&back[i], &koe[i]);
+            }
+        }
+        assert!(states_koe_to_equinoctial(&[], AngleFormat::Degrees, 1).is_empty());
     }
 }

--- a/src/orbits/equinoctial.rs
+++ b/src/orbits/equinoctial.rs
@@ -138,7 +138,7 @@ pub fn states_koe_to_equinoctial(
     angle_format: AngleFormat,
     fr: i8,
 ) -> Vec<SVector<f64, 6>> {
-    batch_map(koe, |x| state_koe_to_equinoctial(x, angle_format, fr))
+    batch_map(|x| state_koe_to_equinoctial(x, angle_format, fr), koe)
 }
 
 /// Converts a batch of equinoctial element sets to Keplerian elements.
@@ -169,7 +169,7 @@ pub fn states_equinoctial_to_koe(
     angle_format: AngleFormat,
     fr: i8,
 ) -> Vec<SVector<f64, 6>> {
-    batch_map(eqn, |x| state_equinoctial_to_koe(x, angle_format, fr))
+    batch_map(|x| state_equinoctial_to_koe(x, angle_format, fr), eqn)
 }
 
 #[cfg(test)]

--- a/src/orbits/mean_elements.rs
+++ b/src/orbits/mean_elements.rs
@@ -118,7 +118,7 @@ enum TransformDirection {
 ///   - `osc[4]`: Argument of perigee `ω` (radians or degrees, per `angle_format`)
 ///   - `osc[5]`: Mean anomaly `M` (radians or degrees, per `angle_format`)
 /// * `method` - Algorithm used to compute mean elements. `MeanElementMethod::Numerical`
-///   is batch-only and always returns `Err` here; use `batch_state_koe_osc_to_mean`.
+///   is batch-only and always returns `Err` here; use `states_koe_osc_to_mean`.
 /// * `angle_format` - Format of angular elements in input and output
 ///
 /// # Returns
@@ -178,7 +178,7 @@ pub fn state_koe_osc_to_mean(
         }
         MeanElementMethod::Numerical(_) => Err(BraheError::Error(
             "Numerical mean-element method requires a batch of states; \
-             use batch_state_koe_osc_to_mean"
+             use states_koe_osc_to_mean"
                 .to_string(),
         )),
     }
@@ -200,7 +200,7 @@ pub fn state_koe_osc_to_mean(
 ///   - `mean[4]`: Argument of perigee `ω` (radians or degrees, per `angle_format`)
 ///   - `mean[5]`: Mean anomaly `M` (radians or degrees, per `angle_format`)
 /// * `method` - Algorithm used to compute osculating elements. `MeanElementMethod::Numerical`
-///   is batch-only and always returns `Err` here; use `batch_state_koe_mean_to_osc`.
+///   is batch-only and always returns `Err` here; use `states_koe_mean_to_osc`.
 /// * `angle_format` - Format of angular elements in input and output
 ///
 /// # Returns
@@ -260,7 +260,7 @@ pub fn state_koe_mean_to_osc(
         }
         MeanElementMethod::Numerical(_) => Err(BraheError::Error(
             "Numerical mean-element method requires a batch of states; \
-             use batch_state_koe_mean_to_osc"
+             use states_koe_mean_to_osc"
                 .to_string(),
         )),
     }
@@ -292,18 +292,18 @@ pub fn state_koe_mean_to_osc(
 /// ```
 /// use nalgebra::SVector;
 /// use brahe::time::Epoch;
-/// use brahe::orbits::{batch_state_koe_osc_to_mean, MeanElementMethod};
+/// use brahe::orbits::{states_koe_osc_to_mean, MeanElementMethod};
 /// use brahe::constants::{R_EARTH, AngleFormat};
 ///
 /// let epochs = vec![Epoch::from_gps_seconds(0.0), Epoch::from_gps_seconds(60.0)];
 /// let osc = SVector::<f64, 6>::new(R_EARTH + 500e3, 0.001, 45.0, 0.0, 0.0, 0.0);
 /// let states = vec![osc, osc];
 ///
-/// let mean = batch_state_koe_osc_to_mean(
+/// let mean = states_koe_osc_to_mean(
 ///     &epochs, &states, MeanElementMethod::BrouwerLyddane, AngleFormat::Degrees,
 /// ).unwrap();
 /// ```
-pub fn batch_state_koe_osc_to_mean(
+pub fn states_koe_osc_to_mean(
     epochs: &[Epoch],
     states: &[SVector<f64, 6>],
     method: MeanElementMethod,
@@ -360,18 +360,18 @@ pub fn batch_state_koe_osc_to_mean(
 /// ```
 /// use nalgebra::SVector;
 /// use brahe::time::Epoch;
-/// use brahe::orbits::{batch_state_koe_mean_to_osc, MeanElementMethod};
+/// use brahe::orbits::{states_koe_mean_to_osc, MeanElementMethod};
 /// use brahe::constants::{R_EARTH, AngleFormat};
 ///
 /// let epochs = vec![Epoch::from_gps_seconds(0.0), Epoch::from_gps_seconds(60.0)];
 /// let mean = SVector::<f64, 6>::new(R_EARTH + 500e3, 0.001, 45.0, 0.0, 0.0, 0.0);
 /// let states = vec![mean, mean];
 ///
-/// let osc = batch_state_koe_mean_to_osc(
+/// let osc = states_koe_mean_to_osc(
 ///     &epochs, &states, MeanElementMethod::BrouwerLyddane, AngleFormat::Degrees,
 /// ).unwrap();
 /// ```
-pub fn batch_state_koe_mean_to_osc(
+pub fn states_koe_mean_to_osc(
     epochs: &[Epoch],
     states: &[SVector<f64, 6>],
     method: MeanElementMethod,
@@ -1088,7 +1088,7 @@ mod tests {
         ];
         let s = SVector::<f64, 6>::new(R_EARTH + 500e3, 0.01, 45.0, 30.0, 60.0, 90.0);
         let states = vec![s, s, s];
-        let out = batch_state_koe_osc_to_mean(
+        let out = states_koe_osc_to_mean(
             &epochs,
             &states,
             MeanElementMethod::BrouwerLyddane,
@@ -1117,7 +1117,7 @@ mod tests {
         ];
         let s = SVector::<f64, 6>::new(R_EARTH + 500e3, 0.01, 45.0, 30.0, 60.0, 90.0);
         let states = vec![s, s];
-        let out = batch_state_koe_osc_to_mean(
+        let out = states_koe_osc_to_mean(
             &epochs,
             &states,
             MeanElementMethod::BrouwerLyddane,
@@ -1149,7 +1149,7 @@ mod tests {
             inverse: Some(inverse),
         };
         let epochs = vec![Epoch::from_gps_seconds(0.0)];
-        let osc = batch_state_koe_mean_to_osc(
+        let osc = states_koe_mean_to_osc(
             &epochs,
             &[mean],
             MeanElementMethod::Numerical(cfg),
@@ -1188,7 +1188,7 @@ mod tests {
             inverse: Some(inverse),
         };
         let epochs = vec![Epoch::from_gps_seconds(0.0)];
-        let osc = batch_state_koe_mean_to_osc(
+        let osc = states_koe_mean_to_osc(
             &epochs,
             &[mean],
             MeanElementMethod::Numerical(cfg),
@@ -1220,7 +1220,7 @@ mod tests {
         assert!(out.is_err());
     }
 
-    /// `batch_state_koe_osc_to_mean` dispatches `MeanElementMethod::Numerical` to
+    /// `states_koe_osc_to_mean` dispatches `MeanElementMethod::Numerical` to
     /// `numerical_osc_to_mean` + `convert_pairs_out`; this path was previously untested
     /// via the public batch API (only the mean->osc Numerical dispatch was covered).
     /// Build a synthesized osculating trajectory analytically (sweeping mean anomaly
@@ -1252,7 +1252,7 @@ mod tests {
             edge: WindowEdgeHandling::Truncate,
             inverse: None,
         };
-        let out = batch_state_koe_osc_to_mean(
+        let out = states_koe_osc_to_mean(
             &epochs,
             &states,
             MeanElementMethod::Numerical(cfg),
@@ -1293,7 +1293,7 @@ mod tests {
             edge: WindowEdgeHandling::Truncate,
             inverse: None,
         };
-        let out = batch_state_koe_osc_to_mean(
+        let out = states_koe_osc_to_mean(
             &epochs,
             &states,
             MeanElementMethod::Numerical(cfg),
@@ -1306,7 +1306,7 @@ mod tests {
         assert_abs_diff_eq!(mid[2], 45.0_f64.to_radians(), epsilon = 2e-3);
     }
 
-    /// `batch_state_koe_mean_to_osc` must reject mismatched `epochs`/`states` lengths
+    /// `states_koe_mean_to_osc` must reject mismatched `epochs`/`states` lengths
     /// (mirrors `test_batch_mismatched_lengths_is_error`, which only covers the
     /// osc->mean direction).
     #[test]
@@ -1319,7 +1319,7 @@ mod tests {
         ];
         let s = SVector::<f64, 6>::new(R_EARTH + 500e3, 0.01, 45.0, 30.0, 60.0, 90.0);
         let states = vec![s, s];
-        let out = batch_state_koe_mean_to_osc(
+        let out = states_koe_mean_to_osc(
             &epochs,
             &states,
             MeanElementMethod::BrouwerLyddane,
@@ -1342,7 +1342,7 @@ mod tests {
         ];
         let s = SVector::<f64, 6>::new(R_EARTH + 500e3, 0.01, 45.0, 30.0, 60.0, 90.0);
         let states = vec![s, s, s];
-        let out = batch_state_koe_mean_to_osc(
+        let out = states_koe_mean_to_osc(
             &epochs,
             &states,
             MeanElementMethod::BrouwerLyddane,

--- a/tests/orbits/test_equinoctial.py
+++ b/tests/orbits/test_equinoctial.py
@@ -41,3 +41,28 @@ def test_equinoctial_fr_defaults_to_one():
     eqn_default = bh.state_koe_to_equinoctial(koe, bh.AngleFormat.DEGREES)
     eqn_explicit = bh.state_koe_to_equinoctial(koe, bh.AngleFormat.DEGREES, 1)
     np.testing.assert_allclose(eqn_default, eqn_explicit)
+
+
+def test_batch_equinoctial():
+    koe = np.array(
+        [
+            [bh.R_EARTH + 500e3 + 1e3 * i, 0.01, 45.0, 30.0 + i, 60.0, 90.0]
+            for i in range(3)
+        ]
+    )
+    for fr in (1, -1):
+        eqn = bh.state_koe_to_equinoctial(koe, bh.AngleFormat.DEGREES, fr)
+        back = bh.state_equinoctial_to_koe(eqn, bh.AngleFormat.DEGREES, fr)
+        assert eqn.shape == (3, 6)
+        for i in range(3):
+            np.testing.assert_array_equal(
+                eqn[i], bh.state_koe_to_equinoctial(koe[i], bh.AngleFormat.DEGREES, fr)
+            )
+            np.testing.assert_array_equal(
+                back[i], bh.state_equinoctial_to_koe(eqn[i], bh.AngleFormat.DEGREES, fr)
+            )
+        np.testing.assert_allclose(back, koe, atol=1e-6)
+        np.testing.assert_array_equal(
+            bh.state_koe_to_equinoctial(koe.T, bh.AngleFormat.DEGREES, fr, axis=0),
+            eqn.T,
+        )

--- a/tests/orbits/test_keplerian.py
+++ b/tests/orbits/test_keplerian.py
@@ -468,7 +468,7 @@ def test_orbital_period_vector():
     oe = [a, 0.01, math.radians(45), 0, 0, 0]
 
     # Test with vector
-    T_vec = brahe.orbital_period(oe)
+    T_vec = brahe.orbital_period(np.array([oe]))[0]
     # Test with scalar (for comparison)
     T_scalar = brahe.orbital_period(a)
 
@@ -481,7 +481,7 @@ def test_orbital_period_general_vector():
     a = brahe.R_EARTH + 500e3
     oe = [a, 0.01, math.radians(45), 0, 0, 0]
 
-    T_vec = brahe.orbital_period_general(oe, brahe.GM_EARTH)
+    T_vec = brahe.orbital_period_general(np.array([oe]), brahe.GM_EARTH)[0]
     T_scalar = brahe.orbital_period_general(a, brahe.GM_EARTH)
 
     assert T_vec == pytest.approx(T_scalar, abs=1e-12)
@@ -492,7 +492,7 @@ def test_mean_motion_vector():
     a = brahe.R_EARTH + 500e3
     oe = [a, 0.01, math.radians(45), 0, 0, 0]
 
-    n_vec = brahe.mean_motion(oe, angle_format=AngleFormat.RADIANS)
+    n_vec = brahe.mean_motion(np.array([oe]), angle_format=AngleFormat.RADIANS)[0]
     n_scalar = brahe.mean_motion(a, angle_format=AngleFormat.RADIANS)
 
     assert n_vec == pytest.approx(n_scalar, abs=1e-12)
@@ -505,8 +505,8 @@ def test_mean_motion_general_vector():
     oe = [a, 0.01, 45, 0, 0, 0]
 
     n_vec = brahe.mean_motion_general(
-        oe, brahe.GM_EARTH, angle_format=AngleFormat.DEGREES
-    )
+        np.array([oe]), brahe.GM_EARTH, angle_format=AngleFormat.DEGREES
+    )[0]
     n_scalar = brahe.mean_motion_general(
         a, brahe.GM_EARTH, angle_format=AngleFormat.DEGREES
     )
@@ -520,7 +520,7 @@ def test_perigee_velocity_vector():
     e = 0.72
     oe = [a, e, math.radians(63.4), 0, 0, 0]
 
-    v_vec = brahe.perigee_velocity(oe)
+    v_vec = brahe.perigee_velocity(np.array([oe]))[0]
     v_scalar = brahe.perigee_velocity(a, e)
 
     assert v_vec == pytest.approx(v_scalar, abs=1e-6)
@@ -532,7 +532,7 @@ def test_periapsis_velocity_vector():
     e = 0.95
     oe = [a, e, math.radians(10), 0, 0, 0]
 
-    v_vec = brahe.periapsis_velocity(oe, gm=brahe.GM_SUN)
+    v_vec = brahe.periapsis_velocity(np.array([oe]), gm=brahe.GM_SUN)[0]
     v_scalar = brahe.periapsis_velocity(a, e, gm=brahe.GM_SUN)
 
     assert v_vec == pytest.approx(v_scalar, abs=1e-6)
@@ -544,7 +544,7 @@ def test_apogee_velocity_vector():
     e = 0.73
     oe = [a, e, math.radians(7), 0, 0, 0]
 
-    v_vec = brahe.apogee_velocity(oe)
+    v_vec = brahe.apogee_velocity(np.array([oe]))[0]
     v_scalar = brahe.apogee_velocity(a, e)
 
     assert v_vec == pytest.approx(v_scalar, abs=1e-6)
@@ -556,7 +556,7 @@ def test_apoapsis_velocity_vector():
     e = 0.3
     oe = [a, e, math.radians(30), 0, 0, 0]
 
-    v_vec = brahe.apoapsis_velocity(oe, gm=brahe.GM_MARS)
+    v_vec = brahe.apoapsis_velocity(np.array([oe]), gm=brahe.GM_MARS)[0]
     v_scalar = brahe.apoapsis_velocity(a, e, gm=brahe.GM_MARS)
 
     assert v_vec == pytest.approx(v_scalar, abs=1e-6)
@@ -568,7 +568,7 @@ def test_periapsis_distance_vector():
     e = 0.2
     oe = [a, e, math.radians(45), 0, 0, 0]
 
-    r_vec = brahe.periapsis_distance(oe)
+    r_vec = brahe.periapsis_distance(np.array([oe]))[0]
     r_scalar = brahe.periapsis_distance(a, e)
 
     assert r_vec == pytest.approx(r_scalar, abs=1e-6)
@@ -580,7 +580,7 @@ def test_apoapsis_distance_vector():
     e = 0.2
     oe = [a, e, math.radians(45), 0, 0, 0]
 
-    r_vec = brahe.apoapsis_distance(oe)
+    r_vec = brahe.apoapsis_distance(np.array([oe]))[0]
     r_scalar = brahe.apoapsis_distance(a, e)
 
     assert r_vec == pytest.approx(r_scalar, abs=1e-6)
@@ -592,7 +592,7 @@ def test_periapsis_altitude_vector():
     e = 0.01
     oe = [a, e, math.radians(45), 0, 0, 0]
 
-    alt_vec = brahe.periapsis_altitude(oe, r_body=brahe.R_EARTH)
+    alt_vec = brahe.periapsis_altitude(np.array([oe]), r_body=brahe.R_EARTH)[0]
     alt_scalar = brahe.periapsis_altitude(a, e, r_body=brahe.R_EARTH)
 
     assert alt_vec == pytest.approx(alt_scalar, abs=1e-6)
@@ -604,7 +604,7 @@ def test_perigee_altitude_vector():
     e = 0.0005
     oe = [a, e, math.radians(51.6), 0, 0, 0]
 
-    alt_vec = brahe.perigee_altitude(oe)
+    alt_vec = brahe.perigee_altitude(np.array([oe]))[0]
     alt_scalar = brahe.perigee_altitude(a, e)
 
     assert alt_vec == pytest.approx(alt_scalar, abs=1e-6)
@@ -616,7 +616,7 @@ def test_apoapsis_altitude_vector():
     e = 0.05
     oe = [a, e, math.radians(30), 0, 0, 0]
 
-    alt_vec = brahe.apoapsis_altitude(oe, r_body=brahe.R_MOON)
+    alt_vec = brahe.apoapsis_altitude(np.array([oe]), r_body=brahe.R_MOON)[0]
     alt_scalar = brahe.apoapsis_altitude(a, e, r_body=brahe.R_MOON)
 
     assert alt_vec == pytest.approx(alt_scalar, abs=1e-6)
@@ -628,7 +628,7 @@ def test_apogee_altitude_vector():
     e = 0.7
     oe = [a, e, math.radians(63.4), 0, 0, 0]
 
-    alt_vec = brahe.apogee_altitude(oe)
+    alt_vec = brahe.apogee_altitude(np.array([oe]))[0]
     alt_scalar = brahe.apogee_altitude(a, e)
 
     assert alt_vec == pytest.approx(alt_scalar, abs=1e-6)
@@ -640,7 +640,9 @@ def test_sun_synchronous_inclination_vector():
     e = 0.001
     oe = [a, e, 97.8, 0, 0, 0]
 
-    inc_vec = brahe.sun_synchronous_inclination(oe, angle_format=AngleFormat.DEGREES)
+    inc_vec = brahe.sun_synchronous_inclination(
+        np.array([oe]), angle_format=AngleFormat.DEGREES
+    )[0]
     inc_scalar = brahe.sun_synchronous_inclination(
         a, e, angle_format=AngleFormat.DEGREES
     )
@@ -654,7 +656,9 @@ def test_anomaly_eccentric_to_mean_vector():
     e = 0.1
     oe = [brahe.R_EARTH + 500e3, e, math.radians(45), 0, 0, E]
 
-    M_vec = brahe.anomaly_eccentric_to_mean(oe, angle_format=AngleFormat.RADIANS)
+    M_vec = brahe.anomaly_eccentric_to_mean(
+        np.array([oe]), angle_format=AngleFormat.RADIANS
+    )[0]
     M_scalar = brahe.anomaly_eccentric_to_mean(E, e, angle_format=AngleFormat.RADIANS)
 
     assert M_vec == pytest.approx(M_scalar, abs=1e-12)
@@ -666,7 +670,9 @@ def test_anomaly_mean_to_eccentric_vector():
     e = 0.3
     oe = [brahe.R_EARTH + 500e3, e, math.radians(45), 0, 0, M]
 
-    E_vec = brahe.anomaly_mean_to_eccentric(oe, angle_format=AngleFormat.RADIANS)
+    E_vec = brahe.anomaly_mean_to_eccentric(
+        np.array([oe]), angle_format=AngleFormat.RADIANS
+    )[0]
     E_scalar = brahe.anomaly_mean_to_eccentric(M, e, angle_format=AngleFormat.RADIANS)
 
     assert E_vec == pytest.approx(E_scalar, abs=1e-12)
@@ -678,7 +684,9 @@ def test_anomaly_true_to_eccentric_vector():
     e = 0.2
     oe = [brahe.R_EARTH + 500e3, e, math.radians(45), 0, 0, nu]
 
-    E_vec = brahe.anomaly_true_to_eccentric(oe, angle_format=AngleFormat.RADIANS)
+    E_vec = brahe.anomaly_true_to_eccentric(
+        np.array([oe]), angle_format=AngleFormat.RADIANS
+    )[0]
     E_scalar = brahe.anomaly_true_to_eccentric(nu, e, angle_format=AngleFormat.RADIANS)
 
     assert E_vec == pytest.approx(E_scalar, abs=1e-12)
@@ -690,7 +698,9 @@ def test_anomaly_eccentric_to_true_vector():
     e = 0.4
     oe = [brahe.R_EARTH + 500e3, e, math.radians(45), 0, 0, E]
 
-    nu_vec = brahe.anomaly_eccentric_to_true(oe, angle_format=AngleFormat.RADIANS)
+    nu_vec = brahe.anomaly_eccentric_to_true(
+        np.array([oe]), angle_format=AngleFormat.RADIANS
+    )[0]
     nu_scalar = brahe.anomaly_eccentric_to_true(E, e, angle_format=AngleFormat.RADIANS)
 
     assert nu_vec == pytest.approx(nu_scalar, abs=1e-12)
@@ -702,7 +712,9 @@ def test_anomaly_true_to_mean_vector():
     e = 0.15
     oe = [brahe.R_EARTH + 500e3, e, math.radians(45), 0, 0, nu]
 
-    M_vec = brahe.anomaly_true_to_mean(oe, angle_format=AngleFormat.RADIANS)
+    M_vec = brahe.anomaly_true_to_mean(
+        np.array([oe]), angle_format=AngleFormat.RADIANS
+    )[0]
     M_scalar = brahe.anomaly_true_to_mean(nu, e, angle_format=AngleFormat.RADIANS)
 
     assert M_vec == pytest.approx(M_scalar, abs=1e-12)
@@ -714,42 +726,55 @@ def test_anomaly_mean_to_true_vector():
     e = 0.25
     oe = [brahe.R_EARTH + 500e3, e, math.radians(45), 0, 0, M]
 
-    nu_vec = brahe.anomaly_mean_to_true(oe, angle_format=AngleFormat.RADIANS)
+    nu_vec = brahe.anomaly_mean_to_true(
+        np.array([oe]), angle_format=AngleFormat.RADIANS
+    )[0]
     nu_scalar = brahe.anomaly_mean_to_true(M, e, angle_format=AngleFormat.RADIANS)
 
     assert nu_vec == pytest.approx(nu_scalar, abs=1e-12)
 
 
 def test_vector_with_numpy_array():
-    """Test that numpy arrays work as Keplerian element vectors"""
+    """Test that a (1, 6) numpy array works as a batch of one Keplerian element set"""
     a = brahe.R_EARTH + 500e3
     e = 0.01
     oe_np = np.array([a, e, math.radians(45), 0, 0, 0])
 
-    T_np = brahe.orbital_period(oe_np)
+    T_np = brahe.orbital_period(np.array([oe_np]))[0]
     T_scalar = brahe.orbital_period(a)
 
     assert T_np == pytest.approx(T_scalar, abs=1e-12)
 
 
 def test_vector_with_list():
-    """Test that Python lists work as Keplerian element vectors"""
+    """Test that a nested list works as a batch of one Keplerian element set"""
     a = brahe.R_EARTH + 500e3
     e = 0.01
     oe_list = [a, e, math.radians(45), 0, 0, 0]
 
-    T_list = brahe.orbital_period(oe_list)
+    T_list = brahe.orbital_period([oe_list])[0]
     T_scalar = brahe.orbital_period(a)
 
     assert T_list == pytest.approx(T_scalar, abs=1e-12)
 
 
-def test_vector_wrong_length():
-    """Test that wrong-length vectors raise appropriate errors"""
-    oe_short = [brahe.R_EARTH + 500e3, 0.01]
+def test_one_dimensional_arrays_are_element_wise():
+    """A 1-D array of any length (including 6) is a set of values, never an element set"""
+    a_values = [brahe.R_EARTH + 500e3, brahe.R_EARTH + 600e3]
+    periods = brahe.orbital_period(a_values)
+    assert periods.shape == (2,)
+    for i, a in enumerate(a_values):
+        assert periods[i] == brahe.orbital_period(a)
 
-    with pytest.raises(ValueError, match="Expected array or list of length 6"):
-        brahe.orbital_period(oe_short)
+    six = np.array([brahe.R_EARTH + 500e3, 0.01, math.radians(45), 0, 0, 0])
+    six_periods = brahe.orbital_period(six)
+    assert six_periods.shape == (6,)
+    assert six_periods[0] == brahe.orbital_period(six[0])
+
+    with pytest.raises(ValueError, match="Parameter 'e' is required"):
+        brahe.perigee_velocity(np.array(a_values))
+    with pytest.raises(ValueError):
+        brahe.perigee_velocity(np.array(a_values), np.array([0.1, 0.2, 0.3]))
 
 
 def test_vector_missing_e_parameter():
@@ -787,13 +812,21 @@ def test_keplerian_element_set_batches():
         out = f(oes, **kwargs)
         assert out.shape == (3,)
         for i in range(3):
-            assert out[i] == f(oes[i], **kwargs)
+            assert out[i] == f(oes[i : i + 1], **kwargs)[0]
     out = brahe.orbital_period_general(oes, brahe.GM_EARTH)
     for i in range(3):
-        assert out[i] == brahe.orbital_period_general(oes[i], brahe.GM_EARTH)
+        assert out[i] == brahe.orbital_period_general(oes[i, 0], brahe.GM_EARTH)
     out = brahe.periapsis_altitude(oes, r_body=brahe.R_EARTH)
     for i in range(3):
-        assert out[i] == brahe.periapsis_altitude(oes[i], r_body=brahe.R_EARTH)
+        assert out[i] == brahe.periapsis_altitude(
+            oes[i, 0], oes[i, 1], r_body=brahe.R_EARTH
+        )
+    np.testing.assert_array_equal(
+        brahe.anomaly_mean_to_true(oes, angle_format=AngleFormat.DEGREES),
+        brahe.anomaly_mean_to_true(
+            oes[:, 5], oes[:, 1], angle_format=AngleFormat.DEGREES
+        ),
+    )
 
 
 def test_keplerian_elementwise_arrays():
@@ -863,16 +896,22 @@ def test_orbital_period_from_state_batch():
     assert isinstance(brahe.orbital_period_from_state(states[0], brahe.GM_EARTH), float)
 
 
-def test_element_set_ignores_e_argument():
-    """A (6,) or (n, 6) element set keeps ignoring an explicit e"""
+def test_element_set_batch_and_explicit_e():
+    """(n, 6) rows are element sets without e; with e every array is element-wise"""
     oe = np.array([brahe.R_EARTH + 500e3, 0.1, 30.0, 0.0, 0.0, 0.0])
-    assert brahe.perigee_velocity(oe, 0.2) == brahe.perigee_velocity(oe)
-    assert brahe.perigee_velocity(oe, 0.2) == brahe.perigee_velocity(oe[0], oe[1])
     oes = np.vstack([oe, oe])
     np.testing.assert_array_equal(
-        brahe.apogee_altitude(oes, 0.5), brahe.apogee_altitude(oes)
+        brahe.perigee_velocity(oes), [brahe.perigee_velocity(oe[0], oe[1])] * 2
     )
-    # A (6, 1) column is not an element set and evaluates element-wise against e
+    # With an explicit e the (2, 6) array is a grid of semi-major axes
+    grid = brahe.perigee_velocity(oes, 0.2)
+    assert grid.shape == (2, 6)
+    assert grid[0, 0] == brahe.perigee_velocity(oe[0], 0.2)
+    # A (6, 1) column is element-wise as well
     col = brahe.periapsis_distance(oe[:, None] * 0 + oe[0], 0.2)
     assert col.shape == (6, 1)
     assert col[0, 0] == brahe.periapsis_distance(oe[0], 0.2)
+    # Columns of an element-state array feed the functions directly
+    np.testing.assert_array_equal(
+        brahe.perigee_velocity(oes[:, 0], oes[:, 1]), brahe.perigee_velocity(oes)
+    )

--- a/tests/orbits/test_keplerian.py
+++ b/tests/orbits/test_keplerian.py
@@ -758,3 +758,106 @@ def test_vector_missing_e_parameter():
 
     with pytest.raises(ValueError, match="Parameter 'e' is required"):
         brahe.perigee_velocity(a)  # Missing required 'e' parameter
+
+
+def test_keplerian_element_set_batches():
+    """(n, 6) arrays evaluate one result per element-set row"""
+    oes = np.array(
+        [
+            [
+                brahe.R_EARTH + 500e3 + 1e3 * i,
+                0.01 + 0.001 * i,
+                97.8,
+                15.0,
+                30.0,
+                45.0 + i,
+            ]
+            for i in range(3)
+        ]
+    )
+    for f, kwargs in (
+        (brahe.orbital_period, {}),
+        (brahe.mean_motion, {"angle_format": AngleFormat.DEGREES}),
+        (brahe.perigee_velocity, {}),
+        (brahe.apogee_altitude, {}),
+        (brahe.sun_synchronous_inclination, {"angle_format": AngleFormat.DEGREES}),
+        (brahe.anomaly_mean_to_eccentric, {"angle_format": AngleFormat.DEGREES}),
+        (brahe.anomaly_mean_to_true, {"angle_format": AngleFormat.DEGREES}),
+    ):
+        out = f(oes, **kwargs)
+        assert out.shape == (3,)
+        for i in range(3):
+            assert out[i] == f(oes[i], **kwargs)
+    out = brahe.orbital_period_general(oes, brahe.GM_EARTH)
+    for i in range(3):
+        assert out[i] == brahe.orbital_period_general(oes[i], brahe.GM_EARTH)
+    out = brahe.periapsis_altitude(oes, r_body=brahe.R_EARTH)
+    for i in range(3):
+        assert out[i] == brahe.periapsis_altitude(oes[i], r_body=brahe.R_EARTH)
+
+
+def test_keplerian_elementwise_arrays():
+    """Arrays with an explicit e evaluate element-wise with broadcasting"""
+    a = np.array([brahe.R_EARTH + 500e3, brahe.R_EARTH + 700e3, brahe.R_EARTH + 900e3])
+    e = np.array([0.001, 0.01, 0.1])
+    out = brahe.perigee_velocity(a, e)
+    assert out.shape == (3,)
+    for i in range(3):
+        assert out[i] == brahe.perigee_velocity(a[i], e[i])
+    out_b = brahe.perigee_velocity(a, 0.01)
+    for i in range(3):
+        assert out_b[i] == brahe.perigee_velocity(a[i], 0.01)
+    out_c = brahe.apoapsis_distance(a[0], e)
+    for i in range(3):
+        assert out_c[i] == brahe.apoapsis_distance(a[0], e[i])
+    grid = brahe.periapsis_distance(a[:, None], e[None, :])
+    assert grid.shape == (3, 3)
+    assert grid[1, 2] == brahe.periapsis_distance(a[1], e[2])
+    M = np.linspace(0.0, 350.0, 5)
+    E = brahe.anomaly_mean_to_eccentric(M, 0.3, angle_format=AngleFormat.DEGREES)
+    assert E.shape == (5,)
+    for i in range(5):
+        assert E[i] == brahe.anomaly_mean_to_eccentric(
+            M[i], 0.3, angle_format=AngleFormat.DEGREES
+        )
+    with pytest.raises(ValueError):
+        brahe.perigee_velocity(a[:2], e)
+    with pytest.raises(ValueError):
+        brahe.perigee_velocity(np.ones((3, 5)))
+
+
+def test_keplerian_pure_numeric_arrays():
+    n = np.array([0.001, 0.0011, 0.0012])
+    out = brahe.semimajor_axis(n, AngleFormat.RADIANS)
+    assert out.shape == (3,)
+    for i in range(3):
+        assert out[i] == brahe.semimajor_axis(n[i], AngleFormat.RADIANS)
+    periods = np.array([5400.0, 6000.0, 86164.0])
+    out = brahe.semimajor_axis_from_orbital_period(periods)
+    for i in range(3):
+        assert out[i] == brahe.semimajor_axis_from_orbital_period(periods[i])
+    out = brahe.semimajor_axis_from_orbital_period_general(
+        periods.reshape(3, 1), brahe.GM_EARTH
+    )
+    assert out.shape == (3, 1)
+    assert isinstance(brahe.semimajor_axis(0.001, AngleFormat.RADIANS), float)
+
+
+def test_orbital_period_from_state_batch():
+    oe = np.array([brahe.R_EARTH + 500e3, 0.01, 97.8, 15.0, 30.0, 45.0])
+    states = np.array(
+        [
+            brahe.state_koe_to_eci(
+                oe + np.array([1e3 * i, 0, 0, 0, 0, 0]), AngleFormat.DEGREES
+            )
+            for i in range(3)
+        ]
+    )
+    out = brahe.orbital_period_from_state(states, brahe.GM_EARTH)
+    assert out.shape == (3,)
+    for i in range(3):
+        assert out[i] == brahe.orbital_period_from_state(states[i], brahe.GM_EARTH)
+    np.testing.assert_array_equal(
+        brahe.orbital_period_from_state(states.T, brahe.GM_EARTH, axis=0), out
+    )
+    assert isinstance(brahe.orbital_period_from_state(states[0], brahe.GM_EARTH), float)

--- a/tests/orbits/test_keplerian.py
+++ b/tests/orbits/test_keplerian.py
@@ -861,3 +861,18 @@ def test_orbital_period_from_state_batch():
         brahe.orbital_period_from_state(states.T, brahe.GM_EARTH, axis=0), out
     )
     assert isinstance(brahe.orbital_period_from_state(states[0], brahe.GM_EARTH), float)
+
+
+def test_element_set_ignores_e_argument():
+    """A (6,) or (n, 6) element set keeps ignoring an explicit e"""
+    oe = np.array([brahe.R_EARTH + 500e3, 0.1, 30.0, 0.0, 0.0, 0.0])
+    assert brahe.perigee_velocity(oe, 0.2) == brahe.perigee_velocity(oe)
+    assert brahe.perigee_velocity(oe, 0.2) == brahe.perigee_velocity(oe[0], oe[1])
+    oes = np.vstack([oe, oe])
+    np.testing.assert_array_equal(
+        brahe.apogee_altitude(oes, 0.5), brahe.apogee_altitude(oes)
+    )
+    # A (6, 1) column is not an element set and evaluates element-wise against e
+    col = brahe.periapsis_distance(oe[:, None] * 0 + oe[0], 0.2)
+    assert col.shape == (6, 1)
+    assert col[0, 0] == brahe.periapsis_distance(oe[0], 0.2)

--- a/tests/orbits/test_mean_elements.py
+++ b/tests/orbits/test_mean_elements.py
@@ -410,7 +410,7 @@ class TestBatchMeanOsculatingConversions:
         s = np.array([brahe.R_EARTH + 500e3, 0.01, 45.0, 30.0, 60.0, 90.0])
         states = np.vstack([s, s, s])
 
-        out_epochs, out_states = brahe.batch_state_koe_osc_to_mean(
+        out_epochs, out_states = brahe.states_koe_osc_to_mean(
             epochs, states, BROUWER_LYDDANE, brahe.AngleFormat.DEGREES
         )
 
@@ -429,7 +429,7 @@ class TestBatchMeanOsculatingConversions:
         s = np.array([brahe.R_EARTH + 500e3, 0.01, 45.0, 30.0, 60.0, 90.0])
         states = np.vstack([s, s, s])
 
-        out_epochs, out_states = brahe.batch_state_koe_mean_to_osc(
+        out_epochs, out_states = brahe.states_koe_mean_to_osc(
             epochs, states, BROUWER_LYDDANE, brahe.AngleFormat.DEGREES
         )
 
@@ -481,7 +481,7 @@ class TestBatchMeanOsculatingConversions:
         )
         method = brahe.MeanElementMethod.numerical(cfg)
 
-        out_epochs, out_states = brahe.batch_state_koe_osc_to_mean(
+        out_epochs, out_states = brahe.states_koe_osc_to_mean(
             epochs, states, method, brahe.AngleFormat.DEGREES
         )
 
@@ -504,7 +504,7 @@ class TestBatchMeanOsculatingConversions:
         method = brahe.MeanElementMethod.numerical(cfg)
 
         with pytest.raises(brahe.BraheError):
-            brahe.batch_state_koe_mean_to_osc(
+            brahe.states_koe_mean_to_osc(
                 epochs, states, method, brahe.AngleFormat.DEGREES
             )
 
@@ -516,7 +516,7 @@ class TestBatchMeanOsculatingConversions:
         states = np.vstack([s, s])  # only 2 rows for 3 epochs
 
         with pytest.raises(brahe.BraheError):
-            brahe.batch_state_koe_osc_to_mean(
+            brahe.states_koe_osc_to_mean(
                 epochs, states, BROUWER_LYDDANE, brahe.AngleFormat.DEGREES
             )
 


### PR DESCRIPTION
# Pull Request

## Description

Completes the vectorization stack for the orbits module. Rust gains `states_koe_to_equinoctial` / `states_equinoctial_to_koe`, and the existing mean-element batch functions are renamed from `batch_state_koe_*` to `states_koe_osc_to_mean` / `states_koe_mean_to_osc` (Rust and Python) to match the plural naming; they stay separate Python functions because they are series-level operations. In Python, the Keplerian scalar functions (`orbital_period`, `perigee_velocity`, `anomaly_mean_to_eccentric`, …) follow one array rule: a `(n, 6)` array without an explicit `e` is a batch of element sets (one result per row); every other array, including a 1-D array of any length, is a set of values evaluated element-wise with numpy broadcasting against `e` (`perigee_velocity(oes[:, 0], oes[:, 1])`). The former reading of a 6-element vector as one element set is removed so `(6,)` and `(n,)` inputs behave the same. The pure numeric functions (`semimajor_axis`, …) accept arrays; `orbital_period_from_state` and the equinoctial conversions accept batched vectors with the `axis` keyword. The stub generator now renders `A or B` return types as a `Union`.

## Changelog

### Added
- Batch equinoctial conversions `states_koe_to_equinoctial` / `states_equinoctial_to_koe` in Rust and batched input in Python.
- Python Keplerian property and anomaly functions accept `(n, 6)` element-set batches and element-wise arrays with numpy broadcasting against `e`; `semimajor_axis*` functions accept arrays; `orbital_period_from_state` accepts batched states.

### Changed
- Python Keplerian property and anomaly functions no longer read a 1-D 6-element array as one element set: 1-D arrays of any length are element-wise values (`orbital_period(oe)` returns six periods; use `orbital_period(oe[0])` or a `(1, 6)` array). Element sets are passed as `(n, 6)` rows.
- `batch_state_koe_osc_to_mean` / `batch_state_koe_mean_to_osc` renamed to `states_koe_osc_to_mean` / `states_koe_mean_to_osc` in Rust and Python.
- `scripts/add_stub_annotations.py` renders `A or B` docstring return types as `Union[A, B]` in the generated stubs.

## Note to Reviewers
The `(6,)`-means-element-set convention was intentionally dropped (breaking) so that 1-D input is uniformly element-wise; the affected `tests/orbits/test_keplerian.py` "vector" tests now pass `(1, 6)` batches and a new test pins the element-wise reading of length-6 input.
