### PR TITLE
Update ruff pre-commit hook to v0.16.3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,7 @@ repos:
 
   # Format Python code
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.2
+    rev: v0.16.3
     hooks:
       - id: ruff-format
         name: ruff format (auto-fix)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,11 @@ exclude_lines = [
 ]
 show_missing = true
 
+[tool.ruff]
+# Lint and format Python sources only; Markdown code blocks use snippet-include syntax.
+include = ["*.py", "*.pyi", "**/pyproject.toml"]
+
 [tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]
 # Ignore F403 (import * used) in __init__.py for backward compatibility pattern
 extend-ignore = ["F403"]


### PR DESCRIPTION
# Pull Request

## Description

Bumps the `ruff-pre-commit` hook from v0.12.2 to v0.16.3. Ruff 0.16 lints and formats Python blocks inside Markdown files by default (which rewrites the docs' `--8<--` snippet includes) and enables a wider default rule set, so `pyproject.toml` now pins the previous behavior explicitly (`include` limited to Python sources; `select = ["E4", "E7", "E9", "F"]`). With that, `pre-commit run --all-files`, `just lint`, and `just format-check` pass on the current tree with no code changes; adopting the expanded default rules can be a separate cleanup.

## Changelog

### Changed
- Development tooling: `ruff` pre-commit hook updated to v0.16.3 with the previous lint rule set and Python-only file discovery pinned in `pyproject.toml`.

## Note to Reviewers
Independent of the vectorization stack (#436–#441). Verified `pre-commit run ruff-check --all-files` and `ruff-format --all-files` pass, and `just lint`/`just format-check` pass with ruff 0.16.3 on `PATH`.