### PR TITLE
Make the vectorization length threshold configurable

### DIFF
--- a/brahe/utils.py
+++ b/brahe/utils.py
@@ -13,10 +13,12 @@ from brahe._brahe import (
     get_celestrak_cache_dir,
     get_eop_cache_dir,
     get_max_threads,
+    # Threading
+    get_vectorization_length_threshold,
     set_ludicrous_speed,
     set_max_threads,
-    # Threading
     set_num_threads,
+    set_vectorization_length_threshold,
 )
 
 __all__ = [
@@ -28,8 +30,10 @@ __all__ = [
     "get_celestrak_cache_dir",
     "get_eop_cache_dir",
     "get_max_threads",
+    # Threading
+    "get_vectorization_length_threshold",
     "set_ludicrous_speed",
     "set_max_threads",
-    # Threading
     "set_num_threads",
+    "set_vectorization_length_threshold",
 ]

--- a/crates/brahe-py/src/lib.rs
+++ b/crates/brahe-py/src/lib.rs
@@ -39,7 +39,8 @@ use brahe::utils::python_interop::BraheError;
 use brahe::utils::{
     BraheError as RustBraheError, format_time_string, get_brahe_cache_dir,
     get_brahe_cache_dir_with_subdir, get_celestrak_cache_dir, get_eop_cache_dir, get_max_threads,
-    set_max_threads, set_num_threads,
+    get_vectorization_length_threshold, set_max_threads, set_num_threads,
+    set_vectorization_length_threshold,
 };
 use brahe::*;
 
@@ -1462,6 +1463,14 @@ pub fn _brahe(py: Python<'_>, module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_function(wrap_pyfunction!(py_set_max_threads, module)?)?;
     module.add_function(wrap_pyfunction!(py_set_ludicrous_speed, module)?)?;
     module.add_function(wrap_pyfunction!(py_get_max_threads, module)?)?;
+    module.add_function(wrap_pyfunction!(
+        py_set_vectorization_length_threshold,
+        module
+    )?)?;
+    module.add_function(wrap_pyfunction!(
+        py_get_vectorization_length_threshold,
+        module
+    )?)?;
 
     // Formatting
     module.add_function(wrap_pyfunction!(py_format_time_string, module)?)?;

--- a/crates/brahe-py/src/utils.rs
+++ b/crates/brahe-py/src/utils.rs
@@ -340,3 +340,50 @@ pub fn py_get_max_threads() -> PyResult<usize> {
 pub fn py_format_time_string(seconds: f64, short: bool) -> PyResult<String> {
     Ok(format_time_string(seconds, short))
 }
+
+/// Sets the minimum batch length at which vectorized (batch) transformation
+/// functions evaluate on the global thread pool.
+///
+/// Batches shorter than the threshold evaluate sequentially, since thread
+/// hand-off overhead would dominate the sub-microsecond per-element kernels.
+/// The default is 1024. A threshold of `0` parallelizes every batch; a very
+/// large threshold disables parallel batch evaluation entirely. The thread
+/// pool itself is configured with `set_num_threads`.
+///
+/// Args:
+///     n (int): Minimum batch length for thread-pool evaluation.
+///
+/// Returns:
+///     None: The threshold is applied globally.
+///
+/// Example:
+///     ```python
+///     import brahe as bh
+///
+///     bh.set_vectorization_length_threshold(4096)
+///     print(bh.get_vectorization_length_threshold())  # Output: 4096
+///     bh.set_vectorization_length_threshold(1024)
+///     ```
+#[pyfunction]
+#[pyo3(name = "set_vectorization_length_threshold")]
+pub fn py_set_vectorization_length_threshold(n: usize) {
+    set_vectorization_length_threshold(n);
+}
+
+/// Returns the minimum batch length at which vectorized (batch)
+/// transformation functions evaluate on the global thread pool.
+///
+/// Returns:
+///     int: The current threshold. Defaults to 1024.
+///
+/// Example:
+///     ```python
+///     import brahe as bh
+///
+///     print(bh.get_vectorization_length_threshold())  # Output: 1024
+///     ```
+#[pyfunction]
+#[pyo3(name = "get_vectorization_length_threshold")]
+pub fn py_get_vectorization_length_threshold() -> usize {
+    get_vectorization_length_threshold()
+}

--- a/src/frames/gcrf_itrf.rs
+++ b/src/frames/gcrf_itrf.rs
@@ -806,7 +806,7 @@ mod tests {
     use crate::frames::*;
     use crate::math::{SVector6, vector6_from_array};
     use crate::time::{Epoch, TimeSystem};
-    use crate::utils::batch::PARALLEL_THRESHOLD;
+    use crate::utils::batch::get_vectorization_length_threshold;
     use crate::utils::testing::setup_global_test_eop;
 
     #[allow(non_snake_case)]
@@ -1043,7 +1043,7 @@ mod tests {
             assert_eq!(*o, state_gcrf_to_itrf(epc[0], *s));
         }
 
-        let states = sample_states(PARALLEL_THRESHOLD + 1);
+        let states = sample_states(get_vectorization_length_threshold() + 1);
         let out = states_gcrf_to_itrf(&epc, &states).unwrap();
         for (s, o) in states.iter().zip(&out) {
             assert_eq!(*o, state_gcrf_to_itrf(epc[0], *s));

--- a/src/utils/batch.rs
+++ b/src/utils/batch.rs
@@ -8,15 +8,64 @@
  */
 
 use rayon::prelude::*;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::time::Epoch;
 use crate::utils::errors::BraheError;
 use crate::utils::threading::get_thread_pool;
 
+/// Default value of the vectorization length threshold.
+pub(crate) const DEFAULT_VECTORIZATION_LENGTH_THRESHOLD: usize = 1024;
+
 /// Minimum batch length at which batch primitives evaluate on the global
 /// rayon thread pool. Below this length evaluation is sequential, since the
 /// per-element kernels are sub-microsecond and thread hand-off would dominate.
-pub(crate) const PARALLEL_THRESHOLD: usize = 1024;
+static VECTORIZATION_LENGTH_THRESHOLD: AtomicUsize =
+    AtomicUsize::new(DEFAULT_VECTORIZATION_LENGTH_THRESHOLD);
+
+/// Sets the minimum batch length at which vectorized (batch) functions
+/// evaluate on the global thread pool. Batches shorter than the threshold
+/// evaluate sequentially.
+///
+/// The default is 1024, chosen so that thread hand-off overhead does not
+/// dominate the sub-microsecond per-element transformation kernels. A
+/// threshold of `0` parallelizes every batch; `usize::MAX` disables
+/// parallel evaluation entirely.
+///
+/// # Arguments
+///
+/// * `n` - Minimum batch length for thread-pool evaluation
+///
+/// # Examples
+///
+/// ```
+/// use brahe::utils::{get_vectorization_length_threshold, set_vectorization_length_threshold};
+///
+/// set_vectorization_length_threshold(4096);
+/// assert_eq!(get_vectorization_length_threshold(), 4096);
+/// set_vectorization_length_threshold(1024);
+/// ```
+pub fn set_vectorization_length_threshold(n: usize) {
+    VECTORIZATION_LENGTH_THRESHOLD.store(n, Ordering::Relaxed);
+}
+
+/// Returns the minimum batch length at which vectorized (batch) functions
+/// evaluate on the global thread pool.
+///
+/// # Returns
+///
+/// The current threshold. Defaults to 1024.
+///
+/// # Examples
+///
+/// ```
+/// use brahe::utils::get_vectorization_length_threshold;
+///
+/// assert!(get_vectorization_length_threshold() >= 1);
+/// ```
+pub fn get_vectorization_length_threshold() -> usize {
+    VECTORIZATION_LENGTH_THRESHOLD.load(Ordering::Relaxed)
+}
 
 /// Resolve the common batch length of a set of slice lengths under the
 /// broadcast rule: every length must be `1` or the common length `N`.
@@ -80,8 +129,9 @@ pub(crate) fn pick<T>(slice: &[T], i: usize) -> &T {
 
 /// Evaluate `f` for every index in `0..n`, preserving order.
 ///
-/// Runs on the global rayon thread pool when `n >= PARALLEL_THRESHOLD` and
-/// sequentially otherwise.
+/// Runs on the global rayon thread pool when `n` is at least the
+/// vectorization length threshold ([`get_vectorization_length_threshold`])
+/// and sequentially otherwise.
 ///
 /// # Arguments
 ///
@@ -101,7 +151,7 @@ pub(crate) fn pick<T>(slice: &[T], i: usize) -> &T {
 /// assert_eq!(squares, vec![0, 1, 4, 9]);
 /// ```
 pub(crate) fn map_indices<U: Send>(f: impl Fn(usize) -> U + Sync, n: usize) -> Vec<U> {
-    if n >= PARALLEL_THRESHOLD {
+    if n >= get_vectorization_length_threshold() {
         get_thread_pool().install(|| (0..n).into_par_iter().map(&f).collect())
     } else {
         (0..n).map(&f).collect()
@@ -218,8 +268,9 @@ pub(crate) fn batch_map_epochs<C: Sync, T: Sync, U: Send>(
 /// Evaluate a fallible `f` for every index in `0..n`, preserving order and
 /// stopping at the first error.
 ///
-/// Runs on the global rayon thread pool when `n >= PARALLEL_THRESHOLD` and
-/// sequentially otherwise.
+/// Runs on the global rayon thread pool when `n` is at least the
+/// vectorization length threshold ([`get_vectorization_length_threshold`])
+/// and sequentially otherwise.
 ///
 /// # Arguments
 ///
@@ -244,7 +295,7 @@ pub(crate) fn try_map_indices<U: Send, E: Send>(
     f: impl Fn(usize) -> Result<U, E> + Sync,
     n: usize,
 ) -> Result<Vec<U>, E> {
-    if n >= PARALLEL_THRESHOLD {
+    if n >= get_vectorization_length_threshold() {
         get_thread_pool().install(|| (0..n).into_par_iter().map(&f).collect())
     } else {
         (0..n).map(&f).collect()
@@ -329,7 +380,7 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use approx::assert_abs_diff_eq;
-    use serial_test::parallel;
+    use serial_test::{parallel, serial};
 
     use super::*;
     use crate::time::Epoch;
@@ -383,7 +434,7 @@ mod tests {
     #[test]
     #[parallel]
     fn test_map_indices_parallel_preserves_order() {
-        let n = PARALLEL_THRESHOLD + 7;
+        let n = get_vectorization_length_threshold() + 7;
         let out = map_indices(|i| i * 10, n);
         let expected: Vec<usize> = (0..n).map(|i| i * 10).collect();
         assert_eq!(out, expected);
@@ -402,7 +453,9 @@ mod tests {
         let small: Vec<f64> = (0..3).map(|i| i as f64).collect();
         assert_eq!(batch_map(|x| x * 2.0, &small), vec![0.0, 2.0, 4.0]);
 
-        let large: Vec<f64> = (0..PARALLEL_THRESHOLD + 3).map(|i| i as f64).collect();
+        let large: Vec<f64> = (0..get_vectorization_length_threshold() + 3)
+            .map(|i| i as f64)
+            .collect();
         let out = batch_map(|x| x * 2.0, &large);
         let expected: Vec<f64> = large.iter().map(|x| x * 2.0).collect();
         assert_eq!(out, expected);
@@ -453,7 +506,7 @@ mod tests {
     #[test]
     #[parallel]
     fn test_batch_zip_parallel_path() {
-        let n = PARALLEL_THRESHOLD + 1;
+        let n = get_vectorization_length_threshold() + 1;
         let a: Vec<f64> = (0..n).map(|i| i as f64).collect();
         let b = [0.5];
         let out = batch_zip(|x, y| x + y, &a, &b).unwrap();
@@ -492,7 +545,9 @@ mod tests {
     fn test_batch_map_epochs_shared_epoch_parallel_still_hoists() {
         let calls = AtomicUsize::new(0);
         let epc = epochs(1);
-        let inputs: Vec<f64> = (0..PARALLEL_THRESHOLD + 1).map(|i| i as f64).collect();
+        let inputs: Vec<f64> = (0..get_vectorization_length_threshold() + 1)
+            .map(|i| i as f64)
+            .collect();
         let out = batch_map_epochs(
             |e| {
                 calls.fetch_add(1, Ordering::SeqCst);
@@ -587,7 +642,9 @@ mod tests {
         );
         assert_eq!(err.unwrap_err(), "too big");
 
-        let large: Vec<f64> = (0..PARALLEL_THRESHOLD + 2).map(|i| i as f64).collect();
+        let large: Vec<f64> = (0..get_vectorization_length_threshold() + 2)
+            .map(|i| i as f64)
+            .collect();
         let out: Vec<f64> = try_batch_map(|x| Ok::<f64, String>(x + 1.0), &large).unwrap();
         let expected: Vec<f64> = large.iter().map(|x| x + 1.0).collect();
         assert_eq!(out, expected);
@@ -660,5 +717,25 @@ mod tests {
                 .unwrap()
                 .is_empty()
         );
+    }
+
+    #[test]
+    #[serial]
+    fn test_vectorization_length_threshold_set_get() {
+        let default = get_vectorization_length_threshold();
+        assert_eq!(default, DEFAULT_VECTORIZATION_LENGTH_THRESHOLD);
+
+        set_vectorization_length_threshold(2);
+        assert_eq!(get_vectorization_length_threshold(), 2);
+        // A three-element batch now takes the thread-pool path
+        let out = batch_map(|x| x * 2.0, &[1.0, 2.0, 3.0]);
+        assert_eq!(out, vec![2.0, 4.0, 6.0]);
+
+        set_vectorization_length_threshold(usize::MAX);
+        let out = batch_map(|x| x + 1.0, &[1.0, 2.0, 3.0]);
+        assert_eq!(out, vec![2.0, 3.0, 4.0]);
+
+        set_vectorization_length_threshold(default);
+        assert_eq!(get_vectorization_length_threshold(), default);
     }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -11,6 +11,7 @@ pub use state_providers::*;
 pub use threading::*;
 
 pub(crate) mod batch;
+pub use batch::{get_vectorization_length_threshold, set_vectorization_length_threshold};
 pub mod cache;
 pub mod download;
 pub mod errors;

--- a/tests/utils/test_threading.py
+++ b/tests/utils/test_threading.py
@@ -2,6 +2,7 @@
 Tests for threading utilities.
 """
 
+import numpy as np
 import pytest
 
 import brahe as bh
@@ -115,3 +116,24 @@ def test_get_max_threads_after_set():
         assert bh.get_max_threads() == n, (
             f"Expected {n} threads, got {bh.get_max_threads()}"
         )
+
+
+def test_vectorization_length_threshold_set_get():
+    default = bh.get_vectorization_length_threshold()
+    assert default == 1024
+
+    bh.set_vectorization_length_threshold(2)
+    assert bh.get_vectorization_length_threshold() == 2
+
+    # A small batch still evaluates correctly on the thread-pool path
+    states = np.array(
+        [[bh.R_EARTH + 500e3 + 1e3 * i, 0.01, 97.8, 15.0, 30.0, 45.0] for i in range(3)]
+    )
+    out = bh.state_koe_to_eci(states, bh.AngleFormat.DEGREES)
+    for i in range(3):
+        np.testing.assert_array_equal(
+            out[i], bh.state_koe_to_eci(states[i], bh.AngleFormat.DEGREES)
+        )
+
+    bh.set_vectorization_length_threshold(default)
+    assert bh.get_vectorization_length_threshold() == default


### PR DESCRIPTION
# Pull Request

## Description

Stacked on #441. Adds `set_vectorization_length_threshold` / `get_vectorization_length_threshold` (Rust and Python, 1:1) controlling the minimum batch length at which the vectorized transformation functions evaluate on the global thread pool, mirroring how `set_num_threads` configures the pool itself. Batches shorter than the threshold evaluate sequentially; the default remains 1024. A threshold of `0` parallelizes every batch and a very large threshold disables parallel batch evaluation entirely.

## Changelog

### Added
- `set_vectorization_length_threshold(n)` / `get_vectorization_length_threshold()` in Rust (`brahe::utils`) and Python to configure the batch length at which vectorized functions use the global thread pool (default 1024).

## Note to Reviewers
Final layer of the vectorization stack, added per review feedback on #436. The threshold is a process-global atomic; the Rust test that mutates it is `#[serial]` and restores the default.
