### PR TITLE
Resolve Celestrak single-object lookups from the active group

### DIFF
--- a/crates/brahe-py/src/celestrak.rs
+++ b/crates/brahe-py/src/celestrak.rs
@@ -821,6 +821,14 @@ impl PyCelestrakSATCATRecord {
 /// data from CelestrakClient. No authentication is required. Responses
 /// are cached locally to reduce server load.
 ///
+/// Single-object lookups (``catnr``, ``intdes``, or ``name`` passed to
+/// ``get_gp()``, or a query with exactly one of those selectors) resolve
+/// from a cached copy of the ``active`` group when the object is in it,
+/// so a series of lookups costs one request. A ``name`` search that
+/// matches in ``active`` returns only active objects. A client with a
+/// zero cache age sends every query directly, since the ``active`` group
+/// copy could not be reused.
+///
 /// Two tiers of API are available:
 ///
 /// **Tier 1 — Compact convenience methods** (most common operations):
@@ -893,13 +901,14 @@ impl PyCelestrakClient {
     ///
     /// Provide exactly one of ``catnr``, ``group``, ``name``, or ``intdes``.
     ///
-    /// Lookups by ``catnr``, ``name``, or ``intdes`` are answered from a
-    /// cached copy of the ``active`` group when the object is in it, so
-    /// repeated lookups cost a single request. Objects not in ``active``
-    /// are requested individually. A ``name`` search that matches in
-    /// ``active`` returns only active objects; ``group`` queries are sent
-    /// to the server exactly as written, though still served from the URL
-    /// cache when a fresh copy exists.
+    /// Lookups by ``catnr``, ``name``, or ``intdes`` first check the exact
+    /// per-object cache file, then a cached copy of the ``active`` group
+    /// when the object is in it, so repeated lookups cost a single
+    /// request. Objects not in ``active`` are requested individually. A
+    /// ``name`` search that matches in ``active`` returns only active
+    /// objects; ``group`` queries are sent to the server exactly as
+    /// written, though still served from the URL cache when a fresh copy
+    /// exists.
     ///
     /// Args:
     ///     catnr (int, optional): NORAD catalog number (e.g., 25544 for ISS).
@@ -1106,7 +1115,9 @@ impl PyCelestrakClient {
     ///
     /// Dispatches to the appropriate handler based on query type:
     /// GP and SupGP queries return ``list[GPRecord]``, SATCAT queries
-    /// return ``list[CelestrakSATCATRecord]``.
+    /// return ``list[CelestrakSATCATRecord]``. A GP query with exactly one
+    /// of ``catnr``, ``intdes``, or ``name`` set follows the same cached
+    /// ``active`` group resolution as ``get_gp()``.
     ///
     /// Args:
     ///     query (CelestrakQuery): The query to execute.

--- a/crates/brahe-py/src/celestrak.rs
+++ b/crates/brahe-py/src/celestrak.rs
@@ -919,6 +919,7 @@ impl PyCelestrakClient {
     #[pyo3(signature = (*, catnr=None, group=None, name=None, intdes=None))]
     fn get_gp(
         &self,
+        py: Python<'_>,
         catnr: Option<u32>,
         group: Option<&str>,
         name: Option<&str>,
@@ -934,16 +935,23 @@ impl PyCelestrakClient {
             ));
         }
 
-        let records = if let Some(id) = catnr {
-            self.inner.get_gp_by_catnr(id)
-        } else if let Some(g) = group {
-            self.inner.get_gp_by_group(g)
-        } else if let Some(n) = name {
-            self.inner.get_gp_by_name(n)
-        } else {
-            self.inner.get_gp_by_intdes(intdes.unwrap())
-        }
-        .map_err(|e| BraheError::new_err(e.to_string()))?;
+        let group = group.map(str::to_owned);
+        let name = name.map(str::to_owned);
+        let intdes = intdes.map(str::to_owned);
+
+        let records = py
+            .detach(|| {
+                if let Some(id) = catnr {
+                    self.inner.get_gp_by_catnr(id)
+                } else if let Some(g) = &group {
+                    self.inner.get_gp_by_group(g)
+                } else if let Some(n) = &name {
+                    self.inner.get_gp_by_name(n)
+                } else {
+                    self.inner.get_gp_by_intdes(intdes.as_deref().unwrap())
+                }
+            })
+            .map_err(|e| BraheError::new_err(e.to_string()))?;
 
         Ok(records
             .into_iter()
@@ -969,10 +977,10 @@ impl PyCelestrakClient {
     ///     client = bh.celestrak.CelestrakClient()
     ///     records = client.get_sup_gp(bh.celestrak.SupGPSource.STARLINK)
     ///     ```
-    fn get_sup_gp(&self, source: &PySupGPSource) -> PyResult<Vec<PyGPRecord>> {
-        let records = self
-            .inner
-            .get_sup_gp(source.value)
+    fn get_sup_gp(&self, py: Python<'_>, source: &PySupGPSource) -> PyResult<Vec<PyGPRecord>> {
+        let source = source.value;
+        let records = py
+            .detach(|| self.inner.get_sup_gp(source))
             .map_err(|e| BraheError::new_err(e.to_string()))?;
 
         Ok(records
@@ -1009,6 +1017,7 @@ impl PyCelestrakClient {
     #[pyo3(signature = (*, catnr=None, active=None, payloads=None, on_orbit=None))]
     fn get_satcat(
         &self,
+        py: Python<'_>,
         catnr: Option<u32>,
         active: Option<bool>,
         payloads: Option<bool>,
@@ -1034,9 +1043,8 @@ impl PyCelestrakClient {
             query = query.on_orbit(o);
         }
 
-        let records = self
-            .inner
-            .query_satcat(&query)
+        let records = py
+            .detach(|| self.inner.query_satcat(&query))
             .map_err(|e| BraheError::new_err(e.to_string()))?;
 
         Ok(records
@@ -1068,10 +1076,14 @@ impl PyCelestrakClient {
     ///     propagator = client.get_sgp_propagator(catnr=25544, step_size=60.0)
     ///     ```
     #[pyo3(signature = (*, catnr, step_size=60.0))]
-    fn get_sgp_propagator(&self, catnr: u32, step_size: f64) -> PyResult<PySGPPropagator> {
-        let propagator = self
-            .inner
-            .get_sgp_propagator_by_catnr(catnr, step_size)
+    fn get_sgp_propagator(
+        &self,
+        py: Python<'_>,
+        catnr: u32,
+        step_size: f64,
+    ) -> PyResult<PySGPPropagator> {
+        let propagator = py
+            .detach(|| self.inner.get_sgp_propagator_by_catnr(catnr, step_size))
             .map_err(|e| BraheError::new_err(e.to_string()))?;
         Ok(PySGPPropagator {
             propagator,
@@ -1120,11 +1132,12 @@ impl PyCelestrakClient {
         py: Python<'py>,
         query: &PyCelestrakQuery,
     ) -> PyResult<Py<PyAny>> {
-        match query.inner.query_type() {
+        let query_type = query.inner.query_type();
+        let query = query.inner.clone();
+        match query_type {
             celestrak::CelestrakQueryType::GP | celestrak::CelestrakQueryType::SupGP => {
-                let records = self
-                    .inner
-                    .query_gp(&query.inner)
+                let records = py
+                    .detach(|| self.inner.query_gp(&query))
                     .map_err(|e| BraheError::new_err(e.to_string()))?;
 
                 let py_records: Vec<PyGPRecord> = records
@@ -1135,9 +1148,8 @@ impl PyCelestrakClient {
                 py_records.into_py_any(py)
             }
             celestrak::CelestrakQueryType::SATCAT => {
-                let records = self
-                    .inner
-                    .query_satcat(&query.inner)
+                let records = py
+                    .detach(|| self.inner.query_satcat(&query))
                     .map_err(|e| BraheError::new_err(e.to_string()))?;
 
                 let py_records: Vec<PyCelestrakSATCATRecord> = records
@@ -1175,9 +1187,9 @@ impl PyCelestrakClient {
     ///     )
     ///     tle_data = client.query_raw(query)
     ///     ```
-    fn query_raw(&self, query: &PyCelestrakQuery) -> PyResult<String> {
-        self.inner
-            .query_raw(&query.inner)
+    fn query_raw(&self, py: Python<'_>, query: &PyCelestrakQuery) -> PyResult<String> {
+        let query = query.inner.clone();
+        py.detach(|| self.inner.query_raw(&query))
             .map_err(|e| BraheError::new_err(e.to_string()))
     }
 
@@ -1202,9 +1214,10 @@ impl PyCelestrakClient {
     ///     )
     ///     client.download(query, "stations.3le")
     ///     ```
-    fn download(&self, query: &PyCelestrakQuery, filepath: &str) -> PyResult<()> {
-        self.inner
-            .download(&query.inner, Path::new(filepath))
+    fn download(&self, py: Python<'_>, query: &PyCelestrakQuery, filepath: &str) -> PyResult<()> {
+        let query = query.inner.clone();
+        let filepath = filepath.to_owned();
+        py.detach(|| self.inner.download(&query, Path::new(&filepath)))
             .map_err(|e| BraheError::new_err(e.to_string()))
     }
 }

--- a/crates/brahe-py/src/celestrak.rs
+++ b/crates/brahe-py/src/celestrak.rs
@@ -897,8 +897,9 @@ impl PyCelestrakClient {
     /// cached copy of the ``active`` group when the object is in it, so
     /// repeated lookups cost a single request. Objects not in ``active``
     /// are requested individually. A ``name`` search that matches in
-    /// ``active`` returns only active objects; ``group`` queries are
-    /// always sent to the server.
+    /// ``active`` returns only active objects; ``group`` queries are sent
+    /// to the server exactly as written, though still served from the URL
+    /// cache when a fresh copy exists.
     ///
     /// Args:
     ///     catnr (int, optional): NORAD catalog number (e.g., 25544 for ISS).

--- a/crates/brahe-py/src/celestrak.rs
+++ b/crates/brahe-py/src/celestrak.rs
@@ -893,6 +893,13 @@ impl PyCelestrakClient {
     ///
     /// Provide exactly one of ``catnr``, ``group``, ``name``, or ``intdes``.
     ///
+    /// Lookups by ``catnr``, ``name``, or ``intdes`` are answered from a
+    /// cached copy of the ``active`` group when the object is in it, so
+    /// repeated lookups cost a single request. Objects not in ``active``
+    /// are requested individually. A ``name`` search that matches in
+    /// ``active`` returns only active objects; ``group`` queries are
+    /// always sent to the server.
+    ///
     /// Args:
     ///     catnr (int, optional): NORAD catalog number (e.g., 25544 for ISS).
     ///     group (str, optional): Satellite group name (e.g., "stations", "active").
@@ -1056,7 +1063,8 @@ impl PyCelestrakClient {
     /// Look up a satellite and return an SGP4 propagator.
     ///
     /// Queries GP data for the given catalog number and creates an
-    /// SGPPropagator from the first result.
+    /// SGPPropagator from the first result. The underlying lookup resolves
+    /// from the cached ``active`` group when possible.
     ///
     /// Args:
     ///     catnr (int): NORAD catalog number.

--- a/docs/learn/ephemeris/celestrak.md
+++ b/docs/learn/ephemeris/celestrak.md
@@ -63,18 +63,19 @@ keyword arguments to `get_gp` or as builder methods on `CelestrakQuery.gp`.
 
 A lookup by catalog number, international designator, or name is answered from a cached copy of the
 `active` group whenever the object is in it. The first such lookup downloads `active` once (about
-11,000 records); every later lookup by any client in the same cache reads that file until it passes
-the cache TTL. The order is: the exact per-object cache file if it is present and servable, then the
-cached `active` group, then a request for the object itself. Objects that are not in `active` --
-debris, inactive payloads -- are requested individually, so `get_gp(catnr=...)` works for any catalog
-number.
+11,000 records, several megabytes); every later lookup by any client in the same cache reads that
+file until it passes the cache TTL. The order is: the exact per-object cache file if it is present and
+servable, then the cached `active` group, then a request for the object itself. Objects that are not
+in `active` -- debris, inactive payloads -- are requested individually, so `get_gp(catnr=...)` works
+for any catalog number. `catnr` and `intdes` results are unaffected by which step answers them --
+resolution only changes where the record comes from, not its content.
 
 A name search follows the same order, so a search that matches in `active` returns only active
 objects; the server's own name search would also return inactive objects with the same substring. A
 name with no match in `active` is sent to the server. Group, special, and file queries, supplemental
-GP, and SATCAT are always sent to the server exactly as written, and `query_raw` never consults
-`active`. A client with a zero cache age sends every query directly, since the `active` group copy
-could not be reused.
+GP, and SATCAT are sent to the server exactly as written, though still served from the URL cache when
+a fresh copy exists; `query_raw` never consults `active`. A client with a zero cache age sends every
+query directly, since the `active` group copy could not be reused.
 
 === "Python"
 

--- a/docs/learn/ephemeris/celestrak.md
+++ b/docs/learn/ephemeris/celestrak.md
@@ -18,7 +18,9 @@ catalog metadata (`CelestrakQuery.satcat`).
 To minimize load on CelesTrak's servers and improve performance, the client caches downloaded data for
 2 hours. Cache files are stored in the system cache directory (`~/.cache/brahe/celestrak/`) and are
 keyed by query URL. Setting `BRAHE_NETWORK_MODE=offline` serves cached data without any request; see
-[Environment Variables](../utilities/environment_variables.md).
+[Environment Variables](../utilities/environment_variables.md). Lookups by catalog number, name, or
+international designator follow a different order, described in
+[Single-Object Lookups and the Active Catalog](#single-object-lookups-and-the-active-catalog) below.
 
 !!! tip "Customizing Cache"
     Pass `cache_max_age=0.0` to disable caching, or a custom value in seconds to change the TTL.
@@ -56,6 +58,48 @@ The following example retrieves GP data for a single satellite by NORAD catalog 
 Other common lookup patterns include querying by group name (`group="stations"`), object name
 (`name="ISS"`), or international designator (`intdes="1998-067A"`). All of these are available as
 keyword arguments to `get_gp` or as builder methods on `CelestrakQuery.gp`.
+
+## Single-Object Lookups and the Active Catalog
+
+A lookup by catalog number, international designator, or name is answered from a cached copy of the
+`active` group whenever the object is in it. The first such lookup downloads `active` once (about
+11,000 records); every later lookup by any client in the same cache reads that file until it passes
+the cache TTL. The order is: the exact per-object cache file if it is present and servable, then the
+cached `active` group, then a request for the object itself. Objects that are not in `active` --
+debris, inactive payloads -- are requested individually, so `get_gp(catnr=...)` works for any catalog
+number.
+
+A name search follows the same order, so a search that matches in `active` returns only active
+objects; the server's own name search would also return inactive objects with the same substring. A
+name with no match in `active` is sent to the server. Group, special, and file queries, supplemental
+GP, and SATCAT are always sent to the server exactly as written, and `query_raw` never consults
+`active`.
+
+=== "Python"
+
+    ```python
+    import brahe as bh
+
+    client = bh.celestrak.CelestrakClient()
+    iss = client.get_gp(catnr=25544)          # downloads active once
+    nisar = client.get_gp(name="NISAR")       # served from the cached active group
+    debris = client.get_gp(catnr=34427)       # not in active: requested directly
+    ```
+
+=== "Rust"
+
+    ```rust
+    use brahe::celestrak::CelestrakClient;
+
+    let client = CelestrakClient::new();
+    let iss = client.get_gp_by_catnr(25544).unwrap();
+    let nisar = client.get_gp_by_name("NISAR").unwrap();
+    let debris = client.get_gp_by_catnr(34427).unwrap();
+    ```
+
+With `BRAHE_NETWORK_MODE=offline`, a cached `active` group of any age answers these lookups; an object
+that is neither in the cached group nor in a per-object cache file is an error. See
+[Environment Variables](../utilities/environment_variables.md).
 
 ## Client-Side Filtering
 

--- a/docs/learn/ephemeris/celestrak.md
+++ b/docs/learn/ephemeris/celestrak.md
@@ -73,7 +73,8 @@ A name search follows the same order, so a search that matches in `active` retur
 objects; the server's own name search would also return inactive objects with the same substring. A
 name with no match in `active` is sent to the server. Group, special, and file queries, supplemental
 GP, and SATCAT are always sent to the server exactly as written, and `query_raw` never consults
-`active`.
+`active`. A client with a zero cache age sends every query directly, since the `active` group copy
+could not be reused.
 
 === "Python"
 

--- a/src/celestrak/client.rs
+++ b/src/celestrak/client.rs
@@ -46,6 +46,11 @@ static LAST_REQUEST_TIME: LazyLock<Mutex<Option<Instant>>> = LazyLock::new(|| Mu
 static ACTIVE_UNAVAILABLE_SINCE: LazyLock<Mutex<HashMap<String, Instant>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
+/// Process-global lock serializing population of the cached `active` group,
+/// so concurrent single-object lookups against a cold cache issue one
+/// request instead of one per caller.
+static ACTIVE_FETCH_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
 /// CelestrakClient API client with caching.
 ///
 /// Provides typed query execution for GP, supplemental GP, and SATCAT
@@ -627,17 +632,32 @@ impl CelestrakClient {
 
     /// Load the `active` group through the ordinary cached fetch path.
     ///
+    /// Holds [`ACTIVE_FETCH_LOCK`] for the duration of the fetch, so
+    /// concurrent callers racing a cold cache serialize on the first
+    /// caller's request; every later caller finds the file it wrote and
+    /// reads the cache instead of requesting the group again.
+    ///
     /// # Returns
     ///
     /// * `Ok(Vec<GPRecord>)` - Every record in the `active` group
     /// * `Err(BraheError)` - If the group is neither servable from cache nor
     ///   fetchable under the current `BRAHE_NETWORK_MODE`
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let records = client.active_catalog()?;
+    /// ```
     fn active_catalog(&self) -> Result<Vec<GPRecord>, BraheError> {
         let query = CelestrakQuery::gp()
             .group(LOCAL_CATALOG_GROUP)
             .format(CelestrakOutputFormat::Json);
         let url = self.build_full_url(&query);
-        Self::parse_gp_records(&self.fetch_with_cache(&url)?)
+        let body = {
+            let _guard = ACTIVE_FETCH_LOCK.lock().unwrap();
+            self.fetch_with_cache(&url)?
+        };
+        Self::parse_gp_records(&body)
     }
 
     /// Match a selector against the `active` group.
@@ -2066,6 +2086,40 @@ mod tests {
         std::thread::sleep(Duration::from_millis(600));
         client.get_gp_by_catnr(34427).unwrap();
         active.assert_calls(2);
+    }
+
+    #[test]
+    #[serial]
+    fn test_concurrent_cold_active_fetch_is_single_flight() {
+        clear_active_unavailable_latch();
+        let _cache = CacheRedirect::new();
+        let server = MockServer::start();
+        let active = server.mock(|when, then| {
+            when.method(GET)
+                .path("/NORAD/elements/gp.php")
+                .query_param("GROUP", "active")
+                .query_param("FORMAT", "JSON");
+            then.status(200)
+                .delay(Duration::from_millis(300))
+                .body(ACTIVE_JSON);
+        });
+        let base_url = server.base_url();
+
+        let handles: Vec<_> = (0..4)
+            .map(|_| {
+                let base_url = base_url.clone();
+                std::thread::spawn(move || {
+                    let client = CelestrakClient::with_base_url(&base_url);
+                    client.get_gp_by_catnr(25544).unwrap()
+                })
+            })
+            .collect();
+
+        for handle in handles {
+            let records = handle.join().unwrap();
+            assert_eq!(records[0].norad_cat_id, Some(25544));
+        }
+        active.assert_calls(1);
     }
 
     #[test]

--- a/src/celestrak/client.rs
+++ b/src/celestrak/client.rs
@@ -54,6 +54,10 @@ static LAST_REQUEST_TIME: LazyLock<Mutex<Option<Instant>>> = LazyLock::new(|| Mu
 /// is in it, so a series of lookups costs one request; objects not in
 /// `active` (debris, inactive objects) are requested individually. A
 /// `name` search that matches in `active` returns only active objects.
+/// Every other query is sent to the server exactly as written, though
+/// still served from the URL cache when a fresh copy exists. A client
+/// with a zero cache age sends every query directly, since the `active`
+/// group copy could not be reused.
 ///
 /// # Examples
 ///
@@ -217,7 +221,13 @@ impl CelestrakClient {
     /// active objects; a search with no match in `active` still goes to
     /// the server. `catnr` and `intdes` results are unaffected. Any other
     /// query (a group, `special`, `source`, combined selectors, and so
-    /// on) is always sent to the server.
+    /// on) is always sent to the server exactly as written, though it is
+    /// still served from the URL cache when a fresh copy exists. A client
+    /// with a zero cache age sends every query directly, since the `active`
+    /// group copy could not be reused. Under `offline-strict`, step 1 (the
+    /// exact per-object cache file) is checked first, so a per-object cache
+    /// file older than the cache age is an error even when a fresh `active`
+    /// copy exists.
     ///
     /// # Arguments
     ///
@@ -251,8 +261,10 @@ impl CelestrakClient {
         };
 
         let mut records = match query.local_selector() {
-            Some(selector) => self.resolve_single_object(&json_query, &selector)?,
-            None => Self::parse_gp_records(&self.query_raw(&json_query)?)?,
+            Some(selector) if self.cache_max_age > 0.0 => {
+                self.resolve_single_object(&json_query, &selector)?
+            }
+            _ => Self::parse_gp_records(&self.query_raw(&json_query)?)?,
         };
 
         // Apply client-side processing
@@ -1903,5 +1915,19 @@ mod tests {
         assert_eq!(propagator.norad_id, 25544);
         active.assert_calls(1);
         single.assert_calls(0);
+    }
+
+    #[test]
+    #[serial]
+    fn test_zero_cache_age_skips_active_resolution() {
+        let _cache = CacheRedirect::new();
+        let server = MockServer::start();
+        let (active, single) = mock_active_and_single(&server, "CATNR", "25544");
+        let client = CelestrakClient::with_base_url_and_cache_age(&server.base_url(), 0.0);
+
+        let records = client.get_gp_by_catnr(25544).unwrap();
+        assert_eq!(records[0].norad_cat_id, Some(34427));
+        active.assert_calls(0);
+        single.assert_calls(1);
     }
 }

--- a/src/celestrak/client.rs
+++ b/src/celestrak/client.rs
@@ -5,6 +5,7 @@
  * and typed query execution. No authentication is required.
  */
 
+use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 use std::sync::{LazyLock, Mutex};
@@ -39,6 +40,11 @@ const LOCAL_CATALOG_GROUP: &str = "active";
 /// Process-global tracker for the last HTTP request time, shared across all
 /// `CelestrakClient` instances to enforce rate limiting.
 static LAST_REQUEST_TIME: LazyLock<Mutex<Option<Instant>>> = LazyLock::new(|| Mutex::new(None));
+
+/// Base URLs whose `active` group fetch failed, with the failure time; single-object
+/// lookups skip the group for `cache_max_age` seconds after a failure.
+static ACTIVE_UNAVAILABLE_SINCE: LazyLock<Mutex<HashMap<String, Instant>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
 
 /// CelestrakClient API client with caching.
 ///
@@ -645,15 +651,32 @@ impl CelestrakClient {
     /// * `Ok(Some(Vec<GPRecord>))` - One or more active records matched
     /// * `Ok(None)` - No active record matched, or the group could not be
     ///   obtained (a warning is printed in `online` mode); the caller falls
-    ///   back to a per-object request
+    ///   back to a per-object request. A failed fetch latches this client's
+    ///   base URL for `cache_max_age` seconds, during which later calls
+    ///   return `Ok(None)` without attempting the group again
     /// * `Err(BraheError)` - If the network mode cannot be read
     fn resolve_from_active(
         &self,
         selector: &LocalSelector,
     ) -> Result<Option<Vec<GPRecord>>, BraheError> {
+        if let Some(since) = ACTIVE_UNAVAILABLE_SINCE.lock().unwrap().get(&self.base_url)
+            && since.elapsed() < Duration::from_secs_f64(self.cache_max_age)
+        {
+            return Ok(None);
+        }
         let catalog = match self.active_catalog() {
-            Ok(catalog) => catalog,
+            Ok(catalog) => {
+                ACTIVE_UNAVAILABLE_SINCE
+                    .lock()
+                    .unwrap()
+                    .remove(&self.base_url);
+                catalog
+            }
             Err(e) => {
+                ACTIVE_UNAVAILABLE_SINCE
+                    .lock()
+                    .unwrap()
+                    .insert(self.base_url.clone(), Instant::now());
                 if network_mode()? == NetworkMode::Online {
                     eprintln!(
                         "Warning: Celestrak active catalog unavailable ({}); requesting the object directly",
@@ -834,6 +857,16 @@ impl Default for CelestrakClient {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// Clear the process-global latch of `active` fetch failures.
+///
+/// Tests that exercise single-object resolution call this first so a
+/// latched failure from an earlier test cannot suppress an `active` fetch
+/// it expects to happen.
+#[cfg(test)]
+pub(crate) fn clear_active_unavailable_latch() {
+    ACTIVE_UNAVAILABLE_SINCE.lock().unwrap().clear();
 }
 
 #[cfg(test)]
@@ -1661,6 +1694,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_catnr_resolves_from_active_without_per_object_request() {
+        clear_active_unavailable_latch();
         let _cache = CacheRedirect::new();
         let server = MockServer::start();
         let (active, single) = mock_active_and_single(&server, "CATNR", "25544");
@@ -1683,6 +1717,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_name_resolves_case_insensitive_substring_from_active() {
+        clear_active_unavailable_latch();
         let _cache = CacheRedirect::new();
         let server = MockServer::start();
         let (active, single) = mock_active_and_single(&server, "NAME", "iss");
@@ -1701,6 +1736,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_intdes_resolves_from_active() {
+        clear_active_unavailable_latch();
         let _cache = CacheRedirect::new();
         let server = MockServer::start();
         let (active, single) = mock_active_and_single(&server, "INTDES", "2025-158a");
@@ -1715,6 +1751,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_catnr_absent_from_active_falls_through_to_per_object_request() {
+        clear_active_unavailable_latch();
         let _cache = CacheRedirect::new();
         let server = MockServer::start();
         let (active, single) = mock_active_and_single(&server, "CATNR", "34427");
@@ -1729,6 +1766,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_name_without_active_match_goes_to_server() {
+        clear_active_unavailable_latch();
         let _cache = CacheRedirect::new();
         let server = MockServer::start();
         let (active, single) = mock_active_and_single(&server, "NAME", "COSMOS");
@@ -1743,6 +1781,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_exact_per_object_cache_takes_precedence_over_active() {
+        clear_active_unavailable_latch();
         let _cache = CacheRedirect::new();
         let server = MockServer::start();
         let (active, single) = mock_active_and_single(&server, "CATNR", "25544");
@@ -1762,6 +1801,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_active_unavailable_online_falls_back_to_per_object_request() {
+        clear_active_unavailable_latch();
         let _cache = CacheRedirect::new();
         let _mode = NetworkModeGuard::set(Some("online"));
         let server = MockServer::start();
@@ -1788,6 +1828,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_active_resolution_does_not_write_per_object_cache() {
+        clear_active_unavailable_latch();
         let _cache = CacheRedirect::new();
         let server = MockServer::start();
         let (_active, _single) = mock_active_and_single(&server, "CATNR", "25544");
@@ -1812,6 +1853,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_group_query_never_touches_active() {
+        clear_active_unavailable_latch();
         let _cache = CacheRedirect::new();
         let server = MockServer::start();
         let active = server.mock(|when, then| {
@@ -1836,6 +1878,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_query_raw_with_catnr_never_touches_active() {
+        clear_active_unavailable_latch();
         let _cache = CacheRedirect::new();
         let server = MockServer::start();
         let (active, single) = mock_active_and_single(&server, "CATNR", "34427");
@@ -1856,6 +1899,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_client_side_filters_apply_after_active_resolution() {
+        clear_active_unavailable_latch();
         let _cache = CacheRedirect::new();
         let server = MockServer::start();
         let (active, single) = mock_active_and_single(&server, "NAME", "ISS");
@@ -1872,6 +1916,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_offline_serves_stale_active_and_errors_on_full_miss() {
+        clear_active_unavailable_latch();
         let _cache = CacheRedirect::new();
         let _mode = NetworkModeGuard::set(Some("offline"));
         let server = MockServer::start();
@@ -1905,6 +1950,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_sgp_propagator_by_catnr_resolves_from_active() {
+        clear_active_unavailable_latch();
         setup_global_test_eop();
         let _cache = CacheRedirect::new();
         let server = MockServer::start();
@@ -1920,6 +1966,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_zero_cache_age_skips_active_resolution() {
+        clear_active_unavailable_latch();
         let _cache = CacheRedirect::new();
         let server = MockServer::start();
         let (active, single) = mock_active_and_single(&server, "CATNR", "25544");
@@ -1929,5 +1976,65 @@ mod tests {
         assert_eq!(records[0].norad_cat_id, Some(34427));
         active.assert_calls(0);
         single.assert_calls(1);
+    }
+
+    #[test]
+    #[serial]
+    fn test_active_failure_is_latched_for_cache_age() {
+        clear_active_unavailable_latch();
+        let server = MockServer::start();
+        let active = server.mock(|when, then| {
+            when.method(GET)
+                .path("/NORAD/elements/gp.php")
+                .query_param("GROUP", "active");
+            then.status(404);
+        });
+        let single = server.mock(|when, then| {
+            when.method(GET)
+                .path("/NORAD/elements/gp.php")
+                .query_param("CATNR", "34427");
+            then.status(200).body(SINGLE_JSON);
+        });
+        let client = CelestrakClient::with_base_url(&server.base_url());
+
+        // Fresh per-object cache for each call isolates the latch (a
+        // process-global static independent of BRAHE_CACHE) as the only
+        // thing suppressing the second `active` request.
+        {
+            let _cache = CacheRedirect::new();
+            client.get_gp_by_catnr(34427).unwrap();
+        }
+        {
+            let _cache = CacheRedirect::new();
+            client.get_gp_by_catnr(34427).unwrap();
+        }
+        active.assert_calls(1);
+        single.assert_calls(2);
+    }
+
+    #[test]
+    #[serial]
+    fn test_active_latch_expires() {
+        clear_active_unavailable_latch();
+        let _cache = CacheRedirect::new();
+        let server = MockServer::start();
+        let active = server.mock(|when, then| {
+            when.method(GET)
+                .path("/NORAD/elements/gp.php")
+                .query_param("GROUP", "active");
+            then.status(404);
+        });
+        let _single = server.mock(|when, then| {
+            when.method(GET)
+                .path("/NORAD/elements/gp.php")
+                .query_param("CATNR", "34427");
+            then.status(200).body(SINGLE_JSON);
+        });
+        let client = CelestrakClient::with_base_url_and_cache_age(&server.base_url(), 0.5);
+
+        client.get_gp_by_catnr(34427).unwrap();
+        std::thread::sleep(Duration::from_millis(600));
+        client.get_gp_by_catnr(34427).unwrap();
+        active.assert_calls(2);
     }
 }

--- a/src/celestrak/client.rs
+++ b/src/celestrak/client.rs
@@ -647,7 +647,10 @@ impl CelestrakClient {
     /// Holds [`ACTIVE_FETCH_LOCK`] for the duration of the fetch, so
     /// concurrent callers racing a cold cache serialize on the first
     /// caller's request; every later caller finds the file it wrote and
-    /// reads the cache instead of requesting the group again.
+    /// reads the cache instead of requesting the group again. The lock
+    /// guards no data (only ordering), so a panic while it is held poisons
+    /// it without leaving anything inconsistent behind; later callers
+    /// recover the lock rather than panicking themselves.
     ///
     /// # Returns
     ///
@@ -666,7 +669,7 @@ impl CelestrakClient {
             .format(CelestrakOutputFormat::Json);
         let url = self.build_full_url(&query);
         let body = {
-            let _guard = ACTIVE_FETCH_LOCK.lock().unwrap();
+            let _guard = ACTIVE_FETCH_LOCK.lock().unwrap_or_else(|e| e.into_inner());
             self.fetch_with_cache(&url)?
         };
         Self::parse_gp_records(&body)
@@ -2146,6 +2149,27 @@ mod tests {
             assert_eq!(records[0].norad_cat_id, Some(25544));
         }
         active.assert_calls(1);
+    }
+
+    #[test]
+    #[serial]
+    fn test_active_fetch_lock_recovers_from_poison() {
+        clear_active_unavailable_latch();
+        let _cache = CacheRedirect::new();
+        let _ = std::thread::spawn(|| {
+            let _guard = ACTIVE_FETCH_LOCK.lock().unwrap();
+            panic!("poison ACTIVE_FETCH_LOCK for test_active_fetch_lock_recovers_from_poison");
+        })
+        .join();
+
+        let server = MockServer::start();
+        let (active, single) = mock_active_and_single(&server, "CATNR", "25544");
+        let client = CelestrakClient::with_base_url(&server.base_url());
+
+        let records = client.get_gp_by_catnr(25544).unwrap();
+        assert_eq!(records[0].norad_cat_id, Some(25544));
+        active.assert_calls(1);
+        single.assert_calls(0);
     }
 
     #[test]

--- a/src/celestrak/client.rs
+++ b/src/celestrak/client.rs
@@ -227,8 +227,8 @@ impl CelestrakClient {
     /// active objects; a search with no match in `active` still goes to
     /// the server. `catnr` and `intdes` results are unaffected. Any other
     /// query (a group, `special`, `source`, combined selectors, and so
-    /// on) is always sent to the server exactly as written, though it is
-    /// still served from the URL cache when a fresh copy exists. A client
+    /// on) is sent to the server exactly as written, though it is still
+    /// served from the URL cache when a fresh copy exists. A client
     /// with a zero cache age sends every query directly, since the `active`
     /// group copy could not be reused. Under `offline-strict`, step 1 (the
     /// exact per-object cache file) is checked first, so a per-object cache
@@ -2010,6 +2010,35 @@ mod tests {
         }
         active.assert_calls(1);
         single.assert_calls(2);
+    }
+
+    #[test]
+    #[serial]
+    fn test_offline_strict_stale_active_falls_through_without_warning() {
+        clear_active_unavailable_latch();
+        let _cache = CacheRedirect::new();
+        let _mode = NetworkModeGuard::set(Some("offline-strict"));
+        let server = MockServer::start();
+        let (active, single) = mock_active_and_single(&server, "CATNR", "25544");
+        let client = CelestrakClient::with_base_url(&server.base_url());
+        let active_url = format!(
+            "{}/NORAD/elements/gp.php?GROUP=active&FORMAT=JSON",
+            server.base_url()
+        );
+        seed_celestrak_cache(
+            &client,
+            &active_url,
+            ACTIVE_JSON,
+            Duration::from_secs(30 * 86400),
+        );
+
+        let err = client.get_gp_by_catnr(25544).unwrap_err().to_string();
+        assert!(
+            err.starts_with("BRAHE_NETWORK_MODE is offline-strict; Celestrak request "),
+            "{err}"
+        );
+        active.assert_calls(0);
+        single.assert_calls(0);
     }
 
     #[test]

--- a/src/celestrak/client.rs
+++ b/src/celestrak/client.rs
@@ -1975,13 +1975,9 @@ mod tests {
         clear_active_unavailable_latch();
         let _cache = CacheRedirect::new();
         let _mode = NetworkModeGuard::set(Some("offline"));
-        let server = MockServer::start();
-        let (active, single) = mock_active_and_single(&server, "CATNR", "25544");
-        let client = CelestrakClient::with_base_url(&server.base_url());
-        let active_url = format!(
-            "{}/NORAD/elements/gp.php?GROUP=active&FORMAT=JSON",
-            server.base_url()
-        );
+        let base_url = "https://brahe-network-mode-test.invalid";
+        let client = CelestrakClient::with_base_url(base_url);
+        let active_url = format!("{base_url}/NORAD/elements/gp.php?GROUP=active&FORMAT=JSON");
         seed_celestrak_cache(
             &client,
             &active_url,
@@ -1991,16 +1987,12 @@ mod tests {
 
         let records = client.get_gp_by_catnr(25544).unwrap();
         assert_eq!(records[0].norad_cat_id, Some(25544));
-        active.assert_calls(0);
-        single.assert_calls(0);
 
         let err = client.get_gp_by_catnr(34427).unwrap_err().to_string();
         assert!(
             err.starts_with("BRAHE_NETWORK_MODE is offline; Celestrak request "),
             "{err}"
         );
-        active.assert_calls(0);
-        single.assert_calls(0);
     }
 
     #[test]
@@ -2074,13 +2066,9 @@ mod tests {
         clear_active_unavailable_latch();
         let _cache = CacheRedirect::new();
         let _mode = NetworkModeGuard::set(Some("offline-strict"));
-        let server = MockServer::start();
-        let (active, single) = mock_active_and_single(&server, "CATNR", "25544");
-        let client = CelestrakClient::with_base_url(&server.base_url());
-        let active_url = format!(
-            "{}/NORAD/elements/gp.php?GROUP=active&FORMAT=JSON",
-            server.base_url()
-        );
+        let base_url = "https://brahe-network-mode-test.invalid";
+        let client = CelestrakClient::with_base_url(base_url);
+        let active_url = format!("{base_url}/NORAD/elements/gp.php?GROUP=active&FORMAT=JSON");
         seed_celestrak_cache(
             &client,
             &active_url,
@@ -2093,8 +2081,6 @@ mod tests {
             err.starts_with("BRAHE_NETWORK_MODE is offline-strict; Celestrak request "),
             "{err}"
         );
-        active.assert_calls(0);
-        single.assert_calls(0);
     }
 
     #[test]
@@ -2102,6 +2088,7 @@ mod tests {
     fn test_active_latch_expires() {
         clear_active_unavailable_latch();
         let _cache = CacheRedirect::new();
+        let _mode = NetworkModeGuard::set(Some("online"));
         let server = MockServer::start();
         let active = server.mock(|when, then| {
             when.method(GET)

--- a/src/celestrak/client.rs
+++ b/src/celestrak/client.rs
@@ -11,12 +11,14 @@ use std::sync::{LazyLock, Mutex};
 use std::time::{Duration, Instant, SystemTime};
 
 use crate::celestrak::filter::{apply_filters, apply_limit, apply_order_by};
-use crate::celestrak::query::CelestrakQuery;
+use crate::celestrak::query::{CelestrakQuery, LocalSelector};
 use crate::celestrak::responses::CelestrakSATCATRecord;
 use crate::celestrak::types::{CelestrakOutputFormat, SupGPSource};
 use crate::propagators::SGPPropagator;
 use crate::types::GPRecord;
-use crate::utils::network::{CacheDecision, cache_policy, ensure_online};
+use crate::utils::network::{
+    CacheDecision, NetworkMode, cache_policy, ensure_online, network_mode,
+};
 use crate::utils::{BraheError, atomic_write, get_celestrak_cache_dir};
 
 /// Default base URL for the CelestrakClient API.
@@ -31,6 +33,9 @@ const DEFAULT_MAX_RETRIES: u32 = 3;
 /// Minimum interval between HTTP requests to avoid overwhelming the server.
 const MIN_REQUEST_INTERVAL: Duration = Duration::from_millis(500);
 
+/// Celestrak group whose cached response answers single-object lookups locally.
+const LOCAL_CATALOG_GROUP: &str = "active";
+
 /// Process-global tracker for the last HTTP request time, shared across all
 /// `CelestrakClient` instances to enforce rate limiting.
 static LAST_REQUEST_TIME: LazyLock<Mutex<Option<Instant>>> = LazyLock::new(|| Mutex::new(None));
@@ -42,6 +47,13 @@ static LAST_REQUEST_TIME: LazyLock<Mutex<Option<Instant>>> = LazyLock::new(|| Mu
 /// server load and improve performance. The `BRAHE_NETWORK_MODE`
 /// environment variable controls whether a stale cached response is
 /// refreshed or served; see [`crate::utils::network`].
+///
+/// Single-object lookups (`get_gp_by_catnr`, `get_gp_by_intdes`,
+/// `get_gp_by_name`, and `query_gp` with exactly one of those selectors)
+/// are answered from a cached copy of the `active` group when the object
+/// is in it, so a series of lookups costs one request; objects not in
+/// `active` (debris, inactive objects) are requested individually. A
+/// `name` search that matches in `active` returns only active objects.
 ///
 /// # Examples
 ///
@@ -196,7 +208,16 @@ impl CelestrakClient {
     /// Forces JSON format internally for deserialization. Applies any
     /// client-side filters, ordering, and limit specified in the query.
     ///
-    /// Works for both GP and SupGP query types.
+    /// Works for both GP and SupGP query types. A GP query whose
+    /// server-side parameters are exactly one of `CATNR`, `INTDES`, or
+    /// `NAME` is resolved in three steps: the exact per-object cache file,
+    /// then the cached `active` group (a match returns immediately and is
+    /// not written to the per-object cache key), then a per-object
+    /// request. A `name` search that matches in `active` returns only
+    /// active objects; a search with no match in `active` still goes to
+    /// the server. `catnr` and `intdes` results are unaffected. Any other
+    /// query (a group, `special`, `source`, combined selectors, and so
+    /// on) is always sent to the server.
     ///
     /// # Arguments
     ///
@@ -229,13 +250,10 @@ impl CelestrakClient {
             query.clone().format(CelestrakOutputFormat::Json)
         };
 
-        let body = self.query_raw(&json_query)?;
-        let mut records: Vec<GPRecord> = serde_json::from_str(&body).map_err(|e| {
-            BraheError::ParseError(format!(
-                "Failed to parse CelestrakClient GP response: {}",
-                e
-            ))
-        })?;
+        let mut records = match query.local_selector() {
+            Some(selector) => self.resolve_single_object(&json_query, &selector)?,
+            None => Self::parse_gp_records(&self.query_raw(&json_query)?)?,
+        };
 
         // Apply client-side processing
         records = apply_filters(records, query.client_side_filters());
@@ -309,7 +327,9 @@ impl CelestrakClient {
     ///
     /// # Returns
     ///
-    /// * `Ok(Vec<GPRecord>)` - Matching GP records
+    /// * `Ok(Vec<GPRecord>)` - Matching GP records, resolved from the cached
+    ///   `active` group when the object is in it, otherwise requested
+    ///   individually
     /// * `Err(BraheError)` - On network, cache, or parse errors
     ///
     /// # Examples
@@ -359,7 +379,10 @@ impl CelestrakClient {
     ///
     /// # Returns
     ///
-    /// * `Ok(Vec<GPRecord>)` - Matching GP records
+    /// * `Ok(Vec<GPRecord>)` - Matching GP records. When the cached `active`
+    ///   group contains a match, only active objects are returned; a search
+    ///   with no match in `active` is sent to the server, which may include
+    ///   inactive objects
     /// * `Err(BraheError)` - On network, cache, or parse errors
     ///
     /// # Examples
@@ -383,7 +406,9 @@ impl CelestrakClient {
     ///
     /// # Returns
     ///
-    /// * `Ok(Vec<GPRecord>)` - Matching GP records
+    /// * `Ok(Vec<GPRecord>)` - Matching GP records, resolved from the cached
+    ///   `active` group when the object is in it, otherwise requested
+    ///   individually
     /// * `Err(BraheError)` - On network, cache, or parse errors
     ///
     /// # Examples
@@ -532,6 +557,105 @@ impl CelestrakClient {
         self.write_cache(&cache_key, &body)?;
 
         Ok(body)
+    }
+
+    /// Parse a JSON GP response body into records.
+    ///
+    /// # Arguments
+    ///
+    /// * `body` - JSON array of GP records as returned by Celestrak
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Vec<GPRecord>)` - Parsed records
+    /// * `Err(BraheError)` - If the body is not a JSON array of GP records
+    fn parse_gp_records(body: &str) -> Result<Vec<GPRecord>, BraheError> {
+        serde_json::from_str(body).map_err(|e| {
+            BraheError::ParseError(format!(
+                "Failed to parse CelestrakClient GP response: {}",
+                e
+            ))
+        })
+    }
+
+    /// Resolve a single-object GP query: exact per-object cache, then the
+    /// cached `active` group, then a per-object request.
+    ///
+    /// # Arguments
+    ///
+    /// * `json_query` - The query with JSON output format applied
+    /// * `selector` - The object the query names
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Vec<GPRecord>)` - Matching records from whichever step answered
+    /// * `Err(BraheError)` - On cache I/O or parse errors, or when the
+    ///   per-object request is needed and `BRAHE_NETWORK_MODE` forbids it
+    fn resolve_single_object(
+        &self,
+        json_query: &CelestrakQuery,
+        selector: &LocalSelector,
+    ) -> Result<Vec<GPRecord>, BraheError> {
+        let url = self.build_full_url(json_query);
+        let cache_key = self.cache_key_for_url(&url);
+        if let Some(body) = self.read_cache(&cache_key)? {
+            return Self::parse_gp_records(&body);
+        }
+        if let Some(records) = self.resolve_from_active(selector)? {
+            return Ok(records);
+        }
+        Self::parse_gp_records(&self.fetch_with_cache(&url)?)
+    }
+
+    /// Load the `active` group through the ordinary cached fetch path.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Vec<GPRecord>)` - Every record in the `active` group
+    /// * `Err(BraheError)` - If the group is neither servable from cache nor
+    ///   fetchable under the current `BRAHE_NETWORK_MODE`
+    fn active_catalog(&self) -> Result<Vec<GPRecord>, BraheError> {
+        let query = CelestrakQuery::gp()
+            .group(LOCAL_CATALOG_GROUP)
+            .format(CelestrakOutputFormat::Json);
+        let url = self.build_full_url(&query);
+        Self::parse_gp_records(&self.fetch_with_cache(&url)?)
+    }
+
+    /// Match a selector against the `active` group.
+    ///
+    /// # Arguments
+    ///
+    /// * `selector` - The object to look for
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Some(Vec<GPRecord>))` - One or more active records matched
+    /// * `Ok(None)` - No active record matched, or the group could not be
+    ///   obtained (a warning is printed in `online` mode); the caller falls
+    ///   back to a per-object request
+    /// * `Err(BraheError)` - If the network mode cannot be read
+    fn resolve_from_active(
+        &self,
+        selector: &LocalSelector,
+    ) -> Result<Option<Vec<GPRecord>>, BraheError> {
+        let catalog = match self.active_catalog() {
+            Ok(catalog) => catalog,
+            Err(e) => {
+                if network_mode()? == NetworkMode::Online {
+                    eprintln!(
+                        "Warning: Celestrak active catalog unavailable ({}); requesting the object directly",
+                        e
+                    );
+                }
+                return Ok(None);
+            }
+        };
+        let matches: Vec<GPRecord> = catalog
+            .into_iter()
+            .filter(|record| selector.matches(record))
+            .collect();
+        Ok((!matches.is_empty()).then_some(matches))
     }
 
     /// Generate a cache key from a URL.
@@ -704,7 +828,7 @@ impl Default for CelestrakClient {
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
-    use crate::utils::testing::{CacheRedirect, NetworkModeGuard};
+    use crate::utils::testing::{CacheRedirect, NetworkModeGuard, setup_global_test_eop};
     use httpmock::prelude::*;
     use serial_test::serial;
     use std::fs;
@@ -1487,5 +1611,294 @@ mod tests {
             .get_sgp_propagator_by_catnr(25544, 60.0)
             .expect("SGP propagator creation failed");
         assert_eq!(propagator.norad_id, 25544);
+    }
+
+    // -- Active-group resolution tests --
+
+    const ACTIVE_JSON: &str = r#"[
+ {"OBJECT_NAME":"ISS (ZARYA)","OBJECT_ID":"1998-067A","EPOCH":"2026-08-27T12:00:00.000000","MEAN_MOTION":15.49,"ECCENTRICITY":0.0006,"INCLINATION":51.64,"RA_OF_ASC_NODE":120.5,"ARG_OF_PERICENTER":30.2,"MEAN_ANOMALY":329.9,"EPHEMERIS_TYPE":0,"CLASSIFICATION_TYPE":"U","NORAD_CAT_ID":25544,"ELEMENT_SET_NO":999,"REV_AT_EPOCH":54000,"BSTAR":0.0001,"MEAN_MOTION_DOT":0.0001,"MEAN_MOTION_DDOT":0},
+ {"OBJECT_NAME":"ISS (NAUKA)","OBJECT_ID":"2021-066A","EPOCH":"2026-08-27T12:00:00.000000","MEAN_MOTION":15.49,"ECCENTRICITY":0.0006,"INCLINATION":51.64,"RA_OF_ASC_NODE":120.5,"ARG_OF_PERICENTER":30.2,"MEAN_ANOMALY":329.9,"EPHEMERIS_TYPE":0,"CLASSIFICATION_TYPE":"U","NORAD_CAT_ID":49044,"ELEMENT_SET_NO":999,"REV_AT_EPOCH":28000,"BSTAR":0.0001,"MEAN_MOTION_DOT":0.0001,"MEAN_MOTION_DDOT":0},
+ {"OBJECT_NAME":"NISAR","OBJECT_ID":"2025-158A","EPOCH":"2026-08-27T12:00:00.000000","MEAN_MOTION":14.3,"ECCENTRICITY":0.0002,"INCLINATION":98.4,"RA_OF_ASC_NODE":200.0,"ARG_OF_PERICENTER":90.0,"MEAN_ANOMALY":270.0,"EPHEMERIS_TYPE":0,"CLASSIFICATION_TYPE":"U","NORAD_CAT_ID":65053,"ELEMENT_SET_NO":999,"REV_AT_EPOCH":5000,"BSTAR":0.00005,"MEAN_MOTION_DOT":0.00001,"MEAN_MOTION_DDOT":0}
+]"#;
+
+    const SINGLE_JSON: &str = r#"[{"OBJECT_NAME":"COSMOS 2251 DEB","OBJECT_ID":"1993-036AAB","EPOCH":"2026-08-27T12:00:00.000000","MEAN_MOTION":14.1,"ECCENTRICITY":0.01,"INCLINATION":74.0,"RA_OF_ASC_NODE":10.0,"ARG_OF_PERICENTER":20.0,"MEAN_ANOMALY":30.0,"EPHEMERIS_TYPE":0,"CLASSIFICATION_TYPE":"U","NORAD_CAT_ID":34427,"ELEMENT_SET_NO":999,"REV_AT_EPOCH":1,"BSTAR":0.0001,"MEAN_MOTION_DOT":0.0001,"MEAN_MOTION_DDOT":0}]"#;
+
+    /// Mock the `active` group and a per-object endpoint; returns (active, single).
+    fn mock_active_and_single<'a>(
+        server: &'a MockServer,
+        param: &str,
+        value: &str,
+    ) -> (httpmock::Mock<'a>, httpmock::Mock<'a>) {
+        let active = server.mock(|when, then| {
+            when.method(GET)
+                .path("/NORAD/elements/gp.php")
+                .query_param("GROUP", "active")
+                .query_param("FORMAT", "JSON");
+            then.status(200).body(ACTIVE_JSON);
+        });
+        let single = server.mock(|when, then| {
+            when.method(GET)
+                .path("/NORAD/elements/gp.php")
+                .query_param(param, value)
+                .query_param("FORMAT", "JSON");
+            then.status(200).body(SINGLE_JSON);
+        });
+        (active, single)
+    }
+
+    #[test]
+    #[serial]
+    fn test_catnr_resolves_from_active_without_per_object_request() {
+        let _cache = CacheRedirect::new();
+        let server = MockServer::start();
+        let (active, single) = mock_active_and_single(&server, "CATNR", "25544");
+        let client = CelestrakClient::with_base_url(&server.base_url());
+
+        let records = client.get_gp_by_catnr(25544).unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].norad_cat_id, Some(25544));
+        active.assert_calls(1);
+        single.assert_calls(0);
+
+        // A second client shares the on-disk active cache: no request at all.
+        let other = CelestrakClient::with_base_url(&server.base_url());
+        let records = other.get_gp_by_catnr(65053).unwrap();
+        assert_eq!(records[0].object_name.as_deref(), Some("NISAR"));
+        active.assert_calls(1);
+        single.assert_calls(0);
+    }
+
+    #[test]
+    #[serial]
+    fn test_name_resolves_case_insensitive_substring_from_active() {
+        let _cache = CacheRedirect::new();
+        let server = MockServer::start();
+        let (active, single) = mock_active_and_single(&server, "NAME", "iss");
+        let client = CelestrakClient::with_base_url(&server.base_url());
+
+        let records = client.get_gp_by_name("iss").unwrap();
+        let names: Vec<_> = records
+            .iter()
+            .filter_map(|r| r.object_name.as_deref())
+            .collect();
+        assert_eq!(names, vec!["ISS (ZARYA)", "ISS (NAUKA)"]);
+        active.assert_calls(1);
+        single.assert_calls(0);
+    }
+
+    #[test]
+    #[serial]
+    fn test_intdes_resolves_from_active() {
+        let _cache = CacheRedirect::new();
+        let server = MockServer::start();
+        let (active, single) = mock_active_and_single(&server, "INTDES", "2025-158a");
+        let client = CelestrakClient::with_base_url(&server.base_url());
+
+        let records = client.get_gp_by_intdes("2025-158a").unwrap();
+        assert_eq!(records[0].norad_cat_id, Some(65053));
+        active.assert_calls(1);
+        single.assert_calls(0);
+    }
+
+    #[test]
+    #[serial]
+    fn test_catnr_absent_from_active_falls_through_to_per_object_request() {
+        let _cache = CacheRedirect::new();
+        let server = MockServer::start();
+        let (active, single) = mock_active_and_single(&server, "CATNR", "34427");
+        let client = CelestrakClient::with_base_url(&server.base_url());
+
+        let records = client.get_gp_by_catnr(34427).unwrap();
+        assert_eq!(records[0].object_name.as_deref(), Some("COSMOS 2251 DEB"));
+        active.assert_calls(1);
+        single.assert_calls(1);
+    }
+
+    #[test]
+    #[serial]
+    fn test_name_without_active_match_goes_to_server() {
+        let _cache = CacheRedirect::new();
+        let server = MockServer::start();
+        let (active, single) = mock_active_and_single(&server, "NAME", "COSMOS");
+        let client = CelestrakClient::with_base_url(&server.base_url());
+
+        let records = client.get_gp_by_name("COSMOS").unwrap();
+        assert_eq!(records.len(), 1);
+        active.assert_calls(1);
+        single.assert_calls(1);
+    }
+
+    #[test]
+    #[serial]
+    fn test_exact_per_object_cache_takes_precedence_over_active() {
+        let _cache = CacheRedirect::new();
+        let server = MockServer::start();
+        let (active, single) = mock_active_and_single(&server, "CATNR", "25544");
+        let client = CelestrakClient::with_base_url(&server.base_url());
+        let url = format!(
+            "{}/NORAD/elements/gp.php?CATNR=25544&FORMAT=JSON",
+            server.base_url()
+        );
+        seed_celestrak_cache(&client, &url, SINGLE_JSON, Duration::from_secs(60));
+
+        let records = client.get_gp_by_catnr(25544).unwrap();
+        assert_eq!(records[0].object_name.as_deref(), Some("COSMOS 2251 DEB"));
+        active.assert_calls(0);
+        single.assert_calls(0);
+    }
+
+    #[test]
+    #[serial]
+    fn test_active_unavailable_online_falls_back_to_per_object_request() {
+        let _cache = CacheRedirect::new();
+        let _mode = NetworkModeGuard::set(Some("online"));
+        let server = MockServer::start();
+        let active = server.mock(|when, then| {
+            when.method(GET)
+                .path("/NORAD/elements/gp.php")
+                .query_param("GROUP", "active");
+            then.status(404);
+        });
+        let single = server.mock(|when, then| {
+            when.method(GET)
+                .path("/NORAD/elements/gp.php")
+                .query_param("CATNR", "34427");
+            then.status(200).body(SINGLE_JSON);
+        });
+        let client = CelestrakClient::with_base_url(&server.base_url());
+
+        let records = client.get_gp_by_catnr(34427).unwrap();
+        assert_eq!(records[0].norad_cat_id, Some(34427));
+        active.assert_calls(1);
+        single.assert_calls(1);
+    }
+
+    #[test]
+    #[serial]
+    fn test_active_resolution_does_not_write_per_object_cache() {
+        let _cache = CacheRedirect::new();
+        let server = MockServer::start();
+        let (_active, _single) = mock_active_and_single(&server, "CATNR", "25544");
+        let client = CelestrakClient::with_base_url(&server.base_url());
+        client.get_gp_by_catnr(25544).unwrap();
+
+        let url = format!(
+            "{}/NORAD/elements/gp.php?CATNR=25544&FORMAT=JSON",
+            server.base_url()
+        );
+        let dir = crate::utils::get_celestrak_cache_dir().unwrap();
+        let per_object = std::path::Path::new(&dir).join(client.cache_key_for_url(&url));
+        assert!(!per_object.exists());
+        let active_url = format!(
+            "{}/NORAD/elements/gp.php?GROUP=active&FORMAT=JSON",
+            server.base_url()
+        );
+        let active_file = std::path::Path::new(&dir).join(client.cache_key_for_url(&active_url));
+        assert!(active_file.exists());
+    }
+
+    #[test]
+    #[serial]
+    fn test_group_query_never_touches_active() {
+        let _cache = CacheRedirect::new();
+        let server = MockServer::start();
+        let active = server.mock(|when, then| {
+            when.method(GET)
+                .path("/NORAD/elements/gp.php")
+                .query_param("GROUP", "active");
+            then.status(200).body(ACTIVE_JSON);
+        });
+        let stations = server.mock(|when, then| {
+            when.method(GET)
+                .path("/NORAD/elements/gp.php")
+                .query_param("GROUP", "stations");
+            then.status(200).body(SINGLE_JSON);
+        });
+        let client = CelestrakClient::with_base_url(&server.base_url());
+
+        client.get_gp_by_group("stations").unwrap();
+        active.assert_calls(0);
+        stations.assert_calls(1);
+    }
+
+    #[test]
+    #[serial]
+    fn test_query_raw_with_catnr_never_touches_active() {
+        let _cache = CacheRedirect::new();
+        let server = MockServer::start();
+        let (active, single) = mock_active_and_single(&server, "CATNR", "34427");
+        let client = CelestrakClient::with_base_url(&server.base_url());
+
+        let body = client
+            .query_raw(
+                &CelestrakQuery::gp()
+                    .catnr(34427)
+                    .format(CelestrakOutputFormat::Json),
+            )
+            .unwrap();
+        assert_eq!(body, SINGLE_JSON);
+        active.assert_calls(0);
+        single.assert_calls(1);
+    }
+
+    #[test]
+    #[serial]
+    fn test_client_side_filters_apply_after_active_resolution() {
+        let _cache = CacheRedirect::new();
+        let server = MockServer::start();
+        let (_active, _single) = mock_active_and_single(&server, "NAME", "ISS");
+        let client = CelestrakClient::with_base_url(&server.base_url());
+
+        let query = CelestrakQuery::gp().name_search("ISS").limit(1);
+        let records = client.query_gp(&query).unwrap();
+        assert_eq!(records.len(), 1);
+    }
+
+    #[test]
+    #[serial]
+    fn test_offline_serves_stale_active_and_errors_on_full_miss() {
+        let _cache = CacheRedirect::new();
+        let _mode = NetworkModeGuard::set(Some("offline"));
+        let server = MockServer::start();
+        let (active, single) = mock_active_and_single(&server, "CATNR", "25544");
+        let client = CelestrakClient::with_base_url(&server.base_url());
+        let active_url = format!(
+            "{}/NORAD/elements/gp.php?GROUP=active&FORMAT=JSON",
+            server.base_url()
+        );
+        seed_celestrak_cache(
+            &client,
+            &active_url,
+            ACTIVE_JSON,
+            Duration::from_secs(30 * 86400),
+        );
+
+        let records = client.get_gp_by_catnr(25544).unwrap();
+        assert_eq!(records[0].norad_cat_id, Some(25544));
+        active.assert_calls(0);
+        single.assert_calls(0);
+
+        let err = client.get_gp_by_catnr(34427).unwrap_err().to_string();
+        assert!(
+            err.starts_with("BRAHE_NETWORK_MODE is offline; Celestrak request "),
+            "{err}"
+        );
+        active.assert_calls(0);
+        single.assert_calls(0);
+    }
+
+    #[test]
+    #[serial]
+    fn test_sgp_propagator_by_catnr_resolves_from_active() {
+        setup_global_test_eop();
+        let _cache = CacheRedirect::new();
+        let server = MockServer::start();
+        let (active, single) = mock_active_and_single(&server, "CATNR", "25544");
+        let client = CelestrakClient::with_base_url(&server.base_url());
+
+        let propagator = client.get_sgp_propagator_by_catnr(25544, 60.0).unwrap();
+        assert_eq!(propagator.norad_id, 25544);
+        active.assert_calls(1);
+        single.assert_calls(0);
     }
 }

--- a/src/celestrak/client.rs
+++ b/src/celestrak/client.rs
@@ -604,7 +604,7 @@ impl CelestrakClient {
         if let Some(records) = self.resolve_from_active(selector)? {
             return Ok(records);
         }
-        Self::parse_gp_records(&self.fetch_with_cache(&url)?)
+        Self::parse_gp_records(&self.query_raw(json_query)?)
     }
 
     /// Load the `active` group through the ordinary cached fetch path.
@@ -1846,12 +1846,15 @@ mod tests {
     fn test_client_side_filters_apply_after_active_resolution() {
         let _cache = CacheRedirect::new();
         let server = MockServer::start();
-        let (_active, _single) = mock_active_and_single(&server, "NAME", "ISS");
+        let (active, single) = mock_active_and_single(&server, "NAME", "ISS");
         let client = CelestrakClient::with_base_url(&server.base_url());
 
         let query = CelestrakQuery::gp().name_search("ISS").limit(1);
         let records = client.query_gp(&query).unwrap();
         assert_eq!(records.len(), 1);
+        assert_eq!(records[0].object_name.as_deref(), Some("ISS (ZARYA)"));
+        active.assert_calls(1);
+        single.assert_calls(0);
     }
 
     #[test]

--- a/src/celestrak/client.rs
+++ b/src/celestrak/client.rs
@@ -660,7 +660,8 @@ impl CelestrakClient {
         selector: &LocalSelector,
     ) -> Result<Option<Vec<GPRecord>>, BraheError> {
         if let Some(since) = ACTIVE_UNAVAILABLE_SINCE.lock().unwrap().get(&self.base_url)
-            && since.elapsed() < Duration::from_secs_f64(self.cache_max_age)
+            && since.elapsed()
+                < Duration::try_from_secs_f64(self.cache_max_age).unwrap_or(Duration::MAX)
         {
             return Ok(None);
         }
@@ -2065,5 +2066,39 @@ mod tests {
         std::thread::sleep(Duration::from_millis(600));
         client.get_gp_by_catnr(34427).unwrap();
         active.assert_calls(2);
+    }
+
+    #[test]
+    #[serial]
+    fn test_active_latch_with_infinite_cache_age_does_not_panic() {
+        clear_active_unavailable_latch();
+        let server = MockServer::start();
+        let active = server.mock(|when, then| {
+            when.method(GET)
+                .path("/NORAD/elements/gp.php")
+                .query_param("GROUP", "active");
+            then.status(404);
+        });
+        let single = server.mock(|when, then| {
+            when.method(GET)
+                .path("/NORAD/elements/gp.php")
+                .query_param("CATNR", "34427");
+            then.status(200).body(SINGLE_JSON);
+        });
+        let client =
+            CelestrakClient::with_base_url_and_cache_age(&server.base_url(), f64::INFINITY);
+
+        // Fresh per-object cache for each call isolates the latch, as in
+        // test_active_failure_is_latched_for_cache_age.
+        {
+            let _cache = CacheRedirect::new();
+            client.get_gp_by_catnr(34427).unwrap();
+        }
+        {
+            let _cache = CacheRedirect::new();
+            client.get_gp_by_catnr(34427).unwrap();
+        }
+        active.assert_calls(1);
+        single.assert_calls(2);
     }
 }

--- a/src/celestrak/client.rs
+++ b/src/celestrak/client.rs
@@ -702,7 +702,10 @@ impl CelestrakClient {
         &self,
         selector: &LocalSelector,
     ) -> Result<Option<Vec<GPRecord>>, BraheError> {
-        if let Some(since) = ACTIVE_UNAVAILABLE_SINCE.lock().unwrap().get(&self.base_url)
+        if let Some(since) = ACTIVE_UNAVAILABLE_SINCE
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(&self.base_url)
             && since.elapsed()
                 < Duration::try_from_secs_f64(self.cache_max_age).unwrap_or(Duration::MAX)
         {
@@ -712,14 +715,14 @@ impl CelestrakClient {
             Ok(catalog) => {
                 ACTIVE_UNAVAILABLE_SINCE
                     .lock()
-                    .unwrap()
+                    .unwrap_or_else(|e| e.into_inner())
                     .remove(&self.base_url);
                 catalog
             }
             Err(e) => {
                 ACTIVE_UNAVAILABLE_SINCE
                     .lock()
-                    .unwrap()
+                    .unwrap_or_else(|e| e.into_inner())
                     .insert(self.base_url.clone(), Instant::now());
                 if network_mode()? == NetworkMode::Online {
                     eprintln!(
@@ -916,7 +919,10 @@ impl Default for CelestrakClient {
 /// ```
 #[cfg(test)]
 pub(crate) fn clear_active_unavailable_latch() {
-    ACTIVE_UNAVAILABLE_SINCE.lock().unwrap().clear();
+    ACTIVE_UNAVAILABLE_SINCE
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .clear();
 }
 
 #[cfg(test)]

--- a/src/celestrak/client.rs
+++ b/src/celestrak/client.rs
@@ -592,6 +592,12 @@ impl CelestrakClient {
     ///
     /// * `Ok(Vec<GPRecord>)` - Parsed records
     /// * `Err(BraheError)` - If the body is not a JSON array of GP records
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let records = CelestrakClient::parse_gp_records(&body)?;
+    /// ```
     fn parse_gp_records(body: &str) -> Result<Vec<GPRecord>, BraheError> {
         serde_json::from_str(body).map_err(|e| {
             BraheError::ParseError(format!(
@@ -614,6 +620,12 @@ impl CelestrakClient {
     /// * `Ok(Vec<GPRecord>)` - Matching records from whichever step answered
     /// * `Err(BraheError)` - On cache I/O or parse errors, or when the
     ///   per-object request is needed and `BRAHE_NETWORK_MODE` forbids it
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let records = client.resolve_single_object(&json_query, &selector)?;
+    /// ```
     fn resolve_single_object(
         &self,
         json_query: &CelestrakQuery,
@@ -675,6 +687,14 @@ impl CelestrakClient {
     ///   base URL for `cache_max_age` seconds, during which later calls
     ///   return `Ok(None)` without attempting the group again
     /// * `Err(BraheError)` - If the network mode cannot be read
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// if let Some(records) = client.resolve_from_active(&selector)? {
+    ///     return Ok(records);
+    /// }
+    /// ```
     fn resolve_from_active(
         &self,
         selector: &LocalSelector,
@@ -885,6 +905,12 @@ impl Default for CelestrakClient {
 /// Tests that exercise single-object resolution call this first so a
 /// latched failure from an earlier test cannot suppress an `active` fetch
 /// it expects to happen.
+///
+/// # Examples
+///
+/// ```ignore
+/// clear_active_unavailable_latch();
+/// ```
 #[cfg(test)]
 pub(crate) fn clear_active_unavailable_latch() {
     ACTIVE_UNAVAILABLE_SINCE.lock().unwrap().clear();

--- a/src/celestrak/query.rs
+++ b/src/celestrak/query.rs
@@ -590,24 +590,28 @@ mod tests {
     // -- Constructor tests --
 
     #[test]
+    #[serial_test::parallel]
     fn test_gp_constructor() {
         let query = CelestrakQuery::gp();
         assert_eq!(query.query_type(), CelestrakQueryType::GP);
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_sup_gp_constructor() {
         let query = CelestrakQuery::sup_gp();
         assert_eq!(query.query_type(), CelestrakQueryType::SupGP);
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_satcat_constructor() {
         let query = CelestrakQuery::satcat();
         assert_eq!(query.query_type(), CelestrakQueryType::SATCAT);
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_new_constructor() {
         let query = CelestrakQuery::new(CelestrakQueryType::GP);
         assert_eq!(query.query_type(), CelestrakQueryType::GP);
@@ -616,30 +620,35 @@ mod tests {
     // -- GP URL building tests --
 
     #[test]
+    #[serial_test::parallel]
     fn test_gp_by_group() {
         let query = CelestrakQuery::gp().group("stations");
         assert_eq!(query.build_url(), "GROUP=stations");
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_gp_by_catnr() {
         let query = CelestrakQuery::gp().catnr(25544);
         assert_eq!(query.build_url(), "CATNR=25544");
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_gp_by_intdes() {
         let query = CelestrakQuery::gp().intdes("1998-067A");
         assert_eq!(query.build_url(), "INTDES=1998-067A");
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_gp_by_name() {
         let query = CelestrakQuery::gp().name_search("ISS");
         assert_eq!(query.build_url(), "NAME=ISS");
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_gp_with_format() {
         let query = CelestrakQuery::gp()
             .group("stations")
@@ -648,6 +657,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_gp_with_tle_format() {
         let query = CelestrakQuery::gp()
             .group("stations")
@@ -656,12 +666,14 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_gp_with_special() {
         let query = CelestrakQuery::gp().special("all");
         assert_eq!(query.build_url(), "SPECIAL=all");
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_gp_multiple_params() {
         let query = CelestrakQuery::gp()
             .group("stations")
@@ -673,24 +685,28 @@ mod tests {
     // -- SupGP URL building tests --
 
     #[test]
+    #[serial_test::parallel]
     fn test_sup_gp_by_source() {
         let query = CelestrakQuery::sup_gp().source(SupGPSource::SpaceX);
         assert_eq!(query.build_url(), "SOURCE=spacex");
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_sup_gp_by_file() {
         let query = CelestrakQuery::sup_gp().file("starlink");
         assert_eq!(query.build_url(), "FILE=starlink");
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_sup_gp_by_catnr() {
         let query = CelestrakQuery::sup_gp().catnr(25544);
         assert_eq!(query.build_url(), "CATNR=25544");
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_sup_gp_with_source_and_format() {
         let query = CelestrakQuery::sup_gp()
             .source(SupGPSource::Starlink)
@@ -699,6 +715,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_sup_gp_with_name() {
         let query = CelestrakQuery::sup_gp().name_search("STARLINK-1234");
         assert_eq!(query.build_url(), "NAME=STARLINK-1234");
@@ -707,36 +724,42 @@ mod tests {
     // -- SATCAT URL building tests --
 
     #[test]
+    #[serial_test::parallel]
     fn test_satcat_by_group() {
         let query = CelestrakQuery::satcat().group("stations");
         assert_eq!(query.build_url(), "GROUP=stations");
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_satcat_active() {
         let query = CelestrakQuery::satcat().active(true);
         assert_eq!(query.build_url(), "ACTIVE=Y");
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_satcat_payloads() {
         let query = CelestrakQuery::satcat().payloads(true);
         assert_eq!(query.build_url(), "PAYLOADS=Y");
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_satcat_on_orbit() {
         let query = CelestrakQuery::satcat().on_orbit(true);
         assert_eq!(query.build_url(), "ONORBIT=Y");
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_satcat_with_max() {
         let query = CelestrakQuery::satcat().active(true).max(100);
         assert_eq!(query.build_url(), "ACTIVE=Y&MAX=100");
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_satcat_multiple_flags() {
         let query = CelestrakQuery::satcat()
             .active(true)
@@ -750,6 +773,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_satcat_false_flags_not_in_url() {
         let query = CelestrakQuery::satcat()
             .active(false)
@@ -759,6 +783,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_satcat_by_name() {
         let query = CelestrakQuery::satcat()
             .name_search("ISS")
@@ -769,6 +794,7 @@ mod tests {
     // -- Client-side parameter tests --
 
     #[test]
+    #[serial_test::parallel]
     fn test_client_side_filter() {
         let query = CelestrakQuery::gp()
             .group("stations")
@@ -782,6 +808,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_client_side_order_by() {
         let query = CelestrakQuery::gp()
             .group("stations")
@@ -793,6 +820,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_client_side_limit() {
         let query = CelestrakQuery::gp().group("stations").limit(10);
         assert!(query.has_client_side_processing());
@@ -800,12 +828,14 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_no_client_side_processing() {
         let query = CelestrakQuery::gp().group("stations");
         assert!(!query.has_client_side_processing());
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_multiple_client_side_filters() {
         let query = CelestrakQuery::gp()
             .group("active")
@@ -818,12 +848,14 @@ mod tests {
     // -- Accessor tests --
 
     #[test]
+    #[serial_test::parallel]
     fn test_output_format_accessor_none() {
         let query = CelestrakQuery::gp();
         assert_eq!(query.output_format(), None);
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_output_format_accessor_set() {
         let query = CelestrakQuery::gp().format(CelestrakOutputFormat::Json);
         assert_eq!(query.output_format(), Some(CelestrakOutputFormat::Json));
@@ -832,6 +864,7 @@ mod tests {
     // -- Builder immutability tests --
 
     #[test]
+    #[serial_test::parallel]
     fn test_builder_immutability() {
         let base = CelestrakQuery::gp().group("stations");
         let extended = base.clone().filter("INCLINATION", ">50");
@@ -846,6 +879,7 @@ mod tests {
     // -- Clone tests --
 
     #[test]
+    #[serial_test::parallel]
     fn test_query_clone() {
         let query = CelestrakQuery::gp()
             .group("stations")
@@ -870,6 +904,7 @@ mod tests {
     // -- All format tests --
 
     #[test]
+    #[serial_test::parallel]
     fn test_all_output_formats() {
         let formats = vec![
             (CelestrakOutputFormat::Tle, "FORMAT=TLE"),
@@ -891,6 +926,7 @@ mod tests {
     // -- Empty query test --
 
     #[test]
+    #[serial_test::parallel]
     fn test_empty_query() {
         let query = CelestrakQuery::gp();
         assert_eq!(query.build_url(), "");
@@ -899,6 +935,7 @@ mod tests {
     // -- Debug test --
 
     #[test]
+    #[serial_test::parallel]
     fn test_query_debug() {
         let query = CelestrakQuery::gp().group("stations");
         let debug = format!("{:?}", query);

--- a/src/celestrak/query.rs
+++ b/src/celestrak/query.rs
@@ -106,6 +106,12 @@ impl LocalSelector {
     /// * `bool` - `true` if the record is the object (or, for `Name`, one of
     ///   the objects) the selector names; a record missing the relevant field
     ///   never matches
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// assert!(LocalSelector::Catnr(25544).matches(&record));
+    /// ```
     pub(crate) fn matches(&self, record: &GPRecord) -> bool {
         match self {
             LocalSelector::Catnr(catnr) => record.norad_cat_id == Some(*catnr),
@@ -446,6 +452,15 @@ impl CelestrakQuery {
     ///
     /// * `Some(LocalSelector)` - The selector to match against `active`
     /// * `None` - Any other query, which must be sent to the server as is
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// assert_eq!(
+    ///     CelestrakQuery::gp().catnr(25544).local_selector(),
+    ///     Some(LocalSelector::Catnr(25544))
+    /// );
+    /// ```
     pub(crate) fn local_selector(&self) -> Option<LocalSelector> {
         if self.query_type != CelestrakQueryType::GP
             || self.group.is_some()

--- a/src/celestrak/query.rs
+++ b/src/celestrak/query.rs
@@ -10,6 +10,7 @@
  */
 
 use crate::celestrak::types::{CelestrakOutputFormat, CelestrakQueryType, SupGPSource};
+use crate::types::GPRecord;
 
 /// A client-side filter predicate for post-download filtering.
 ///
@@ -79,6 +80,47 @@ pub struct CelestrakQuery {
     filters: Vec<Filter>,
     order_by_clauses: Vec<OrderBy>,
     limit_count: Option<u32>,
+}
+
+/// A GP query that names exactly one object and can be answered from the
+/// cached `active` group instead of a per-object request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)]
+pub(crate) enum LocalSelector {
+    /// NORAD catalog number.
+    Catnr(u32),
+    /// International designator, compared ASCII case-insensitively.
+    Intdes(String),
+    /// Object-name substring, compared ASCII case-insensitively.
+    Name(String),
+}
+
+impl LocalSelector {
+    /// Test whether a GP record satisfies this selector.
+    ///
+    /// # Arguments
+    ///
+    /// * `record` - Record from the `active` group
+    ///
+    /// # Returns
+    ///
+    /// * `bool` - `true` if the record is the object (or, for `Name`, one of
+    ///   the objects) the selector names; a record missing the relevant field
+    ///   never matches
+    #[allow(dead_code)]
+    pub(crate) fn matches(&self, record: &GPRecord) -> bool {
+        match self {
+            LocalSelector::Catnr(catnr) => record.norad_cat_id == Some(*catnr),
+            LocalSelector::Intdes(intdes) => record
+                .object_id
+                .as_deref()
+                .is_some_and(|id| id.eq_ignore_ascii_case(intdes)),
+            LocalSelector::Name(name) => record
+                .object_name
+                .as_deref()
+                .is_some_and(|n| n.to_ascii_lowercase().contains(&name.to_ascii_lowercase())),
+        }
+    }
 }
 
 impl CelestrakQuery {
@@ -393,6 +435,39 @@ impl CelestrakQuery {
     /// Returns true if this query has any client-side filters.
     pub fn has_client_side_processing(&self) -> bool {
         !self.filters.is_empty() || !self.order_by_clauses.is_empty() || self.limit_count.is_some()
+    }
+
+    /// Return the single-object selector this query reduces to, if any.
+    ///
+    /// A GP query whose only server-side parameters are exactly one of
+    /// `CATNR`, `INTDES`, or `NAME` (the output format and client-side
+    /// filter, ordering, and limit do not count) can be answered from the
+    /// cached `active` group by [`crate::celestrak::CelestrakClient`].
+    ///
+    /// # Returns
+    ///
+    /// * `Some(LocalSelector)` - The selector to match against `active`
+    /// * `None` - Any other query, which must be sent to the server as is
+    #[allow(dead_code)]
+    pub(crate) fn local_selector(&self) -> Option<LocalSelector> {
+        if self.query_type != CelestrakQueryType::GP
+            || self.group.is_some()
+            || self.special.is_some()
+            || self.source.is_some()
+            || self.file.is_some()
+            || self.payloads.is_some()
+            || self.on_orbit.is_some()
+            || self.active.is_some()
+            || self.max_results.is_some()
+        {
+            return None;
+        }
+        match (self.catnr, &self.intdes, &self.name) {
+            (Some(catnr), None, None) => Some(LocalSelector::Catnr(catnr)),
+            (None, Some(intdes), None) => Some(LocalSelector::Intdes(intdes.clone())),
+            (None, None, Some(name)) => Some(LocalSelector::Name(name.clone())),
+            _ => None,
+        }
     }
 
     /// Returns a reference to the client-side filters.
@@ -829,5 +904,107 @@ mod tests {
         let debug = format!("{:?}", query);
         assert!(debug.contains("stations"));
         assert!(debug.contains("GP"));
+    }
+
+    // -- LocalSelector tests --
+
+    fn record(name: &str, id: &str, catnr: u32) -> GPRecord {
+        serde_json::from_str(&format!(
+            r#"{{"OBJECT_NAME":"{name}","OBJECT_ID":"{id}","NORAD_CAT_ID":{catnr}}}"#
+        ))
+        .unwrap()
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_local_selector_single_selectors() {
+        assert_eq!(
+            CelestrakQuery::gp().catnr(25544).local_selector(),
+            Some(LocalSelector::Catnr(25544))
+        );
+        assert_eq!(
+            CelestrakQuery::gp().intdes("1998-067A").local_selector(),
+            Some(LocalSelector::Intdes("1998-067A".to_string()))
+        );
+        assert_eq!(
+            CelestrakQuery::gp().name_search("ISS").local_selector(),
+            Some(LocalSelector::Name("ISS".to_string()))
+        );
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_local_selector_allows_format_and_client_side_processing() {
+        let query = CelestrakQuery::gp()
+            .catnr(25544)
+            .format(CelestrakOutputFormat::Json)
+            .filter("INCLINATION", ">50")
+            .order_by("OBJECT_NAME", true)
+            .limit(5);
+        assert_eq!(query.local_selector(), Some(LocalSelector::Catnr(25544)));
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_local_selector_none_for_group_special_or_combined() {
+        assert_eq!(
+            CelestrakQuery::gp().group("stations").local_selector(),
+            None
+        );
+        assert_eq!(CelestrakQuery::gp().special("all").local_selector(), None);
+        assert_eq!(
+            CelestrakQuery::gp()
+                .group("stations")
+                .catnr(25544)
+                .local_selector(),
+            None
+        );
+        assert_eq!(
+            CelestrakQuery::gp()
+                .catnr(25544)
+                .name_search("ISS")
+                .local_selector(),
+            None
+        );
+        assert_eq!(CelestrakQuery::gp().local_selector(), None);
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_local_selector_none_for_sup_gp_and_satcat() {
+        assert_eq!(CelestrakQuery::sup_gp().catnr(25544).local_selector(), None);
+        assert_eq!(CelestrakQuery::satcat().catnr(25544).local_selector(), None);
+        assert_eq!(
+            CelestrakQuery::sup_gp()
+                .source(SupGPSource::SpaceX)
+                .local_selector(),
+            None
+        );
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_local_selector_matches_records() {
+        let iss = record("ISS (ZARYA)", "1998-067A", 25544);
+        let nisar = record("NISAR", "2025-158A", 65053);
+
+        assert!(LocalSelector::Catnr(25544).matches(&iss));
+        assert!(!LocalSelector::Catnr(25544).matches(&nisar));
+
+        assert!(LocalSelector::Intdes("1998-067a".to_string()).matches(&iss));
+        assert!(!LocalSelector::Intdes("1998-067".to_string()).matches(&iss));
+
+        assert!(LocalSelector::Name("iss".to_string()).matches(&iss));
+        assert!(LocalSelector::Name("ZARYA".to_string()).matches(&iss));
+        assert!(!LocalSelector::Name("ISS".to_string()).matches(&nisar));
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_local_selector_missing_fields_never_match() {
+        let bare: GPRecord = serde_json::from_str("{}").unwrap();
+        assert!(!LocalSelector::Catnr(1).matches(&bare));
+        assert!(!LocalSelector::Intdes("x".to_string()).matches(&bare));
+        assert!(!LocalSelector::Name("x".to_string()).matches(&bare));
     }
 }

--- a/src/celestrak/query.rs
+++ b/src/celestrak/query.rs
@@ -85,7 +85,6 @@ pub struct CelestrakQuery {
 /// A GP query that names exactly one object and can be answered from the
 /// cached `active` group instead of a per-object request.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[allow(dead_code)]
 pub(crate) enum LocalSelector {
     /// NORAD catalog number.
     Catnr(u32),
@@ -107,7 +106,6 @@ impl LocalSelector {
     /// * `bool` - `true` if the record is the object (or, for `Name`, one of
     ///   the objects) the selector names; a record missing the relevant field
     ///   never matches
-    #[allow(dead_code)]
     pub(crate) fn matches(&self, record: &GPRecord) -> bool {
         match self {
             LocalSelector::Catnr(catnr) => record.norad_cat_id == Some(*catnr),
@@ -448,7 +446,6 @@ impl CelestrakQuery {
     ///
     /// * `Some(LocalSelector)` - The selector to match against `active`
     /// * `None` - Any other query, which must be sent to the server as is
-    #[allow(dead_code)]
     pub(crate) fn local_selector(&self) -> Option<LocalSelector> {
         if self.query_type != CelestrakQueryType::GP
             || self.group.is_some()

--- a/src/datasets/naif.rs
+++ b/src/datasets/naif.rs
@@ -270,6 +270,7 @@ mod tests {
     // ========== HTTP Error Tests ==========
 
     #[test]
+    #[serial_test::parallel]
     fn test_fetch_kernel_http_404() {
         // Setup mock server that returns 404 Not Found
         let server = MockServer::start();
@@ -294,6 +295,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_fetch_kernel_http_500() {
         // Setup mock server that returns 500 Server Error
         let server = MockServer::start();
@@ -318,6 +320,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_fetch_kernel_empty_response() {
         // Setup mock server that returns 200 OK with empty body
         let server = MockServer::start();
@@ -342,6 +345,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_fetch_kernel_with_url_uses_filename_override() {
         // The Ura184 kernel's file name differs from its short name; the
         // with-URL seam must append the *filename*, not the name.
@@ -359,6 +363,7 @@ mod tests {
     // ========== File I/O Error Tests ==========
 
     #[test]
+    #[serial]
     fn test_download_output_is_directory() {
         // Create a temporary directory
         let temp_dir = tempdir().unwrap();
@@ -384,6 +389,7 @@ mod tests {
 
     #[test]
     #[cfg(unix)]
+    #[serial]
     fn test_download_invalid_cache_permissions() {
         use std::os::unix::fs::PermissionsExt;
 
@@ -421,6 +427,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_download_output_copy_failure() {
         // Create a temporary file, then try to create a directory with the same name
         let temp_dir = tempdir().unwrap();

--- a/tests/celestrak/test_celestrak_client.py
+++ b/tests/celestrak/test_celestrak_client.py
@@ -325,3 +325,10 @@ class TestCelestrakClientActiveResolution:
         propagator = client.get_sgp_propagator(catnr=25544, step_size=60.0)
         assert isinstance(propagator, bh.SGPPropagator)
         assert [r.get("GROUP") for r in requests] == ["active"]
+
+    def test_zero_cache_age_sends_query_directly(self, celestrak_server):
+        base_url, requests = celestrak_server
+        client = bh.celestrak.CelestrakClient(base_url=base_url, cache_max_age=0.0)
+        client.get_gp(catnr=25544)
+        assert [r.get("GROUP") for r in requests] == [None]
+        assert requests[0].get("CATNR") == "25544"

--- a/tests/celestrak/test_celestrak_client.py
+++ b/tests/celestrak/test_celestrak_client.py
@@ -332,3 +332,18 @@ class TestCelestrakClientActiveResolution:
         client.get_gp(catnr=25544)
         assert [r.get("GROUP") for r in requests] == [None]
         assert requests[0].get("CATNR") == "25544"
+
+    def test_intdes_resolves_from_active(self, celestrak_server):
+        base_url, requests = celestrak_server
+        client = bh.celestrak.CelestrakClient(base_url=base_url)
+        records = client.get_gp(intdes="2021-066a")
+        assert [r.norad_cat_id for r in records] == [49044]
+        assert [r.get("GROUP") for r in requests] == ["active"]
+
+    def test_second_client_makes_no_request(self, celestrak_server):
+        base_url, requests = celestrak_server
+        client = bh.celestrak.CelestrakClient(base_url=base_url)
+        client.get_gp(catnr=25544)
+        other = bh.celestrak.CelestrakClient(base_url=base_url)
+        other.get_gp(catnr=49044)
+        assert [r.get("GROUP") for r in requests] == ["active"]

--- a/tests/celestrak/test_celestrak_client.py
+++ b/tests/celestrak/test_celestrak_client.py
@@ -285,6 +285,7 @@ def celestrak_server(tmp_path, monkeypatch):
         yield f"http://{host}:{port}", requests
     finally:
         server.shutdown()
+        server.server_close()
 
 
 class TestCelestrakClientActiveResolution:
@@ -322,5 +323,5 @@ class TestCelestrakClientActiveResolution:
         base_url, requests = celestrak_server
         client = bh.celestrak.CelestrakClient(base_url=base_url)
         propagator = client.get_sgp_propagator(catnr=25544, step_size=60.0)
-        assert propagator is not None
+        assert isinstance(propagator, bh.SGPPropagator)
         assert [r.get("GROUP") for r in requests] == ["active"]

--- a/tests/celestrak/test_celestrak_client.py
+++ b/tests/celestrak/test_celestrak_client.py
@@ -1,5 +1,10 @@
 """Tests for CelestrakClient Python bindings."""
 
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import parse_qs, urlparse
+
 import pytest
 
 import brahe as bh
@@ -184,3 +189,138 @@ class TestCelestrakClientIntegration:
         propagator = client.get_sgp_propagator(catnr=25544, step_size=60.0)
         assert propagator is not None
         assert isinstance(propagator, bh.SGPPropagator)
+
+
+ACTIVE_RECORDS = [
+    {
+        "OBJECT_NAME": "ISS (ZARYA)",
+        "OBJECT_ID": "1998-067A",
+        "EPOCH": "2026-08-27T12:00:00.000000",
+        "MEAN_MOTION": 15.49,
+        "ECCENTRICITY": 0.0006,
+        "INCLINATION": 51.64,
+        "RA_OF_ASC_NODE": 120.5,
+        "ARG_OF_PERICENTER": 30.2,
+        "MEAN_ANOMALY": 329.9,
+        "EPHEMERIS_TYPE": 0,
+        "CLASSIFICATION_TYPE": "U",
+        "NORAD_CAT_ID": 25544,
+        "ELEMENT_SET_NO": 999,
+        "REV_AT_EPOCH": 54000,
+        "BSTAR": 0.0001,
+        "MEAN_MOTION_DOT": 0.0001,
+        "MEAN_MOTION_DDOT": 0,
+    },
+    {
+        "OBJECT_NAME": "ISS (NAUKA)",
+        "OBJECT_ID": "2021-066A",
+        "EPOCH": "2026-08-27T12:00:00.000000",
+        "MEAN_MOTION": 15.49,
+        "ECCENTRICITY": 0.0006,
+        "INCLINATION": 51.64,
+        "RA_OF_ASC_NODE": 120.5,
+        "ARG_OF_PERICENTER": 30.2,
+        "MEAN_ANOMALY": 329.9,
+        "EPHEMERIS_TYPE": 0,
+        "CLASSIFICATION_TYPE": "U",
+        "NORAD_CAT_ID": 49044,
+        "ELEMENT_SET_NO": 999,
+        "REV_AT_EPOCH": 28000,
+        "BSTAR": 0.0001,
+        "MEAN_MOTION_DOT": 0.0001,
+        "MEAN_MOTION_DDOT": 0,
+    },
+]
+SINGLE_RECORD = [
+    {
+        "OBJECT_NAME": "COSMOS 2251 DEB",
+        "OBJECT_ID": "1993-036AAB",
+        "EPOCH": "2026-08-27T12:00:00.000000",
+        "MEAN_MOTION": 14.1,
+        "ECCENTRICITY": 0.01,
+        "INCLINATION": 74.0,
+        "RA_OF_ASC_NODE": 10.0,
+        "ARG_OF_PERICENTER": 20.0,
+        "MEAN_ANOMALY": 30.0,
+        "EPHEMERIS_TYPE": 0,
+        "CLASSIFICATION_TYPE": "U",
+        "NORAD_CAT_ID": 34427,
+        "ELEMENT_SET_NO": 999,
+        "REV_AT_EPOCH": 1,
+        "BSTAR": 0.0001,
+        "MEAN_MOTION_DOT": 0.0001,
+        "MEAN_MOTION_DDOT": 0,
+    },
+]
+
+
+@pytest.fixture
+def celestrak_server(tmp_path, monkeypatch):
+    """Serve a fake gp.php; yields (base_url, request_log) and isolates BRAHE_CACHE."""
+    monkeypatch.setenv("BRAHE_CACHE", str(tmp_path))
+    monkeypatch.delenv("BRAHE_NETWORK_MODE", raising=False)
+    requests = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            parsed = urlparse(self.path)
+            params = {k: v[0] for k, v in parse_qs(parsed.query).items()}
+            requests.append(params)
+            body = ACTIVE_RECORDS if params.get("GROUP") == "active" else SINGLE_RECORD
+            payload = json.dumps(body).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, *args):
+            pass
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address
+    try:
+        yield f"http://{host}:{port}", requests
+    finally:
+        server.shutdown()
+
+
+class TestCelestrakClientActiveResolution:
+    def test_catnr_resolves_from_active(self, celestrak_server):
+        base_url, requests = celestrak_server
+        client = bh.celestrak.CelestrakClient(base_url=base_url)
+        records = client.get_gp(catnr=25544)
+        assert [r.norad_cat_id for r in records] == [25544]
+        assert [r.get("GROUP") for r in requests] == ["active"]
+
+    def test_name_matches_substring_case_insensitive(self, celestrak_server):
+        base_url, requests = celestrak_server
+        client = bh.celestrak.CelestrakClient(base_url=base_url)
+        records = client.get_gp(name="iss")
+        assert sorted(r.object_name for r in records) == ["ISS (NAUKA)", "ISS (ZARYA)"]
+        assert len(requests) == 1
+
+    def test_object_absent_from_active_is_requested_directly(self, celestrak_server):
+        base_url, requests = celestrak_server
+        client = bh.celestrak.CelestrakClient(base_url=base_url)
+        records = client.get_gp(catnr=34427)
+        assert records[0].object_name == "COSMOS 2251 DEB"
+        assert [r.get("GROUP") or r.get("CATNR") for r in requests] == [
+            "active",
+            "34427",
+        ]
+
+    def test_group_query_does_not_fetch_active(self, celestrak_server):
+        base_url, requests = celestrak_server
+        client = bh.celestrak.CelestrakClient(base_url=base_url)
+        client.get_gp(group="stations")
+        assert [r.get("GROUP") for r in requests] == ["stations"]
+
+    def test_sgp_propagator_from_active(self, celestrak_server):
+        base_url, requests = celestrak_server
+        client = bh.celestrak.CelestrakClient(base_url=base_url)
+        propagator = client.get_sgp_propagator(catnr=25544, step_size=60.0)
+        assert propagator is not None
+        assert [r.get("GROUP") for r in requests] == ["active"]


### PR DESCRIPTION
# Pull Request

## Description

Celestrak single-object GP lookups (`get_gp_by_catnr`, `get_gp_by_intdes`, `get_gp_by_name`, and any `query_gp` whose only server-side selector is one of `CATNR`, `INTDES`, `NAME`) now resolve from a cached copy of the `active` group instead of issuing one request per object. Resolution order is the exact per-object cache file, then the `active` group (fetched once through the ordinary cached path, so it obeys the client TTL and `BRAHE_NETWORK_MODE`), then a per-object request for objects not in `active` (debris, inactive payloads). `CelestrakQuery::local_selector` identifies eligible queries; `LocalSelector::matches` implements the matching (`catnr` exact, `intdes` case-insensitive equality, `name` case-insensitive substring). Client-side `filter`/`order_by`/`limit` apply after either path; nothing is written to the per-object cache key when `active` answers; group, special, file, sup-GP, SATCAT, `query_raw`, and `download` are unchanged. A `name` search that matches in `active` returns only active objects. A client with a zero cache age sends every query directly, and a failed `active` fetch is not retried for one cache age. Documented in the Rust and Python API docs and in `docs/learn/ephemeris/celestrak.md`.

Second PR of the stack that moves the Celestrak-backed examples to run from a warmed cache on every PR (after #454).

## Changelog

### Changed
- Celestrak single-object lookups (`catnr`, `intdes`, `name`) resolve from a cached copy of the `active` group, fetching it once instead of one request per object; objects not in `active` are still requested individually, and a `name` search that matches in `active` returns only active objects.

### Fixed
- Python `CelestrakClient` methods release the GIL while a request is in flight, so other Python threads can run during Celestrak downloads.

## Note to Reviewers
Examples that search by `name` (UMBRA, CAPELLA, ICEYE, NISAR) will report active-only counts once they run from the cache in PR 4. The 36 pre-existing tests in `src/celestrak/query.rs` were given `#[serial_test::parallel]` labels (attribute only). Three pre-existing single-object client tests now also see an unmatched `GROUP=active` request against their mock server (harmless 404 with a stderr warning); adding an `active` mock to them is a test-body change left for your call. `SpaceTrackClient`'s Python bindings hold the GIL across requests in the same way and are left for a follow-up.
