### PR TITLE
Name the resource in download and offline errors

### DIFF
--- a/src/celestrak/client.rs
+++ b/src/celestrak/client.rs
@@ -883,6 +883,7 @@ impl CelestrakClient {
             ureq::Error::StatusCode(429 | 500 | 502 | 503 | 504)
                 | ureq::Error::Io(_)
                 | ureq::Error::Timeout(_)
+                | ureq::Error::HostNotFound
                 | ureq::Error::ConnectionFailed
         )
     }
@@ -1604,6 +1605,21 @@ mod tests {
         let result = client.query_raw(&query);
         assert!(result.is_err());
         mock.assert_calls(2); // 1 initial + 1 retry
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_is_retryable_error_transport_failures() {
+        for e in [
+            ureq::Error::HostNotFound,
+            ureq::Error::ConnectionFailed,
+            ureq::Error::StatusCode(503),
+        ] {
+            assert!(CelestrakClient::is_retryable_error(&e), "{e}");
+        }
+        assert!(!CelestrakClient::is_retryable_error(
+            &ureq::Error::StatusCode(404)
+        ));
     }
 
     #[test]

--- a/src/datasets/naif.rs
+++ b/src/datasets/naif.rs
@@ -59,12 +59,13 @@ fn fetch_kernel_from_url(url: &str, label: &str) -> Result<Vec<u8>, BraheError> 
     // Retries transient network/server failures with exponential backoff so a
     // single dropped connection to NAIF (e.g. "Connection refused") doesn't fail
     // an otherwise-recoverable download.
-    let buffer = crate::utils::download::download_bytes(url).map_err(|e| {
-        BraheError::Error(format!(
-            "Failed to download kernel {} from NAIF: {}",
-            label, e
-        ))
-    })?;
+    let buffer = crate::utils::download::download_bytes(url, &format!("NAIF kernel {label}"))
+        .map_err(|e| {
+            BraheError::Error(format!(
+                "Failed to download kernel {} from NAIF: {}",
+                label, e
+            ))
+        })?;
 
     if buffer.is_empty() {
         return Err(BraheError::Error(format!(

--- a/src/datasets/star_catalogs/fetch.rs
+++ b/src/datasets/star_catalogs/fetch.rs
@@ -92,7 +92,7 @@ pub(crate) fn read_cache(
 ///
 /// * `Result<String, BraheError>` - File contents as a string
 pub(crate) fn download(url: &str) -> Result<String, BraheError> {
-    let bytes = download_bytes_with_user_agent(url, USER_AGENT)
+    let bytes = download_bytes_with_user_agent(url, "star catalog", USER_AGENT)
         .map_err(|e| BraheError::IoError(format!("Star catalog request failed: {}", e)))?;
 
     String::from_utf8(bytes).map_err(|e| {

--- a/src/datasets/star_catalogs/fetch.rs
+++ b/src/datasets/star_catalogs/fetch.rs
@@ -93,7 +93,7 @@ pub(crate) fn read_cache(
 /// * `Result<String, BraheError>` - File contents as a string
 pub(crate) fn download(url: &str) -> Result<String, BraheError> {
     let bytes = download_bytes_with_user_agent(url, "star catalog", USER_AGENT)
-        .map_err(|e| BraheError::IoError(format!("Star catalog request failed: {}", e)))?;
+        .map_err(|e| BraheError::IoError(e.to_string()))?;
 
     String::from_utf8(bytes).map_err(|e| {
         BraheError::IoError(format!("Star catalog response is not valid UTF-8: {}", e))

--- a/src/orbit_dynamics/ocean_tides.rs
+++ b/src/orbit_dynamics/ocean_tides.rs
@@ -66,9 +66,7 @@ pub fn fes2004_coefficients_path() -> Result<PathBuf, BraheError> {
         return Ok(path);
     }
 
-    fetch_and_cache_fes2004(&path, || {
-        download_bytes(FES2004_URL, "FES2004 ocean tide model")
-    })?;
+    fetch_and_cache_fes2004(&path, || download_bytes(FES2004_URL, "FES2004 tide model"))?;
     Ok(path)
 }
 

--- a/src/orbit_dynamics/ocean_tides.rs
+++ b/src/orbit_dynamics/ocean_tides.rs
@@ -66,7 +66,9 @@ pub fn fes2004_coefficients_path() -> Result<PathBuf, BraheError> {
         return Ok(path);
     }
 
-    fetch_and_cache_fes2004(&path, || download_bytes(FES2004_URL))?;
+    fetch_and_cache_fes2004(&path, || {
+        download_bytes(FES2004_URL, "FES2004 ocean tide model")
+    })?;
     Ok(path)
 }
 

--- a/src/utils/download.rs
+++ b/src/utils/download.rs
@@ -401,6 +401,48 @@ mod tests {
 
     #[test]
     #[serial_test::parallel]
+    fn test_download_bytes_retries_truncated_body() {
+        // A body that ends before its declared length fails in the read phase.
+        // That is a transport error, so the whole request is retried up to the
+        // attempt cap and the final error names the description. A raw socket
+        // stands in for the server because HTTP mock servers refuse to send a
+        // body shorter than the Content-Length they declare.
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let connections = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&connections);
+        std::thread::spawn(move || {
+            for stream in listener.incoming().flatten() {
+                let mut stream = stream;
+                let mut request = [0u8; 1024];
+                let _ = stream.read(&mut request);
+                let _ = stream.write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Length: 1000\r\nConnection: close\r\n\r\nshort",
+                );
+                counter.fetch_add(1, Ordering::SeqCst);
+            }
+        });
+
+        let err = download_bytes(
+            &format!("http://127.0.0.1:{port}/kernel.bsp"),
+            "test kernel",
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("reading test kernel response body"), "{err}");
+        assert_eq!(
+            connections.load(Ordering::SeqCst),
+            MAX_DOWNLOAD_ATTEMPTS as usize
+        );
+    }
+
+    #[test]
+    #[serial_test::parallel]
     fn test_download_bytes_does_not_retry_client_error() {
         // A 404 is not transient: download_bytes must fail after a single request.
         let server = MockServer::start();

--- a/src/utils/download.rs
+++ b/src/utils/download.rs
@@ -222,21 +222,44 @@ pub(crate) fn download_to_file(
 /// Unlike [`download_to_file`], the response body is read through a streaming
 /// reader rather than ureq's convenience string method, so large binary payloads
 /// (e.g. multi-MB SPICE kernels) are not subject to ureq's default in-memory
-/// response size limit. The returned error carries the URL and attempt count;
-/// callers are expected to wrap it with product-specific context.
-pub(crate) fn download_bytes(url: &str) -> Result<Vec<u8>, BraheError> {
-    download_bytes_impl(url, None)
+/// response size limit. Errors name `description`, the URL, and the attempt
+/// count; when `BRAHE_NETWORK_MODE` forbids the request, the error names
+/// `description` as the resource that cannot be downloaded.
+///
+/// # Arguments
+///
+/// * `url` - The URL to fetch.
+/// * `description` - Human-readable product label for error messages.
+///
+/// # Returns
+///
+/// * `Ok(Vec<u8>)` - The response body.
+/// * `Err(BraheError)` - On a non-retryable status or exhausted retries.
+pub(crate) fn download_bytes(url: &str, description: &str) -> Result<Vec<u8>, BraheError> {
+    download_bytes_impl(url, description, None)
 }
 
 /// As [`download_bytes`], but sending a caller-specified `User-Agent` header.
 ///
 /// Some mirrors (e.g. the star catalog data source) return `403 Forbidden` to
 /// default HTTP client user agents and require a browser-like one instead.
+///
+/// # Arguments
+///
+/// * `url` - The URL to fetch.
+/// * `description` - Human-readable product label for error messages.
+/// * `user_agent` - Value sent as the request's `User-Agent` header.
+///
+/// # Returns
+///
+/// * `Ok(Vec<u8>)` - The response body.
+/// * `Err(BraheError)` - On a non-retryable status or exhausted retries.
 pub(crate) fn download_bytes_with_user_agent(
     url: &str,
+    description: &str,
     user_agent: &str,
 ) -> Result<Vec<u8>, BraheError> {
-    download_bytes_impl(url, Some(user_agent))
+    download_bytes_impl(url, description, Some(user_agent))
 }
 
 /// Shared retry/backoff core for [`download_bytes`] and
@@ -246,6 +269,7 @@ pub(crate) fn download_bytes_with_user_agent(
 /// # Arguments
 ///
 /// * `url` - The URL to fetch.
+/// * `description` - Human-readable product label for error messages.
 /// * `user_agent` - Optional `User-Agent` header value.
 ///
 /// # Returns
@@ -258,10 +282,14 @@ pub(crate) fn download_bytes_with_user_agent(
 /// # Examples
 ///
 /// ```ignore
-/// let bytes = download_bytes_impl(url, Some("Mozilla/5.0 (compatible; brahe)"))?;
+/// let bytes = download_bytes_impl(url, "star catalog", Some("Mozilla/5.0 (compatible; brahe)"))?;
 /// ```
-fn download_bytes_impl(url: &str, user_agent: Option<&str>) -> Result<Vec<u8>, BraheError> {
-    ensure_online(url, url)?;
+fn download_bytes_impl(
+    url: &str,
+    description: &str,
+    user_agent: Option<&str>,
+) -> Result<Vec<u8>, BraheError> {
+    ensure_online(url, &format!("{description} ({url})"))?;
 
     let mut attempt: u32 = 0;
 
@@ -282,8 +310,8 @@ fn download_bytes_impl(url: &str, user_agent: Option<&str>) -> Result<Vec<u8>, B
                     continue;
                 }
                 return Err(BraheError::Error(format!(
-                    "request to {} failed after {} attempt(s): {}",
-                    url, attempt, e
+                    "{} request to {} failed after {} attempt(s): {}",
+                    description, url, attempt, e
                 )));
             }
         };
@@ -301,8 +329,8 @@ fn download_bytes_impl(url: &str, user_agent: Option<&str>) -> Result<Vec<u8>, B
                     continue;
                 }
                 return Err(BraheError::Error(format!(
-                    "reading response body from {} failed after {} attempt(s): {}",
-                    url, attempt, e
+                    "reading {} response body from {} failed after {} attempt(s): {}",
+                    description, url, attempt, e
                 )));
             }
         }
@@ -326,7 +354,7 @@ mod tests {
             then.status(200).body("kernel-bytes");
         });
 
-        let bytes = download_bytes(&server.url("/kernel.bsp")).unwrap();
+        let bytes = download_bytes(&server.url("/kernel.bsp"), "test kernel").unwrap();
         assert_eq!(bytes, b"kernel-bytes");
     }
 
@@ -346,6 +374,7 @@ mod tests {
 
         let bytes = download_bytes_with_user_agent(
             &server.url("/catalog.txt"),
+            "test catalog",
             "Mozilla/5.0 (compatible; brahe)",
         )
         .unwrap();
@@ -365,7 +394,7 @@ mod tests {
             then.status(503);
         });
 
-        let result = download_bytes(&server.url("/kernel.bsp"));
+        let result = download_bytes(&server.url("/kernel.bsp"), "test kernel");
         assert!(result.is_err());
         assert_eq!(mock.calls(), MAX_DOWNLOAD_ATTEMPTS as usize);
     }
@@ -380,7 +409,7 @@ mod tests {
             then.status(404);
         });
 
-        let result = download_bytes(&server.url("/kernel.bsp"));
+        let result = download_bytes(&server.url("/kernel.bsp"), "test kernel");
         assert!(result.is_err());
         assert_eq!(mock.calls(), 1);
     }
@@ -508,9 +537,12 @@ mod tests {
             then.status(200).body("kernel-bytes");
         });
 
-        let err = download_bytes("https://brahe-network-mode-test.invalid/kernel.bsp")
-            .unwrap_err()
-            .to_string();
+        let err = download_bytes(
+            "https://brahe-network-mode-test.invalid/kernel.bsp",
+            "test kernel",
+        )
+        .unwrap_err()
+        .to_string();
         assert!(
             err.starts_with("BRAHE_NETWORK_MODE is offline-strict; "),
             "{err}"

--- a/src/utils/download.rs
+++ b/src/utils/download.rs
@@ -235,6 +235,15 @@ pub(crate) fn download_to_file(
 ///
 /// * `Ok(Vec<u8>)` - The response body.
 /// * `Err(BraheError)` - On a non-retryable status or exhausted retries.
+///
+/// # Examples
+///
+/// ```ignore
+/// let kernel = download_bytes(
+///     "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/de440s.bsp",
+///     "NAIF kernel de440s",
+/// )?;
+/// ```
 pub(crate) fn download_bytes(url: &str, description: &str) -> Result<Vec<u8>, BraheError> {
     download_bytes_impl(url, description, None)
 }
@@ -254,6 +263,16 @@ pub(crate) fn download_bytes(url: &str, description: &str) -> Result<Vec<u8>, Br
 ///
 /// * `Ok(Vec<u8>)` - The response body.
 /// * `Err(BraheError)` - On a non-retryable status or exhausted retries.
+///
+/// # Examples
+///
+/// ```ignore
+/// let catalog = download_bytes_with_user_agent(
+///     "https://cdsarc.cds.unistra.fr/ftp/I/239/hip_main.dat",
+///     "star catalog",
+///     "Mozilla/5.0 (compatible; brahe)",
+/// )?;
+/// ```
 pub(crate) fn download_bytes_with_user_agent(
     url: &str,
     description: &str,

--- a/src/utils/network.rs
+++ b/src/utils/network.rs
@@ -1,8 +1,8 @@
 /*!
  * Network access policy controlled by the `BRAHE_NETWORK_MODE` environment variable.
  *
- * Every function in brahe that opens a network connection calls [`ensure_online`]
- * first, and every cache with a time-to-live consults [`cache_policy`] before
+ * Every function in brahe that opens a network connection calls `ensure_online`
+ * first, and every cache with a time-to-live consults `cache_policy` before
  * deciding whether a cached file is served or refreshed. The variable therefore
  * gives a single switch for running brahe without network access. A request to a
  * loopback address is never treated as network access, so local mock servers used
@@ -27,7 +27,7 @@ pub const NETWORK_MODE_ENV: &str = "BRAHE_NETWORK_MODE";
 /// | `OfflineStrict` | never | served | error | error |
 ///
 /// A request to a loopback address is exempt from the `requests` column in every
-/// mode; see [`ensure_online`].
+/// mode; see `ensure_online`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NetworkMode {
     /// Requests are allowed and stale caches are refreshed.
@@ -99,7 +99,8 @@ pub fn network_mode() -> Result<NetworkMode, BraheError> {
 
 /// Extract the host from a URL's authority, dropping scheme, user-info, and port.
 ///
-/// Strips a leading `scheme://`, takes the authority up to the first `/`, `?`,
+/// Strips a leading `scheme://` (or the `//` of a scheme-relative URL), takes
+/// the authority up to the first `/`, `?`,
 /// `#`, or `\` (a backslash is treated as an authority terminator too, since
 /// WHATWG URL parsing does the same for special schemes — otherwise a host
 /// like `evil.com\@127.0.0.1` would be misread as user-info on `127.0.0.1`
@@ -124,9 +125,13 @@ pub fn network_mode() -> Result<NetworkMode, BraheError> {
 /// assert_eq!(url_host("http://user@Localhost:8080/x"), "localhost");
 /// assert_eq!(url_host("http://[::1]:1234/a"), "::1");
 /// assert_eq!(url_host("evil.com\\@127.0.0.1"), "evil.com");
+/// assert_eq!(url_host("//example.org/path"), "example.org");
 /// ```
 fn url_host(url: &str) -> String {
-    let after_scheme = url.split("://").nth(1).unwrap_or(url);
+    let after_scheme = match url.split_once("://") {
+        Some((_, rest)) => rest,
+        None => url.strip_prefix("//").unwrap_or(url),
+    };
     let authority_end = after_scheme
         .find(['/', '?', '#', '\\'])
         .unwrap_or(after_scheme.len());
@@ -346,9 +351,29 @@ mod tests {
 
     #[test]
     #[serial_test::parallel]
+    fn test_url_host() {
+        for (url, host) in [
+            ("http://user@Localhost:8080/x", "localhost"),
+            (
+                "https://celestrak.org/NORAD/elements/gp.php?GROUP=active",
+                "celestrak.org",
+            ),
+            ("http://[::1]:1234/a", "::1"),
+            ("evil.com\\@127.0.0.1", "evil.com"),
+            ("//example.org/path", "example.org"),
+            ("//127.0.0.1:9/x", "127.0.0.1"),
+            ("example.org:443", "example.org"),
+        ] {
+            assert_eq!(url_host(url), host, "{url}");
+        }
+    }
+
+    #[test]
+    #[serial_test::parallel]
     fn test_is_loopback_url() {
         for url in [
             "http://localhost:8080/x",
+            "//127.0.0.1/x",
             "http://127.0.0.1:9",
             "http://127.5.6.7/",
             "http://[::1]:1234/a",


### PR DESCRIPTION
# Pull Request

## Description

Three small hardening items around network access. `download_bytes` and `download_bytes_with_user_agent` take a `description` like `download_string` already does, so an offline refusal reads `BRAHE_NETWORK_MODE is offline; NAIF kernel de440s (https://…) is not cached and cannot be downloaded` and a transport failure reads `NAIF kernel de440s request to https://… failed after 3 attempt(s): …` instead of naming only the URL; the NAIF kernel, star catalog, and FES2004 callers pass their labels. `CelestrakClient::is_retryable_error` now treats `ureq::Error::HostNotFound` as transient, matching the shared `utils::download` retry set, so a DNS hiccup on a Celestrak request is retried like a refused connection. `url_host` (behind the `BRAHE_NETWORK_MODE` loopback exemption) parses scheme-relative URLs (`//host/path`) at their authority instead of returning an empty host.

Sixth PR of the stack (after #454, #457, #460, #462, and #465).

## Changelog

### Fixed
- Download errors for NAIF kernels, star catalogs, and the FES2004 model name the resource as well as the URL, including the `BRAHE_NETWORK_MODE` refusal message.
- The Celestrak client retries requests that fail with a DNS `HostNotFound` error, consistent with the other download paths.
- Loopback detection for `BRAHE_NETWORK_MODE` handles scheme-relative URLs.

## Note to Reviewers
`download_bytes`/`download_bytes_with_user_agent` are `pub(crate)`, so the signature change is internal. The `url_host` and `is_retryable_error` unit tests cover the new cases directly.
