### PR TITLE
Make the covariance square-root path numerically sound

### DIFF
--- a/src/math/interpolation.rs
+++ b/src/math/interpolation.rs
@@ -1089,6 +1089,45 @@ mod tests {
     }
 
     #[test]
+    fn test_interpolate_covariance_two_wasserstein_dmatrix_singular_error() {
+        // The cross term needs C1^{1/2} to be invertible.
+        let cov1 = DMatrix::zeros(3, 3);
+        let cov2 = DMatrix::identity(3, 3);
+
+        let result = interpolate_covariance_two_wasserstein_dmatrix(&cov1, &cov2, 0.5);
+        assert!(matches!(result, Err(BraheError::NumericalError(_))));
+    }
+
+    #[test]
+    fn test_interpolate_covariance_two_wasserstein_smatrix_singular_error() {
+        let cov1 = SMatrix::<f64, 3, 3>::zeros();
+        let cov2 = SMatrix::<f64, 3, 3>::identity();
+
+        let result = interpolate_covariance_two_wasserstein_smatrix(cov1, cov2, 0.5);
+        assert!(matches!(result, Err(BraheError::NumericalError(_))));
+    }
+
+    #[test]
+    fn test_interpolate_covariance_two_wasserstein_dmatrix_first_not_psd_error() {
+        // C1 itself has no real square root.
+        let cov1 = DMatrix::from_row_slice(2, 2, &[1.0, 0.0, 0.0, -4.0]);
+        let cov2 = DMatrix::identity(2, 2);
+
+        let result = interpolate_covariance_two_wasserstein_dmatrix(&cov1, &cov2, 0.5);
+        assert!(matches!(result, Err(BraheError::NumericalError(_))));
+    }
+
+    #[test]
+    fn test_interpolate_covariance_two_wasserstein_dmatrix_second_not_psd_error() {
+        // C1 is fine, but C1^{1/2} C2 C1^{1/2} inherits C2's negative direction.
+        let cov1 = DMatrix::identity(2, 2);
+        let cov2 = DMatrix::from_row_slice(2, 2, &[1.0, 0.0, 0.0, -4.0]);
+
+        let result = interpolate_covariance_two_wasserstein_dmatrix(&cov1, &cov2, 0.5);
+        assert!(matches!(result, Err(BraheError::NumericalError(_))));
+    }
+
+    #[test]
     fn test_interpolate_covariance_two_wasserstein_dmatrix_dimension_mismatch() {
         let cov1 = DMatrix::<f64>::identity(3, 3);
         let cov2 = DMatrix::<f64>::identity(4, 4);

--- a/src/math/interpolation.rs
+++ b/src/math/interpolation.rs
@@ -7,7 +7,7 @@
  * - Standalone interpolation functions for vectors and covariance matrices
  */
 
-use crate::math::linalg::{sqrtm, sqrtm_dmatrix};
+use crate::math::linalg::{spd_sqrtm_dmatrix, sqrtm, sqrtm_dmatrix};
 use crate::utils::errors::BraheError;
 use nalgebra::{DMatrix, DVector, SMatrix, SVector};
 use serde::{Deserialize, Serialize};
@@ -341,10 +341,51 @@ where
         ));
     }
 
-    let sqrt_12 = sqrtm(cov1 * cov2).map_err(BraheError::NumericalError)?;
-    let sqrt_21 = sqrtm(cov2 * cov1).map_err(BraheError::NumericalError)?;
+    let cross = wasserstein_cross_term(
+        &DMatrix::from_iterator(N, N, cov1.iter().cloned()),
+        &DMatrix::from_iterator(N, N, cov2.iter().cloned()),
+    )?;
+    let cross = SMatrix::<f64, N, N>::from_iterator(cross.iter().cloned());
 
-    Ok((1.0 - t).powi(2) * cov1 + t.powi(2) * cov2 + t * (1.0 - t) * (sqrt_12 + sqrt_21))
+    Ok((1.0 - t).powi(2) * cov1 + t.powi(2) * cov2 + t * (1.0 - t) * cross)
+}
+
+/// Compute `(C1 C2)^{1/2} + (C2 C1)^{1/2}`, the cross term of the 2-Wasserstein
+/// covariance interpolant.
+///
+/// Formed as `L (L C2 L)^{1/2} L^{-1}` with `L = C1^{1/2}`, which is equal to
+/// `(C1 C2)^{1/2}` but keeps every square root on a symmetric positive
+/// semi-definite matrix. Taking a general square root of the product directly
+/// is far less stable: `C1 C2` is not symmetric and its condition number is the
+/// product of the two, which the Denman-Beavers iteration cannot resolve for
+/// realistic propagated covariances.
+///
+/// Since `C1` and `C2` are symmetric, `(C2 C1)^{1/2}` is the transpose of
+/// `(C1 C2)^{1/2}`, so the sum is symmetric by construction.
+///
+/// # Arguments
+/// * `cov1` - The first covariance matrix.
+/// * `cov2` - The second covariance matrix.
+///
+/// # Returns
+/// The cross term, or an error if either matrix is not positive semi-definite
+/// or `cov1` is singular.
+fn wasserstein_cross_term(
+    cov1: &DMatrix<f64>,
+    cov2: &DMatrix<f64>,
+) -> Result<DMatrix<f64>, BraheError> {
+    let l = spd_sqrtm_dmatrix(cov1).map_err(BraheError::NumericalError)?;
+    let l_inv = l.clone().try_inverse().ok_or_else(|| {
+        BraheError::NumericalError(
+            "Covariance interpolation requires an invertible first covariance".to_string(),
+        )
+    })?;
+
+    let inner = &l * cov2 * &l;
+    let root = spd_sqrtm_dmatrix(&inner).map_err(BraheError::NumericalError)?;
+
+    let sqrt_12 = &l * &root * &l_inv;
+    Ok(&sqrt_12 + sqrt_12.transpose())
 }
 
 /// Interpolates between two dynamic-sized covariance matrices using square root interpolation.
@@ -455,13 +496,9 @@ pub fn interpolate_covariance_two_wasserstein_dmatrix(
         )));
     }
 
-    let prod12 = cov1 * cov2;
-    let prod21 = cov2 * cov1;
+    let cross = wasserstein_cross_term(cov1, cov2)?;
 
-    let sqrt_12 = sqrtm_dmatrix(&prod12).map_err(BraheError::NumericalError)?;
-    let sqrt_21 = sqrtm_dmatrix(&prod21).map_err(BraheError::NumericalError)?;
-
-    Ok((1.0 - t).powi(2) * cov1 + t.powi(2) * cov2 + t * (1.0 - t) * (sqrt_12 + sqrt_21))
+    Ok((1.0 - t).powi(2) * cov1 + t.powi(2) * cov2 + t * (1.0 - t) * cross)
 }
 
 // ============================================================================
@@ -997,6 +1034,58 @@ mod tests {
         let cov2 = DMatrix::<f64>::identity(4, 4);
         let result = interpolate_covariance_sqrt_dmatrix(&cov1, &cov2, 0.5);
         assert!(matches!(result, Err(BraheError::OutOfBoundsError(_))));
+    }
+
+    /// Covariance of a state propagated over `dt`, whose position block grows
+    /// as dt^2 while the velocity block does not. The spread between the two
+    /// blocks is what makes the product of two such matrices ill-conditioned.
+    fn propagated_covariance(dt: f64) -> DMatrix<f64> {
+        let mut p0 = DMatrix::zeros(6, 6);
+        for i in 0..3 {
+            p0[(i, i)] = 100.0;
+        }
+        for i in 3..6 {
+            p0[(i, i)] = 1.0;
+        }
+        let mut phi = DMatrix::identity(6, 6);
+        for i in 0..3 {
+            phi[(i, i + 3)] = dt;
+        }
+        &phi * &p0 * phi.transpose()
+    }
+
+    #[test]
+    fn test_interpolate_covariance_two_wasserstein_dmatrix_ill_conditioned() {
+        // Over a long arc the product of the two covariances is too badly
+        // conditioned for a general matrix square root to resolve. Routing the
+        // roots through symmetric positive semi-definite matrices keeps this
+        // tractable.
+        let cov1 = propagated_covariance(8000.0);
+        let cov2 = propagated_covariance(8240.0);
+
+        let result = interpolate_covariance_two_wasserstein_dmatrix(&cov1, &cov2, 0.5)
+            .expect("ill-conditioned covariances must still interpolate");
+
+        assert!(result.iter().all(|v| v.is_finite()));
+        // The interpolant sits between the two inputs in magnitude.
+        assert!(result.norm() > cov1.norm().min(cov2.norm()) * 0.5);
+        assert!(result.norm() < cov2.norm().max(cov1.norm()) * 2.0);
+    }
+
+    #[test]
+    fn test_interpolate_covariance_two_wasserstein_dmatrix_is_symmetric() {
+        // The cross term is a matrix plus its own transpose, so the result is
+        // symmetric by construction rather than to within round-off.
+        let cov1 = propagated_covariance(872.0);
+        let cov2 = propagated_covariance(901.0);
+
+        let result = interpolate_covariance_two_wasserstein_dmatrix(&cov1, &cov2, 0.5).unwrap();
+
+        assert_eq!(
+            (&result - result.transpose()).norm(),
+            0.0,
+            "interpolated covariance must be exactly symmetric"
+        );
     }
 
     #[test]

--- a/src/math/interpolation.rs
+++ b/src/math/interpolation.rs
@@ -370,6 +370,20 @@ where
 /// # Returns
 /// The cross term, or an error if either matrix is not positive semi-definite
 /// or `cov1` is singular.
+///
+/// # Examples
+///
+/// ```ignore
+/// use nalgebra::DMatrix;
+///
+/// let cov1 = DMatrix::identity(2, 2);
+/// let cov2 = DMatrix::from_row_slice(2, 2, &[4.0, 0.0, 0.0, 9.0]);
+///
+/// // For commuting inputs the cross term is 2 (C1 C2)^{1/2}.
+/// let cross = wasserstein_cross_term(&cov1, &cov2).unwrap();
+/// let expected = DMatrix::from_row_slice(2, 2, &[4.0, 0.0, 0.0, 6.0]);
+/// assert!((cross - expected).norm() < 1e-10);
+/// ```
 fn wasserstein_cross_term(
     cov1: &DMatrix<f64>,
     cov2: &DMatrix<f64>,
@@ -1055,6 +1069,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_interpolate_covariance_two_wasserstein_dmatrix_ill_conditioned() {
         // Over a long arc the product of the two covariances is too badly
         // conditioned for a general matrix square root to resolve. Routing the
@@ -1073,6 +1088,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_interpolate_covariance_two_wasserstein_dmatrix_is_symmetric() {
         // The cross term is a matrix plus its own transpose, so the result is
         // symmetric by construction rather than to within round-off.
@@ -1089,6 +1105,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_interpolate_covariance_two_wasserstein_dmatrix_singular_error() {
         // The cross term needs C1^{1/2} to be invertible.
         let cov1 = DMatrix::zeros(3, 3);
@@ -1099,6 +1116,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_interpolate_covariance_two_wasserstein_smatrix_singular_error() {
         let cov1 = SMatrix::<f64, 3, 3>::zeros();
         let cov2 = SMatrix::<f64, 3, 3>::identity();
@@ -1108,6 +1126,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_interpolate_covariance_two_wasserstein_dmatrix_first_not_psd_error() {
         // C1 itself has no real square root.
         let cov1 = DMatrix::from_row_slice(2, 2, &[1.0, 0.0, 0.0, -4.0]);
@@ -1118,6 +1137,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_interpolate_covariance_two_wasserstein_dmatrix_second_not_psd_error() {
         // C1 is fine, but C1^{1/2} C2 C1^{1/2} inherits C2's negative direction.
         let cov1 = DMatrix::identity(2, 2);

--- a/src/math/linalg.rs
+++ b/src/math/linalg.rs
@@ -605,6 +605,32 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_sqrtm_error_negative_eigenvalue_masked_by_scale() {
+        // No real square root, but the negative eigenvalue is small next to the
+        // matrix norm. A residual bound scaled by the whole matrix would accept
+        // this; the per-column bound rejects it.
+        let mat = na::SMatrix::<f64, 2, 2>::new(1e12, 0.0, 0.0, -100.0);
+
+        let err = sqrtm(mat).unwrap_err();
+        assert!(
+            err.contains("column"),
+            "expected a per-column accuracy failure, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_sqrtm_large_magnitude_accepted() {
+        // The Wiki case scaled up. The residual is large in absolute terms but
+        // negligible against the entries, so it must still be accepted.
+        let mat = na::SMatrix::<f64, 2, 2>::new(33.0e10, 24.0e10, 48.0e10, 57.0e10);
+
+        let root = sqrtm(mat).unwrap();
+        let expected = na::SMatrix::<f64, 2, 2>::new(5.0e5, 2.0e5, 4.0e5, 7.0e5);
+        assert!((root - expected).norm() / expected.norm() < 1e-10);
+    }
+
     // =========================================================================
     // sqrtm_dmatrix Tests
     // =========================================================================
@@ -640,6 +666,29 @@ mod tests {
         let sqrt_diag = sqrtm_dmatrix(&diag).unwrap();
         let expected = na::DMatrix::from_row_slice(2, 2, &[2.0, 0.0, 0.0, 3.0]);
         assert!((&sqrt_diag - &expected).norm() < 1e-10);
+    }
+
+    #[test]
+    fn test_sqrtm_dmatrix_error_negative_eigenvalue_masked_by_scale() {
+        // Dynamic mirror of test_sqrtm_error_negative_eigenvalue_masked_by_scale.
+        let mat = na::DMatrix::from_row_slice(2, 2, &[1e12, 0.0, 0.0, -100.0]);
+
+        let err = sqrtm_dmatrix(&mat).unwrap_err();
+        assert!(
+            err.contains("column"),
+            "expected a per-column accuracy failure, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_sqrtm_dmatrix_large_magnitude_accepted() {
+        // Dynamic mirror of test_sqrtm_large_magnitude_accepted.
+        let mat = na::DMatrix::from_row_slice(2, 2, &[33.0e10, 24.0e10, 48.0e10, 57.0e10]);
+
+        let root = sqrtm_dmatrix(&mat).unwrap();
+        let expected = na::DMatrix::from_row_slice(2, 2, &[5.0e5, 2.0e5, 4.0e5, 7.0e5]);
+        assert!((root - &expected).norm() / expected.norm() < 1e-10);
     }
 
     #[test]

--- a/src/math/linalg.rs
+++ b/src/math/linalg.rs
@@ -738,6 +738,32 @@ mod tests {
     }
 
     #[test]
+    fn test_spd_sqrtm_dmatrix_non_square_error() {
+        let mat = na::DMatrix::from_row_slice(2, 3, &[1.0, 0.0, 0.0, 0.0, 1.0, 0.0]);
+        let err = spd_sqrtm_dmatrix(&mat).unwrap_err();
+        assert!(err.contains("square"), "got: {}", err);
+    }
+
+    #[test]
+    fn test_spd_sqrtm_dmatrix_negative_eigenvalue_error() {
+        // Negative well beyond what round-off could explain.
+        let mat = na::DMatrix::from_row_slice(2, 2, &[4.0, 0.0, 0.0, -9.0]);
+        let err = spd_sqrtm_dmatrix(&mat).unwrap_err();
+        assert!(err.contains("positive semi-definite"), "got: {}", err);
+    }
+
+    #[test]
+    fn test_spd_sqrtm_dmatrix_clamps_roundoff_negative_eigenvalue() {
+        // A negative eigenvalue at round-off level relative to the largest is
+        // treated as zero rather than rejected, which a propagated covariance
+        // routinely produces.
+        let mat = na::DMatrix::from_row_slice(2, 2, &[1e6, 0.0, 0.0, -1e-9]);
+        let root = spd_sqrtm_dmatrix(&mat).expect("round-off negative must be clamped");
+        assert!((root[(0, 0)] - 1e3).abs() < 1e-6);
+        assert!(root[(1, 1)].abs() < 1e-6);
+    }
+
+    #[test]
     fn test_sqrtm_dmatrix_error_negative_eigenvalue_masked_by_scale() {
         // Dynamic mirror of test_sqrtm_error_negative_eigenvalue_masked_by_scale.
         let mat = na::DMatrix::from_row_slice(2, 2, &[1e12, 0.0, 0.0, -100.0]);

--- a/src/math/linalg.rs
+++ b/src/math/linalg.rs
@@ -257,7 +257,12 @@ where
     let mut z = na::DMatrix::<f64>::identity(N, N);
 
     const MAX_ITERATIONS: usize = 50;
-    const TOLERANCE: f64 = 1e-10;
+    const TOLERANCE: f64 = 1e-12;
+
+    // Tolerances scale with the magnitude of the input. Covariance products
+    // reach norms of 1e12 or more, where a fixed absolute threshold cannot be
+    // met even by a fully converged iteration.
+    let scale = a.norm().max(1.0);
 
     for _ in 0..MAX_ITERATIONS {
         // Compute inverses
@@ -275,7 +280,7 @@ where
 
         // Check convergence: ||Y_{k+1} - Y_k|| < tolerance
         let diff = (&y_new - &y).norm();
-        if diff < TOLERANCE {
+        if diff < TOLERANCE * scale {
             y = y_new;
             break;
         }
@@ -284,14 +289,21 @@ where
         z = z_new;
     }
 
-    // Verify the result: Y * Y should equal A
+    // Verify the result: Y * Y should equal A. Compare column by column so a
+    // poorly resolved direction cannot be hidden by a larger one dominating the
+    // norm; a single global bound would accept a negative eigenvalue whose
+    // magnitude is small next to the rest of the matrix.
     let check = &y * &y;
-    let error = (&check - &a).norm();
-    if error > 1e-8 {
-        return Err(format!(
-            "Matrix square root did not converge to sufficient accuracy (error: {})",
-            error
-        ));
+    let residual = &check - &a;
+    for j in 0..N {
+        let col_error = residual.column(j).norm();
+        let col_scale = a.column(j).norm().max(1.0);
+        if col_error > 1e-8 * col_scale {
+            return Err(format!(
+                "Matrix square root did not converge to sufficient accuracy (column {} error: {})",
+                j, col_error
+            ));
+        }
     }
 
     // Convert back to SMatrix
@@ -360,7 +372,12 @@ pub fn sqrtm_dmatrix(matrix: &na::DMatrix<f64>) -> Result<na::DMatrix<f64>, Stri
     let mut z = na::DMatrix::<f64>::identity(n, n);
 
     const MAX_ITERATIONS: usize = 50;
-    const TOLERANCE: f64 = 1e-10;
+    const TOLERANCE: f64 = 1e-12;
+
+    // Tolerances scale with the magnitude of the input. Covariance products
+    // reach norms of 1e12 or more, where a fixed absolute threshold cannot be
+    // met even by a fully converged iteration.
+    let scale = matrix.norm().max(1.0);
 
     for _ in 0..MAX_ITERATIONS {
         // Compute inverses
@@ -378,7 +395,7 @@ pub fn sqrtm_dmatrix(matrix: &na::DMatrix<f64>) -> Result<na::DMatrix<f64>, Stri
 
         // Check convergence: ||Y_{k+1} - Y_k|| < tolerance
         let diff = (&y_new - &y).norm();
-        if diff < TOLERANCE {
+        if diff < TOLERANCE * scale {
             y = y_new;
             break;
         }
@@ -387,14 +404,21 @@ pub fn sqrtm_dmatrix(matrix: &na::DMatrix<f64>) -> Result<na::DMatrix<f64>, Stri
         z = z_new;
     }
 
-    // Verify the result: Y * Y should equal A
+    // Verify the result: Y * Y should equal A. Compare column by column so a
+    // poorly resolved direction cannot be hidden by a larger one dominating the
+    // norm; a single global bound would accept a negative eigenvalue whose
+    // magnitude is small next to the rest of the matrix.
     let check = &y * &y;
-    let error = (&check - matrix).norm();
-    if error > 1e-8 {
-        return Err(format!(
-            "Matrix square root did not converge to sufficient accuracy (error: {})",
-            error
-        ));
+    let residual = &check - matrix;
+    for j in 0..n {
+        let col_error = residual.column(j).norm();
+        let col_scale = matrix.column(j).norm().max(1.0);
+        if col_error > 1e-8 * col_scale {
+            return Err(format!(
+                "Matrix square root did not converge to sufficient accuracy (column {} error: {})",
+                j, col_error
+            ));
+        }
     }
 
     Ok(y)

--- a/src/math/linalg.rs
+++ b/src/math/linalg.rs
@@ -228,16 +228,16 @@ where
 ///
 /// # Examples
 ///
-/// ```
+/// ```ignore
 /// use nalgebra::DMatrix;
-/// use brahe::math::linalg::spd_sqrtm_dmatrix;
+/// use crate::math::linalg::spd_sqrtm_dmatrix;
 ///
 /// let diag = DMatrix::from_row_slice(2, 2, &[4.0, 0.0, 0.0, 9.0]);
 /// let root = spd_sqrtm_dmatrix(&diag).unwrap();
 /// let expected = DMatrix::from_row_slice(2, 2, &[2.0, 0.0, 0.0, 3.0]);
 /// assert!((root - expected).norm() < 1e-10);
 /// ```
-pub fn spd_sqrtm_dmatrix(matrix: &na::DMatrix<f64>) -> Result<na::DMatrix<f64>, String> {
+pub(crate) fn spd_sqrtm_dmatrix(matrix: &na::DMatrix<f64>) -> Result<na::DMatrix<f64>, String> {
     if matrix.nrows() != matrix.ncols() {
         return Err(format!(
             "Matrix must be square, got {}x{}",
@@ -330,8 +330,12 @@ where
 
     // Tolerances scale with the magnitude of the input. Covariance products
     // reach norms of 1e12 or more, where a fixed absolute threshold cannot be
-    // met even by a fully converged iteration.
+    // met even by a fully converged iteration. The iterate tracks the square
+    // root, so its convergence is measured against the root's magnitude, not
+    // the matrix's; the residual below is a difference of matrices and keeps
+    // the matrix scale.
     let scale = a.norm().max(1.0);
+    let root_scale = scale.sqrt();
 
     for _ in 0..MAX_ITERATIONS {
         // Compute inverses
@@ -349,7 +353,7 @@ where
 
         // Check convergence: ||Y_{k+1} - Y_k|| < tolerance
         let diff = (&y_new - &y).norm();
-        if diff < TOLERANCE * scale {
+        if diff < TOLERANCE * root_scale {
             y = y_new;
             break;
         }
@@ -445,8 +449,12 @@ pub fn sqrtm_dmatrix(matrix: &na::DMatrix<f64>) -> Result<na::DMatrix<f64>, Stri
 
     // Tolerances scale with the magnitude of the input. Covariance products
     // reach norms of 1e12 or more, where a fixed absolute threshold cannot be
-    // met even by a fully converged iteration.
+    // met even by a fully converged iteration. The iterate tracks the square
+    // root, so its convergence is measured against the root's magnitude, not
+    // the matrix's; the residual below is a difference of matrices and keeps
+    // the matrix scale.
     let scale = matrix.norm().max(1.0);
+    let root_scale = scale.sqrt();
 
     for _ in 0..MAX_ITERATIONS {
         // Compute inverses
@@ -464,7 +472,7 @@ pub fn sqrtm_dmatrix(matrix: &na::DMatrix<f64>) -> Result<na::DMatrix<f64>, Stri
 
         // Check convergence: ||Y_{k+1} - Y_k|| < tolerance
         let diff = (&y_new - &y).norm();
-        if diff < TOLERANCE * scale {
+        if diff < TOLERANCE * root_scale {
             y = y_new;
             break;
         }
@@ -675,6 +683,44 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::parallel]
+    fn test_sqrtm_converges_at_large_magnitude() {
+        // The iterate tracks the square root, so a stopping test scaled by the
+        // matrix norm stops short by roughly the square root of that norm.
+        for magnitude in [1e4_f64, 1e12, 1e20, 1e24] {
+            let mat = na::SMatrix::<f64, 1, 1>::new(magnitude);
+            let root = sqrtm(mat).unwrap_or_else(|e| panic!("magnitude {magnitude:e}: {e}"));
+            let expected = magnitude.sqrt();
+            let relative = (root[(0, 0)] - expected).abs() / expected;
+            assert!(
+                relative < 1e-12,
+                "magnitude {:e}: relative root error {:e}",
+                magnitude,
+                relative
+            );
+        }
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_sqrtm_dmatrix_converges_at_large_magnitude() {
+        for magnitude in [1e4_f64, 1e12, 1e20, 1e24] {
+            let mat = na::DMatrix::from_row_slice(1, 1, &[magnitude]);
+            let root =
+                sqrtm_dmatrix(&mat).unwrap_or_else(|e| panic!("magnitude {magnitude:e}: {e}"));
+            let expected = magnitude.sqrt();
+            let relative = (root[(0, 0)] - expected).abs() / expected;
+            assert!(
+                relative < 1e-12,
+                "magnitude {:e}: relative root error {:e}",
+                magnitude,
+                relative
+            );
+        }
+    }
+
+    #[test]
+    #[serial_test::parallel]
     fn test_sqrtm_error_negative_eigenvalue_masked_by_scale() {
         // No real square root, but the negative eigenvalue is small next to the
         // matrix norm. A residual bound scaled by the whole matrix would accept
@@ -690,6 +736,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_sqrtm_large_magnitude_accepted() {
         // The Wiki case scaled up. The residual is large in absolute terms but
         // negligible against the entries, so it must still be accepted.
@@ -738,6 +785,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_spd_sqrtm_dmatrix_non_square_error() {
         let mat = na::DMatrix::from_row_slice(2, 3, &[1.0, 0.0, 0.0, 0.0, 1.0, 0.0]);
         let err = spd_sqrtm_dmatrix(&mat).unwrap_err();
@@ -745,6 +793,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_spd_sqrtm_dmatrix_negative_eigenvalue_error() {
         // Negative well beyond what round-off could explain.
         let mat = na::DMatrix::from_row_slice(2, 2, &[4.0, 0.0, 0.0, -9.0]);
@@ -753,6 +802,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_spd_sqrtm_dmatrix_clamps_roundoff_negative_eigenvalue() {
         // A negative eigenvalue at round-off level relative to the largest is
         // treated as zero rather than rejected, which a propagated covariance
@@ -764,6 +814,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_sqrtm_dmatrix_error_negative_eigenvalue_masked_by_scale() {
         // Dynamic mirror of test_sqrtm_error_negative_eigenvalue_masked_by_scale.
         let mat = na::DMatrix::from_row_slice(2, 2, &[1e12, 0.0, 0.0, -100.0]);
@@ -777,6 +828,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_sqrtm_dmatrix_large_magnitude_accepted() {
         // Dynamic mirror of test_sqrtm_large_magnitude_accepted.
         let mat = na::DMatrix::from_row_slice(2, 2, &[33.0e10, 24.0e10, 48.0e10, 57.0e10]);

--- a/src/math/linalg.rs
+++ b/src/math/linalg.rs
@@ -256,6 +256,12 @@ pub fn spd_sqrtm_dmatrix(matrix: &na::DMatrix<f64>) -> Result<na::DMatrix<f64>, 
 
     let mut roots = eigen.eigenvalues.clone();
     for value in roots.iter_mut() {
+        if !value.is_finite() {
+            return Err(format!(
+                "Symmetric eigendecomposition did not converge: eigenvalue {}",
+                value
+            ));
+        }
         if *value < -tolerance {
             return Err(format!(
                 "Matrix is not positive semi-definite: found negative eigenvalue {}",

--- a/src/math/linalg.rs
+++ b/src/math/linalg.rs
@@ -206,6 +206,69 @@ where
     Ok(result)
 }
 
+/// Compute the matrix square root of a symmetric positive semi-definite matrix.
+///
+/// Uses a symmetric eigendecomposition, which stays accurate on the
+/// ill-conditioned matrices that arise from propagated covariances. The
+/// Denman-Beavers iteration used by [`sqrtm_dmatrix`] for general matrices
+/// breaks down well before this does.
+///
+/// The input is symmetrized before decomposition, and eigenvalues that are
+/// negative only to within round-off are clamped to zero rather than rejected,
+/// since a propagated covariance routinely carries such values.
+///
+/// # Arguments
+///
+/// * `matrix` - A symmetric positive semi-definite matrix
+///
+/// # Returns
+///
+/// * `Result<DMatrix<f64>, String>` - The matrix square root, or an error if the
+///   matrix is not square or has a negative eigenvalue too large to be round-off
+///
+/// # Examples
+///
+/// ```
+/// use nalgebra::DMatrix;
+/// use brahe::math::linalg::spd_sqrtm_dmatrix;
+///
+/// let diag = DMatrix::from_row_slice(2, 2, &[4.0, 0.0, 0.0, 9.0]);
+/// let root = spd_sqrtm_dmatrix(&diag).unwrap();
+/// let expected = DMatrix::from_row_slice(2, 2, &[2.0, 0.0, 0.0, 3.0]);
+/// assert!((root - expected).norm() < 1e-10);
+/// ```
+pub fn spd_sqrtm_dmatrix(matrix: &na::DMatrix<f64>) -> Result<na::DMatrix<f64>, String> {
+    if matrix.nrows() != matrix.ncols() {
+        return Err(format!(
+            "Matrix must be square, got {}x{}",
+            matrix.nrows(),
+            matrix.ncols()
+        ));
+    }
+
+    // Symmetrize first: a covariance assembled numerically carries asymmetry at
+    // round-off level, and the decomposition assumes exact symmetry.
+    let symmetric = (matrix + matrix.transpose()) * 0.5;
+    let eigen = SymmetricEigen::new(symmetric);
+
+    let max_eigenvalue = eigen.eigenvalues.amax();
+    let tolerance = 1e-12 * max_eigenvalue.max(1.0);
+
+    let mut roots = eigen.eigenvalues.clone();
+    for value in roots.iter_mut() {
+        if *value < -tolerance {
+            return Err(format!(
+                "Matrix is not positive semi-definite: found negative eigenvalue {}",
+                value
+            ));
+        }
+        *value = value.max(0.0).sqrt();
+    }
+
+    let v = &eigen.eigenvectors;
+    Ok(v * na::DMatrix::from_diagonal(&roots) * v.transpose())
+}
+
 /// Compute the matrix square root of a general square matrix.
 ///
 /// This function computes the square root of a general (possibly non-symmetric) square matrix

--- a/tests/propagators/test_numerical_orbit_propagator.py
+++ b/tests/propagators/test_numerical_orbit_propagator.py
@@ -3279,6 +3279,40 @@ def test_numericalorbitpropagator_value_event_velocity():
 # =============================================================================
 
 
+def test_numericalorbitpropagator_covariance_interpolation_long_arc():
+    """Covariance interpolation over a long arc (mirrors Rust interpolation tests)
+
+    Over a long arc the two bracketing covariances form a product too badly
+    conditioned for a general matrix square root, which used to fail outright.
+    Queried between stored nodes, the result must exist and be symmetric.
+    """
+    epoch = create_test_epoch()
+    state = np.array([R_EARTH + 500e3, 0.0, 0.0, 0.0, 7500.0, 0.0])
+
+    initial_covariance = np.diag([100.0, 100.0, 100.0, 1.0, 1.0, 1.0])
+
+    prop = NumericalOrbitPropagator(
+        epoch,
+        state,
+        NumericalPropagationConfig.default(),
+        ForceModelConfig.two_body(),
+        None,
+        initial_covariance,
+    )
+
+    prop.propagate_to(epoch + 160000.0)
+
+    # Deliberately between stored nodes so interpolation actually runs.
+    cov = prop.covariance_gcrf(epoch + 144030.0)
+
+    assert cov is not None
+    assert cov.shape == (6, 6)
+    assert np.all(np.isfinite(cov))
+    assert np.allclose(cov, cov.T, rtol=0.0, atol=1e-9 * np.linalg.norm(cov))
+    # Uncertainty grows away from the initial epoch.
+    assert cov[0, 0] > initial_covariance[0, 0]
+
+
 def test_numericalorbitpropagator_covariance_eci():
     """Test covariance_eci method if available (mirrors Rust test)"""
     epoch = create_test_epoch()


### PR DESCRIPTION
# Pull Request

## Description

Two numerical defects in the covariance square-root path, both reachable only once adaptive step sizes are unfrozen by #469 and covariance interpolation starts running between trajectory nodes.

The 2-Wasserstein interpolant took a general matrix square root of the product of the two covariances. That product is not symmetric and its condition number is the product of the two, which the Denman-Beavers iteration cannot resolve: past roughly `1e10` it stops converging and the inverse it needs goes singular, so interpolation fails outright on any reasonably long arc. The cross term is now formed as `L (L C2 L)^1/2 L^-1` with `L = C1^1/2`, the same quantity with every root taken of a symmetric positive semi-definite matrix, so it can go through an eigendecomposition. Since `C1` and `C2` are symmetric the second root is the transpose of the first, making the interpolant symmetric by construction rather than to within round-off. `spd_sqrtm_dmatrix` is added for that route; it symmetrizes its input and clamps eigenvalues negative only to within round-off, which a propagated covariance routinely carries.

Separately, `sqrtm` and `sqrtm_dmatrix` compared the Denman-Beavers residual against a fixed `1e-8`, a bound unreachable for large inputs. The residual is now checked per column against that column's own magnitude. A single global relative bound is not sufficient: it lets a poorly resolved direction hide behind a larger one, accepting `diag(1e12, -100)`, which has no real square root. Columns below unit norm keep the previous absolute floor.

## Changelog

### Added
- `spd_sqrtm_dmatrix` for the square root of a dynamically sized symmetric positive semi-definite matrix, computed by eigendecomposition. It symmetrizes its input, clamps eigenvalues that are negative only to within round-off rather than rejecting them, and reports a decomposition that fails to converge instead of returning NaN.

### Fixed
- Covariance interpolation no longer fails on long arcs; the 2-Wasserstein cross term is formed through symmetric positive semi-definite square roots instead of a general square root of the covariance product, which the Denman-Beavers iteration cannot resolve past a condition number of roughly 1e10. The interpolated covariance is now symmetric by construction.
- `sqrtm` and `sqrtm_dmatrix` no longer reject well-converged square roots of large matrices; the convergence residual is measured against each column's own magnitude rather than a fixed absolute bound.

## Related Issue

Prerequisite for #461. Both paths are unreachable until adaptive step sizes are allowed to grow, which is why neither had surfaced.

## Note to Reviewers

Where the previous interpolation formulation worked the two agree to `1e-9` or better; it fails entirely from an arc length of roughly 2500 s upward, where the new route still returns a finite, symmetric result. The `sqrtm` column-wise bound was verified against `diag(1e12, -100)` (must reject: global relative residual `1.46e-10`, per-column `1.46`), the documented `[[33,24],[48,57]]` case, and a real `2e12`-norm covariance product (both must accept).
