### PR TITLE
Order event bisection brackets by propagation direction

### DIFF
--- a/src/events/common.rs
+++ b/src/events/common.rs
@@ -95,7 +95,8 @@ impl<const S: usize, const P: usize> STimeEvent<S, P> {
     /// Set custom step reduction factor for bisection search
     ///
     /// When a zero-crossing is detected, the new step size is set to this
-    /// factor times the bracket width. Default: 0.2
+    /// factor times the bracket width. Default: 0.2. The search clamps the
+    /// value to `[0.1, 0.5]` so the bracket is guaranteed to contract.
     pub fn with_step_reduction_factor(mut self, factor: f64) -> Self {
         self.step_reduction_factor = factor;
         self
@@ -225,7 +226,8 @@ impl DTimeEvent {
     /// Set custom step reduction factor for bisection search
     ///
     /// When a zero-crossing is detected, the new step size is set to this
-    /// factor times the bracket width. Default: 0.2
+    /// factor times the bracket width. Default: 0.2. The search clamps the
+    /// value to `[0.1, 0.5]` so the bracket is guaranteed to contract.
     pub fn with_step_reduction_factor(mut self, factor: f64) -> Self {
         self.step_reduction_factor = factor;
         self
@@ -365,7 +367,8 @@ impl<const S: usize, const P: usize> SValueEvent<S, P> {
     /// Set custom step reduction factor for bisection search
     ///
     /// When a zero-crossing is detected, the new step size is set to this
-    /// factor times the bracket width. Default: 0.2
+    /// factor times the bracket width. Default: 0.2. The search clamps the
+    /// value to `[0.1, 0.5]` so the bracket is guaranteed to contract.
     pub fn with_step_reduction_factor(mut self, factor: f64) -> Self {
         self.step_reduction_factor = factor;
         self
@@ -483,7 +486,8 @@ impl DValueEvent {
     /// Set custom step reduction factor for bisection search
     ///
     /// When a zero-crossing is detected, the new step size is set to this
-    /// factor times the bracket width. Default: 0.2
+    /// factor times the bracket width. Default: 0.2. The search clamps the
+    /// value to `[0.1, 0.5]` so the bracket is guaranteed to contract.
     pub fn with_step_reduction_factor(mut self, factor: f64) -> Self {
         self.step_reduction_factor = factor;
         self
@@ -618,7 +622,8 @@ impl<const S: usize, const P: usize> SBinaryEvent<S, P> {
     /// Set custom step reduction factor for bisection search
     ///
     /// When a zero-crossing is detected, the new step size is set to this
-    /// factor times the bracket width. Default: 0.2
+    /// factor times the bracket width. Default: 0.2. The search clamps the
+    /// value to `[0.1, 0.5]` so the bracket is guaranteed to contract.
     pub fn with_step_reduction_factor(mut self, factor: f64) -> Self {
         self.step_reduction_factor = factor;
         self
@@ -738,7 +743,8 @@ impl DBinaryEvent {
     /// Set custom step reduction factor for bisection search
     ///
     /// When a zero-crossing is detected, the new step size is set to this
-    /// factor times the bracket width. Default: 0.2
+    /// factor times the bracket width. Default: 0.2. The search clamps the
+    /// value to `[0.1, 0.5]` so the bracket is guaranteed to contract.
     pub fn with_step_reduction_factor(mut self, factor: f64) -> Self {
         self.step_reduction_factor = factor;
         self

--- a/src/events/detection.rs
+++ b/src/events/detection.rs
@@ -39,6 +39,10 @@ pub enum StepDirection {
 /// * `params` - Optional parameter vector
 /// * `bracket_low` - Lower bound of search bracket (earlier time)
 /// * `bracket_high` - Upper bound of search bracket (later time)
+/// * `depth` - Recursion depth of this call, counted from zero at the entry
+///   point (unitless). Each level narrows the bracket; the search returns its
+///   best estimate once `MAX_BISECTION_DEPTH` is reached, so a bracket that
+///   fails to contract cannot recurse without end.
 ///
 /// # Returns
 /// Event time and state, or None if no event found within search window
@@ -196,7 +200,8 @@ where
 /// Find event time using bisection search (dynamic-sized)
 ///
 /// Uses bracketing bisection to refine the event time to within the specified
-/// tolerance. See `bisection_search` for algorithm details.
+/// tolerance. See `bisection_search` for algorithm details and for the argument
+/// list, including the `depth` recursion counter and its bound.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn bisection_search_d<F>(
     detector: &dyn DEventDetector,
@@ -650,6 +655,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_scan_for_event_backward() {
         // Backward propagation hands the scan prev_time later than
         // current_time, so the bracket bounds arrive reversed in time.

--- a/src/events/detection.rs
+++ b/src/events/detection.rs
@@ -649,6 +649,41 @@ mod tests {
         assert_eq!(event.detector_index, 0);
     }
 
+    #[test]
+    fn test_scan_for_event_backward() {
+        // Backward propagation hands the scan prev_time later than
+        // current_time, so the bracket bounds arrive reversed in time.
+        let start_epoch = Epoch::from_jd(2451545.0, TimeSystem::UTC);
+        let target_epoch = start_epoch + 50.0;
+
+        let detector = SimpleTimeEvent {
+            target_time: target_epoch,
+            name: "Backward Scan".to_string(),
+        };
+
+        let state_fn = |_t: Epoch| Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0);
+
+        let prev_time = start_epoch + 100.0;
+        let current_time = start_epoch;
+        let prev_state = state_fn(prev_time);
+        let current_state = state_fn(current_time);
+
+        let result = sscan_for_event(
+            &detector,
+            0,
+            &state_fn,
+            prev_time,
+            current_time,
+            &prev_state,
+            &current_state,
+            None,
+        );
+
+        let event = result.expect("event inside the backward interval must be found");
+        assert!((event.window_open - target_epoch).abs() < detector.time_tolerance());
+        assert_eq!(event.name, "Backward Scan");
+    }
+
     /// Configurable time event with custom step reduction factor
     struct ConfigurableTimeEvent {
         target_time: Epoch,

--- a/src/events/detection.rs
+++ b/src/events/detection.rs
@@ -53,18 +53,25 @@ pub(crate) fn bisection_search<const S: usize, const P: usize, F>(
     params: Option<&SVector<f64, P>>,
     bracket_low: Epoch,
     bracket_high: Epoch,
+    depth: usize,
 ) -> Option<(Epoch, SVector<f64, S>)>
 where
     F: Fn(Epoch) -> SVector<f64, S>,
 {
     let time_tol = detector.time_tolerance();
     let value_tol = detector.value_tolerance();
-    let step_factor = detector.step_reduction_factor();
+    // Worst-case contraction per level is max(factor, 1 - factor): a factor at
+    // either extreme leaves the bracket barely narrower each level and would
+    // exhaust the depth budget before reaching the time tolerance. Clamping
+    // keeps contraction at 0.9 or better, well inside MAX_BISECTION_DEPTH.
+    let step_factor = detector.step_reduction_factor().clamp(0.1, 0.5);
     let target_value = detector.target_value();
 
-    // TERMINATION: Bracket is tight enough
+    // TERMINATION: Bracket is tight enough, or the refinement budget is spent.
+    // Each level should shrink the bracket; the depth bound keeps a bracket that
+    // fails to narrow from recursing without end.
     let bracket_width = (bracket_high - bracket_low).abs();
-    if bracket_width <= time_tol {
+    if bracket_width <= time_tol || depth >= MAX_BISECTION_DEPTH {
         // Return the midpoint of the bracket
         let mid_time = bracket_low + bracket_width / 2.0;
         let mid_state = state_fn(mid_time);
@@ -176,6 +183,7 @@ where
                 params,
                 new_low,
                 new_high,
+                depth + 1,
             );
         }
 
@@ -200,18 +208,25 @@ pub(crate) fn bisection_search_d<F>(
     params: Option<&DVector<f64>>,
     bracket_low: Epoch,
     bracket_high: Epoch,
+    depth: usize,
 ) -> Option<(Epoch, DVector<f64>)>
 where
     F: Fn(Epoch) -> DVector<f64>,
 {
     let time_tol = detector.time_tolerance();
     let value_tol = detector.value_tolerance();
-    let step_factor = detector.step_reduction_factor();
+    // Worst-case contraction per level is max(factor, 1 - factor): a factor at
+    // either extreme leaves the bracket barely narrower each level and would
+    // exhaust the depth budget before reaching the time tolerance. Clamping
+    // keeps contraction at 0.9 or better, well inside MAX_BISECTION_DEPTH.
+    let step_factor = detector.step_reduction_factor().clamp(0.1, 0.5);
     let target_value = detector.target_value();
 
-    // TERMINATION: Bracket is tight enough
+    // TERMINATION: Bracket is tight enough, or the refinement budget is spent.
+    // Each level should shrink the bracket; the depth bound keeps a bracket that
+    // fails to narrow from recursing without end.
     let bracket_width = (bracket_high - bracket_low).abs();
-    if bracket_width <= time_tol {
+    if bracket_width <= time_tol || depth >= MAX_BISECTION_DEPTH {
         // Return the midpoint of the bracket
         let mid_time = bracket_low + bracket_width / 2.0;
         let mid_state = state_fn(mid_time);
@@ -323,6 +338,7 @@ where
                 params,
                 new_low,
                 new_high,
+                depth + 1,
             );
         }
 
@@ -331,6 +347,12 @@ where
         current_crossing = next_crossing;
     }
 }
+
+/// Maximum bisection refinement levels before returning the best estimate.
+///
+/// Each level narrows the bracket by the detector's step reduction factor, so
+/// this bound is far above what any convergent search needs.
+const MAX_BISECTION_DEPTH: usize = 200;
 
 /// Scan for events in a time interval (static-sized)
 ///
@@ -390,16 +412,32 @@ where
     let dt = (current_time - prev_time).abs();
     let initial_step = dt / 4.0; // Start with quarter of interval
 
+    // Backward propagation hands us prev_time later than current_time. The
+    // bracket bounds are ordered by time, and the search walks from prev_time
+    // toward current_time, so the step direction follows that ordering.
+    let forward = current_time >= prev_time;
+    let (bracket_low, bracket_high) = if forward {
+        (prev_time, current_time)
+    } else {
+        (current_time, prev_time)
+    };
+    let step_direction = if forward {
+        StepDirection::Forward
+    } else {
+        StepDirection::Backward
+    };
+
     let result = bisection_search(
         detector,
         state_fn,
         prev_time,
-        StepDirection::Forward,
+        step_direction,
         initial_step,
         prev_crossing,
         params,
-        prev_time,
-        current_time,
+        bracket_low,
+        bracket_high,
+        0,
     );
 
     result.map(|(event_time, event_state)| {
@@ -460,16 +498,32 @@ where
     let dt = (current_time - prev_time).abs();
     let initial_step = dt / 4.0;
 
+    // Backward propagation hands us prev_time later than current_time. The
+    // bracket bounds are ordered by time, and the search walks from prev_time
+    // toward current_time, so the step direction follows that ordering.
+    let forward = current_time >= prev_time;
+    let (bracket_low, bracket_high) = if forward {
+        (prev_time, current_time)
+    } else {
+        (current_time, prev_time)
+    };
+    let step_direction = if forward {
+        StepDirection::Forward
+    } else {
+        StepDirection::Backward
+    };
+
     let result = bisection_search_d(
         detector,
         state_fn,
         prev_time,
-        StepDirection::Forward,
+        step_direction,
         initial_step,
         prev_crossing,
         params,
-        prev_time,
-        current_time,
+        bracket_low,
+        bracket_high,
+        0,
     );
 
     result.map(|(event_time, event_state)| {
@@ -547,6 +601,7 @@ mod tests {
             None,
             start_epoch,
             start_epoch + 200.0,
+            0,
         );
 
         assert!(result.is_some());
@@ -658,6 +713,7 @@ mod tests {
             None,
             start_epoch,
             start_epoch + 200.0,
+            0,
         );
 
         assert!(result.is_some());
@@ -694,6 +750,7 @@ mod tests {
             None,
             start_epoch,
             start_epoch + 100.0,
+            0,
         );
 
         assert!(result.is_some());
@@ -730,6 +787,7 @@ mod tests {
             None,
             start_epoch,
             start_epoch + 100.0,
+            0,
         );
 
         assert!(result.is_some());

--- a/src/math/interpolation.rs
+++ b/src/math/interpolation.rs
@@ -1089,6 +1089,45 @@ mod tests {
     }
 
     #[test]
+    fn test_interpolate_covariance_two_wasserstein_dmatrix_singular_error() {
+        // The cross term needs C1^{1/2} to be invertible.
+        let cov1 = DMatrix::zeros(3, 3);
+        let cov2 = DMatrix::identity(3, 3);
+
+        let result = interpolate_covariance_two_wasserstein_dmatrix(&cov1, &cov2, 0.5);
+        assert!(matches!(result, Err(BraheError::NumericalError(_))));
+    }
+
+    #[test]
+    fn test_interpolate_covariance_two_wasserstein_smatrix_singular_error() {
+        let cov1 = SMatrix::<f64, 3, 3>::zeros();
+        let cov2 = SMatrix::<f64, 3, 3>::identity();
+
+        let result = interpolate_covariance_two_wasserstein_smatrix(cov1, cov2, 0.5);
+        assert!(matches!(result, Err(BraheError::NumericalError(_))));
+    }
+
+    #[test]
+    fn test_interpolate_covariance_two_wasserstein_dmatrix_first_not_psd_error() {
+        // C1 itself has no real square root.
+        let cov1 = DMatrix::from_row_slice(2, 2, &[1.0, 0.0, 0.0, -4.0]);
+        let cov2 = DMatrix::identity(2, 2);
+
+        let result = interpolate_covariance_two_wasserstein_dmatrix(&cov1, &cov2, 0.5);
+        assert!(matches!(result, Err(BraheError::NumericalError(_))));
+    }
+
+    #[test]
+    fn test_interpolate_covariance_two_wasserstein_dmatrix_second_not_psd_error() {
+        // C1 is fine, but C1^{1/2} C2 C1^{1/2} inherits C2's negative direction.
+        let cov1 = DMatrix::identity(2, 2);
+        let cov2 = DMatrix::from_row_slice(2, 2, &[1.0, 0.0, 0.0, -4.0]);
+
+        let result = interpolate_covariance_two_wasserstein_dmatrix(&cov1, &cov2, 0.5);
+        assert!(matches!(result, Err(BraheError::NumericalError(_))));
+    }
+
+    #[test]
     fn test_interpolate_covariance_two_wasserstein_dmatrix_dimension_mismatch() {
         let cov1 = DMatrix::<f64>::identity(3, 3);
         let cov2 = DMatrix::<f64>::identity(4, 4);

--- a/src/math/interpolation.rs
+++ b/src/math/interpolation.rs
@@ -7,7 +7,7 @@
  * - Standalone interpolation functions for vectors and covariance matrices
  */
 
-use crate::math::linalg::{sqrtm, sqrtm_dmatrix};
+use crate::math::linalg::{spd_sqrtm_dmatrix, sqrtm, sqrtm_dmatrix};
 use crate::utils::errors::BraheError;
 use nalgebra::{DMatrix, DVector, SMatrix, SVector};
 use serde::{Deserialize, Serialize};
@@ -341,10 +341,51 @@ where
         ));
     }
 
-    let sqrt_12 = sqrtm(cov1 * cov2).map_err(BraheError::NumericalError)?;
-    let sqrt_21 = sqrtm(cov2 * cov1).map_err(BraheError::NumericalError)?;
+    let cross = wasserstein_cross_term(
+        &DMatrix::from_iterator(N, N, cov1.iter().cloned()),
+        &DMatrix::from_iterator(N, N, cov2.iter().cloned()),
+    )?;
+    let cross = SMatrix::<f64, N, N>::from_iterator(cross.iter().cloned());
 
-    Ok((1.0 - t).powi(2) * cov1 + t.powi(2) * cov2 + t * (1.0 - t) * (sqrt_12 + sqrt_21))
+    Ok((1.0 - t).powi(2) * cov1 + t.powi(2) * cov2 + t * (1.0 - t) * cross)
+}
+
+/// Compute `(C1 C2)^{1/2} + (C2 C1)^{1/2}`, the cross term of the 2-Wasserstein
+/// covariance interpolant.
+///
+/// Formed as `L (L C2 L)^{1/2} L^{-1}` with `L = C1^{1/2}`, which is equal to
+/// `(C1 C2)^{1/2}` but keeps every square root on a symmetric positive
+/// semi-definite matrix. Taking a general square root of the product directly
+/// is far less stable: `C1 C2` is not symmetric and its condition number is the
+/// product of the two, which the Denman-Beavers iteration cannot resolve for
+/// realistic propagated covariances.
+///
+/// Since `C1` and `C2` are symmetric, `(C2 C1)^{1/2}` is the transpose of
+/// `(C1 C2)^{1/2}`, so the sum is symmetric by construction.
+///
+/// # Arguments
+/// * `cov1` - The first covariance matrix.
+/// * `cov2` - The second covariance matrix.
+///
+/// # Returns
+/// The cross term, or an error if either matrix is not positive semi-definite
+/// or `cov1` is singular.
+fn wasserstein_cross_term(
+    cov1: &DMatrix<f64>,
+    cov2: &DMatrix<f64>,
+) -> Result<DMatrix<f64>, BraheError> {
+    let l = spd_sqrtm_dmatrix(cov1).map_err(BraheError::NumericalError)?;
+    let l_inv = l.clone().try_inverse().ok_or_else(|| {
+        BraheError::NumericalError(
+            "Covariance interpolation requires an invertible first covariance".to_string(),
+        )
+    })?;
+
+    let inner = &l * cov2 * &l;
+    let root = spd_sqrtm_dmatrix(&inner).map_err(BraheError::NumericalError)?;
+
+    let sqrt_12 = &l * &root * &l_inv;
+    Ok(&sqrt_12 + sqrt_12.transpose())
 }
 
 /// Interpolates between two dynamic-sized covariance matrices using square root interpolation.
@@ -455,13 +496,9 @@ pub fn interpolate_covariance_two_wasserstein_dmatrix(
         )));
     }
 
-    let prod12 = cov1 * cov2;
-    let prod21 = cov2 * cov1;
+    let cross = wasserstein_cross_term(cov1, cov2)?;
 
-    let sqrt_12 = sqrtm_dmatrix(&prod12).map_err(BraheError::NumericalError)?;
-    let sqrt_21 = sqrtm_dmatrix(&prod21).map_err(BraheError::NumericalError)?;
-
-    Ok((1.0 - t).powi(2) * cov1 + t.powi(2) * cov2 + t * (1.0 - t) * (sqrt_12 + sqrt_21))
+    Ok((1.0 - t).powi(2) * cov1 + t.powi(2) * cov2 + t * (1.0 - t) * cross)
 }
 
 // ============================================================================
@@ -997,6 +1034,58 @@ mod tests {
         let cov2 = DMatrix::<f64>::identity(4, 4);
         let result = interpolate_covariance_sqrt_dmatrix(&cov1, &cov2, 0.5);
         assert!(matches!(result, Err(BraheError::OutOfBoundsError(_))));
+    }
+
+    /// Covariance of a state propagated over `dt`, whose position block grows
+    /// as dt^2 while the velocity block does not. The spread between the two
+    /// blocks is what makes the product of two such matrices ill-conditioned.
+    fn propagated_covariance(dt: f64) -> DMatrix<f64> {
+        let mut p0 = DMatrix::zeros(6, 6);
+        for i in 0..3 {
+            p0[(i, i)] = 100.0;
+        }
+        for i in 3..6 {
+            p0[(i, i)] = 1.0;
+        }
+        let mut phi = DMatrix::identity(6, 6);
+        for i in 0..3 {
+            phi[(i, i + 3)] = dt;
+        }
+        &phi * &p0 * phi.transpose()
+    }
+
+    #[test]
+    fn test_interpolate_covariance_two_wasserstein_dmatrix_ill_conditioned() {
+        // Over a long arc the product of the two covariances is too badly
+        // conditioned for a general matrix square root to resolve. Routing the
+        // roots through symmetric positive semi-definite matrices keeps this
+        // tractable.
+        let cov1 = propagated_covariance(8000.0);
+        let cov2 = propagated_covariance(8240.0);
+
+        let result = interpolate_covariance_two_wasserstein_dmatrix(&cov1, &cov2, 0.5)
+            .expect("ill-conditioned covariances must still interpolate");
+
+        assert!(result.iter().all(|v| v.is_finite()));
+        // The interpolant sits between the two inputs in magnitude.
+        assert!(result.norm() > cov1.norm().min(cov2.norm()) * 0.5);
+        assert!(result.norm() < cov2.norm().max(cov1.norm()) * 2.0);
+    }
+
+    #[test]
+    fn test_interpolate_covariance_two_wasserstein_dmatrix_is_symmetric() {
+        // The cross term is a matrix plus its own transpose, so the result is
+        // symmetric by construction rather than to within round-off.
+        let cov1 = propagated_covariance(872.0);
+        let cov2 = propagated_covariance(901.0);
+
+        let result = interpolate_covariance_two_wasserstein_dmatrix(&cov1, &cov2, 0.5).unwrap();
+
+        assert_eq!(
+            (&result - result.transpose()).norm(),
+            0.0,
+            "interpolated covariance must be exactly symmetric"
+        );
     }
 
     #[test]

--- a/src/math/interpolation.rs
+++ b/src/math/interpolation.rs
@@ -370,6 +370,20 @@ where
 /// # Returns
 /// The cross term, or an error if either matrix is not positive semi-definite
 /// or `cov1` is singular.
+///
+/// # Examples
+///
+/// ```ignore
+/// use nalgebra::DMatrix;
+///
+/// let cov1 = DMatrix::identity(2, 2);
+/// let cov2 = DMatrix::from_row_slice(2, 2, &[4.0, 0.0, 0.0, 9.0]);
+///
+/// // For commuting inputs the cross term is 2 (C1 C2)^{1/2}.
+/// let cross = wasserstein_cross_term(&cov1, &cov2).unwrap();
+/// let expected = DMatrix::from_row_slice(2, 2, &[4.0, 0.0, 0.0, 6.0]);
+/// assert!((cross - expected).norm() < 1e-10);
+/// ```
 fn wasserstein_cross_term(
     cov1: &DMatrix<f64>,
     cov2: &DMatrix<f64>,
@@ -1055,6 +1069,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_interpolate_covariance_two_wasserstein_dmatrix_ill_conditioned() {
         // Over a long arc the product of the two covariances is too badly
         // conditioned for a general matrix square root to resolve. Routing the
@@ -1073,6 +1088,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_interpolate_covariance_two_wasserstein_dmatrix_is_symmetric() {
         // The cross term is a matrix plus its own transpose, so the result is
         // symmetric by construction rather than to within round-off.
@@ -1089,6 +1105,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_interpolate_covariance_two_wasserstein_dmatrix_singular_error() {
         // The cross term needs C1^{1/2} to be invertible.
         let cov1 = DMatrix::zeros(3, 3);
@@ -1099,6 +1116,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_interpolate_covariance_two_wasserstein_smatrix_singular_error() {
         let cov1 = SMatrix::<f64, 3, 3>::zeros();
         let cov2 = SMatrix::<f64, 3, 3>::identity();
@@ -1108,6 +1126,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_interpolate_covariance_two_wasserstein_dmatrix_first_not_psd_error() {
         // C1 itself has no real square root.
         let cov1 = DMatrix::from_row_slice(2, 2, &[1.0, 0.0, 0.0, -4.0]);
@@ -1118,6 +1137,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_interpolate_covariance_two_wasserstein_dmatrix_second_not_psd_error() {
         // C1 is fine, but C1^{1/2} C2 C1^{1/2} inherits C2's negative direction.
         let cov1 = DMatrix::identity(2, 2);

--- a/src/math/linalg.rs
+++ b/src/math/linalg.rs
@@ -605,6 +605,32 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_sqrtm_error_negative_eigenvalue_masked_by_scale() {
+        // No real square root, but the negative eigenvalue is small next to the
+        // matrix norm. A residual bound scaled by the whole matrix would accept
+        // this; the per-column bound rejects it.
+        let mat = na::SMatrix::<f64, 2, 2>::new(1e12, 0.0, 0.0, -100.0);
+
+        let err = sqrtm(mat).unwrap_err();
+        assert!(
+            err.contains("column"),
+            "expected a per-column accuracy failure, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_sqrtm_large_magnitude_accepted() {
+        // The Wiki case scaled up. The residual is large in absolute terms but
+        // negligible against the entries, so it must still be accepted.
+        let mat = na::SMatrix::<f64, 2, 2>::new(33.0e10, 24.0e10, 48.0e10, 57.0e10);
+
+        let root = sqrtm(mat).unwrap();
+        let expected = na::SMatrix::<f64, 2, 2>::new(5.0e5, 2.0e5, 4.0e5, 7.0e5);
+        assert!((root - expected).norm() / expected.norm() < 1e-10);
+    }
+
     // =========================================================================
     // sqrtm_dmatrix Tests
     // =========================================================================
@@ -640,6 +666,29 @@ mod tests {
         let sqrt_diag = sqrtm_dmatrix(&diag).unwrap();
         let expected = na::DMatrix::from_row_slice(2, 2, &[2.0, 0.0, 0.0, 3.0]);
         assert!((&sqrt_diag - &expected).norm() < 1e-10);
+    }
+
+    #[test]
+    fn test_sqrtm_dmatrix_error_negative_eigenvalue_masked_by_scale() {
+        // Dynamic mirror of test_sqrtm_error_negative_eigenvalue_masked_by_scale.
+        let mat = na::DMatrix::from_row_slice(2, 2, &[1e12, 0.0, 0.0, -100.0]);
+
+        let err = sqrtm_dmatrix(&mat).unwrap_err();
+        assert!(
+            err.contains("column"),
+            "expected a per-column accuracy failure, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_sqrtm_dmatrix_large_magnitude_accepted() {
+        // Dynamic mirror of test_sqrtm_large_magnitude_accepted.
+        let mat = na::DMatrix::from_row_slice(2, 2, &[33.0e10, 24.0e10, 48.0e10, 57.0e10]);
+
+        let root = sqrtm_dmatrix(&mat).unwrap();
+        let expected = na::DMatrix::from_row_slice(2, 2, &[5.0e5, 2.0e5, 4.0e5, 7.0e5]);
+        assert!((root - &expected).norm() / expected.norm() < 1e-10);
     }
 
     #[test]

--- a/src/math/linalg.rs
+++ b/src/math/linalg.rs
@@ -738,6 +738,32 @@ mod tests {
     }
 
     #[test]
+    fn test_spd_sqrtm_dmatrix_non_square_error() {
+        let mat = na::DMatrix::from_row_slice(2, 3, &[1.0, 0.0, 0.0, 0.0, 1.0, 0.0]);
+        let err = spd_sqrtm_dmatrix(&mat).unwrap_err();
+        assert!(err.contains("square"), "got: {}", err);
+    }
+
+    #[test]
+    fn test_spd_sqrtm_dmatrix_negative_eigenvalue_error() {
+        // Negative well beyond what round-off could explain.
+        let mat = na::DMatrix::from_row_slice(2, 2, &[4.0, 0.0, 0.0, -9.0]);
+        let err = spd_sqrtm_dmatrix(&mat).unwrap_err();
+        assert!(err.contains("positive semi-definite"), "got: {}", err);
+    }
+
+    #[test]
+    fn test_spd_sqrtm_dmatrix_clamps_roundoff_negative_eigenvalue() {
+        // A negative eigenvalue at round-off level relative to the largest is
+        // treated as zero rather than rejected, which a propagated covariance
+        // routinely produces.
+        let mat = na::DMatrix::from_row_slice(2, 2, &[1e6, 0.0, 0.0, -1e-9]);
+        let root = spd_sqrtm_dmatrix(&mat).expect("round-off negative must be clamped");
+        assert!((root[(0, 0)] - 1e3).abs() < 1e-6);
+        assert!(root[(1, 1)].abs() < 1e-6);
+    }
+
+    #[test]
     fn test_sqrtm_dmatrix_error_negative_eigenvalue_masked_by_scale() {
         // Dynamic mirror of test_sqrtm_error_negative_eigenvalue_masked_by_scale.
         let mat = na::DMatrix::from_row_slice(2, 2, &[1e12, 0.0, 0.0, -100.0]);

--- a/src/math/linalg.rs
+++ b/src/math/linalg.rs
@@ -257,7 +257,12 @@ where
     let mut z = na::DMatrix::<f64>::identity(N, N);
 
     const MAX_ITERATIONS: usize = 50;
-    const TOLERANCE: f64 = 1e-10;
+    const TOLERANCE: f64 = 1e-12;
+
+    // Tolerances scale with the magnitude of the input. Covariance products
+    // reach norms of 1e12 or more, where a fixed absolute threshold cannot be
+    // met even by a fully converged iteration.
+    let scale = a.norm().max(1.0);
 
     for _ in 0..MAX_ITERATIONS {
         // Compute inverses
@@ -275,7 +280,7 @@ where
 
         // Check convergence: ||Y_{k+1} - Y_k|| < tolerance
         let diff = (&y_new - &y).norm();
-        if diff < TOLERANCE {
+        if diff < TOLERANCE * scale {
             y = y_new;
             break;
         }
@@ -284,14 +289,21 @@ where
         z = z_new;
     }
 
-    // Verify the result: Y * Y should equal A
+    // Verify the result: Y * Y should equal A. Compare column by column so a
+    // poorly resolved direction cannot be hidden by a larger one dominating the
+    // norm; a single global bound would accept a negative eigenvalue whose
+    // magnitude is small next to the rest of the matrix.
     let check = &y * &y;
-    let error = (&check - &a).norm();
-    if error > 1e-8 {
-        return Err(format!(
-            "Matrix square root did not converge to sufficient accuracy (error: {})",
-            error
-        ));
+    let residual = &check - &a;
+    for j in 0..N {
+        let col_error = residual.column(j).norm();
+        let col_scale = a.column(j).norm().max(1.0);
+        if col_error > 1e-8 * col_scale {
+            return Err(format!(
+                "Matrix square root did not converge to sufficient accuracy (column {} error: {})",
+                j, col_error
+            ));
+        }
     }
 
     // Convert back to SMatrix
@@ -360,7 +372,12 @@ pub fn sqrtm_dmatrix(matrix: &na::DMatrix<f64>) -> Result<na::DMatrix<f64>, Stri
     let mut z = na::DMatrix::<f64>::identity(n, n);
 
     const MAX_ITERATIONS: usize = 50;
-    const TOLERANCE: f64 = 1e-10;
+    const TOLERANCE: f64 = 1e-12;
+
+    // Tolerances scale with the magnitude of the input. Covariance products
+    // reach norms of 1e12 or more, where a fixed absolute threshold cannot be
+    // met even by a fully converged iteration.
+    let scale = matrix.norm().max(1.0);
 
     for _ in 0..MAX_ITERATIONS {
         // Compute inverses
@@ -378,7 +395,7 @@ pub fn sqrtm_dmatrix(matrix: &na::DMatrix<f64>) -> Result<na::DMatrix<f64>, Stri
 
         // Check convergence: ||Y_{k+1} - Y_k|| < tolerance
         let diff = (&y_new - &y).norm();
-        if diff < TOLERANCE {
+        if diff < TOLERANCE * scale {
             y = y_new;
             break;
         }
@@ -387,14 +404,21 @@ pub fn sqrtm_dmatrix(matrix: &na::DMatrix<f64>) -> Result<na::DMatrix<f64>, Stri
         z = z_new;
     }
 
-    // Verify the result: Y * Y should equal A
+    // Verify the result: Y * Y should equal A. Compare column by column so a
+    // poorly resolved direction cannot be hidden by a larger one dominating the
+    // norm; a single global bound would accept a negative eigenvalue whose
+    // magnitude is small next to the rest of the matrix.
     let check = &y * &y;
-    let error = (&check - matrix).norm();
-    if error > 1e-8 {
-        return Err(format!(
-            "Matrix square root did not converge to sufficient accuracy (error: {})",
-            error
-        ));
+    let residual = &check - matrix;
+    for j in 0..n {
+        let col_error = residual.column(j).norm();
+        let col_scale = matrix.column(j).norm().max(1.0);
+        if col_error > 1e-8 * col_scale {
+            return Err(format!(
+                "Matrix square root did not converge to sufficient accuracy (column {} error: {})",
+                j, col_error
+            ));
+        }
     }
 
     Ok(y)

--- a/src/math/linalg.rs
+++ b/src/math/linalg.rs
@@ -228,16 +228,16 @@ where
 ///
 /// # Examples
 ///
-/// ```
+/// ```ignore
 /// use nalgebra::DMatrix;
-/// use brahe::math::linalg::spd_sqrtm_dmatrix;
+/// use crate::math::linalg::spd_sqrtm_dmatrix;
 ///
 /// let diag = DMatrix::from_row_slice(2, 2, &[4.0, 0.0, 0.0, 9.0]);
 /// let root = spd_sqrtm_dmatrix(&diag).unwrap();
 /// let expected = DMatrix::from_row_slice(2, 2, &[2.0, 0.0, 0.0, 3.0]);
 /// assert!((root - expected).norm() < 1e-10);
 /// ```
-pub fn spd_sqrtm_dmatrix(matrix: &na::DMatrix<f64>) -> Result<na::DMatrix<f64>, String> {
+pub(crate) fn spd_sqrtm_dmatrix(matrix: &na::DMatrix<f64>) -> Result<na::DMatrix<f64>, String> {
     if matrix.nrows() != matrix.ncols() {
         return Err(format!(
             "Matrix must be square, got {}x{}",
@@ -330,8 +330,12 @@ where
 
     // Tolerances scale with the magnitude of the input. Covariance products
     // reach norms of 1e12 or more, where a fixed absolute threshold cannot be
-    // met even by a fully converged iteration.
+    // met even by a fully converged iteration. The iterate tracks the square
+    // root, so its convergence is measured against the root's magnitude, not
+    // the matrix's; the residual below is a difference of matrices and keeps
+    // the matrix scale.
     let scale = a.norm().max(1.0);
+    let root_scale = scale.sqrt();
 
     for _ in 0..MAX_ITERATIONS {
         // Compute inverses
@@ -349,7 +353,7 @@ where
 
         // Check convergence: ||Y_{k+1} - Y_k|| < tolerance
         let diff = (&y_new - &y).norm();
-        if diff < TOLERANCE * scale {
+        if diff < TOLERANCE * root_scale {
             y = y_new;
             break;
         }
@@ -445,8 +449,12 @@ pub fn sqrtm_dmatrix(matrix: &na::DMatrix<f64>) -> Result<na::DMatrix<f64>, Stri
 
     // Tolerances scale with the magnitude of the input. Covariance products
     // reach norms of 1e12 or more, where a fixed absolute threshold cannot be
-    // met even by a fully converged iteration.
+    // met even by a fully converged iteration. The iterate tracks the square
+    // root, so its convergence is measured against the root's magnitude, not
+    // the matrix's; the residual below is a difference of matrices and keeps
+    // the matrix scale.
     let scale = matrix.norm().max(1.0);
+    let root_scale = scale.sqrt();
 
     for _ in 0..MAX_ITERATIONS {
         // Compute inverses
@@ -464,7 +472,7 @@ pub fn sqrtm_dmatrix(matrix: &na::DMatrix<f64>) -> Result<na::DMatrix<f64>, Stri
 
         // Check convergence: ||Y_{k+1} - Y_k|| < tolerance
         let diff = (&y_new - &y).norm();
-        if diff < TOLERANCE * scale {
+        if diff < TOLERANCE * root_scale {
             y = y_new;
             break;
         }
@@ -675,6 +683,44 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::parallel]
+    fn test_sqrtm_converges_at_large_magnitude() {
+        // The iterate tracks the square root, so a stopping test scaled by the
+        // matrix norm stops short by roughly the square root of that norm.
+        for magnitude in [1e4_f64, 1e12, 1e20, 1e24] {
+            let mat = na::SMatrix::<f64, 1, 1>::new(magnitude);
+            let root = sqrtm(mat).unwrap_or_else(|e| panic!("magnitude {magnitude:e}: {e}"));
+            let expected = magnitude.sqrt();
+            let relative = (root[(0, 0)] - expected).abs() / expected;
+            assert!(
+                relative < 1e-12,
+                "magnitude {:e}: relative root error {:e}",
+                magnitude,
+                relative
+            );
+        }
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_sqrtm_dmatrix_converges_at_large_magnitude() {
+        for magnitude in [1e4_f64, 1e12, 1e20, 1e24] {
+            let mat = na::DMatrix::from_row_slice(1, 1, &[magnitude]);
+            let root =
+                sqrtm_dmatrix(&mat).unwrap_or_else(|e| panic!("magnitude {magnitude:e}: {e}"));
+            let expected = magnitude.sqrt();
+            let relative = (root[(0, 0)] - expected).abs() / expected;
+            assert!(
+                relative < 1e-12,
+                "magnitude {:e}: relative root error {:e}",
+                magnitude,
+                relative
+            );
+        }
+    }
+
+    #[test]
+    #[serial_test::parallel]
     fn test_sqrtm_error_negative_eigenvalue_masked_by_scale() {
         // No real square root, but the negative eigenvalue is small next to the
         // matrix norm. A residual bound scaled by the whole matrix would accept
@@ -690,6 +736,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_sqrtm_large_magnitude_accepted() {
         // The Wiki case scaled up. The residual is large in absolute terms but
         // negligible against the entries, so it must still be accepted.
@@ -738,6 +785,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_spd_sqrtm_dmatrix_non_square_error() {
         let mat = na::DMatrix::from_row_slice(2, 3, &[1.0, 0.0, 0.0, 0.0, 1.0, 0.0]);
         let err = spd_sqrtm_dmatrix(&mat).unwrap_err();
@@ -745,6 +793,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_spd_sqrtm_dmatrix_negative_eigenvalue_error() {
         // Negative well beyond what round-off could explain.
         let mat = na::DMatrix::from_row_slice(2, 2, &[4.0, 0.0, 0.0, -9.0]);
@@ -753,6 +802,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_spd_sqrtm_dmatrix_clamps_roundoff_negative_eigenvalue() {
         // A negative eigenvalue at round-off level relative to the largest is
         // treated as zero rather than rejected, which a propagated covariance
@@ -764,6 +814,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_sqrtm_dmatrix_error_negative_eigenvalue_masked_by_scale() {
         // Dynamic mirror of test_sqrtm_error_negative_eigenvalue_masked_by_scale.
         let mat = na::DMatrix::from_row_slice(2, 2, &[1e12, 0.0, 0.0, -100.0]);
@@ -777,6 +828,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::parallel]
     fn test_sqrtm_dmatrix_large_magnitude_accepted() {
         // Dynamic mirror of test_sqrtm_large_magnitude_accepted.
         let mat = na::DMatrix::from_row_slice(2, 2, &[33.0e10, 24.0e10, 48.0e10, 57.0e10]);

--- a/src/math/linalg.rs
+++ b/src/math/linalg.rs
@@ -256,6 +256,12 @@ pub fn spd_sqrtm_dmatrix(matrix: &na::DMatrix<f64>) -> Result<na::DMatrix<f64>, 
 
     let mut roots = eigen.eigenvalues.clone();
     for value in roots.iter_mut() {
+        if !value.is_finite() {
+            return Err(format!(
+                "Symmetric eigendecomposition did not converge: eigenvalue {}",
+                value
+            ));
+        }
         if *value < -tolerance {
             return Err(format!(
                 "Matrix is not positive semi-definite: found negative eigenvalue {}",

--- a/src/math/linalg.rs
+++ b/src/math/linalg.rs
@@ -206,6 +206,69 @@ where
     Ok(result)
 }
 
+/// Compute the matrix square root of a symmetric positive semi-definite matrix.
+///
+/// Uses a symmetric eigendecomposition, which stays accurate on the
+/// ill-conditioned matrices that arise from propagated covariances. The
+/// Denman-Beavers iteration used by [`sqrtm_dmatrix`] for general matrices
+/// breaks down well before this does.
+///
+/// The input is symmetrized before decomposition, and eigenvalues that are
+/// negative only to within round-off are clamped to zero rather than rejected,
+/// since a propagated covariance routinely carries such values.
+///
+/// # Arguments
+///
+/// * `matrix` - A symmetric positive semi-definite matrix
+///
+/// # Returns
+///
+/// * `Result<DMatrix<f64>, String>` - The matrix square root, or an error if the
+///   matrix is not square or has a negative eigenvalue too large to be round-off
+///
+/// # Examples
+///
+/// ```
+/// use nalgebra::DMatrix;
+/// use brahe::math::linalg::spd_sqrtm_dmatrix;
+///
+/// let diag = DMatrix::from_row_slice(2, 2, &[4.0, 0.0, 0.0, 9.0]);
+/// let root = spd_sqrtm_dmatrix(&diag).unwrap();
+/// let expected = DMatrix::from_row_slice(2, 2, &[2.0, 0.0, 0.0, 3.0]);
+/// assert!((root - expected).norm() < 1e-10);
+/// ```
+pub fn spd_sqrtm_dmatrix(matrix: &na::DMatrix<f64>) -> Result<na::DMatrix<f64>, String> {
+    if matrix.nrows() != matrix.ncols() {
+        return Err(format!(
+            "Matrix must be square, got {}x{}",
+            matrix.nrows(),
+            matrix.ncols()
+        ));
+    }
+
+    // Symmetrize first: a covariance assembled numerically carries asymmetry at
+    // round-off level, and the decomposition assumes exact symmetry.
+    let symmetric = (matrix + matrix.transpose()) * 0.5;
+    let eigen = SymmetricEigen::new(symmetric);
+
+    let max_eigenvalue = eigen.eigenvalues.amax();
+    let tolerance = 1e-12 * max_eigenvalue.max(1.0);
+
+    let mut roots = eigen.eigenvalues.clone();
+    for value in roots.iter_mut() {
+        if *value < -tolerance {
+            return Err(format!(
+                "Matrix is not positive semi-definite: found negative eigenvalue {}",
+                value
+            ));
+        }
+        *value = value.max(0.0).sqrt();
+    }
+
+    let v = &eigen.eigenvectors;
+    Ok(v * na::DMatrix::from_diagonal(&roots) * v.transpose())
+}
+
 /// Compute the matrix square root of a general square matrix.
 ///
 /// This function computes the square root of a general (possibly non-symmetric) square matrix

--- a/src/propagators/dnumerical_orbit_propagator.rs
+++ b/src/propagators/dnumerical_orbit_propagator.rs
@@ -1556,9 +1556,17 @@ impl DNumericalOrbitPropagator {
             return Ok(EventProcessingResult::NoEvents);
         }
 
-        // 1. Sort events chronologically by window_open time
+        // 1. Sort events in the order the propagation encounters them. Going
+        // backward that is descending in time, so the first callback picked
+        // below is the one actually reached first.
         let mut sorted_events = detected_events;
-        sorted_events.sort_by(|(_, a), (_, b)| a.window_open.partial_cmp(&b.window_open).unwrap());
+        if self.dt >= 0.0 {
+            sorted_events
+                .sort_by(|(_, a), (_, b)| a.window_open.partial_cmp(&b.window_open).unwrap());
+        } else {
+            sorted_events
+                .sort_by(|(_, a), (_, b)| b.window_open.partial_cmp(&a.window_open).unwrap());
+        }
 
         // 2. Find first event with callback
         let first_callback_idx = sorted_events
@@ -3828,6 +3836,7 @@ mod tests {
     use crate::eop::{EOPExtrapolation, FileEOPProvider, set_global_eop_provider};
     use crate::events::{DAltitudeEvent, DTimeEvent, EventDirection};
     use crate::frames::position_eci_to_ecef;
+    use crate::integrators::IntegratorConfig;
     use crate::orbit_dynamics::gravity::{
         GravityModelType, set_global_gravity_model, set_global_gravity_model_to_tide_system,
     };
@@ -6694,6 +6703,125 @@ mod tests {
 
     #[test]
     #[serial_test::parallel]
+    fn test_dnumericalorbitpropagator_event_backward_bracket_ordering() {
+        setup_global_test_eop();
+
+        let epoch = Epoch::from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+        let state = DVector::from_vec(vec![R_EARTH + 500e3, 0.0, 0.0, 0.0, 7500.0, 0.0]);
+
+        // Wide steps so the backward refinement runs on a bracket broad enough
+        // to expose the ordering of its bounds.
+        let config = NumericalPropagationConfig {
+            integrator: IntegratorConfig {
+                abs_tol: 1e-1,
+                rel_tol: 1e-2,
+                initial_step: Some(900.0),
+                max_step: Some(900.0),
+                ..IntegratorConfig::default()
+            },
+            ..NumericalPropagationConfig::default()
+        };
+
+        let mut prop = DNumericalOrbitPropagator::new(
+            epoch,
+            state,
+            config,
+            ForceModelConfig::earth_gravity(),
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+        prop.propagate_to(epoch + 3600.0).unwrap();
+
+        // Target an event strictly inside the backward interval so the
+        // refinement runs on a bracket whose bounds arrive reversed in time.
+        let event_epoch = epoch + 1800.0;
+        prop.clear_events();
+        prop.add_event_detector(Box::new(DTimeEvent::new(event_epoch, "Backward Event")));
+
+        prop.propagate_to(epoch + 1200.0).unwrap();
+
+        assert_eq!(prop.current_epoch(), epoch + 1200.0);
+
+        let detected = prop
+            .event_log()
+            .iter()
+            .find(|e| e.name == "Backward Event")
+            .expect("Event inside the backward interval should be detected");
+        assert!(
+            (detected.window_open - event_epoch).abs() < 1e-3,
+            "Event should be located at its target epoch, off by {} s",
+            detected.window_open - event_epoch
+        );
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_dnumericalorbitpropagator_backward_callback_order() {
+        use std::sync::{Arc, Mutex};
+
+        setup_global_test_eop();
+
+        let epoch = Epoch::from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+        let state = DVector::from_vec(vec![R_EARTH + 500e3, 0.0, 0.0, 0.0, 7500.0, 0.0]);
+
+        // A single 1000 s step so both events fall inside one step and the
+        // ordering within process_events_smart is what decides which fires.
+        let config = NumericalPropagationConfig {
+            integrator: IntegratorConfig {
+                abs_tol: 1e-1,
+                rel_tol: 1e-2,
+                initial_step: Some(1000.0),
+                max_step: Some(1000.0),
+                ..IntegratorConfig::default()
+            },
+            ..NumericalPropagationConfig::default()
+        };
+
+        let mut prop = DNumericalOrbitPropagator::new(
+            epoch,
+            state,
+            config,
+            ForceModelConfig::two_body_gravity(),
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+        prop.propagate_to(epoch + 1000.0).unwrap();
+
+        // Two callbacks inside the single backward step. Travelling backward
+        // the later one is reached first, so it must fire first.
+        let order = Arc::new(Mutex::new(Vec::<&'static str>::new()));
+        for (offset, tag) in [(800.0, "late"), (200.0, "early")] {
+            let order = Arc::clone(&order);
+            prop.add_event_detector(Box::new(
+                DTimeEvent::new(epoch + offset, tag).with_callback(Box::new(
+                    move |_t, state, _params| {
+                        order.lock().unwrap().push(tag);
+                        (Some(state.clone()), None, EventAction::Continue)
+                    },
+                )),
+            ));
+        }
+
+        prop.propagate_to(epoch).unwrap();
+
+        let fired = order.lock().unwrap().clone();
+        assert_eq!(
+            fired,
+            vec!["late", "early"],
+            "Backward propagation must reach the later event first"
+        );
+    }
+
+    #[test]
+    #[serial_test::parallel]
     fn test_dnumericalorbitpropagator_event_detection_log_persistence_across_reset_termination() {
         setup_global_test_eop();
 
@@ -6840,7 +6968,6 @@ mod tests {
         );
 
         // Use fixed-step RK4 with 900-second steps to ensure both events occur in same step
-        use crate::integrators::IntegratorConfig;
         use crate::propagators::IntegratorMethod;
         let prop_config = NumericalPropagationConfig {
             method: IntegratorMethod::RK4,

--- a/src/propagators/dnumerical_propagator.rs
+++ b/src/propagators/dnumerical_propagator.rs
@@ -978,9 +978,17 @@ impl DNumericalPropagator {
             return Ok(EventProcessingResult::NoEvents);
         }
 
-        // 1. Sort events chronologically by window_open time
+        // 1. Sort events in the order the propagation encounters them. Going
+        // backward that is descending in time, so the first callback picked
+        // below is the one actually reached first.
         let mut sorted_events = detected_events;
-        sorted_events.sort_by(|(_, a), (_, b)| a.window_open.partial_cmp(&b.window_open).unwrap());
+        if self.dt >= 0.0 {
+            sorted_events
+                .sort_by(|(_, a), (_, b)| a.window_open.partial_cmp(&b.window_open).unwrap());
+        } else {
+            sorted_events
+                .sort_by(|(_, a), (_, b)| b.window_open.partial_cmp(&a.window_open).unwrap());
+        }
 
         // 2. Find first event with callback
         let first_callback_idx = sorted_events

--- a/src/propagators/dnumerical_propagator.rs
+++ b/src/propagators/dnumerical_propagator.rs
@@ -2327,6 +2327,7 @@ impl Identifiable for DNumericalPropagator {
 mod tests {
     use super::*;
     use crate::events::{DEventCallback, DTimeEvent, DValueEvent, EventDirection};
+    use crate::integrators::IntegratorConfig;
     use crate::propagators::NumericalPropagationConfig;
     use crate::propagators::traits::DStatePropagator as DStatePropagatorTrait;
     use crate::time::TimeSystem;
@@ -3827,6 +3828,100 @@ mod tests {
         assert!(prop.terminated());
         let time_diff: f64 = prop.current_epoch() - (initial_epoch + 5.0);
         assert!(time_diff.abs() < 1.0);
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_dnumericalpropagator_backward_callback_order() {
+        use crate::events::EventAction;
+        use std::sync::{Arc, Mutex};
+
+        let epoch = Epoch::from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+        let state = DVector::from_vec(vec![1.0, 0.0]);
+        // A slow oscillator so a single 10 s step is accepted and spans both
+        // events; the ordering inside process_events_smart then decides which
+        // callback fires. At the default omega the step would be rejected and
+        // the events would land in separate steps, hiding the ordering.
+        let config = NumericalPropagationConfig {
+            integrator: IntegratorConfig {
+                abs_tol: 1e-1,
+                rel_tol: 1e-1,
+                initial_step: Some(10.0),
+                max_step: Some(10.0),
+                ..IntegratorConfig::default()
+            },
+            ..NumericalPropagationConfig::default()
+        };
+        let mut prop =
+            DNumericalPropagator::new(epoch, state, sho_dynamics(0.01), config, None, None, None)
+                .unwrap();
+
+        prop.propagate_to(epoch + 10.0).unwrap();
+
+        let order = Arc::new(Mutex::new(Vec::<&'static str>::new()));
+        for (offset, tag) in [(8.0, "late"), (2.0, "early")] {
+            let order = Arc::clone(&order);
+            let callback: DEventCallback = Box::new(move |_epoch, state, _params| {
+                order.lock().unwrap().push(tag);
+                (Some(state.clone()), None, EventAction::Continue)
+            });
+            prop.add_event_detector(Box::new(
+                DTimeEvent::new(epoch + offset, tag.to_string()).with_callback(callback),
+            ));
+        }
+
+        prop.propagate_to(epoch).unwrap();
+
+        let fired = order.lock().unwrap().clone();
+        assert_eq!(
+            fired,
+            vec!["late", "early"],
+            "Backward propagation must reach the later event first"
+        );
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_dnumericalpropagator_forward_callback_order() {
+        use crate::events::EventAction;
+        use std::sync::{Arc, Mutex};
+
+        let epoch = Epoch::from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+        let state = DVector::from_vec(vec![1.0, 0.0]);
+        let config = NumericalPropagationConfig {
+            integrator: IntegratorConfig {
+                abs_tol: 1e-1,
+                rel_tol: 1e-1,
+                initial_step: Some(10.0),
+                max_step: Some(10.0),
+                ..IntegratorConfig::default()
+            },
+            ..NumericalPropagationConfig::default()
+        };
+        let mut prop =
+            DNumericalPropagator::new(epoch, state, sho_dynamics(0.01), config, None, None, None)
+                .unwrap();
+
+        let order = Arc::new(Mutex::new(Vec::<&'static str>::new()));
+        for (offset, tag) in [(8.0, "late"), (2.0, "early")] {
+            let order = Arc::clone(&order);
+            let callback: DEventCallback = Box::new(move |_epoch, state, _params| {
+                order.lock().unwrap().push(tag);
+                (Some(state.clone()), None, EventAction::Continue)
+            });
+            prop.add_event_detector(Box::new(
+                DTimeEvent::new(epoch + offset, tag.to_string()).with_callback(callback),
+            ));
+        }
+
+        prop.propagate_to(epoch + 10.0).unwrap();
+
+        let fired = order.lock().unwrap().clone();
+        assert_eq!(
+            fired,
+            vec!["early", "late"],
+            "Forward propagation must reach the earlier event first"
+        );
     }
 
     #[test]

--- a/src/propagators/sgp_propagator.rs
+++ b/src/propagators/sgp_propagator.rs
@@ -1936,8 +1936,14 @@ impl SGPPropagator {
             }
         }
 
-        // Sort events chronologically
-        events.sort_by(|a, b| a.window_open.partial_cmp(&b.window_open).unwrap());
+        // Sort events in the order the propagation encounters them. Going
+        // backward that is descending in time, so the caller processes the one
+        // actually reached first and stops there if it is terminal.
+        if epoch_curr >= epoch_prev {
+            events.sort_by(|a, b| a.window_open.partial_cmp(&b.window_open).unwrap());
+        } else {
+            events.sort_by(|a, b| b.window_open.partial_cmp(&a.window_open).unwrap());
+        }
 
         events
     }
@@ -4262,6 +4268,44 @@ mod tests {
 
         // Event time should be very close to target
         assert_abs_diff_eq!(events[0].window_open.jd(), target_time.jd(), epsilon = 1e-8);
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_sgppropagator_backward_event_order() {
+        use crate::events::EventAction;
+        use std::sync::{Arc, Mutex};
+
+        setup_global_test_eop();
+        // A step wide enough to contain both events, so the order the scan
+        // returns them is what decides which callback runs first.
+        let mut prop = SGPPropagator::from_tle(ISS_LINE1, ISS_LINE2, 600.0).unwrap();
+        let epoch = prop.initial_epoch();
+
+        prop.propagate_to(epoch + 600.0).unwrap();
+        prop.clear_events();
+
+        let order = Arc::new(Mutex::new(Vec::<&'static str>::new()));
+        for (offset, tag) in [(480.0, "late"), (120.0, "early")] {
+            let order = Arc::clone(&order);
+            prop.add_event_detector(Box::new(
+                DTimeEvent::new(epoch + offset, tag).with_callback(Box::new(
+                    move |_t, state, _params| {
+                        order.lock().unwrap().push(tag);
+                        (Some(state.clone()), None, EventAction::Continue)
+                    },
+                )),
+            ));
+        }
+
+        prop.step_by(-600.0).unwrap();
+
+        let fired = order.lock().unwrap().clone();
+        assert_eq!(
+            fired,
+            vec!["late", "early"],
+            "Backward propagation must reach the later event first"
+        );
     }
 
     #[test]

--- a/tests/propagators/test_numerical_orbit_propagator.py
+++ b/tests/propagators/test_numerical_orbit_propagator.py
@@ -17,11 +17,13 @@ from brahe import (
     ForceModelConfig,
     GravityConfiguration,
     IntegrationMethod,
+    IntegratorConfig,
     NumericalOrbitPropagator,
     NumericalPropagationConfig,
     OrbitFrame,
     ReferenceFrame,
     TimeSystem,
+    VariationalConfig,
     orbital_period,
     periapsis_velocity,
     spk_state,
@@ -1607,6 +1609,91 @@ def test_numericalorbitpropagator_event_backward_propagation():
     # Events during backward propagation may or may not be detected
     # This test verifies the propagation completes without error
     assert True
+
+
+def test_numericalorbitpropagator_backward_event_bracket_ordering():
+    """Event inside a backward interval is found and located (mirrors Rust test)
+
+    Backward propagation hands the refinement its bracket bounds reversed in
+    time; an unordered bracket used to lose the event entirely.
+    """
+    from brahe import TimeEvent
+
+    epoch = create_test_epoch()
+    state = np.array([R_EARTH + 500e3, 0.0, 0.0, 0.0, 7500.0, 0.0])
+
+    prop = NumericalOrbitPropagator(
+        epoch,
+        state,
+        NumericalPropagationConfig(
+            IntegrationMethod.DP54,
+            IntegratorConfig(
+                abs_tol=1e-1, rel_tol=1e-2, initial_step=900.0, max_step=900.0
+            ),
+            VariationalConfig(),
+        ),
+        ForceModelConfig.earth_gravity(),
+        None,
+    )
+    prop.propagate_to(epoch + 3600.0)
+
+    event_epoch = epoch + 1800.0
+    prop.clear_events()
+    prop.add_event_detector(TimeEvent(event_epoch, "Backward Event"))
+
+    prop.propagate_to(epoch + 1200.0)
+
+    matches = [e for e in prop.event_log() if e.name == "Backward Event"]
+    assert len(matches) == 1, "event inside the backward interval must be detected"
+    assert abs(matches[0].window_open - event_epoch) < 1e-3
+
+
+def test_numericalorbitpropagator_backward_callback_order():
+    """Backward propagation reaches the later event first (mirrors Rust test)"""
+    from brahe import EventAction, TimeEvent
+
+    epoch = create_test_epoch()
+    state = np.array([R_EARTH + 500e3, 0.0, 0.0, 0.0, 7500.0, 0.0])
+
+    # One step spanning both events, so the ordering inside event processing is
+    # what decides which callback fires.
+    prop = NumericalOrbitPropagator(
+        epoch,
+        state,
+        NumericalPropagationConfig(
+            IntegrationMethod.DP54,
+            IntegratorConfig(
+                abs_tol=1e-1, rel_tol=1e-2, initial_step=1000.0, max_step=1000.0
+            ),
+            VariationalConfig(),
+        ),
+        ForceModelConfig.two_body(),
+        None,
+    )
+    prop.propagate_to(epoch + 1000.0)
+
+    fired = []
+
+    def make_callback(tag):
+        def callback(_epoch, state):
+            fired.append(tag)
+            return (state.copy(), EventAction.CONTINUE)
+
+        return callback
+
+    for offset, tag in ((800.0, "late"), (200.0, "early")):
+        prop.add_event_detector(
+            TimeEvent(epoch + offset, tag).with_callback(make_callback(tag))
+        )
+
+    # Force a single backward step spanning both events, so the ordering inside
+    # event processing is what decides which callback fires.
+    prop.step_size = 1000.0
+    prop.propagate_to(epoch)
+
+    assert fired == ["late", "early"], (
+        f"backward propagation must reach the later event first, got {fired}"
+    )
 
 
 def test_numericalorbitpropagator_event_log_persistence():

--- a/tests/propagators/test_numerical_orbit_propagator.py
+++ b/tests/propagators/test_numerical_orbit_propagator.py
@@ -3279,6 +3279,40 @@ def test_numericalorbitpropagator_value_event_velocity():
 # =============================================================================
 
 
+def test_numericalorbitpropagator_covariance_interpolation_long_arc():
+    """Covariance interpolation over a long arc (mirrors Rust interpolation tests)
+
+    Over a long arc the two bracketing covariances form a product too badly
+    conditioned for a general matrix square root, which used to fail outright.
+    Queried between stored nodes, the result must exist and be symmetric.
+    """
+    epoch = create_test_epoch()
+    state = np.array([R_EARTH + 500e3, 0.0, 0.0, 0.0, 7500.0, 0.0])
+
+    initial_covariance = np.diag([100.0, 100.0, 100.0, 1.0, 1.0, 1.0])
+
+    prop = NumericalOrbitPropagator(
+        epoch,
+        state,
+        NumericalPropagationConfig.default(),
+        ForceModelConfig.two_body(),
+        None,
+        initial_covariance,
+    )
+
+    prop.propagate_to(epoch + 160000.0)
+
+    # Deliberately between stored nodes so interpolation actually runs.
+    cov = prop.covariance_gcrf(epoch + 144030.0)
+
+    assert cov is not None
+    assert cov.shape == (6, 6)
+    assert np.all(np.isfinite(cov))
+    assert np.allclose(cov, cov.T, rtol=0.0, atol=1e-9 * np.linalg.norm(cov))
+    # Uncertainty grows away from the initial epoch.
+    assert cov[0, 0] > initial_covariance[0, 0]
+
+
 def test_numericalorbitpropagator_covariance_eci():
     """Test covariance_eci method if available (mirrors Rust test)"""
     epoch = create_test_epoch()


### PR DESCRIPTION
# Pull Request

## Description

Two defects in event detection during backward propagation, both reachable only once adaptive step sizes are unfrozen by #469.

`dscan_for_event` and `sscan_for_event` passed `prev_time` and `current_time` to the bisection search as low and high bounds unconditionally, and always stepped forward. Going backward, `current_time` precedes `prev_time`, so the bracket arrived inverted: the clamp jumped straight to the far bound, the bracket never narrowed, and the search recursed until the stack overflowed. The bounds are now ordered by time and the step direction derived from that ordering. The recursion is additionally bounded, and the step reduction factor clamped — contraction per level is `max(factor, 1 - factor)`, so a factor near either extreme stalls refinement, and the factor is an overridable trait method that a setter-side check would not cover.

`process_events_smart` sorted detected events ascending by `window_open` regardless of direction. Travelling backward the latest event is reached first, so picking the earliest fired the wrong callback and skipped every event above it. Events are now sorted in the order propagation encounters them.

## Changelog

### Fixed
- Event detection during backward propagation no longer overflows the stack; the bisection bracket bounds are ordered by time rather than assuming forward propagation, and the refinement recursion is bounded.
- Backward propagation no longer skips event callbacks; detected events within a step are processed in the order propagation reaches them rather than always ascending in time.

## Related Issue

Prerequisite for #461.

## Note to Reviewers

Both regression tests fail on this branch with only their respective fix reverted, so each discriminates independently: the bracket test loses the event outright, and the callback test fires `["early"]` instead of `["late", "early"]`. Reproducing the ordering defect requires both events inside a single step, which is why it needs an explicit wide-step configuration rather than the default.
