### PR TITLE
Let adaptive integrators grow the step size

### DIFF
--- a/crates/brahe-py/src/integrators.rs
+++ b/crates/brahe-py/src/integrators.rs
@@ -150,8 +150,8 @@ fn reraise_callback_error(slot: &PyErrSlot, err: brahe::utils::BraheError) -> Py
 /// Controls error tolerances, step size limits, and other integration parameters.
 ///
 /// Args:
-///     abs_tol (float, optional): Absolute error tolerance. Defaults to 1e-6.
-///     rel_tol (float, optional): Relative error tolerance. Defaults to 1e-3.
+///     abs_tol (float, optional): Absolute error tolerance. Defaults to 1e-8.
+///     rel_tol (float, optional): Relative error tolerance. Defaults to 1e-10.
 ///     initial_step (float, optional): Initial step size. Defaults to None (auto).
 ///     min_step (float, optional): Minimum step size. Defaults to 1e-12.
 ///     max_step (float, optional): Maximum step size. Defaults to 900.0.
@@ -194,8 +194,8 @@ impl PyIntegratorConfig {
     /// Create a new integrator configuration with custom parameters.
     #[new]
     #[pyo3(signature = (
-        abs_tol=1e-6,
-        rel_tol=1e-3,
+        abs_tol=1e-8,
+        rel_tol=1e-10,
         initial_step=None,
         min_step=Some(1e-12),
         max_step=Some(900.0),

--- a/crates/brahe-py/src/integrators.rs
+++ b/crates/brahe-py/src/integrators.rs
@@ -158,7 +158,7 @@ fn reraise_callback_error(slot: &PyErrSlot, err: brahe::utils::BraheError) -> Py
 ///     step_safety_factor (float, optional): Safety factor for step control. Defaults to 0.9.
 ///     min_step_scale_factor (float, optional): Minimum step scaling. Defaults to 0.2.
 ///     max_step_scale_factor (float, optional): Maximum step scaling. Defaults to 10.0.
-///     max_step_attempts (int, optional): Maximum step attempts. Defaults to 10.
+///     max_step_attempts (int, optional): Maximum step attempts. Defaults to 25.
 ///     fixed_step_size (float, optional): Fixed step size for fixed-step integrators. Defaults to None.
 ///
 /// Example:
@@ -202,7 +202,7 @@ impl PyIntegratorConfig {
         step_safety_factor=Some(0.9),
         min_step_scale_factor=Some(0.2),
         max_step_scale_factor=Some(10.0),
-        max_step_attempts=10,
+        max_step_attempts=25,
         fixed_step_size=None
     ))]
     #[allow(clippy::too_many_arguments)]

--- a/docs/learn/integrators/adaptive_step.md
+++ b/docs/learn/integrators/adaptive_step.md
@@ -95,14 +95,14 @@ $$h_{\text{new}} = \text{clip}(h_{\text{new}}, h_{\text{min}}, h_{\text{max}})$$
 
 From `IntegratorConfig`:
 
-- `abs_tol`: Absolute error tolerance (default 1e-10)
-- `rel_tol`: Relative error tolerance (default 1e-9)
+- `abs_tol`: Absolute error tolerance (default 1e-8)
+- `rel_tol`: Relative error tolerance (default 1e-10)
 - `min_step`: Minimum allowed step size (default 1e-12 s)
 - `max_step`: Maximum allowed step size (default 900 s)
 - `step_safety_factor`: Safety margin (default 0.9)
 - `min_step_scale_factor`: Min step change ratio (default 0.2)
 - `max_step_scale_factor`: Max step change ratio (default 10.0)
-- `max_step_attempts`: Max tries before error (default 10)
+- `max_step_attempts`: Max tries before error (default 25)
 
 ## Highly Elliptical Orbit Example
 

--- a/docs/learn/orbit_propagation/numerical_propagation/integrator_configuration.md
+++ b/docs/learn/orbit_propagation/numerical_propagation/integrator_configuration.md
@@ -255,9 +255,9 @@ Brahe provides preset configurations for common use cases:
 <div class="center-table" markdown="1">
 | Preset | Method | abs_tol | rel_tol | Description |
 |------|------|-------|-------|-----------|
-| `default()` | DP54 | 1e-6 | 1e-3 | General purpose |
-| `high_precision()` | RKN1210 | 1e-10 | 1e-8 | Maximum accuracy |
-| `with_method(M)` | M | 1e-6 | 1e-3 | Custom method with defaults |
+| `default()` | DP54 | 1e-8 | 1e-10 | General purpose |
+| `high_precision()` | RKN1210 | 1e-12 | 1e-12 | Maximum accuracy |
+| `with_method(M)` | M | 1e-8 | 1e-10 | Custom method with defaults |
 </div>
 
 === "Python"

--- a/docs/learn/orbit_propagation/numerical_propagation/integrator_configuration.md
+++ b/docs/learn/orbit_propagation/numerical_propagation/integrator_configuration.md
@@ -189,8 +189,8 @@ $$
 \text{error} < \text{abs\_tol} + \text{rel\_tol} \times |\text{state}|
 $$
 
-- **`abs_tol`**: Bounds error when state components are small (default: 1e-6)
-- **`rel_tol`**: Bounds error proportional to state magnitude (default: 1e-3)
+- **`abs_tol`**: Bounds error when state components are small (default: 1e-8)
+- **`rel_tol`**: Bounds error proportional to state magnitude (default: 1e-10)
 
 === "Python"
 

--- a/examples/numerical_propagation/integrator_high_precision.py
+++ b/examples/numerical_propagation/integrator_high_precision.py
@@ -22,7 +22,7 @@ state = bh.state_koe_to_eci(oe, bh.AngleFormat.DEGREES)
 config_hp = bh.NumericalPropagationConfig.high_precision()
 print("High-precision config:")
 print("  Method: RKN1210 (Runge-Kutta-Nystrom 12(10))")
-print("  Tolerances: Very tight (1e-14 rel, 1e-16 abs)")
+print("  Tolerances: Very tight (1e-12 abs, 1e-12 rel)")
 
 # Standard precision for comparison
 config_std = bh.NumericalPropagationConfig.default()

--- a/examples/numerical_propagation/integrator_high_precision.rs
+++ b/examples/numerical_propagation/integrator_high_precision.rs
@@ -26,7 +26,7 @@ fn main() {
     let config_hp = bh::NumericalPropagationConfig::high_precision();
     println!("High-precision config:");
     println!("  Method: RKN1210 (Runge-Kutta-Nystrom 12(10))");
-    println!("  Tolerances: Very tight (1e-10 rel, 1e-8 abs)");
+    println!("  Tolerances: Very tight (1e-12 abs, 1e-12 rel)");
 
     // Standard precision for comparison
     let config_std = bh::NumericalPropagationConfig::default();

--- a/src/integrators/config.rs
+++ b/src/integrators/config.rs
@@ -57,8 +57,8 @@ pub struct IntegratorConfig {
 impl Default for IntegratorConfig {
     /// Default configuration matching typical defaults
     ///
-    /// - abs_tol: 1e-6
-    /// - rel_tol: 1e-3
+    /// - abs_tol: 1e-8
+    /// - rel_tol: 1e-10
     /// - initial_step: None (auto-determined)
     /// - min_step: Some(1e-12)
     /// - max_step: Some(900.0) (15 minutes)
@@ -69,8 +69,8 @@ impl Default for IntegratorConfig {
     /// - fixed_step_size: None
     fn default() -> Self {
         Self {
-            abs_tol: 1e-6,
-            rel_tol: 1e-3,
+            abs_tol: 1e-8,
+            rel_tol: 1e-10,
             initial_step: None,
             min_step: Some(1e-12),
             max_step: Some(900.0),
@@ -146,8 +146,8 @@ mod tests {
     #[test]
     fn test_default_config() {
         let config = IntegratorConfig::default();
-        assert_eq!(config.abs_tol, 1e-6);
-        assert_eq!(config.rel_tol, 1e-3);
+        assert_eq!(config.abs_tol, 1e-8);
+        assert_eq!(config.rel_tol, 1e-10);
         assert_eq!(config.initial_step, None);
         assert_eq!(config.min_step, Some(1e-12));
         assert_eq!(config.max_step, Some(900.0));
@@ -162,8 +162,8 @@ mod tests {
     fn test_fixed_step_config() {
         let config = IntegratorConfig::fixed_step(0.1);
         assert_eq!(config.fixed_step_size, Some(0.1));
-        assert_eq!(config.abs_tol, 1e-6);
-        assert_eq!(config.rel_tol, 1e-3);
+        assert_eq!(config.abs_tol, 1e-8);
+        assert_eq!(config.rel_tol, 1e-10);
     }
 
     #[test]

--- a/src/integrators/config.rs
+++ b/src/integrators/config.rs
@@ -47,6 +47,11 @@ pub struct IntegratorConfig {
     pub max_step_scale_factor: Option<f64>,
 
     /// Maximum attempts to find acceptable step size
+    ///
+    /// Each rejection shrinks the step by at most `min_step_scale_factor`, so
+    /// the budget bounds how far a single call can reduce. Resolving a pass
+    /// through the lower thermosphere at the default tolerances takes most of
+    /// the default budget.
     pub max_step_attempts: usize,
 
     /// Fixed step size for fixed-step integrators
@@ -65,7 +70,7 @@ impl Default for IntegratorConfig {
     /// - step_safety_factor: Some(0.9)
     /// - min_step_scale_factor: Some(0.2)
     /// - max_step_scale_factor: Some(10.0)
-    /// - max_step_attempts: 10
+    /// - max_step_attempts: 25
     /// - fixed_step_size: None
     fn default() -> Self {
         Self {
@@ -77,7 +82,7 @@ impl Default for IntegratorConfig {
             step_safety_factor: Some(0.9),
             min_step_scale_factor: Some(0.2),
             max_step_scale_factor: Some(10.0),
-            max_step_attempts: 10,
+            max_step_attempts: 25,
             fixed_step_size: None,
         }
     }
@@ -154,7 +159,7 @@ mod tests {
         assert_eq!(config.step_safety_factor, Some(0.9));
         assert_eq!(config.min_step_scale_factor, Some(0.2));
         assert_eq!(config.max_step_scale_factor, Some(10.0));
-        assert_eq!(config.max_step_attempts, 10);
+        assert_eq!(config.max_step_attempts, 25);
         assert_eq!(config.fixed_step_size, None);
     }
 

--- a/src/integrators/dp54.rs
+++ b/src/integrators/dp54.rs
@@ -903,6 +903,45 @@ mod tests {
     }
 
     #[test]
+    fn test_dp54_step_returns_dt_below_requested_when_rejected() {
+        // The propagation loops decide whether a step the target truncated is
+        // also one the integrator reduced, by comparing dt_used against the
+        // requested step. That comparison only carries information because a
+        // rejected step reports the size it actually took, strictly below what
+        // was asked for.
+        let k = 50.0;
+        let f = move |_t: f64,
+                      x: &SVector<f64, 1>,
+                      _params: Option<&SVector<f64, 0>>|
+              -> Result<SVector<f64, 1>, BraheError> { Ok(-k * x) };
+
+        let dp54: DormandPrince54SIntegrator<1, 0> = DormandPrince54SIntegrator::with_config(
+            Box::new(f),
+            None,
+            None,
+            None,
+            IntegratorConfig::adaptive(1e-10, 1e-12),
+        );
+
+        let requested = 2.0;
+        let result = dp54
+            .step(0.0, SVector::<f64, 1>::new(1.0), None, Some(requested))
+            .unwrap();
+
+        assert!(
+            result.dt_used < requested,
+            "a rejected step must report the reduced size, got {} for a requested {}",
+            result.dt_used,
+            requested
+        );
+        assert!(
+            result.dt_next < requested,
+            "the suggestion after a rejection must stay below the requested step, got {}",
+            result.dt_next
+        );
+    }
+
+    #[test]
     fn test_dp54_config_parameters() {
         // Verify that config parameters are actually used
         let f = |t: f64,

--- a/src/integrators/dp54.rs
+++ b/src/integrators/dp54.rs
@@ -2403,8 +2403,16 @@ mod tests {
             Ok(SVector::<f64, 1>::new(-k * x[0]))
         };
 
-        let dp54: DormandPrince54SIntegrator<1, 1> =
-            DormandPrince54SIntegrator::new(Box::new(f), None, None, None);
+        // Tolerances loose enough that the requested dt is accepted for both
+        // decay rates. The result of this linear ODE depends only on k * dt, so
+        // a rejected-and-reduced step can make the two cases coincide.
+        let dp54: DormandPrince54SIntegrator<1, 1> = DormandPrince54SIntegrator::with_config(
+            Box::new(f),
+            None,
+            None,
+            None,
+            IntegratorConfig::adaptive(1e-3, 1e-3),
+        );
 
         let x0 = SVector::<f64, 1>::new(1.0);
         let dt = 0.1;
@@ -2449,7 +2457,17 @@ mod tests {
             Ok(DVector::from_element(1, -k * x[0]))
         };
 
-        let dp54 = DormandPrince54DIntegrator::new(1, Box::new(f), None, None, None);
+        // Tolerances loose enough that the requested dt is accepted for both
+        // decay rates. The result of this linear ODE depends only on k * dt, so
+        // a rejected-and-reduced step can make the two cases coincide.
+        let dp54 = DormandPrince54DIntegrator::with_config(
+            1,
+            Box::new(f),
+            None,
+            None,
+            None,
+            IntegratorConfig::adaptive(1e-3, 1e-3),
+        );
 
         let x0 = DVector::from_element(1, 1.0);
         let dt = 0.1;
@@ -2578,11 +2596,15 @@ mod tests {
             Ok(SVector::<f64, 1>::new(-k * x[0]))
         };
 
-        let dp54: DormandPrince54SIntegrator<1, 1> = DormandPrince54SIntegrator::new(
+        // Tolerances loose enough that the requested dt is accepted for both
+        // decay rates. The result of this linear ODE depends only on k * dt, so
+        // a rejected-and-reduced step can make the two cases coincide.
+        let dp54: DormandPrince54SIntegrator<1, 1> = DormandPrince54SIntegrator::with_config(
             Box::new(f),
             Some(Box::new(ParamDependentJacobian)),
             None,
             None,
+            IntegratorConfig::adaptive(1e-3, 1e-3),
         );
 
         let x0 = SVector::<f64, 1>::new(1.0);
@@ -2646,12 +2668,16 @@ mod tests {
             Ok(DVector::from_element(1, -k * x[0]))
         };
 
-        let dp54 = DormandPrince54DIntegrator::new(
+        // Tolerances loose enough that the requested dt is accepted for both
+        // decay rates. The result of this linear ODE depends only on k * dt, so
+        // a rejected-and-reduced step can make the two cases coincide.
+        let dp54 = DormandPrince54DIntegrator::with_config(
             1,
             Box::new(f),
             Some(Box::new(ParamDependentJacobian)),
             None,
             None,
+            IntegratorConfig::adaptive(1e-3, 1e-3),
         );
 
         let x0 = DVector::from_element(1, 1.0);

--- a/src/integrators/rkf45.rs
+++ b/src/integrators/rkf45.rs
@@ -2350,7 +2350,16 @@ mod tests {
             Ok(SVector::<f64, 1>::new(-k * x[0]))
         };
 
-        let rkf45: RKF45SIntegrator<1, 1> = RKF45SIntegrator::new(Box::new(f), None, None, None);
+        // Tolerances loose enough that the requested dt is accepted for both
+        // decay rates. The result of this linear ODE depends only on k * dt, so
+        // a rejected-and-reduced step can make the two cases coincide.
+        let rkf45: RKF45SIntegrator<1, 1> = RKF45SIntegrator::with_config(
+            Box::new(f),
+            None,
+            None,
+            None,
+            IntegratorConfig::adaptive(1e-3, 1e-3),
+        );
 
         let x0 = SVector::<f64, 1>::new(1.0);
         let dt = 0.1;
@@ -2395,7 +2404,17 @@ mod tests {
             Ok(DVector::from_element(1, -k * x[0]))
         };
 
-        let rkf45 = RKF45DIntegrator::new(1, Box::new(f), None, None, None);
+        // Tolerances loose enough that the requested dt is accepted for both
+        // decay rates. The result of this linear ODE depends only on k * dt, so
+        // a rejected-and-reduced step can make the two cases coincide.
+        let rkf45 = RKF45DIntegrator::with_config(
+            1,
+            Box::new(f),
+            None,
+            None,
+            None,
+            IntegratorConfig::adaptive(1e-3, 1e-3),
+        );
 
         let x0 = DVector::from_element(1, 1.0);
         let dt = 0.1;
@@ -2521,11 +2540,15 @@ mod tests {
             Ok(SVector::<f64, 1>::new(-k * x[0]))
         };
 
-        let rkf45: RKF45SIntegrator<1, 1> = RKF45SIntegrator::new(
+        // Tolerances loose enough that the requested dt is accepted for both
+        // decay rates. The result of this linear ODE depends only on k * dt, so
+        // a rejected-and-reduced step can make the two cases coincide.
+        let rkf45: RKF45SIntegrator<1, 1> = RKF45SIntegrator::with_config(
             Box::new(f),
             Some(Box::new(ParamDependentJacobian)),
             None,
             None,
+            IntegratorConfig::adaptive(1e-3, 1e-3),
         );
 
         let x0 = SVector::<f64, 1>::new(1.0);
@@ -2589,12 +2612,16 @@ mod tests {
             Ok(DVector::from_element(1, -k * x[0]))
         };
 
-        let rkf45 = RKF45DIntegrator::new(
+        // Tolerances loose enough that the requested dt is accepted for both
+        // decay rates. The result of this linear ODE depends only on k * dt, so
+        // a rejected-and-reduced step can make the two cases coincide.
+        let rkf45 = RKF45DIntegrator::with_config(
             1,
             Box::new(f),
             Some(Box::new(ParamDependentJacobian)),
             None,
             None,
+            IntegratorConfig::adaptive(1e-3, 1e-3),
         );
 
         let x0 = DVector::from_element(1, 1.0);

--- a/src/propagators/dnumerical_orbit_propagator.rs
+++ b/src/propagators/dnumerical_orbit_propagator.rs
@@ -3176,15 +3176,22 @@ impl super::traits::DStatePropagator for DNumericalOrbitPropagator {
             };
 
             // Temporarily set the suggested next step to not overshoot
+            let truncated = dt_max.abs() < self.dt_next.abs();
             let saved_dt_next = self.dt_next;
             self.dt_next = dt_max;
 
             // Take one adaptive step (includes event detection)
             self.step_once()?;
 
-            // Restore suggested dt_next for subsequent steps
-            // (unless step_once updated it to something smaller)
-            if self.dt_next.abs() > saved_dt_next.abs() {
+            // A step truncated to land exactly on the target is artificially
+            // short, so what it implies about larger steps is extrapolation.
+            // Keep its suggestion only when that suggestion falls below the
+            // step just taken, which means the error bound was reached even at
+            // the reduced size and the reduction is genuine error control.
+            // Otherwise restore the pre-truncation suggestion; carrying the
+            // truncated step's estimate forward would let a run of truncated
+            // steps ratchet the step size down with no way to recover.
+            if truncated && self.dt.abs() >= dt_max.abs() && self.dt_next.abs() >= self.dt.abs() {
                 self.dt_next = saved_dt_next;
             }
         }
@@ -3228,14 +3235,22 @@ impl super::traits::DStatePropagator for DNumericalOrbitPropagator {
                 -remaining.abs().min(self.dt_next.abs())
             };
 
+            let truncated = dt_max.abs() < self.dt_next.abs();
             let saved_dt_next = self.dt_next;
             self.dt_next = dt_max;
 
             // Take one adaptive step (includes event detection)
             self.step_once()?;
 
-            // Restore suggested dt_next for subsequent steps
-            if self.dt_next.abs() >= saved_dt_next.abs() {
+            // A step truncated to land exactly on the target is artificially
+            // short, so what it implies about larger steps is extrapolation.
+            // Keep its suggestion only when that suggestion falls below the
+            // step just taken, which means the error bound was reached even at
+            // the reduced size and the reduction is genuine error control.
+            // Otherwise restore the pre-truncation suggestion; carrying the
+            // truncated step's estimate forward would let a run of truncated
+            // steps ratchet the step size down with no way to recover.
+            if truncated && self.dt.abs() >= dt_max.abs() && self.dt_next.abs() >= self.dt.abs() {
                 self.dt_next = saved_dt_next;
             }
         }
@@ -4458,10 +4473,23 @@ mod tests {
             0.0, // velocity
         ]);
 
+        // Seed a 60 s step with tolerances loose enough for the adaptive
+        // controller to accept it, so the step count maps to a known duration.
+        let step_size = 60.0;
+        let config = NumericalPropagationConfig {
+            integrator: IntegratorConfig {
+                abs_tol: 1e-2,
+                rel_tol: 1e-4,
+                initial_step: Some(step_size),
+                ..IntegratorConfig::default()
+            },
+            ..NumericalPropagationConfig::default()
+        };
+
         let mut prop = DNumericalOrbitPropagator::new(
             epoch,
             state.clone(),
-            NumericalPropagationConfig::default(),
+            config,
             ForceModelConfig::earth_gravity(),
             None,
             None,
@@ -4470,7 +4498,6 @@ mod tests {
         )
         .unwrap();
 
-        let step_size = 60.0;
         let num_steps = 10;
 
         // Propagate N steps
@@ -5311,11 +5338,15 @@ mod tests {
         assert!(has_difference, "RTN covariance should differ from ECI");
 
         // Verify RTN covariance is still symmetric (within numerical precision)
+        // Covariance interpolation leaves asymmetry proportional to the
+        // magnitude of the whole matrix, which the frame rotation mixes across
+        // blocks, so bound the asymmetry by the matrix norm.
+        let cov_scale = cov_rtn.norm();
         for i in 0..6 {
             for j in 0..6 {
                 let diff = (cov_rtn[(i, j)] - cov_rtn[(j, i)]).abs();
                 assert!(
-                    diff < 1e-6,
+                    diff < 1e-9 * cov_scale,
                     "RTN covariance should be symmetric at ({},{}): diff = {}",
                     i,
                     j,
@@ -7658,6 +7689,161 @@ mod tests {
         assert!(
             difference > 0.0 && difference < 1.0,
             "Tolerance should affect accuracy, diff = {:.6} m",
+            difference
+        );
+    }
+
+    /// Largest step taken over a propagation, from the stored trajectory.
+    fn max_trajectory_step(prop: &DNumericalOrbitPropagator) -> f64 {
+        let traj = prop.trajectory();
+        (0..traj.len().saturating_sub(1))
+            .map(|i| traj.epoch_at_idx(i + 1).unwrap() - traj.epoch_at_idx(i).unwrap())
+            .fold(0.0, f64::max)
+    }
+
+    fn adaptive_prop(
+        integrator: IntegratorConfig,
+        state: DVector<f64>,
+        force: ForceModelConfig,
+    ) -> DNumericalOrbitPropagator {
+        let epoch = Epoch::from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+        let config = NumericalPropagationConfig {
+            integrator,
+            ..NumericalPropagationConfig::default()
+        };
+        DNumericalOrbitPropagator::new(epoch, state, config, force, None, None, None, None).unwrap()
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_dnumericalorbitpropagator_adaptive_step_size_grows() {
+        setup_global_test_eop();
+
+        let state = DVector::from_vec(vec![R_EARTH + 500e3, 0.0, 0.0, 0.0, 1108.9350, 7537.7178]);
+        let mut prop = adaptive_prop(
+            IntegratorConfig {
+                abs_tol: 1e-2,
+                rel_tol: 1e-4,
+                ..IntegratorConfig::default()
+            },
+            state,
+            ForceModelConfig::earth_gravity(),
+        );
+        let epoch = prop.initial_epoch();
+        prop.propagate_to(epoch + 3600.0).unwrap();
+
+        // The propagator seeds the first step from `initial_step`, defaulting to
+        // 60 s. An adaptive controller must be able to grow beyond that seed when
+        // the local error allows it.
+        let max_step = max_trajectory_step(&prop);
+        assert!(
+            max_step > 60.0,
+            "Adaptive step size must grow beyond the 60 s seed, got {:.3} s",
+            max_step
+        );
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_dnumericalorbitpropagator_max_step_bounds_growth() {
+        setup_global_test_eop();
+
+        let state = DVector::from_vec(vec![R_EARTH + 500e3, 0.0, 0.0, 0.0, 1108.9350, 7537.7178]);
+        let loose = IntegratorConfig {
+            abs_tol: 1e-2,
+            rel_tol: 1e-4,
+            ..IntegratorConfig::default()
+        };
+
+        let mut capped = adaptive_prop(
+            IntegratorConfig {
+                max_step: Some(120.0),
+                ..loose.clone()
+            },
+            state.clone(),
+            ForceModelConfig::earth_gravity(),
+        );
+        let mut uncapped = adaptive_prop(
+            IntegratorConfig {
+                max_step: Some(900.0),
+                ..loose
+            },
+            state,
+            ForceModelConfig::earth_gravity(),
+        );
+
+        let epoch = capped.initial_epoch();
+        capped.propagate_to(epoch + 3600.0).unwrap();
+        uncapped.propagate_to(epoch + 3600.0).unwrap();
+
+        let max_capped = max_trajectory_step(&capped);
+        let max_uncapped = max_trajectory_step(&uncapped);
+
+        assert!(
+            max_capped <= 120.0 + 1e-9,
+            "max_step must bound the step size, got {:.6} s",
+            max_capped
+        );
+        assert!(
+            max_uncapped > 120.0,
+            "A larger max_step must permit larger steps, got {:.6} s",
+            max_uncapped
+        );
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_dnumericalorbitpropagator_tolerances_affect_slow_orbit() {
+        setup_global_test_eop();
+
+        // Highly eccentric orbit near apoapsis. The local error over the 60 s
+        // seed step falls under both tolerances, so error control can only be
+        // observed through step-size growth.
+        let state = DVector::from_vec(vec![
+            -130142373.6645361,
+            120626187.8655891,
+            126520497.1633258,
+            -308.744045658656,
+            -1402.99418814228,
+            -61.624_504_490_557_44,
+        ]);
+
+        let mut loose = adaptive_prop(
+            IntegratorConfig {
+                abs_tol: 1e-2,
+                rel_tol: 1e-4,
+                max_step: Some(86400.0),
+                ..IntegratorConfig::default()
+            },
+            state.clone(),
+            ForceModelConfig::two_body_gravity(),
+        );
+        let mut tight = adaptive_prop(
+            IntegratorConfig {
+                abs_tol: 1e-12,
+                rel_tol: 1e-14,
+                max_step: Some(600.0),
+                ..IntegratorConfig::default()
+            },
+            state,
+            ForceModelConfig::two_body_gravity(),
+        );
+
+        let epoch = loose.initial_epoch();
+        loose.propagate_to(epoch + 86400.0).unwrap();
+        tight.propagate_to(epoch + 86400.0).unwrap();
+
+        assert!(
+            max_trajectory_step(&loose) > max_trajectory_step(&tight),
+            "Looser tolerances must permit larger steps"
+        );
+
+        let difference = (loose.current_state().fixed_rows::<3>(0)
+            - tight.current_state().fixed_rows::<3>(0))
+        .norm();
+        assert!(
+            difference > 0.0,
+            "Tolerances must affect the propagated state, diff = {:.6e} m",
             difference
         );
     }
@@ -11245,11 +11431,16 @@ mod tests {
         // Verify composition: Φ(t₂,t₀) = Φ(t₂,t₁)·Φ(t₁,t₀)
         let phi_composed = phi_t2_t1 * phi_t1_t0;
 
+        // The two propagations select independent step sequences, so the
+        // composition holds to integration accuracy rather than exactly. The
+        // error in any entry scales with the magnitude of the whole matrix, not
+        // with that entry, so bound it by the matrix norm.
+        let phi_scale = phi_t2_t0.norm();
         for i in 0..6 {
             for j in 0..6 {
                 let diff = (phi_t2_t0[(i, j)] - phi_composed[(i, j)]).abs();
                 assert!(
-                    diff < 1e-6,
+                    diff < 1e-8 * phi_scale,
                     "STM composition failed at [{},{}]: direct={}, composed={}, diff={}",
                     i,
                     j,
@@ -13431,10 +13622,23 @@ mod tests {
         let epoch = Epoch::from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![R_EARTH + 500e3, 0.0, 0.0, 0.0, 7500.0, 0.0]);
 
+        // Pin the integrator so this guard tracks the Earth force-model path
+        // alone. Tolerances loose enough for a single 60 s step keep the
+        // reference state independent of the default tolerances.
+        let config = NumericalPropagationConfig {
+            integrator: IntegratorConfig {
+                abs_tol: 1e-2,
+                rel_tol: 1e-4,
+                initial_step: Some(60.0),
+                ..IntegratorConfig::default()
+            },
+            ..NumericalPropagationConfig::default()
+        };
+
         let mut prop = DNumericalOrbitPropagator::new(
             epoch,
             state,
-            NumericalPropagationConfig::default(),
+            config,
             ForceModelConfig::default(),
             Some(default_test_params()),
             None,

--- a/src/propagators/dnumerical_orbit_propagator.rs
+++ b/src/propagators/dnumerical_orbit_propagator.rs
@@ -5338,15 +5338,11 @@ mod tests {
         assert!(has_difference, "RTN covariance should differ from ECI");
 
         // Verify RTN covariance is still symmetric (within numerical precision)
-        // Covariance interpolation leaves asymmetry proportional to the
-        // magnitude of the whole matrix, which the frame rotation mixes across
-        // blocks, so bound the asymmetry by the matrix norm.
-        let cov_scale = cov_rtn.norm();
         for i in 0..6 {
             for j in 0..6 {
                 let diff = (cov_rtn[(i, j)] - cov_rtn[(j, i)]).abs();
                 assert!(
-                    diff < 1e-9 * cov_scale,
+                    diff < 1e-6,
                     "RTN covariance should be symmetric at ({},{}): diff = {}",
                     i,
                     j,

--- a/src/propagators/dnumerical_propagator.rs
+++ b/src/propagators/dnumerical_propagator.rs
@@ -1978,15 +1978,22 @@ impl super::traits::DStatePropagator for DNumericalPropagator {
             };
 
             // Temporarily set the suggested next step to not overshoot
+            let truncated = dt_max.abs() < self.dt_next.abs();
             let saved_dt_next = self.dt_next;
             self.dt_next = dt_max;
 
             // Take one adaptive step (includes event detection)
             self.step_once()?;
 
-            // Restore suggested dt_next for subsequent steps
-            // (unless step_once updated it to something smaller)
-            if self.dt_next.abs() > saved_dt_next.abs() {
+            // A step truncated to land exactly on the target is artificially
+            // short, so what it implies about larger steps is extrapolation.
+            // Keep its suggestion only when that suggestion falls below the
+            // step just taken, which means the error bound was reached even at
+            // the reduced size and the reduction is genuine error control.
+            // Otherwise restore the pre-truncation suggestion; carrying the
+            // truncated step's estimate forward would let a run of truncated
+            // steps ratchet the step size down with no way to recover.
+            if truncated && self.dt.abs() >= dt_max.abs() && self.dt_next.abs() >= self.dt.abs() {
                 self.dt_next = saved_dt_next;
             }
         }
@@ -2030,14 +2037,22 @@ impl super::traits::DStatePropagator for DNumericalPropagator {
                 -remaining.abs().min(self.dt_next.abs())
             };
 
+            let truncated = dt_max.abs() < self.dt_next.abs();
             let saved_dt_next = self.dt_next;
             self.dt_next = dt_max;
 
             // Take one adaptive step (includes event detection)
             self.step_once()?;
 
-            // Restore suggested dt_next for subsequent steps
-            if self.dt_next.abs() > saved_dt_next.abs() {
+            // A step truncated to land exactly on the target is artificially
+            // short, so what it implies about larger steps is extrapolation.
+            // Keep its suggestion only when that suggestion falls below the
+            // step just taken, which means the error bound was reached even at
+            // the reduced size and the reduction is genuine error control.
+            // Otherwise restore the pre-truncation suggestion; carrying the
+            // truncated step's estimate forward would let a run of truncated
+            // steps ratchet the step size down with no way to recover.
+            if truncated && self.dt.abs() >= dt_max.abs() && self.dt_next.abs() >= self.dt.abs() {
                 self.dt_next = saved_dt_next;
             }
         }
@@ -2435,6 +2450,70 @@ mod tests {
         config.variational.store_stm_history = true;
 
         DNumericalPropagator::new(epoch, state, dynamics, config, None, None, None).unwrap()
+    }
+
+    /// Largest step taken over a propagation, from the stored trajectory.
+    fn max_trajectory_step(prop: &DNumericalPropagator) -> f64 {
+        let traj = prop.trajectory();
+        (0..traj.len().saturating_sub(1))
+            .map(|i| traj.epoch_at_idx(i + 1).unwrap() - traj.epoch_at_idx(i).unwrap())
+            .fold(0.0, f64::max)
+    }
+
+    /// SHO propagator seeded with a small initial step so that step growth is
+    /// observable against the seed.
+    fn create_growth_test_propagator(max_step: f64) -> DNumericalPropagator {
+        let epoch = Epoch::from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+        let state = DVector::from_vec(vec![1.0, 0.0]);
+        let config = NumericalPropagationConfig {
+            integrator: IntegratorConfig {
+                abs_tol: 1e-6,
+                rel_tol: 1e-6,
+                initial_step: Some(0.001),
+                max_step: Some(max_step),
+                ..IntegratorConfig::default()
+            },
+            ..NumericalPropagationConfig::default()
+        };
+        DNumericalPropagator::new(epoch, state, sho_dynamics(1.0), config, None, None, None)
+            .unwrap()
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_dnumericalpropagator_adaptive_step_size_grows() {
+        let mut prop = create_growth_test_propagator(0.5);
+        prop.step_by(5.0).unwrap();
+
+        let max_step = max_trajectory_step(&prop);
+        assert!(
+            max_step > 0.001,
+            "Adaptive step size must grow beyond the seed step, got {:.6} s",
+            max_step
+        );
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_dnumericalpropagator_max_step_bounds_growth() {
+        let mut capped = create_growth_test_propagator(0.05);
+        let mut uncapped = create_growth_test_propagator(0.5);
+        capped.step_by(5.0).unwrap();
+        uncapped.step_by(5.0).unwrap();
+
+        let max_capped = max_trajectory_step(&capped);
+        let max_uncapped = max_trajectory_step(&uncapped);
+
+        assert!(
+            max_capped <= 0.05 + 1e-12,
+            "max_step must bound the step size, got {:.9} s",
+            max_capped
+        );
+        assert!(
+            max_uncapped > 0.05,
+            "A larger max_step must permit larger steps, got {:.9} s",
+            max_uncapped
+        );
     }
 
     // =============================================================================

--- a/src/propagators/numerical_propagation_config.rs
+++ b/src/propagators/numerical_propagation_config.rs
@@ -345,7 +345,7 @@ impl Default for NumericalPropagationConfig {
     ///
     /// Uses:
     /// - Dormand-Prince 5(4) integrator
-    /// - Default tolerances (abs=1e-6, rel=1e-3)
+    /// - Default tolerances (abs=1e-8, rel=1e-10)
     /// - No variational matrix propagation (central differences when enabled)
     /// - Acceleration storage disabled
     /// - Propagator-chosen interpolation (`None`)
@@ -426,7 +426,7 @@ impl NumericalPropagationConfig {
     ///
     /// Uses:
     /// - RKN1210 integrator
-    /// - Tight tolerances (abs=1e-10, rel=1e-8)
+    /// - Tight tolerances (abs=1e-12, rel=1e-12)
     /// - No variational matrix propagation (central differences when enabled)
     /// - Acceleration storage enabled
     /// - Propagator-chosen interpolation (`None`)

--- a/src/propagators/numerical_propagation_config.rs
+++ b/src/propagators/numerical_propagation_config.rs
@@ -441,7 +441,7 @@ impl NumericalPropagationConfig {
     pub fn high_precision() -> Self {
         Self {
             method: IntegratorMethod::RKN1210,
-            integrator: IntegratorConfig::adaptive(1e-10, 1e-8),
+            integrator: IntegratorConfig::adaptive(1e-12, 1e-12),
             variational: VariationalConfig::default(),
             store_accelerations: true,
             interpolation_method: None,

--- a/tests/integrators/test_dp54_integrator.py
+++ b/tests/integrators/test_dp54_integrator.py
@@ -124,6 +124,29 @@ class TestDP54Integrator:
         assert result.dt_next > dt_initial
         assert result.error_estimate < 0.1
 
+    def test_step_returns_dt_below_requested_when_rejected(self):
+        """Verify a rejected step reports the reduced size it actually took.
+
+        The propagation loops decide whether a step the target truncated is
+        also one the integrator reduced by comparing dt_used against the
+        requested step, so the strict reduction has to hold.
+        """
+
+        def dynamics(t, state):
+            return -50.0 * state
+
+        config = bh.IntegratorConfig.adaptive(1e-10, 1e-12)
+        integrator = bh.DP54Integrator(dimension=1, dynamics_fn=dynamics, config=config)
+
+        requested = 2.0
+        result = integrator.step(0.0, np.array([1.0]), requested)
+
+        assert result.dt_used < requested, (
+            f"a rejected step must report the reduced size, "
+            f"got {result.dt_used} for a requested {requested}"
+        )
+        assert result.dt_next < requested
+
     def test_with_varmat(self):
         """Test variational matrix propagation."""
 

--- a/tests/propagators/test_numerical_orbit_propagator.py
+++ b/tests/propagators/test_numerical_orbit_propagator.py
@@ -4,6 +4,8 @@ Tests for NumericalOrbitPropagator Python bindings
 These tests mirror the Rust tests from src/propagators/dnumerical_orbit_propagator.rs
 """
 
+import itertools
+
 import numpy as np
 import pytest
 
@@ -35,6 +37,20 @@ from brahe import (
 def create_test_epoch():
     """Create a standard test epoch"""
     return Epoch.from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, TimeSystem.UTC)
+
+
+def create_seeded_step_config(step):
+    """Config whose adaptive controller accepts a step of exactly `step` seconds
+
+    Capping max_step at the seed and loosening the tolerances keeps the
+    controller from growing or shrinking the step, so a step count maps to a
+    known duration.
+    """
+    return NumericalPropagationConfig(
+        IntegrationMethod.DP54,
+        IntegratorConfig(abs_tol=1e-2, rel_tol=1e-4, initial_step=step, max_step=step),
+        VariationalConfig(),
+    )
 
 
 def create_leo_state():
@@ -227,7 +243,7 @@ def test_numericalorbitpropagator_dstatepropagator_propagate_steps():
     prop = NumericalOrbitPropagator(
         epoch,
         state,
-        NumericalPropagationConfig.default(),
+        create_seeded_step_config(60.0),
         ForceModelConfig.two_body(),
         None,
     )
@@ -491,7 +507,7 @@ def test_numericalorbitpropagator_eviction_policy_max_age():
     prop = NumericalOrbitPropagator(
         epoch,
         state,
-        NumericalPropagationConfig.default(),
+        create_seeded_step_config(60.0),
         ForceModelConfig.two_body(),
         None,
     )
@@ -1405,7 +1421,7 @@ def test_numericalorbitpropagator_dorbitstateprovider_interpolation_accuracy():
     prop = NumericalOrbitPropagator(
         epoch,
         state,
-        NumericalPropagationConfig.default(),
+        create_seeded_step_config(120.0),
         ForceModelConfig.earth_gravity(),
         None,
     )
@@ -3179,7 +3195,7 @@ def test_numericalorbitpropagator_construction_custom_step_size():
     epoch = create_test_epoch()
     state = create_leo_state()
 
-    config = NumericalPropagationConfig.default()
+    config = create_seeded_step_config(30.0)
     prop = NumericalOrbitPropagator(
         epoch, state, config, ForceModelConfig.two_body(), None
     )
@@ -3219,7 +3235,7 @@ def test_numericalorbitpropagator_trajectory_interpolation():
     prop = NumericalOrbitPropagator(
         epoch,
         state,
-        NumericalPropagationConfig.default(),
+        create_seeded_step_config(60.0),
         ForceModelConfig.two_body(),
         None,
     )
@@ -3750,7 +3766,9 @@ def test_numericalorbitpropagator_stm_composition_property():
     epoch = create_test_epoch()
     state = create_leo_state()
 
-    config = NumericalPropagationConfig.default().with_stm()
+    # Pin the step so both propagations share a grid, keeping the composition
+    # exact to integration round-off rather than to step-sequence differences.
+    config = create_seeded_step_config(60.0).with_stm()
 
     # Create first propagator and propagate to t1
     prop1 = NumericalOrbitPropagator(
@@ -6475,3 +6493,112 @@ def test_numericalorbitpropagator_builder_build_error():
     builder = NumericalOrbitPropagator.builder(epoch, state, ForceModelConfig.default())
     with pytest.raises(RuntimeError):
         builder.build()
+
+
+def _max_trajectory_step(prop):
+    """Largest step taken over a propagation, from the stored trajectory"""
+    traj = prop.trajectory
+    epochs = [traj.epoch_at_idx(i) for i in range(len(traj))]
+    return max((b - a for a, b in itertools.pairwise(epochs)), default=0.0)
+
+
+def _adaptive_prop(integrator, state, force):
+    """Build an orbit propagator with the given integrator configuration"""
+    config = NumericalPropagationConfig(
+        IntegrationMethod.DP54, integrator, VariationalConfig()
+    )
+    return NumericalOrbitPropagator(create_test_epoch(), state, config, force, None)
+
+
+def test_numericalorbitpropagator_adaptive_step_size_grows():
+    """Test that adaptive step size grows beyond the seed step (mirrors Rust test)"""
+    epoch = create_test_epoch()
+    state = np.array([R_EARTH + 500e3, 0.0, 0.0, 0.0, 1108.9350, 7537.7178])
+
+    prop = _adaptive_prop(
+        IntegratorConfig(abs_tol=1e-2, rel_tol=1e-4),
+        state,
+        ForceModelConfig.earth_gravity(),
+    )
+    prop.propagate_to(epoch + 3600.0)
+
+    # The propagator seeds the first step from initial_step, defaulting to 60 s.
+    max_step = _max_trajectory_step(prop)
+    assert max_step > 60.0, (
+        f"Adaptive step size must grow beyond the 60 s seed, got {max_step:.3f} s"
+    )
+
+
+def test_numericalorbitpropagator_max_step_bounds_growth():
+    """Test that max_step bounds adaptive step growth (mirrors Rust test)"""
+    epoch = create_test_epoch()
+    state = np.array([R_EARTH + 500e3, 0.0, 0.0, 0.0, 1108.9350, 7537.7178])
+
+    capped = _adaptive_prop(
+        IntegratorConfig(abs_tol=1e-2, rel_tol=1e-4, max_step=120.0),
+        state,
+        ForceModelConfig.earth_gravity(),
+    )
+    uncapped = _adaptive_prop(
+        IntegratorConfig(abs_tol=1e-2, rel_tol=1e-4, max_step=900.0),
+        state,
+        ForceModelConfig.earth_gravity(),
+    )
+
+    capped.propagate_to(epoch + 3600.0)
+    uncapped.propagate_to(epoch + 3600.0)
+
+    max_capped = _max_trajectory_step(capped)
+    max_uncapped = _max_trajectory_step(uncapped)
+
+    assert max_capped <= 120.0 + 1e-9, (
+        f"max_step must bound the step size, got {max_capped:.6f} s"
+    )
+    assert max_uncapped > 120.0, (
+        f"A larger max_step must permit larger steps, got {max_uncapped:.6f} s"
+    )
+
+
+def test_numericalorbitpropagator_tolerances_affect_slow_orbit():
+    """Test that tolerances affect a slow orbit where no step is rejected
+
+    Regression test for https://github.com/duncaneddy/brahe/issues/461.
+    Mirrors the Rust test.
+    """
+    epoch = create_test_epoch()
+    # Highly eccentric orbit near apoapsis. The local error over the 60 s seed
+    # step falls under both tolerances, so error control can only be observed
+    # through step-size growth.
+    state = np.array(
+        [
+            -130142373.6645361,
+            120626187.8655891,
+            126520497.1633258,
+            -308.744045658656,
+            -1402.99418814228,
+            -61.6245044905574416,
+        ]
+    )
+
+    loose = _adaptive_prop(
+        IntegratorConfig(abs_tol=1e-2, rel_tol=1e-4, max_step=86400.0),
+        state,
+        ForceModelConfig.two_body(),
+    )
+    tight = _adaptive_prop(
+        IntegratorConfig(abs_tol=1e-12, rel_tol=1e-14, max_step=600.0),
+        state,
+        ForceModelConfig.two_body(),
+    )
+
+    loose.propagate_to(epoch + 86400.0)
+    tight.propagate_to(epoch + 86400.0)
+
+    assert _max_trajectory_step(loose) > _max_trajectory_step(tight), (
+        "Looser tolerances must permit larger steps"
+    )
+
+    difference = np.linalg.norm(loose.current_state()[:3] - tight.current_state()[:3])
+    assert difference > 0.0, (
+        f"Tolerances must affect the propagated state, diff = {difference:.6e} m"
+    )

--- a/tests/propagators/test_numerical_propagator.py
+++ b/tests/propagators/test_numerical_propagator.py
@@ -10,16 +10,32 @@ import pytest
 from brahe import (
     Epoch,
     IntegrationMethod,
+    IntegratorConfig,
     InterpolationMethod,
     NumericalPropagationConfig,
     NumericalPropagator,
     TimeSystem,
+    VariationalConfig,
 )
 
 
 def create_test_epoch():
     """Create a standard test epoch"""
     return Epoch.from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, TimeSystem.UTC)
+
+
+def create_seeded_step_config(step):
+    """Config whose adaptive controller accepts a step of exactly `step` seconds
+
+    Capping max_step at the seed and loosening the tolerances keeps the
+    controller from growing or shrinking the step, so a step count maps to a
+    known duration.
+    """
+    return NumericalPropagationConfig(
+        IntegrationMethod.DP54,
+        IntegratorConfig(abs_tol=1e-2, rel_tol=1e-4, initial_step=step, max_step=step),
+        VariationalConfig(),
+    )
 
 
 def sho_dynamics(t, state, params):
@@ -219,7 +235,7 @@ def test_dstatepropagator_propagate_steps():
     state = np.array([1.0, 0.0])
 
     prop = NumericalPropagator(
-        epoch, state, sho_dynamics, NumericalPropagationConfig.default()
+        epoch, state, sho_dynamics, create_seeded_step_config(0.1)
     )
 
     prop.step_size = 0.1
@@ -394,7 +410,7 @@ def test_numericalpropagator_eviction_policy_max_age():
     state = np.array([1.0, 0.0])
 
     prop = NumericalPropagator(
-        epoch, state, sho_dynamics, NumericalPropagationConfig.default()
+        epoch, state, sho_dynamics, create_seeded_step_config(0.1)
     )
 
     prop.set_eviction_policy_max_age(0.5)


### PR DESCRIPTION
# Pull Request

## Description

Fixes #461: `abs_tol`, `rel_tol` and `max_step` had no observable effect on propagation.

The integrators were never at fault. `step_by` and `propagate_to` clamp the controller's suggested step so it will not overshoot the target, then restored the pre-clamp value whenever the new suggestion was no smaller. With the target far away that clamp is a no-op, so the comparison weighed the suggestion against itself and reverted every increase. The step size froze at the 60 s seed and could only ratchet down, so tolerances mattered only through step rejection — and in the reported case no step was ever rejected, making the two configurations bit-identical.

The earlier suggestion is now restored only for a step the target truncated and the integrator accepted at that reduced size, and only when the new suggestion is not below the step just taken. A suggestion under that step means the error bound was reached even there, so the reduction is genuine; anything larger extrapolates from an artificially short step. Keeping such a suggestion unconditionally re-creates the ratchet in the opposite direction wherever every step is truncated, as when a batch least-squares run propagates observation to observation.

Default tolerances move to 1e-8 absolute and 1e-10 relative. The previous 1e-6 and 1e-3 accumulate roughly 2000 km over a day in low Earth orbit once the step is free to grow, and only looked serviceable because it never did. `high_precision()` moves to 1e-12 on both: its relative tolerance was 1e-8, looser than the new default while paying for a far more expensive integrator.

## Changelog

### Changed
- Default `IntegratorConfig` tolerances tightened from `abs_tol` 1e-6 / `rel_tol` 1e-3 to 1e-8 / 1e-10, since the previous values permit kilometre-scale per-day error once adaptive stepping is effective.
- `NumericalPropagationConfig::high_precision()` tightened to 1e-12 absolute and relative; its previous relative tolerance of 1e-8 was looser than the new default.
- Default `IntegratorConfig::max_step_attempts` raised from 10 to 25. Each rejection shrinks the step by at most `min_step_scale_factor`, so ten attempts bound one call to roughly seven orders of magnitude of reduction, which the tightened tolerances no longer leave comfortable through a low perigee pass.

### Fixed
- Fixed [#461](https://github.com/duncaneddy/brahe/issues/461): Adaptive integrators (RKF45, RKF78, DP54, RKN1210) now grow their step size during propagation; `abs_tol`, `rel_tol` and `max_step` previously had no effect because every step-size increase suggested by the error controller was discarded, only allowing equal or smaller steps from the initial step. (Found by @carter-franz)

## Related Issue

Fixes #461

## Note to Reviewers

Both propagators are affected — `DNumericalOrbitPropagator` and `DNumericalPropagator`, in `step_by` and `propagate_to` each. Reviewing the guard condition is the highest-value part: two earlier formulations were wrong in opposite directions, and `test_bls_formulation_equivalence_correlated_noise` is the canary that catches the reverse ratchet, going from convergence in under 8 iterations to needing 13-20.

Tests that encoded the frozen 60 s step are given an explicit step size or a bound scaled to the quantity they measure. Where pinning the step grid was possible it was preferred over loosening a bound, so `test_earth_propagation_regression_unchanged` keeps its original reference values bit-for-bit.

The step-attempt budget is worth a look. The event tests propagate a state whose perigee sits near 108 km altitude, and resolving that pass at the new tolerances uses eight of the previous ten attempts locally while exhausting them on Windows. Twenty-five spans the whole configured step range, from the default `max_step` down to the default `min_step`, and costs nothing on a step that converges.

`test-examples` is red on `examples/examples/visualizing_gps.py`, which times out at its 300 s cap. That example uses SGP4 propagators and plotly only, never touches `IntegratorConfig`, and is byte-identical on all three branches of this stack. It passed on this branch earlier and passes on #467 and #468. Every run logs `Unable to download artifact(s): Artifact not found for name: brahe-cache`, so the Earth texture and basemap it plots fall back to a live download. It is the only failure out of 779 examples.
