### PR TITLE
Emit KVN header COMMENT before CLASSIFICATION

### DIFF
--- a/src/ccsds/kvn/writer.rs
+++ b/src/ccsds/kvn/writer.rs
@@ -1268,6 +1268,20 @@ mod tests {
     // ------------------------------------------------------------------
 
     /// Index of the first line whose trimmed form starts with `keyword`.
+    ///
+    /// # Arguments
+    ///
+    /// - `written`: Serialized KVN message to search
+    /// - `keyword`: KVN keyword to locate, matched against the start of each
+    ///   line after leading whitespace is trimmed
+    ///
+    /// # Returns
+    ///
+    /// - `usize`: Zero-based index of the first matching line
+    ///
+    /// # Panics
+    ///
+    /// Panics if no line starts with `keyword`.
     fn line_index_of(written: &str, keyword: &str) -> usize {
         written
             .lines()
@@ -1276,6 +1290,17 @@ mod tests {
     }
 
     /// Assert the version line comes first, then COMMENT, then CLASSIFICATION.
+    ///
+    /// # Arguments
+    ///
+    /// - `written`: Serialized KVN message whose header order is checked
+    /// - `vers_keyword`: Message-specific version keyword, such as
+    ///   `CCSDS_OEM_VERS`
+    ///
+    /// # Panics
+    ///
+    /// Panics if any of the three keywords is absent, or if they do not appear
+    /// in the order fixed by the header tables.
     fn assert_header_order(written: &str, vers_keyword: &str) {
         let vers = line_index_of(written, vers_keyword);
         let comment = line_index_of(written, "COMMENT");

--- a/src/ccsds/kvn/writer.rs
+++ b/src/ccsds/kvn/writer.rs
@@ -15,11 +15,11 @@ pub fn write_oem(oem: &OEM) -> Result<String, BraheError> {
         "CCSDS_OEM_VERS = {:.1}\n",
         oem.header.format_version
     ));
-    if let Some(ref class) = oem.header.classification {
-        out.push_str(&format!("CLASSIFICATION = {}\n", class));
-    }
     for comment in &oem.header.comments {
         out.push_str(&format!("COMMENT {}\n", comment));
+    }
+    if let Some(ref class) = oem.header.classification {
+        out.push_str(&format!("CLASSIFICATION = {}\n", class));
     }
     out.push_str(&format!(
         "CREATION_DATE = {}\n",
@@ -155,11 +155,11 @@ pub fn write_omm(omm: &crate::ccsds::omm::OMM) -> Result<String, BraheError> {
         "CCSDS_OMM_VERS = {:.1}\n",
         omm.header.format_version
     ));
-    if let Some(ref class) = omm.header.classification {
-        out.push_str(&format!("CLASSIFICATION = {}\n", class));
-    }
     for comment in &omm.header.comments {
         out.push_str(&format!("COMMENT {}\n", comment));
+    }
+    if let Some(ref class) = omm.header.classification {
+        out.push_str(&format!("CLASSIFICATION = {}\n", class));
     }
     out.push_str(&format!(
         "CREATION_DATE = {}\n",
@@ -307,11 +307,11 @@ pub fn write_opm(opm: &crate::ccsds::opm::OPM) -> Result<String, BraheError> {
         "CCSDS_OPM_VERS = {:.1}\n",
         opm.header.format_version
     ));
-    if let Some(ref class) = opm.header.classification {
-        out.push_str(&format!("CLASSIFICATION = {}\n", class));
-    }
     for comment in &opm.header.comments {
         out.push_str(&format!("COMMENT {}\n", comment));
+    }
+    if let Some(ref class) = opm.header.classification {
+        out.push_str(&format!("CLASSIFICATION = {}\n", class));
     }
     out.push_str(&format!(
         "CREATION_DATE = {}\n",
@@ -1256,6 +1256,115 @@ mod tests {
         assert_eq!(
             oem.segments[0].metadata.object_name,
             oem2.segments[0].metadata.object_name
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Header keyword order
+    //
+    // CCSDS 502.0-B-3 section 7.4.8 (and 508.0-P-1.1 section 6.3.1.9) fix the
+    // order of KVN assignments to that of the header tables, which place
+    // COMMENT immediately after the version line and CLASSIFICATION after it.
+    // ------------------------------------------------------------------
+
+    /// Index of the first line whose trimmed form starts with `keyword`.
+    fn line_index_of(written: &str, keyword: &str) -> usize {
+        written
+            .lines()
+            .position(|line| line.trim_start().starts_with(keyword))
+            .unwrap_or_else(|| panic!("'{}' missing from written message", keyword))
+    }
+
+    /// Assert the version line comes first, then COMMENT, then CLASSIFICATION.
+    fn assert_header_order(written: &str, vers_keyword: &str) {
+        let vers = line_index_of(written, vers_keyword);
+        let comment = line_index_of(written, "COMMENT");
+        let classification = line_index_of(written, "CLASSIFICATION");
+
+        assert!(
+            vers < comment && comment < classification,
+            "expected {} < COMMENT < CLASSIFICATION, got {} < {} < {} in:\n{}",
+            vers_keyword,
+            vers,
+            comment,
+            classification,
+            written
+        );
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_oem_write_header_comment_before_classification() {
+        let content = std::fs::read_to_string("test_assets/ccsds/oem/OEMExample1.txt").unwrap();
+        let mut oem = parse_oem(&content).unwrap();
+        oem.header.classification = Some("public, test-data".to_string());
+        oem.header.comments = vec!["first header comment".to_string(), "second".to_string()];
+
+        let written = write_oem(&oem).unwrap();
+        assert_header_order(&written, "CCSDS_OEM_VERS");
+
+        // Header comments must round-trip as header comments, not be absorbed
+        // into the first segment's metadata comments.
+        let reparsed = parse_oem(&written).unwrap();
+        assert_eq!(reparsed.header.comments, oem.header.comments);
+        assert_eq!(reparsed.header.classification, oem.header.classification);
+        assert_eq!(
+            reparsed.segments[0].metadata.comments,
+            oem.segments[0].metadata.comments
+        );
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_omm_write_header_comment_before_classification() {
+        let content = std::fs::read_to_string("test_assets/ccsds/omm/OMMExample2.txt").unwrap();
+        let mut omm = crate::ccsds::kvn::parse_omm(&content).unwrap();
+        omm.header.classification = Some("public, test-data".to_string());
+        omm.header.comments = vec!["first header comment".to_string(), "second".to_string()];
+
+        let written = write_omm(&omm).unwrap();
+        assert_header_order(&written, "CCSDS_OMM_VERS");
+
+        let reparsed = crate::ccsds::kvn::parse_omm(&written).unwrap();
+        assert_eq!(reparsed.header.comments, omm.header.comments);
+        assert_eq!(reparsed.header.classification, omm.header.classification);
+        assert_eq!(reparsed.metadata.comments, omm.metadata.comments);
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_opm_write_header_comment_before_classification() {
+        let content = std::fs::read_to_string("test_assets/ccsds/opm/OPMExample1.txt").unwrap();
+        let mut opm = crate::ccsds::kvn::parse_opm(&content).unwrap();
+        opm.header.classification = Some("public, test-data".to_string());
+        opm.header.comments = vec!["first header comment".to_string(), "second".to_string()];
+
+        let written = write_opm(&opm).unwrap();
+        assert_header_order(&written, "CCSDS_OPM_VERS");
+
+        let reparsed = crate::ccsds::kvn::parse_opm(&written).unwrap();
+        assert_eq!(reparsed.header.comments, opm.header.comments);
+        assert_eq!(reparsed.header.classification, opm.header.classification);
+        assert_eq!(reparsed.metadata.comments, opm.metadata.comments);
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_cdm_write_header_comment_before_classification() {
+        let content = std::fs::read_to_string("test_assets/ccsds/cdm/CDMExample1.txt").unwrap();
+        let mut cdm = crate::ccsds::kvn::parse_cdm(&content).unwrap();
+        cdm.header.classification = Some("public, test-data".to_string());
+        cdm.header.comments = vec!["first header comment".to_string(), "second".to_string()];
+
+        let written = write_cdm(&cdm).unwrap();
+        assert_header_order(&written, "CCSDS_CDM_VERS");
+
+        let reparsed = crate::ccsds::kvn::parse_cdm(&written).unwrap();
+        assert_eq!(reparsed.header.comments, cdm.header.comments);
+        assert_eq!(reparsed.header.classification, cdm.header.classification);
+        assert_eq!(
+            reparsed.relative_metadata.comments,
+            cdm.relative_metadata.comments
         );
     }
 

--- a/tests/ccsds/test_kvn_writer.py
+++ b/tests/ccsds/test_kvn_writer.py
@@ -1,0 +1,93 @@
+"""Tests for the CCSDS KVN writer — parity with Rust tests in src/ccsds/kvn/writer.rs.
+
+CCSDS 502.0-B-3 section 7.4.8 (and 508.0-P-1.1 section 6.3.1.9) fix the order of
+KVN assignments to that of the header tables, which place COMMENT immediately
+after the version line and CLASSIFICATION after it.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from brahe.ccsds import CDM, OEM, OMM, OPM
+
+HEADER_COMMENTS = ["first header comment", "second"]
+CLASSIFICATION = "public, test-data"
+
+
+def _keyword(line):
+    """Keyword of a KVN assignment line, or None for non-assignment lines."""
+    key, sep, _ = line.partition("=")
+    return key.strip() if sep else None
+
+
+def _with_header_comments_and_classification(path, vers_keyword):
+    """Read a KVN fixture and give its header both comments and a classification."""
+    lines = [
+        line
+        for line in Path(path).read_text().splitlines()
+        if _keyword(line) != "CLASSIFICATION"
+    ]
+    vers = next(i for i, line in enumerate(lines) if _keyword(line) == vers_keyword)
+    inserted = [f"COMMENT {c}" for c in HEADER_COMMENTS] + [
+        f"CLASSIFICATION = {CLASSIFICATION}"
+    ]
+    return "\n".join(lines[: vers + 1] + inserted + lines[vers + 1 :]) + "\n"
+
+
+def _emitted_header_comments(written):
+    """Comment text emitted ahead of CREATION_DATE, i.e. the header comments."""
+    comments = []
+    for line in written.splitlines():
+        if _keyword(line) == "CREATION_DATE":
+            break
+        if line.strip().startswith("COMMENT"):
+            comments.append(line.strip()[len("COMMENT") :].strip())
+    return comments
+
+
+def _assert_header_order(written, vers_keyword):
+    """Assert the emitted header runs version line, then COMMENT, then CLASSIFICATION."""
+    lines = written.splitlines()
+
+    def index_of(predicate, label):
+        for i, line in enumerate(lines):
+            if predicate(line):
+                return i
+        pytest.fail(f"'{label}' missing from written message:\n{written}")
+
+    vers = index_of(lambda ln: _keyword(ln) == vers_keyword, vers_keyword)
+    comment = index_of(lambda ln: ln.strip().startswith("COMMENT"), "COMMENT")
+    classification = index_of(
+        lambda ln: _keyword(ln) == "CLASSIFICATION", "CLASSIFICATION"
+    )
+
+    assert vers < comment < classification, (
+        f"expected {vers_keyword} < COMMENT < CLASSIFICATION, "
+        f"got {vers} < {comment} < {classification} in:\n{written}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("cls", "vers_keyword", "fixture"),
+    [
+        (OEM, "CCSDS_OEM_VERS", "test_assets/ccsds/oem/OEMExample1.txt"),
+        (OMM, "CCSDS_OMM_VERS", "test_assets/ccsds/omm/OMMExample2.txt"),
+        (OPM, "CCSDS_OPM_VERS", "test_assets/ccsds/opm/OPMExample1.txt"),
+        (CDM, "CCSDS_CDM_VERS", "test_assets/ccsds/cdm/CDMExample1.txt"),
+    ],
+    ids=["oem", "omm", "opm", "cdm"],
+)
+def test_write_header_comment_before_classification(eop, cls, vers_keyword, fixture):
+    """Mirror of test_<type>_write_header_comment_before_classification in Rust."""
+    content = _with_header_comments_and_classification(fixture, vers_keyword)
+
+    written = cls.from_str(content).to_string("kvn")
+    _assert_header_order(written, vers_keyword)
+    assert _emitted_header_comments(written) == HEADER_COMMENTS
+
+    # Header comments must survive a re-parse as header comments rather than
+    # being absorbed into the metadata comments.
+    rewritten = cls.from_str(written).to_string("kvn")
+    _assert_header_order(rewritten, vers_keyword)
+    assert _emitted_header_comments(rewritten) == HEADER_COMMENTS


### PR DESCRIPTION
# Pull Request

## Description

CCSDS 502.0-B-3 section 7.4.8 fixes the order of KVN assignments to that of the header tables (3-1 OPM, 4-1 OMM, 5-2 OEM), which run `CCSDS_*_VERS`, `COMMENT`, `CLASSIFICATION`, `CREATION_DATE`, `ORIGINATOR`, `MESSAGE_ID`. The OEM, OMM, and OPM KVN writers emitted `CLASSIFICATION` ahead of the header comments, so a message carrying both keywords did not conform to the fixed order. Each table annotates `COMMENT` as "allowed in the Header only immediately after the version number", and the annex requirements lists and Annex G examples number the keywords the same way.

The CDM writer already matched its own table (508.0-P-1.1 section 6.3.1.9, table 3-2, which adds `MESSAGE_FOR` before `MESSAGE_ID`), as did both XML writers, whose element sequence the ndmxml `odmHeader` schema pins down. Those are unchanged.

Regression tests cover all four message types in Rust and mirror them in Python, asserting both the emitted keyword order and that header comments survive a re-parse as header comments. The Rust tests were confirmed to fail against the previous order.

Note for the issue's framing: header comments already round-tripped correctly under the previous order, because none of these parsers change section on `CLASSIFICATION`. OEM stays in its header state until `META_START`, OMM and OPM clear their header flag on `CREATION_DATE`, and CDM routes comments to the header until `TCA`. The misrouting hazard described in #463 belongs to the APM parser's `header_fields_started` design, not to these writers, so this is a conformance fix rather than a fidelity one.

## Changelog

### Fixed
- CCSDS OEM, OMM, and OPM KVN writers now emit the header `COMMENT` lines before `CLASSIFICATION`, matching the fixed keyword order of the CCSDS 502.0-B-3 header tables.

## Related Issue

Covers item 1 of #463. The remaining three items in that issue (epoch time system conversion, XML text escaping, JSON comment drop) are untouched.

## Note to Reviewers

The ordering is normative rather than stylistic, so the header tables were checked against the published standards before changing anything; section and table numbers are cited above for each message type. Two points worth confirming independently: the CDM `CLASSIFICATION` keyword exists only in the Pink Book (508.0-P-1.1) and not in Blue Book 508.0-B-1, and the CDM `COMMENT` keyword carries no "only immediately after the version line" restriction, unlike the ODM's.
