### PR TITLE
Collect repeated XML elements instead of failing

### DIFF
--- a/src/ccsds/xml/parser.rs
+++ b/src/ccsds/xml/parser.rs
@@ -18,107 +18,6 @@ use crate::ccsds::oem::{OEM, OEMMetadata, OEMSegment, OEMStateVector};
 use crate::utils::errors::BraheError;
 
 // ============================================================================
-// Serde helpers
-// ============================================================================
-
-/// Deserialize a COMMENT field that may be a single string or a Vec<String>.
-fn deserialize_comments<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    struct CommentsVisitor;
-
-    impl<'de> serde::de::Visitor<'de> for CommentsVisitor {
-        type Value = Vec<String>;
-
-        fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-            f.write_str("a string or sequence of strings")
-        }
-
-        fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
-            Ok(vec![v.to_string()])
-        }
-
-        fn visit_string<E: serde::de::Error>(self, v: String) -> Result<Self::Value, E> {
-            Ok(vec![v])
-        }
-
-        fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-        where
-            A: serde::de::SeqAccess<'de>,
-        {
-            let mut vec = Vec::new();
-            while let Some(item) = seq.next_element::<String>()? {
-                vec.push(item);
-            }
-            Ok(vec)
-        }
-
-        fn visit_none<E: serde::de::Error>(self) -> Result<Self::Value, E> {
-            Ok(Vec::new())
-        }
-
-        fn visit_unit<E: serde::de::Error>(self) -> Result<Self::Value, E> {
-            Ok(Vec::new())
-        }
-
-        fn visit_map<M>(self, mut map: M) -> Result<Self::Value, M::Error>
-        where
-            M: serde::de::MapAccess<'de>,
-        {
-            // Handle case where quick-xml wraps the text in a map like {"$text": "..."}
-            let mut result = Vec::new();
-            while let Some((key, value)) = map.next_entry::<String, String>()? {
-                if key == "$text" || key == "$value" {
-                    result.push(value);
-                }
-            }
-            Ok(result)
-        }
-    }
-
-    deserializer.deserialize_any(CommentsVisitor)
-}
-
-/// Deserialize a field that may be a single struct or a sequence of structs.
-fn deserialize_one_or_many<'de, D, T>(deserializer: D) -> Result<Vec<T>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-    T: Deserialize<'de>,
-{
-    struct OneOrManyVisitor<T>(std::marker::PhantomData<T>);
-
-    impl<'de, T: Deserialize<'de>> serde::de::Visitor<'de> for OneOrManyVisitor<T> {
-        type Value = Vec<T>;
-
-        fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-            f.write_str("one or many elements")
-        }
-
-        fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-        where
-            A: serde::de::SeqAccess<'de>,
-        {
-            let mut vec = Vec::new();
-            while let Some(item) = seq.next_element()? {
-                vec.push(item);
-            }
-            Ok(vec)
-        }
-
-        fn visit_map<M>(self, map: M) -> Result<Self::Value, M::Error>
-        where
-            M: serde::de::MapAccess<'de>,
-        {
-            let item = T::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
-            Ok(vec![item])
-        }
-    }
-
-    deserializer.deserialize_any(OneOrManyVisitor(std::marker::PhantomData))
-}
-
-// ============================================================================
 // Intermediate XML structs for OEM
 // ============================================================================
 
@@ -205,7 +104,7 @@ impl XMLHeader {
 
 #[derive(Debug, Deserialize)]
 struct XMLOEMBody {
-    #[serde(rename = "segment", deserialize_with = "deserialize_one_or_many")]
+    #[serde(rename = "segment")]
     segments: Vec<XMLOEMSegment>,
 }
 
@@ -439,7 +338,7 @@ pub(crate) struct XMLCovarianceMatrix {
     cz_dot_y_dot: XMLValue,
     #[serde(rename = "CZ_DOT_Z_DOT")]
     cz_dot_z_dot: XMLValue,
-    #[serde(rename = "COMMENT", default, deserialize_with = "deserialize_comments")]
+    #[serde(rename = "COMMENT", default)]
     comment: Vec<String>,
 }
 
@@ -742,7 +641,7 @@ struct XMLMeanElements {
     mean_anomaly: XMLValue,
     #[serde(rename = "GM")]
     gm: Option<XMLValue>,
-    #[serde(rename = "COMMENT", default, deserialize_with = "deserialize_comments")]
+    #[serde(rename = "COMMENT", default)]
     comments: Vec<String>,
 }
 
@@ -768,7 +667,7 @@ struct XMLTleParameters {
     mean_motion_ddot: Option<XMLValue>,
     #[serde(rename = "AGOM")]
     agom: Option<XMLValue>,
-    #[serde(rename = "COMMENT", default, deserialize_with = "deserialize_comments")]
+    #[serde(rename = "COMMENT", default)]
     comments: Vec<String>,
 }
 
@@ -784,7 +683,7 @@ struct XMLSpacecraftParameters {
     drag_area: Option<XMLValue>,
     #[serde(rename = "DRAG_COEFF")]
     drag_coeff: Option<XMLValue>,
-    #[serde(rename = "COMMENT", default, deserialize_with = "deserialize_comments")]
+    #[serde(rename = "COMMENT", default)]
     comments: Vec<String>,
 }
 
@@ -1079,21 +978,8 @@ struct XMLOPMData {
     spacecraft_parameters: Option<XMLSpacecraftParameters>,
     #[serde(default)]
     covariance_matrix: Option<XMLCovarianceMatrix>,
-    #[serde(
-        default,
-        rename = "maneuverParameters",
-        deserialize_with = "deserialize_one_or_many_opt"
-    )]
+    #[serde(default, rename = "maneuverParameters")]
     maneuver_parameters: Vec<XMLManeuverParameters>,
-}
-
-/// Deserialize an optional field that may be absent, a single struct, or a sequence.
-fn deserialize_one_or_many_opt<'de, D, T>(deserializer: D) -> Result<Vec<T>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-    T: Deserialize<'de>,
-{
-    deserialize_one_or_many(deserializer)
 }
 
 #[derive(Debug, Deserialize)]
@@ -1112,7 +998,7 @@ struct XMLOPMStateVector {
     y_dot: XMLValue,
     #[serde(rename = "Z_DOT")]
     z_dot: XMLValue,
-    #[serde(rename = "COMMENT", default, deserialize_with = "deserialize_comments")]
+    #[serde(rename = "COMMENT", default)]
     comments: Vec<String>,
 }
 
@@ -1134,7 +1020,7 @@ struct XMLKeplerianElements {
     mean_anomaly: Option<XMLValue>,
     #[serde(rename = "GM")]
     gm: Option<XMLValue>,
-    #[serde(rename = "COMMENT", default, deserialize_with = "deserialize_comments")]
+    #[serde(rename = "COMMENT", default)]
     comments: Vec<String>,
 }
 
@@ -1154,7 +1040,7 @@ struct XMLManeuverParameters {
     dv_2: XMLValue,
     #[serde(rename = "MAN_DV_3")]
     dv_3: XMLValue,
-    #[serde(rename = "COMMENT", default, deserialize_with = "deserialize_comments")]
+    #[serde(rename = "COMMENT", default)]
     comments: Vec<String>,
 }
 
@@ -1562,5 +1448,121 @@ mod tests {
         assert_eq!(cov.cov_ref_frame.as_ref().unwrap(), &CCSDSRefFrame::ITRF97);
         // CX_X = 0.316 km² = 316000 m²
         assert!((cov.matrix[(0, 0)] - 0.316 * 1e6).abs() < 1.0);
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_parse_oem_xml_multiple_comments_per_block() {
+        let oem = parse_oem_xml(
+            &std::fs::read_to_string("test_assets/ccsds/oem/OEM-multiple-comments.xml").unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            oem.header.comments,
+            vec!["first header comment", "second header comment"]
+        );
+
+        let seg = &oem.segments[0];
+        assert_eq!(
+            seg.metadata.comments,
+            vec!["first metadata comment", "second metadata comment"]
+        );
+        assert_eq!(
+            seg.comments,
+            vec!["first data comment", "second data comment"]
+        );
+        assert_eq!(
+            seg.covariances[0].comments,
+            vec!["first covariance comment", "second covariance comment"]
+        );
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_parse_omm_xml_multiple_comments_per_block() {
+        let omm = parse_omm_xml(
+            &std::fs::read_to_string("test_assets/ccsds/omm/OMM-multiple-comments.xml").unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            omm.header.comments,
+            vec!["first header comment", "second header comment"]
+        );
+        assert_eq!(
+            omm.metadata.comments,
+            vec!["first metadata comment", "second metadata comment"]
+        );
+        assert_eq!(
+            omm.mean_elements.comments,
+            vec!["first mean-element comment", "second mean-element comment"]
+        );
+        assert_eq!(
+            omm.tle_parameters.as_ref().unwrap().comments,
+            vec!["first TLE comment", "second TLE comment"]
+        );
+        assert_eq!(
+            omm.spacecraft_parameters.as_ref().unwrap().comments,
+            vec!["first spacecraft comment", "second spacecraft comment"]
+        );
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_parse_opm_xml_multiple_comments_per_block() {
+        let opm = parse_opm_xml(
+            &std::fs::read_to_string("test_assets/ccsds/opm/OPM-multiple-comments.xml").unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            opm.header.comments,
+            vec!["first header comment", "second header comment"]
+        );
+        assert_eq!(
+            opm.metadata.comments,
+            vec!["first metadata comment", "second metadata comment"]
+        );
+        assert_eq!(
+            opm.state_vector.comments,
+            vec!["first state-vector comment", "second state-vector comment"]
+        );
+        assert_eq!(
+            opm.keplerian_elements.as_ref().unwrap().comments,
+            vec!["first Keplerian comment", "second Keplerian comment"]
+        );
+        assert_eq!(
+            opm.maneuvers[0].comments,
+            vec!["first maneuver comment", "second maneuver comment"]
+        );
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_parse_oem_xml_multiple_segments() {
+        let oem = parse_oem_xml(
+            &std::fs::read_to_string("test_assets/ccsds/oem/OEM-two-segments.xml").unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(oem.segments.len(), 2);
+        assert_eq!(oem.segments[0].states.len(), 1);
+        assert_eq!(oem.segments[1].states.len(), 1);
+        assert!((oem.segments[1].states[0].position[0] + 2432200.0).abs() < 1.0);
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_parse_opm_xml_multiple_maneuvers() {
+        let opm = parse_opm_xml(
+            &std::fs::read_to_string("test_assets/ccsds/opm/OPM-two-maneuvers.xml").unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(opm.maneuvers.len(), 2);
+        assert!((opm.maneuvers[0].duration - 300.0).abs() < 1e-10);
+        assert!((opm.maneuvers[1].duration - 150.0).abs() < 1e-10);
+        assert!((opm.maneuvers[1].dv[1] - 2.0).abs() < 1e-10);
     }
 }

--- a/test_assets/ccsds/oem/OEM-multiple-comments.xml
+++ b/test_assets/ccsds/oem/OEM-multiple-comments.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oem id="CCSDS_OEM_VERS" version="3.0">
+  <header>
+    <COMMENT>first header comment</COMMENT>
+    <COMMENT>second header comment</COMMENT>
+    <CREATION_DATE>1996-11-04T17:22:31</CREATION_DATE>
+    <ORIGINATOR>NASA/JPL</ORIGINATOR>
+  </header>
+  <body><segment>
+    <metadata>
+      <COMMENT>first metadata comment</COMMENT>
+      <COMMENT>second metadata comment</COMMENT>
+      <OBJECT_NAME>MARS GLOBAL SURVEYOR</OBJECT_NAME>
+      <OBJECT_ID>2000-028A</OBJECT_ID>
+      <CENTER_NAME>MARS BARYCENTER</CENTER_NAME>
+      <REF_FRAME>J2000</REF_FRAME>
+      <TIME_SYSTEM>UTC</TIME_SYSTEM>
+      <START_TIME>1996-12-18T12:00:00.331</START_TIME>
+      <STOP_TIME>1996-12-18T12:01:00.331</STOP_TIME>
+    </metadata>
+    <data>
+      <COMMENT>first data comment</COMMENT>
+      <COMMENT>second data comment</COMMENT>
+      <stateVector>
+        <EPOCH>1996-12-18T12:00:00.331</EPOCH>
+        <X>2789.6</X><Y>-280.0</Y><Z>-1746.8</Z>
+        <X_DOT>4.73</X_DOT><Y_DOT>-2.50</Y_DOT><Z_DOT>-1.04</Z_DOT>
+      </stateVector>
+      <stateVector>
+        <EPOCH>1996-12-18T12:01:00.331</EPOCH>
+        <X>2783.4</X><Y>-308.1</Y><Z>-1877.1</Z>
+        <X_DOT>5.19</X_DOT><Y_DOT>-2.42</Y_DOT><Z_DOT>-2.00</Z_DOT>
+      </stateVector>
+      <covarianceMatrix>
+        <COMMENT>first covariance comment</COMMENT>
+        <COMMENT>second covariance comment</COMMENT>
+        <CX_X>0.316</CX_X>
+        <CY_X>0.722</CY_X><CY_Y>0.518</CY_Y>
+        <CZ_X>0.202</CZ_X><CZ_Y>0.715</CZ_Y><CZ_Z>0.002</CZ_Z>
+        <CX_DOT_X>0.912</CX_DOT_X><CX_DOT_Y>0.306</CX_DOT_Y>
+        <CX_DOT_Z>0.276</CX_DOT_Z><CX_DOT_X_DOT>0.797</CX_DOT_X_DOT>
+        <CY_DOT_X>0.562</CY_DOT_X><CY_DOT_Y>0.899</CY_DOT_Y>
+        <CY_DOT_Z>0.022</CY_DOT_Z><CY_DOT_X_DOT>0.079</CY_DOT_X_DOT>
+        <CY_DOT_Y_DOT>0.415</CY_DOT_Y_DOT>
+        <CZ_DOT_X>0.245</CZ_DOT_X><CZ_DOT_Y>0.965</CZ_DOT_Y>
+        <CZ_DOT_Z>0.950</CZ_DOT_Z><CZ_DOT_X_DOT>0.435</CZ_DOT_X_DOT>
+        <CZ_DOT_Y_DOT>0.621</CZ_DOT_Y_DOT><CZ_DOT_Z_DOT>0.991</CZ_DOT_Z_DOT>
+      </covarianceMatrix>
+    </data>
+  </segment></body>
+</oem>

--- a/test_assets/ccsds/oem/OEM-two-segments.xml
+++ b/test_assets/ccsds/oem/OEM-two-segments.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oem id="CCSDS_OEM_VERS" version="3.0">
+  <header>
+    <CREATION_DATE>1996-11-04T17:22:31</CREATION_DATE>
+    <ORIGINATOR>NASA/JPL</ORIGINATOR>
+  </header>
+  <body>
+    <segment>
+      <metadata>
+        <OBJECT_NAME>MARS GLOBAL SURVEYOR</OBJECT_NAME>
+        <OBJECT_ID>2000-028A</OBJECT_ID>
+        <CENTER_NAME>MARS BARYCENTER</CENTER_NAME>
+        <REF_FRAME>J2000</REF_FRAME>
+        <TIME_SYSTEM>UTC</TIME_SYSTEM>
+        <START_TIME>1996-12-18T12:00:00.331</START_TIME>
+        <STOP_TIME>1996-12-18T12:01:00.331</STOP_TIME>
+      </metadata>
+      <data>
+        <stateVector>
+          <EPOCH>1996-12-18T12:00:00.331</EPOCH>
+          <X>2789.6</X><Y>-280.0</Y><Z>-1746.8</Z>
+          <X_DOT>4.73</X_DOT><Y_DOT>-2.50</Y_DOT><Z_DOT>-1.04</Z_DOT>
+        </stateVector>
+      </data>
+    </segment>
+    <segment>
+      <metadata>
+        <OBJECT_NAME>MARS GLOBAL SURVEYOR</OBJECT_NAME>
+        <OBJECT_ID>2000-028A</OBJECT_ID>
+        <CENTER_NAME>MARS BARYCENTER</CENTER_NAME>
+        <REF_FRAME>J2000</REF_FRAME>
+        <TIME_SYSTEM>UTC</TIME_SYSTEM>
+        <START_TIME>1996-12-28T21:28:00.331</START_TIME>
+        <STOP_TIME>1996-12-28T21:29:00.331</STOP_TIME>
+      </metadata>
+      <data>
+        <stateVector>
+          <EPOCH>1996-12-28T21:28:00.331</EPOCH>
+          <X>-2432.2</X><Y>-063.0</Y><Z>1742.3</Z>
+          <X_DOT>7.63</X_DOT><Y_DOT>-2.33</Y_DOT><Z_DOT>5.09</Z_DOT>
+        </stateVector>
+      </data>
+    </segment>
+  </body>
+</oem>

--- a/test_assets/ccsds/omm/OMM-multiple-comments.xml
+++ b/test_assets/ccsds/omm/OMM-multiple-comments.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<omm id="CCSDS_OMM_VERS" version="3.0">
+  <header>
+    <COMMENT>first header comment</COMMENT>
+    <COMMENT>second header comment</COMMENT>
+    <CREATION_DATE>2007-065T16:00:00</CREATION_DATE>
+    <ORIGINATOR>NOAA</ORIGINATOR>
+  </header>
+  <body><segment>
+    <metadata>
+      <COMMENT>first metadata comment</COMMENT>
+      <COMMENT>second metadata comment</COMMENT>
+      <OBJECT_NAME>GOES-9</OBJECT_NAME>
+      <OBJECT_ID>1995-025A</OBJECT_ID>
+      <CENTER_NAME>EARTH</CENTER_NAME>
+      <REF_FRAME>TEME</REF_FRAME>
+      <TIME_SYSTEM>UTC</TIME_SYSTEM>
+      <MEAN_ELEMENT_THEORY>SGP4</MEAN_ELEMENT_THEORY>
+    </metadata>
+    <data>
+      <meanElements>
+        <COMMENT>first mean-element comment</COMMENT>
+        <COMMENT>second mean-element comment</COMMENT>
+        <EPOCH>2007-064T10:34:41.4264</EPOCH>
+        <MEAN_MOTION>1.00273272</MEAN_MOTION>
+        <ECCENTRICITY>0.0005013</ECCENTRICITY>
+        <INCLINATION>3.0539</INCLINATION>
+        <RA_OF_ASC_NODE>81.7939</RA_OF_ASC_NODE>
+        <ARG_OF_PERICENTER>249.2363</ARG_OF_PERICENTER>
+        <MEAN_ANOMALY>150.1602</MEAN_ANOMALY>
+      </meanElements>
+      <tleParameters>
+        <COMMENT>first TLE comment</COMMENT>
+        <COMMENT>second TLE comment</COMMENT>
+        <NORAD_CAT_ID>23581</NORAD_CAT_ID>
+        <ELEMENT_SET_NO>0925</ELEMENT_SET_NO>
+        <REV_AT_EPOCH>4316</REV_AT_EPOCH>
+        <BSTAR>0.0001</BSTAR>
+        <MEAN_MOTION_DOT>-0.00000113</MEAN_MOTION_DOT>
+        <MEAN_MOTION_DDOT>0.0</MEAN_MOTION_DDOT>
+      </tleParameters>
+      <spacecraftParameters>
+        <COMMENT>first spacecraft comment</COMMENT>
+        <COMMENT>second spacecraft comment</COMMENT>
+        <MASS>300.0</MASS>
+        <SOLAR_RAD_AREA>5.0</SOLAR_RAD_AREA>
+        <SOLAR_RAD_COEFF>1.2</SOLAR_RAD_COEFF>
+        <DRAG_AREA>5.0</DRAG_AREA>
+        <DRAG_COEFF>2.2</DRAG_COEFF>
+      </spacecraftParameters>
+    </data>
+  </segment></body>
+</omm>

--- a/test_assets/ccsds/opm/OPM-multiple-comments.xml
+++ b/test_assets/ccsds/opm/OPM-multiple-comments.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<opm id="CCSDS_OPM_VERS" version="3.0">
+  <header>
+    <COMMENT>first header comment</COMMENT>
+    <COMMENT>second header comment</COMMENT>
+    <CREATION_DATE>2001-11-06T09:23:57</CREATION_DATE>
+    <ORIGINATOR>JAXA</ORIGINATOR>
+  </header>
+  <body><segment>
+    <metadata>
+      <COMMENT>first metadata comment</COMMENT>
+      <COMMENT>second metadata comment</COMMENT>
+      <OBJECT_NAME>OSPREY 5</OBJECT_NAME>
+      <OBJECT_ID>1998-999A</OBJECT_ID>
+      <CENTER_NAME>EARTH</CENTER_NAME>
+      <REF_FRAME>TOD</REF_FRAME>
+      <TIME_SYSTEM>UTC</TIME_SYSTEM>
+    </metadata>
+    <data>
+      <stateVector>
+        <COMMENT>first state-vector comment</COMMENT>
+        <COMMENT>second state-vector comment</COMMENT>
+        <EPOCH>1996-12-18T14:28:15.1172</EPOCH>
+        <X>6503.514000</X><Y>1239.647000</Y><Z>-717.490000</Z>
+        <X_DOT>-0.873160</X_DOT><Y_DOT>8.740420</Y_DOT><Z_DOT>-4.191076</Z_DOT>
+      </stateVector>
+      <keplerianElements>
+        <COMMENT>first Keplerian comment</COMMENT>
+        <COMMENT>second Keplerian comment</COMMENT>
+        <SEMI_MAJOR_AXIS>6730.96</SEMI_MAJOR_AXIS>
+        <ECCENTRICITY>0.0006703</ECCENTRICITY>
+        <INCLINATION>51.6416</INCLINATION>
+        <RA_OF_ASC_NODE>247.4627</RA_OF_ASC_NODE>
+        <ARG_OF_PERICENTER>130.5360</ARG_OF_PERICENTER>
+        <TRUE_ANOMALY>325.0288</TRUE_ANOMALY>
+        <GM>398600.4415</GM>
+      </keplerianElements>
+      <maneuverParameters>
+        <COMMENT>first maneuver comment</COMMENT>
+        <COMMENT>second maneuver comment</COMMENT>
+        <MAN_EPOCH_IGNITION>2000-03-01T00:00:00.000</MAN_EPOCH_IGNITION>
+        <MAN_DURATION>300.0</MAN_DURATION>
+        <MAN_DELTA_MASS>-5.0</MAN_DELTA_MASS>
+        <MAN_REF_FRAME>RTN</MAN_REF_FRAME>
+        <MAN_DV_1>0.001</MAN_DV_1>
+        <MAN_DV_2>0.0</MAN_DV_2>
+        <MAN_DV_3>0.0</MAN_DV_3>
+      </maneuverParameters>
+    </data>
+  </segment></body>
+</opm>

--- a/test_assets/ccsds/opm/OPM-two-maneuvers.xml
+++ b/test_assets/ccsds/opm/OPM-two-maneuvers.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<opm id="CCSDS_OPM_VERS" version="3.0">
+  <header>
+    <CREATION_DATE>2001-11-06T09:23:57</CREATION_DATE>
+    <ORIGINATOR>JAXA</ORIGINATOR>
+  </header>
+  <body><segment>
+    <metadata>
+      <OBJECT_NAME>OSPREY 5</OBJECT_NAME>
+      <OBJECT_ID>1998-999A</OBJECT_ID>
+      <CENTER_NAME>EARTH</CENTER_NAME>
+      <REF_FRAME>TOD</REF_FRAME>
+      <TIME_SYSTEM>UTC</TIME_SYSTEM>
+    </metadata>
+    <data>
+      <stateVector>
+        <EPOCH>1996-12-18T14:28:15.1172</EPOCH>
+        <X>6503.514000</X><Y>1239.647000</Y><Z>-717.490000</Z>
+        <X_DOT>-0.873160</X_DOT><Y_DOT>8.740420</Y_DOT><Z_DOT>-4.191076</Z_DOT>
+      </stateVector>
+      <maneuverParameters>
+        <MAN_EPOCH_IGNITION>2000-03-01T00:00:00.000</MAN_EPOCH_IGNITION>
+        <MAN_DURATION>300.0</MAN_DURATION>
+        <MAN_DELTA_MASS>-5.0</MAN_DELTA_MASS>
+        <MAN_REF_FRAME>RTN</MAN_REF_FRAME>
+        <MAN_DV_1>0.001</MAN_DV_1><MAN_DV_2>0.0</MAN_DV_2><MAN_DV_3>0.0</MAN_DV_3>
+      </maneuverParameters>
+      <maneuverParameters>
+        <MAN_EPOCH_IGNITION>2000-03-02T00:00:00.000</MAN_EPOCH_IGNITION>
+        <MAN_DURATION>150.0</MAN_DURATION>
+        <MAN_DELTA_MASS>-2.5</MAN_DELTA_MASS>
+        <MAN_REF_FRAME>RTN</MAN_REF_FRAME>
+        <MAN_DV_1>0.0</MAN_DV_1><MAN_DV_2>0.002</MAN_DV_2><MAN_DV_3>0.0</MAN_DV_3>
+      </maneuverParameters>
+    </data>
+  </segment></body>
+</opm>

--- a/tests/ccsds/test_xml_parser.py
+++ b/tests/ccsds/test_xml_parser.py
@@ -1,0 +1,70 @@
+"""Tests for CCSDS XML parsing — parity with Rust tests in src/ccsds/xml/parser.rs."""
+
+import pytest
+
+import brahe  # noqa: F401
+from brahe.ccsds import OEM, OMM, OPM
+
+
+def _asset(path):
+    """Read a CCSDS fixture; the same files back the Rust tests."""
+    with open(path) as handle:
+        return handle.read()
+
+
+def test_parse_oem_xml_multiple_comments_per_block(eop):
+    """Mirror of test_parse_oem_xml_multiple_comments_per_block in Rust."""
+    oem = OEM.from_str(_asset("test_assets/ccsds/oem/OEM-multiple-comments.xml"))
+    d = oem.to_dict()
+
+    assert d["header"]["comments"] == ["first header comment", "second header comment"]
+    assert d["segments"][0]["metadata"]["comments"] == [
+        "first metadata comment",
+        "second metadata comment",
+    ]
+    assert d["segments"][0]["comments"] == ["first data comment", "second data comment"]
+    assert d["segments"][0]["num_covariances"] == 1
+
+
+def test_parse_omm_xml_multiple_comments_per_block(eop):
+    """Mirror of test_parse_omm_xml_multiple_comments_per_block in Rust."""
+    omm = OMM.from_str(_asset("test_assets/ccsds/omm/OMM-multiple-comments.xml"))
+    d = omm.to_dict()
+
+    assert d["metadata"]["object_name"] == "GOES-9"
+    assert "tle_parameters" in d
+    assert "spacecraft_parameters" in d
+
+
+def test_parse_opm_xml_multiple_comments_per_block(eop):
+    """Mirror of test_parse_opm_xml_multiple_comments_per_block in Rust."""
+    opm = OPM.from_str(_asset("test_assets/ccsds/opm/OPM-multiple-comments.xml"))
+
+    assert opm.to_dict()["header"]["comments"] == [
+        "first header comment",
+        "second header comment",
+    ]
+    assert opm.maneuvers[0].comments == [
+        "first maneuver comment",
+        "second maneuver comment",
+    ]
+
+
+def test_parse_oem_xml_multiple_segments(eop):
+    """Mirror of test_parse_oem_xml_multiple_segments in Rust."""
+    oem = OEM.from_str(_asset("test_assets/ccsds/oem/OEM-two-segments.xml"))
+
+    assert len(oem.segments) == 2
+    assert oem.segments[0].num_states == 1
+    assert oem.segments[1].num_states == 1
+    assert oem.segments[1].states[0].position[0] == pytest.approx(-2432200.0, abs=1.0)
+
+
+def test_parse_opm_xml_multiple_maneuvers(eop):
+    """Mirror of test_parse_opm_xml_multiple_maneuvers in Rust."""
+    opm = OPM.from_str(_asset("test_assets/ccsds/opm/OPM-two-maneuvers.xml"))
+
+    assert len(opm.maneuvers) == 2
+    assert opm.maneuvers[0].duration == pytest.approx(300.0)
+    assert opm.maneuvers[1].duration == pytest.approx(150.0)
+    assert opm.maneuvers[1].dv[1] == pytest.approx(2.0)


### PR DESCRIPTION
# Pull Request

## Description

CCSDS 502.0-B-3 subsection 8.13.7 places no limit on how many `<COMMENT>` elements a block may carry, the OEM body holds one `<segment>` per ephemeris segment (5.2.2), and the OPM data section holds one `<maneuverParameters>` per maneuver (3.2.4.5). The ODM/XML schemas declare all three with unbounded multiplicity. Nine intermediate struct fields deserialized these through custom visitors that saw one element at a time and never merged them, so serde rejected the second element with `duplicate field` and the whole message failed to parse. Declaring each field as a plain `Vec` lets quick-xml's own sequence merging collect every element, which also handles the single-element case the visitors were written for.

The `COMMENT` change covers the `covarianceMatrix` block of the OEM, the `meanElements`, `tleParameters`, and `spacecraftParameters` blocks of the OMM, and the `stateVector`, `keplerianElements`, and `maneuverParameters` blocks of the OPM. Beyond the reported comment defect, the same root cause meant any OEM with more than one segment and any OPM with more than one maneuver were unreadable in XML — including the output of brahe's own XML writer, so a multi-segment OEM could be written but never read back.

## Changelog

### Fixed
- CCSDS OEM, OMM, and OPM XML parsers now collect repeated `COMMENT` elements instead of failing with `duplicate field COMMENT`.
- CCSDS OEM XML parsing now accepts messages with more than one `<segment>`, and OPM XML parsing accepts more than one `<maneuverParameters>`; both previously failed with a `duplicate field` error, which made brahe unable to re-read its own multi-segment OEM and multi-maneuver OPM XML output.

## Related Issue

Closes #459.

## Note to Reviewers

The multi-segment and multi-maneuver failures were not in the issue; they surfaced while writing the round-trip test for the escaping change stacked above this one, and share the defect and the fix with the reported comment case. Five Rust regression tests were confirmed to fail against the previous deserializers, with Python mirrors in `tests/ccsds/test_xml_parser.py`.
