### PR TITLE
Write ODM epochs in the message's declared time system

### DIFF
--- a/crates/brahe-py/src/ccsds.rs
+++ b/crates/brahe-py/src/ccsds.rs
@@ -1388,7 +1388,7 @@ impl PyOEM {
         )?;
         header.set_item(
             "creation_date",
-            brahe::ccsds::common::format_ccsds_datetime(&self.inner.header.creation_date),
+            brahe::ccsds::common::format_ccsds_datetime_in(&self.inner.header.creation_date, &brahe::ccsds::common::CCSDSTimeSystem::UTC),
         )?;
         header.set_item("originator", &self.inner.header.originator)?;
         header.set_item("message_id", self.inner.header.message_id.as_deref())?;
@@ -1409,11 +1409,11 @@ impl PyOEM {
             meta.set_item("time_system", format!("{}", seg.metadata.time_system))?;
             meta.set_item(
                 "start_time",
-                brahe::ccsds::common::format_ccsds_datetime(&seg.metadata.start_time),
+                brahe::ccsds::common::format_ccsds_datetime_in(&seg.metadata.start_time, &seg.metadata.time_system),
             )?;
             meta.set_item(
                 "stop_time",
-                brahe::ccsds::common::format_ccsds_datetime(&seg.metadata.stop_time),
+                brahe::ccsds::common::format_ccsds_datetime_in(&seg.metadata.stop_time, &seg.metadata.time_system),
             )?;
             meta.set_item("interpolation", seg.metadata.interpolation.as_deref())?;
             meta.set_item("interpolation_degree", seg.metadata.interpolation_degree)?;
@@ -1426,7 +1426,7 @@ impl PyOEM {
                 let sv_dict = pyo3::types::PyDict::new(py);
                 sv_dict.set_item(
                     "epoch",
-                    brahe::ccsds::common::format_ccsds_datetime(&sv.epoch),
+                    brahe::ccsds::common::format_ccsds_datetime_in(&sv.epoch, &seg.metadata.time_system),
                 )?;
                 sv_dict.set_item("position", sv.position.to_vec())?;
                 sv_dict.set_item("velocity", sv.velocity.to_vec())?;
@@ -2606,7 +2606,7 @@ impl PyOMM {
         header.set_item("format_version", self.inner.header.format_version)?;
         header.set_item(
             "creation_date",
-            brahe::ccsds::common::format_ccsds_datetime(&self.inner.header.creation_date),
+            brahe::ccsds::common::format_ccsds_datetime_in(&self.inner.header.creation_date, &brahe::ccsds::common::CCSDSTimeSystem::UTC),
         )?;
         header.set_item("originator", &self.inner.header.originator)?;
         dict.set_item("header", header)?;
@@ -2631,7 +2631,7 @@ impl PyOMM {
         let me = pyo3::types::PyDict::new(py);
         me.set_item(
             "epoch",
-            brahe::ccsds::common::format_ccsds_datetime(&self.inner.mean_elements.epoch),
+            brahe::ccsds::common::format_ccsds_datetime_in(&self.inner.mean_elements.epoch, &self.inner.metadata.time_system),
         )?;
         me.set_item("mean_motion", self.inner.mean_elements.mean_motion)?;
         me.set_item(
@@ -3428,7 +3428,7 @@ impl PyOPM {
         header.set_item("format_version", self.inner.header.format_version)?;
         header.set_item(
             "creation_date",
-            brahe::ccsds::common::format_ccsds_datetime(&self.inner.header.creation_date),
+            brahe::ccsds::common::format_ccsds_datetime_in(&self.inner.header.creation_date, &brahe::ccsds::common::CCSDSTimeSystem::UTC),
         )?;
         header.set_item("originator", &self.inner.header.originator)?;
         header.set_item("comments", &self.inner.header.comments)?;
@@ -3450,7 +3450,7 @@ impl PyOPM {
         let sv = pyo3::types::PyDict::new(py);
         sv.set_item(
             "epoch",
-            brahe::ccsds::common::format_ccsds_datetime(&self.inner.state_vector.epoch),
+            brahe::ccsds::common::format_ccsds_datetime_in(&self.inner.state_vector.epoch, &self.inner.metadata.time_system),
         )?;
         sv.set_item("position", self.inner.state_vector.position.to_vec())?;
         sv.set_item("velocity", self.inner.state_vector.velocity.to_vec())?;
@@ -3488,7 +3488,7 @@ impl PyOPM {
                 let m_dict = pyo3::types::PyDict::new(py);
                 m_dict.set_item(
                     "epoch_ignition",
-                    brahe::ccsds::common::format_ccsds_datetime(&m.epoch_ignition),
+                    brahe::ccsds::common::format_ccsds_datetime_in(&m.epoch_ignition, &self.inner.metadata.time_system),
                 )?;
                 m_dict.set_item("duration", m.duration)?;
                 m_dict.set_item("delta_mass", m.delta_mass)?;
@@ -4666,7 +4666,7 @@ impl PyCDM {
     fn __repr__(&self) -> String {
         format!(
             "CDM(tca={}, miss_distance={:.1}m, obj1='{}', obj2='{}')",
-            brahe::ccsds::common::format_ccsds_datetime(self.inner.tca()),
+            brahe::ccsds::common::format_ccsds_datetime_in(self.inner.tca(), &brahe::ccsds::common::CCSDSTimeSystem::UTC),
             self.inner.miss_distance(),
             self.inner.object1.metadata.object_name,
             self.inner.object2.metadata.object_name,

--- a/src/ccsds/common.rs
+++ b/src/ccsds/common.rs
@@ -534,6 +534,45 @@ pub fn format_ccsds_datetime(epoch: &Epoch) -> String {
     }
 }
 
+/// Format an `Epoch` as a CCSDS datetime string in a given CCSDS time system.
+///
+/// CCSDS 502.0-B-3 subsection 7.5.11 ties every time or epoch keyword other
+/// than `CREATION_DATE` to the message's `TIME_SYSTEM`, and CCSDS 508.0-B-1
+/// subsection 6.2.3.4 fixes every CDM time tag to UTC. An `Epoch` carries its
+/// own time system, which need not be the one the message declares, so writers
+/// convert before formatting.
+///
+/// Five CCSDS time systems — `MET`, `MRT`, `SCLK`, `GMST`, and `TDR` — are
+/// mission- or spacecraft-specific clocks with no fixed relationship to the
+/// physical time systems `Epoch` represents. For those the epoch is formatted
+/// as stored, unconverted.
+///
+/// # Arguments
+///
+/// * `epoch` - The epoch to format.
+/// * `time_system` - The CCSDS time system the message declares.
+///
+/// # Returns
+///
+/// * `String` - The epoch rendered as `YYYY-MM-DDThh:mm:ss.sss`.
+///
+/// # Examples
+///
+/// ```
+/// use brahe::ccsds::common::{CCSDSTimeSystem, format_ccsds_datetime_in};
+/// use brahe::time::{Epoch, TimeSystem};
+///
+/// let epoch = Epoch::from_datetime(2024, 3, 1, 12, 0, 0.0, 0.0, TimeSystem::TAI);
+/// let written = format_ccsds_datetime_in(&epoch, &CCSDSTimeSystem::UTC);
+/// assert!(written.starts_with("2024-03-01T11:59:"));
+/// ```
+pub fn format_ccsds_datetime_in(epoch: &Epoch, time_system: &CCSDSTimeSystem) -> String {
+    match time_system.to_time_system() {
+        Some(ts) => format_ccsds_datetime(&epoch.to_time_system(ts)),
+        None => format_ccsds_datetime(epoch),
+    }
+}
+
 /// Strip unit annotations from a CCSDS KVN value string.
 ///
 /// CCSDS KVN values may contain optional unit annotations in square brackets
@@ -713,6 +752,10 @@ pub fn covariance_to_lower_triangular(matrix: &SMatrix<f64, 6, 6>, scale: f64) -
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
+    use crate::ccsds::cdm::CDM;
+    use crate::ccsds::oem::OEM;
+    use crate::ccsds::omm::OMM;
+    use crate::ccsds::opm::OPM;
 
     #[test]
     fn test_ccsds_format_display() {
@@ -1264,5 +1307,242 @@ mod tests {
         assert!(CCSDSTimeSystem::GMST.to_time_system().is_none());
         assert!(CCSDSTimeSystem::MRT.to_time_system().is_none());
         assert!(CCSDSTimeSystem::SCLK.to_time_system().is_none());
+    }
+
+    /// Retag an epoch into another time system without moving the instant, the
+    /// way a user-constructed message can end up holding epochs in a system
+    /// other than the one its metadata declares.
+    fn retag(e: &Epoch) -> Epoch {
+        e.to_time_system(crate::time::TimeSystem::TAI)
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_format_ccsds_datetime_in_converts_to_declared_system() {
+        let utc = Epoch::from_datetime(2024, 3, 1, 12, 0, 0.0, 0.0, crate::time::TimeSystem::UTC);
+
+        // Same instant, formatted in each declared system.
+        assert_eq!(
+            format_ccsds_datetime_in(&utc, &CCSDSTimeSystem::UTC),
+            "2024-03-01T12:00:00.000"
+        );
+        assert_eq!(
+            format_ccsds_datetime_in(&utc, &CCSDSTimeSystem::TAI),
+            "2024-03-01T12:00:37.000"
+        );
+
+        // The epoch's own time system does not influence the result.
+        assert_eq!(
+            format_ccsds_datetime_in(&retag(&utc), &CCSDSTimeSystem::UTC),
+            format_ccsds_datetime_in(&utc, &CCSDSTimeSystem::UTC)
+        );
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_format_ccsds_datetime_in_leaves_mission_clocks_unconverted() {
+        let tai = Epoch::from_datetime(2024, 3, 1, 12, 0, 0.0, 0.0, crate::time::TimeSystem::TAI);
+
+        // MET, MRT, SCLK, GMST, and TDR have no `TimeSystem` counterpart, so
+        // the epoch is written exactly as stored.
+        for ts in [
+            CCSDSTimeSystem::MET,
+            CCSDSTimeSystem::MRT,
+            CCSDSTimeSystem::SCLK,
+            CCSDSTimeSystem::GMST,
+            CCSDSTimeSystem::TDR,
+        ] {
+            assert_eq!(
+                format_ccsds_datetime_in(&tai, &ts),
+                format_ccsds_datetime(&tai)
+            );
+        }
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_writers_use_declared_time_system_not_epoch_time_system() {
+        let formats = [CCSDSFormat::KVN, CCSDSFormat::XML, CCSDSFormat::JSON];
+
+        // OEM
+        let src = std::fs::read_to_string("test_assets/ccsds/oem/OEMExample1.txt").unwrap();
+        let oem = OEM::from_str(&src).unwrap();
+        let mut retagged = oem.clone();
+        retagged.header.creation_date = retag(&retagged.header.creation_date);
+        for seg in &mut retagged.segments {
+            seg.metadata.start_time = retag(&seg.metadata.start_time);
+            seg.metadata.stop_time = retag(&seg.metadata.stop_time);
+            seg.metadata.useable_start_time = seg.metadata.useable_start_time.as_ref().map(retag);
+            seg.metadata.useable_stop_time = seg.metadata.useable_stop_time.as_ref().map(retag);
+            for sv in &mut seg.states {
+                sv.epoch = retag(&sv.epoch);
+            }
+            for cov in &mut seg.covariances {
+                cov.epoch = cov.epoch.as_ref().map(retag);
+            }
+        }
+        for format in formats {
+            assert_eq!(
+                retagged.to_string(format).unwrap(),
+                oem.to_string(format).unwrap(),
+                "OEM {:?} output depends on the epoch's own time system",
+                format
+            );
+        }
+
+        // OMM
+        let src = std::fs::read_to_string("test_assets/ccsds/omm/OMMExample2.txt").unwrap();
+        let mut omm = OMM::from_str(&src).unwrap();
+        // The fixture leaves these unset, so populate them: every epoch the
+        // writers can emit has to follow the declared system, not just the
+        // ones a stock message happens to carry.
+        omm.metadata.ref_frame_epoch = Some(omm.mean_elements.epoch);
+        omm.covariance = Some(CCSDSCovariance {
+            epoch: Some(omm.mean_elements.epoch),
+            cov_ref_frame: None,
+            matrix: SMatrix::<f64, 6, 6>::identity(),
+            comments: Vec::new(),
+        });
+        let omm = omm;
+        let mut retagged = omm.clone();
+        retagged.header.creation_date = retag(&retagged.header.creation_date);
+        retagged.mean_elements.epoch = retag(&retagged.mean_elements.epoch);
+        retagged.metadata.ref_frame_epoch = retagged.metadata.ref_frame_epoch.as_ref().map(retag);
+        if let Some(ref mut cov) = retagged.covariance {
+            cov.epoch = cov.epoch.as_ref().map(retag);
+        }
+        for format in formats {
+            assert_eq!(
+                retagged.to_string(format).unwrap(),
+                omm.to_string(format).unwrap(),
+                "OMM {:?} output depends on the epoch's own time system",
+                format
+            );
+        }
+
+        // OPM
+        let src = std::fs::read_to_string("test_assets/ccsds/opm/OPMExample2.txt").unwrap();
+        let mut opm = OPM::from_str(&src).unwrap();
+        assert!(!opm.maneuvers.is_empty(), "fixture has maneuvers");
+        opm.metadata.ref_frame_epoch = Some(opm.state_vector.epoch);
+        opm.covariance = Some(CCSDSCovariance {
+            epoch: Some(opm.state_vector.epoch),
+            cov_ref_frame: None,
+            matrix: SMatrix::<f64, 6, 6>::identity(),
+            comments: Vec::new(),
+        });
+        let opm = opm;
+        let mut retagged = opm.clone();
+        retagged.header.creation_date = retag(&retagged.header.creation_date);
+        retagged.state_vector.epoch = retag(&retagged.state_vector.epoch);
+        retagged.metadata.ref_frame_epoch = retagged.metadata.ref_frame_epoch.as_ref().map(retag);
+        if let Some(ref mut cov) = retagged.covariance {
+            cov.epoch = cov.epoch.as_ref().map(retag);
+        }
+        for man in &mut retagged.maneuvers {
+            man.epoch_ignition = retag(&man.epoch_ignition);
+        }
+        for format in formats {
+            assert_eq!(
+                retagged.to_string(format).unwrap(),
+                opm.to_string(format).unwrap(),
+                "OPM {:?} output depends on the epoch's own time system",
+                format
+            );
+        }
+
+        // CDM
+        let src = std::fs::read_to_string("test_assets/ccsds/cdm/CDMExample1.txt").unwrap();
+        let mut cdm = CDM::from_str(&src).unwrap();
+        cdm.relative_metadata.previous_message_epoch = Some(cdm.relative_metadata.tca);
+        cdm.relative_metadata.next_message_epoch = Some(cdm.relative_metadata.tca);
+        let cdm = cdm;
+        let mut retagged = cdm.clone();
+        retagged.header.creation_date = retag(&retagged.header.creation_date);
+        retagged.relative_metadata.tca = retag(&retagged.relative_metadata.tca);
+        retagged.relative_metadata.previous_message_epoch = retagged
+            .relative_metadata
+            .previous_message_epoch
+            .as_ref()
+            .map(retag);
+        retagged.relative_metadata.next_message_epoch = retagged
+            .relative_metadata
+            .next_message_epoch
+            .as_ref()
+            .map(retag);
+        for format in formats {
+            assert_eq!(
+                retagged.to_string(format).unwrap(),
+                cdm.to_string(format).unwrap(),
+                "CDM {:?} output depends on the epoch's own time system",
+                format
+            );
+        }
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_ref_frame_epoch_survives_a_non_utc_time_system() {
+        // Under a non-UTC TIME_SYSTEM the message has to come back declaring
+        // that same system, with every epoch on it. REF_FRAME_EPOCH precedes
+        // TIME_SYSTEM in the fixed keyword order and JSON object keys put
+        // START_TIME ahead of it, so a reader that resolves either eagerly
+        // falls back to UTC and shifts the instant by the scale offset.
+        let source = std::fs::read_to_string("test_assets/ccsds/oem/OEMExample1.txt").unwrap();
+        let mut oem = OEM::from_str(&source).unwrap();
+        let segment = &mut oem.segments[0];
+        segment.metadata.ref_frame_epoch = Some(segment.metadata.start_time);
+        segment.metadata.time_system = CCSDSTimeSystem::TAI;
+        let expected = segment.metadata.ref_frame_epoch.unwrap();
+
+        let start = segment.metadata.start_time;
+
+        for format in [CCSDSFormat::KVN, CCSDSFormat::XML, CCSDSFormat::JSON] {
+            let reparsed = OEM::from_str(&oem.to_string(format).unwrap()).unwrap();
+
+            assert_eq!(
+                reparsed.segments[0].metadata.time_system,
+                CCSDSTimeSystem::TAI,
+                "{:?} did not round-trip the declared time system",
+                format
+            );
+
+            let got = reparsed.segments[0].metadata.ref_frame_epoch.unwrap();
+            assert!(
+                (got - expected).abs() < 1e-9,
+                "{:?} shifted REF_FRAME_EPOCH by {} s",
+                format,
+                got - expected
+            );
+
+            let got_start = reparsed.segments[0].metadata.start_time;
+            assert!(
+                (got_start - start).abs() < 1e-9,
+                "{:?} shifted START_TIME by {} s",
+                format,
+                got_start - start
+            );
+        }
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_write_oem_epochs_follow_the_declared_time_system() {
+        let src = std::fs::read_to_string("test_assets/ccsds/oem/OEMExample1.txt").unwrap();
+        let mut oem = OEM::from_str(&src).unwrap();
+        assert_eq!(oem.segments[0].metadata.time_system, CCSDSTimeSystem::UTC);
+        assert!(
+            oem.to_string(CCSDSFormat::KVN)
+                .unwrap()
+                .contains("START_TIME = 1996-12-18T12:00:00.331")
+        );
+
+        // Redeclaring TIME_SYSTEM moves the written epochs onto that scale.
+        oem.segments[0].metadata.time_system = CCSDSTimeSystem::TAI;
+        assert!(
+            oem.to_string(CCSDSFormat::KVN)
+                .unwrap()
+                .contains("START_TIME = 1996-12-18T12:00:30.331")
+        );
     }
 }

--- a/src/ccsds/interop.rs
+++ b/src/ccsds/interop.rs
@@ -8,7 +8,7 @@
 use nalgebra::{DVector, SVector};
 
 use crate::ccsds::common::{
-    CCSDSRefFrame, CCSDSTimeSystem, ODMHeader, format_ccsds_datetime, parse_ccsds_datetime,
+    CCSDSRefFrame, CCSDSTimeSystem, ODMHeader, format_ccsds_datetime_in, parse_ccsds_datetime,
 };
 use crate::ccsds::oem::OEM;
 use crate::ccsds::omm::{OMM, OMMMetadata, OMMTleParameters, OMMeanElements};
@@ -343,12 +343,16 @@ impl OMM {
     ///
     /// * `GPRecord` - GP record with fields populated from the OMM
     pub fn to_gp_record(&self) -> GPRecord {
-        let epoch_str = format_ccsds_datetime(&self.mean_elements.epoch);
+        let epoch_str =
+            format_ccsds_datetime_in(&self.mean_elements.epoch, &self.metadata.time_system);
 
         GPRecord {
             ccsds_omm_vers: Some(format!("{:.1}", self.header.format_version)),
             comment: None,
-            creation_date: Some(format_ccsds_datetime(&self.header.creation_date)),
+            creation_date: Some(format_ccsds_datetime_in(
+                &self.header.creation_date,
+                &CCSDSTimeSystem::UTC,
+            )),
             originator: Some(self.header.originator.clone()),
             object_name: Some(self.metadata.object_name.clone()),
             object_id: Some(self.metadata.object_id.clone()),

--- a/src/ccsds/json.rs
+++ b/src/ccsds/json.rs
@@ -9,10 +9,19 @@
 use serde_json::{Map, Value, json};
 
 use crate::ccsds::common::{
-    CCSDSJsonKeyCase, covariance_to_lower_triangular, format_ccsds_datetime,
+    CCSDSJsonKeyCase, CCSDSTimeSystem, covariance_to_lower_triangular, format_ccsds_datetime_in,
 };
 use crate::ccsds::error::ccsds_parse_error;
 use crate::utils::errors::BraheError;
+
+/// Metadata keys that must be flattened before any other.
+///
+/// CCSDS 502.0-B-3 subsection 7.5.11 reads every epoch in the message's
+/// `TIME_SYSTEM`, and the KVN parsers these readers delegate to apply the
+/// scale declared so far, so the declaration has to precede the epochs it
+/// governs. JSON object keys arrive in an order that would otherwise put
+/// `START_TIME` and `REF_FRAME_EPOCH` ahead of it.
+const TIME_SYSTEM_FIRST: [&str; 1] = ["TIME_SYSTEM"];
 
 /// Convert a CCSDS keyword to the appropriate case for JSON output.
 ///
@@ -50,7 +59,7 @@ pub fn parse_oem_json(content: &str) -> Result<crate::ccsds::oem::OEM, BraheErro
             // Metadata block
             kvn_lines.push("META_START".to_string());
             if let Some(meta) = seg.get("metadata") {
-                flatten_object(&mut kvn_lines, meta);
+                flatten_object_ordered(&mut kvn_lines, meta, &TIME_SYSTEM_FIRST);
             }
             kvn_lines.push("META_STOP".to_string());
 
@@ -163,7 +172,10 @@ pub fn write_oem_json(
     }
     header.insert(
         key("CREATION_DATE", key_case),
-        json!(format_ccsds_datetime(&oem.header.creation_date)),
+        json!(format_ccsds_datetime_in(
+            &oem.header.creation_date,
+            &CCSDSTimeSystem::UTC
+        )),
     );
     header.insert(key("ORIGINATOR", key_case), json!(&oem.header.originator));
     if let Some(ref msg_id) = oem.header.message_id {
@@ -194,7 +206,7 @@ pub fn write_oem_json(
         if let Some(ref epoch) = seg.metadata.ref_frame_epoch {
             meta.insert(
                 key("REF_FRAME_EPOCH", key_case),
-                json!(format_ccsds_datetime(epoch)),
+                json!(format_ccsds_datetime_in(epoch, &seg.metadata.time_system)),
             );
         }
         meta.insert(
@@ -203,23 +215,29 @@ pub fn write_oem_json(
         );
         meta.insert(
             key("START_TIME", key_case),
-            json!(format_ccsds_datetime(&seg.metadata.start_time)),
+            json!(format_ccsds_datetime_in(
+                &seg.metadata.start_time,
+                &seg.metadata.time_system
+            )),
         );
         if let Some(ref t) = seg.metadata.useable_start_time {
             meta.insert(
                 key("USEABLE_START_TIME", key_case),
-                json!(format_ccsds_datetime(t)),
+                json!(format_ccsds_datetime_in(t, &seg.metadata.time_system)),
             );
         }
         if let Some(ref t) = seg.metadata.useable_stop_time {
             meta.insert(
                 key("USEABLE_STOP_TIME", key_case),
-                json!(format_ccsds_datetime(t)),
+                json!(format_ccsds_datetime_in(t, &seg.metadata.time_system)),
             );
         }
         meta.insert(
             key("STOP_TIME", key_case),
-            json!(format_ccsds_datetime(&seg.metadata.stop_time)),
+            json!(format_ccsds_datetime_in(
+                &seg.metadata.stop_time,
+                &seg.metadata.time_system
+            )),
         );
         if let Some(ref interp) = seg.metadata.interpolation {
             meta.insert(key("INTERPOLATION", key_case), json!(interp));
@@ -235,7 +253,10 @@ pub fn write_oem_json(
             let mut state_obj = Map::new();
             state_obj.insert(
                 key("EPOCH", key_case),
-                json!(format_ccsds_datetime(&sv.epoch)),
+                json!(format_ccsds_datetime_in(
+                    &sv.epoch,
+                    &seg.metadata.time_system
+                )),
             );
             state_obj.insert(key("X", key_case), json!(sv.position[0] / 1000.0));
             state_obj.insert(key("Y", key_case), json!(sv.position[1] / 1000.0));
@@ -258,7 +279,10 @@ pub fn write_oem_json(
             for cov in &seg.covariances {
                 let mut cov_obj = Map::new();
                 if let Some(ref epoch) = cov.epoch {
-                    cov_obj.insert(key("EPOCH", key_case), json!(format_ccsds_datetime(epoch)));
+                    cov_obj.insert(
+                        key("EPOCH", key_case),
+                        json!(format_ccsds_datetime_in(epoch, &seg.metadata.time_system)),
+                    );
                 }
                 if let Some(ref frame) = cov.cov_ref_frame {
                     cov_obj.insert(key("COV_REF_FRAME", key_case), json!(format!("{}", frame)));
@@ -345,7 +369,9 @@ pub fn parse_omm_json(content: &str) -> Result<crate::ccsds::omm::OMM, BraheErro
 
     for section in &ordered_sections {
         if let Some(obj) = v.get(*section).or_else(|| v.get(section.to_uppercase())) {
-            if *section == "covariance" {
+            if *section == "metadata" {
+                flatten_object_ordered(&mut kvn_lines, obj, &TIME_SYSTEM_FIRST);
+            } else if *section == "covariance" {
                 flatten_object_ordered(&mut kvn_lines, obj, &cov_key_order);
             } else {
                 flatten_object(&mut kvn_lines, obj);
@@ -375,7 +401,10 @@ pub fn write_omm_json(
     }
     header.insert(
         key("CREATION_DATE", key_case),
-        json!(format_ccsds_datetime(&omm.header.creation_date)),
+        json!(format_ccsds_datetime_in(
+            &omm.header.creation_date,
+            &CCSDSTimeSystem::UTC
+        )),
     );
     header.insert(key("ORIGINATOR", key_case), json!(&omm.header.originator));
     if let Some(ref msg_id) = omm.header.message_id {
@@ -401,7 +430,7 @@ pub fn write_omm_json(
     if let Some(ref epoch) = omm.metadata.ref_frame_epoch {
         meta.insert(
             key("REF_FRAME_EPOCH", key_case),
-            json!(format_ccsds_datetime(epoch)),
+            json!(format_ccsds_datetime_in(epoch, &omm.metadata.time_system)),
         );
     }
     meta.insert(
@@ -418,7 +447,10 @@ pub fn write_omm_json(
     let mut me = Map::new();
     me.insert(
         key("EPOCH", key_case),
-        json!(format_ccsds_datetime(&omm.mean_elements.epoch)),
+        json!(format_ccsds_datetime_in(
+            &omm.mean_elements.epoch,
+            &omm.metadata.time_system
+        )),
     );
     if let Some(v) = omm.mean_elements.mean_motion {
         me.insert(key("MEAN_MOTION", key_case), json!(v));
@@ -599,7 +631,9 @@ pub fn parse_opm_json(content: &str) -> Result<crate::ccsds::opm::OPM, BraheErro
 
     for section in &ordered_sections {
         if let Some(obj) = v.get(*section).or_else(|| v.get(section.to_uppercase())) {
-            if *section == "keplerian_elements" {
+            if *section == "metadata" {
+                flatten_object_ordered(&mut kvn_lines, obj, &TIME_SYSTEM_FIRST);
+            } else if *section == "keplerian_elements" {
                 flatten_object_ordered(&mut kvn_lines, obj, &kep_key_order);
             } else if *section == "covariance" {
                 flatten_object_ordered(&mut kvn_lines, obj, &cov_key_order);
@@ -649,7 +683,10 @@ pub fn write_opm_json(
     }
     header.insert(
         key("CREATION_DATE", key_case),
-        json!(format_ccsds_datetime(&opm.header.creation_date)),
+        json!(format_ccsds_datetime_in(
+            &opm.header.creation_date,
+            &CCSDSTimeSystem::UTC
+        )),
     );
     header.insert(key("ORIGINATOR", key_case), json!(&opm.header.originator));
     if let Some(ref msg_id) = opm.header.message_id {
@@ -675,7 +712,7 @@ pub fn write_opm_json(
     if let Some(ref epoch) = opm.metadata.ref_frame_epoch {
         meta.insert(
             key("REF_FRAME_EPOCH", key_case),
-            json!(format_ccsds_datetime(epoch)),
+            json!(format_ccsds_datetime_in(epoch, &opm.metadata.time_system)),
         );
     }
     meta.insert(
@@ -688,7 +725,10 @@ pub fn write_opm_json(
     let mut sv = Map::new();
     sv.insert(
         key("EPOCH", key_case),
-        json!(format_ccsds_datetime(&opm.state_vector.epoch)),
+        json!(format_ccsds_datetime_in(
+            &opm.state_vector.epoch,
+            &opm.metadata.time_system
+        )),
     );
     sv.insert(
         key("X", key_case),
@@ -780,7 +820,10 @@ pub fn write_opm_json(
             let mut m = Map::new();
             m.insert(
                 key("MAN_EPOCH_IGNITION", key_case),
-                json!(format_ccsds_datetime(&man.epoch_ignition)),
+                json!(format_ccsds_datetime_in(
+                    &man.epoch_ignition,
+                    &opm.metadata.time_system
+                )),
             );
             m.insert(key("MAN_DURATION", key_case), json!(man.duration));
             if let Some(dm) = man.delta_mass {
@@ -985,7 +1028,10 @@ pub fn write_cdm_json(
     }
     header.insert(
         key("CREATION_DATE", key_case),
-        json!(format_ccsds_datetime(&cdm.header.creation_date)),
+        json!(format_ccsds_datetime_in(
+            &cdm.header.creation_date,
+            &CCSDSTimeSystem::UTC
+        )),
     );
     header.insert(key("ORIGINATOR", key_case), json!(&cdm.header.originator));
     if let Some(ref mf) = cdm.header.message_for {
@@ -1000,7 +1046,10 @@ pub fn write_cdm_json(
     if let Some(ref v) = rm.conjunction_id {
         rel.insert(key("CONJUNCTION_ID", key_case), json!(v));
     }
-    rel.insert(key("TCA", key_case), json!(format_ccsds_datetime(&rm.tca)));
+    rel.insert(
+        key("TCA", key_case),
+        json!(format_ccsds_datetime_in(&rm.tca, &CCSDSTimeSystem::UTC)),
+    );
     rel.insert(key("MISS_DISTANCE", key_case), json!(rm.miss_distance));
     if let Some(v) = rm.mahalanobis_distance {
         rel.insert(key("MAHALANOBIS_DISTANCE", key_case), json!(v));
@@ -1056,25 +1105,25 @@ pub fn write_cdm_json(
     if let Some(ref v) = rm.start_screen_period {
         rel.insert(
             key("START_SCREEN_PERIOD", key_case),
-            json!(format_ccsds_datetime(v)),
+            json!(format_ccsds_datetime_in(v, &CCSDSTimeSystem::UTC)),
         );
     }
     if let Some(ref v) = rm.stop_screen_period {
         rel.insert(
             key("STOP_SCREEN_PERIOD", key_case),
-            json!(format_ccsds_datetime(v)),
+            json!(format_ccsds_datetime_in(v, &CCSDSTimeSystem::UTC)),
         );
     }
     if let Some(ref v) = rm.screen_entry_time {
         rel.insert(
             key("SCREEN_ENTRY_TIME", key_case),
-            json!(format_ccsds_datetime(v)),
+            json!(format_ccsds_datetime_in(v, &CCSDSTimeSystem::UTC)),
         );
     }
     if let Some(ref v) = rm.screen_exit_time {
         rel.insert(
             key("SCREEN_EXIT_TIME", key_case),
-            json!(format_ccsds_datetime(v)),
+            json!(format_ccsds_datetime_in(v, &CCSDSTimeSystem::UTC)),
         );
     }
     if let Some(v) = rm.screen_pc_threshold {
@@ -1114,13 +1163,13 @@ pub fn write_cdm_json(
     if let Some(ref v) = rm.previous_message_epoch {
         rel.insert(
             key("PREVIOUS_MESSAGE_EPOCH", key_case),
-            json!(format_ccsds_datetime(v)),
+            json!(format_ccsds_datetime_in(v, &CCSDSTimeSystem::UTC)),
         );
     }
     if let Some(ref v) = rm.next_message_epoch {
         rel.insert(
             key("NEXT_MESSAGE_EPOCH", key_case),
-            json!(format_ccsds_datetime(v)),
+            json!(format_ccsds_datetime_in(v, &CCSDSTimeSystem::UTC)),
         );
     }
     root.insert("relative_metadata".into(), Value::Object(rel));

--- a/src/ccsds/kvn/parser.rs
+++ b/src/ccsds/kvn/parser.rs
@@ -111,7 +111,7 @@ pub fn parse_oem(content: &str) -> Result<OEM, BraheError> {
     let mut meta_object_id: Option<String> = None;
     let mut meta_center_name: Option<String> = None;
     let mut meta_ref_frame: Option<CCSDSRefFrame> = None;
-    let mut meta_ref_frame_epoch: Option<Epoch> = None;
+    let mut meta_ref_frame_epoch: Option<String> = None;
     let mut meta_time_system: Option<CCSDSTimeSystem> = None;
     let mut meta_start_time: Option<Epoch> = None;
     let mut meta_useable_start_time: Option<Epoch> = None;
@@ -174,10 +174,7 @@ pub fn parse_oem(content: &str) -> Result<OEM, BraheError> {
                     "OBJECT_ID" => meta_object_id = Some(value),
                     "CENTER_NAME" => meta_center_name = Some(value),
                     "REF_FRAME" => meta_ref_frame = Some(CCSDSRefFrame::parse(&value)),
-                    "REF_FRAME_EPOCH" => {
-                        let ts = meta_time_system.as_ref().unwrap_or(&CCSDSTimeSystem::UTC);
-                        meta_ref_frame_epoch = Some(parse_ccsds_datetime(&value, ts)?);
-                    }
+                    "REF_FRAME_EPOCH" => meta_ref_frame_epoch = Some(value),
                     "TIME_SYSTEM" => {
                         let ts = CCSDSTimeSystem::parse(&value)?;
                         active_time_system = ts.clone();
@@ -223,7 +220,15 @@ pub fn parse_oem(content: &str) -> Result<OEM, BraheError> {
                             ref_frame: meta_ref_frame
                                 .take()
                                 .ok_or_else(|| ccsds_missing_field("OEM", "REF_FRAME"))?,
-                            ref_frame_epoch: meta_ref_frame_epoch.take(),
+                            ref_frame_epoch: meta_ref_frame_epoch
+                                .take()
+                                .map(|raw| {
+                                    parse_ccsds_datetime(
+                                        &raw,
+                                        meta_time_system.as_ref().unwrap_or(&CCSDSTimeSystem::UTC),
+                                    )
+                                })
+                                .transpose()?,
                             time_system: meta_time_system
                                 .take()
                                 .ok_or_else(|| ccsds_missing_field("OEM", "TIME_SYSTEM"))?,
@@ -475,7 +480,7 @@ pub fn parse_omm(content: &str) -> Result<OMM, BraheError> {
     let mut object_id: Option<String> = None;
     let mut center_name: Option<String> = None;
     let mut ref_frame: Option<CCSDSRefFrame> = None;
-    let mut ref_frame_epoch: Option<Epoch> = None;
+    let mut ref_frame_epoch: Option<String> = None;
     let mut time_system: Option<CCSDSTimeSystem> = None;
     let mut mean_element_theory: Option<String> = None;
 
@@ -567,10 +572,7 @@ pub fn parse_omm(content: &str) -> Result<OMM, BraheError> {
                     "REF_FRAME" => {
                         ref_frame = Some(CCSDSRefFrame::parse(val));
                     }
-                    "REF_FRAME_EPOCH" => {
-                        ref_frame_epoch =
-                            Some(parse_ccsds_datetime(val, &active_ts(&time_system))?);
-                    }
+                    "REF_FRAME_EPOCH" => ref_frame_epoch = Some(val.to_string()),
                     "TIME_SYSTEM" => {
                         time_system = Some(CCSDSTimeSystem::parse(val)?);
                     }
@@ -779,7 +781,9 @@ pub fn parse_omm(content: &str) -> Result<OMM, BraheError> {
         object_id: object_id.ok_or_else(|| ccsds_missing_field("OMM", "OBJECT_ID"))?,
         center_name: center_name.ok_or_else(|| ccsds_missing_field("OMM", "CENTER_NAME"))?,
         ref_frame: ref_frame.ok_or_else(|| ccsds_missing_field("OMM", "REF_FRAME"))?,
-        ref_frame_epoch,
+        ref_frame_epoch: ref_frame_epoch
+            .map(|raw| parse_ccsds_datetime(&raw, &active_ts(&time_system)))
+            .transpose()?,
         time_system: time_system.ok_or_else(|| ccsds_missing_field("OMM", "TIME_SYSTEM"))?,
         mean_element_theory: mean_element_theory
             .ok_or_else(|| ccsds_missing_field("OMM", "MEAN_ELEMENT_THEORY"))?,
@@ -900,7 +904,7 @@ pub fn parse_opm(content: &str) -> Result<OPM, BraheError> {
     let mut object_id: Option<String> = None;
     let mut center_name: Option<String> = None;
     let mut ref_frame: Option<CCSDSRefFrame> = None;
-    let mut ref_frame_epoch: Option<Epoch> = None;
+    let mut ref_frame_epoch: Option<String> = None;
     let mut time_system: Option<CCSDSTimeSystem> = None;
 
     // State vector
@@ -1016,10 +1020,7 @@ pub fn parse_opm(content: &str) -> Result<OPM, BraheError> {
                     "REF_FRAME" if ref_frame.is_none() => {
                         ref_frame = Some(CCSDSRefFrame::parse(val));
                     }
-                    "REF_FRAME_EPOCH" => {
-                        ref_frame_epoch =
-                            Some(parse_ccsds_datetime(val, &active_ts(&time_system))?);
-                    }
+                    "REF_FRAME_EPOCH" => ref_frame_epoch = Some(val.to_string()),
                     "TIME_SYSTEM" => {
                         time_system = Some(CCSDSTimeSystem::parse(val)?);
                     }
@@ -1333,7 +1334,9 @@ pub fn parse_opm(content: &str) -> Result<OPM, BraheError> {
             object_id: object_id.ok_or_else(|| ccsds_missing_field("OPM", "OBJECT_ID"))?,
             center_name: center_name.ok_or_else(|| ccsds_missing_field("OPM", "CENTER_NAME"))?,
             ref_frame: ref_frame.ok_or_else(|| ccsds_missing_field("OPM", "REF_FRAME"))?,
-            ref_frame_epoch,
+            ref_frame_epoch: ref_frame_epoch
+                .map(|raw| parse_ccsds_datetime(&raw, &active_ts(&time_system)))
+                .transpose()?,
             time_system: time_system.ok_or_else(|| ccsds_missing_field("OPM", "TIME_SYSTEM"))?,
             comments: metadata_comments,
         },

--- a/src/ccsds/kvn/writer.rs
+++ b/src/ccsds/kvn/writer.rs
@@ -2,7 +2,9 @@
  * KVN writer for CCSDS OEM, OMM, and OPM messages.
  */
 
-use crate::ccsds::common::{covariance_to_lower_triangular, format_ccsds_datetime};
+use crate::ccsds::common::{
+    CCSDSTimeSystem, covariance_to_lower_triangular, format_ccsds_datetime_in,
+};
 use crate::ccsds::oem::OEM;
 use crate::utils::errors::BraheError;
 
@@ -23,7 +25,7 @@ pub fn write_oem(oem: &OEM) -> Result<String, BraheError> {
     }
     out.push_str(&format!(
         "CREATION_DATE = {}\n",
-        format_ccsds_datetime(&oem.header.creation_date)
+        format_ccsds_datetime_in(&oem.header.creation_date, &CCSDSTimeSystem::UTC)
     ));
     out.push_str(&format!("ORIGINATOR = {}\n", oem.header.originator));
     if let Some(ref msg_id) = oem.header.message_id {
@@ -46,29 +48,29 @@ pub fn write_oem(oem: &OEM) -> Result<String, BraheError> {
         if let Some(ref epoch) = segment.metadata.ref_frame_epoch {
             out.push_str(&format!(
                 "REF_FRAME_EPOCH = {}\n",
-                format_ccsds_datetime(epoch)
+                format_ccsds_datetime_in(epoch, &segment.metadata.time_system)
             ));
         }
         out.push_str(&format!("TIME_SYSTEM = {}\n", segment.metadata.time_system));
         out.push_str(&format!(
             "START_TIME = {}\n",
-            format_ccsds_datetime(&segment.metadata.start_time)
+            format_ccsds_datetime_in(&segment.metadata.start_time, &segment.metadata.time_system)
         ));
         if let Some(ref t) = segment.metadata.useable_start_time {
             out.push_str(&format!(
                 "USEABLE_START_TIME = {}\n",
-                format_ccsds_datetime(t)
+                format_ccsds_datetime_in(t, &segment.metadata.time_system)
             ));
         }
         if let Some(ref t) = segment.metadata.useable_stop_time {
             out.push_str(&format!(
                 "USEABLE_STOP_TIME = {}\n",
-                format_ccsds_datetime(t)
+                format_ccsds_datetime_in(t, &segment.metadata.time_system)
             ));
         }
         out.push_str(&format!(
             "STOP_TIME = {}\n",
-            format_ccsds_datetime(&segment.metadata.stop_time)
+            format_ccsds_datetime_in(&segment.metadata.stop_time, &segment.metadata.time_system)
         ));
         if let Some(ref interp) = segment.metadata.interpolation {
             out.push_str(&format!("INTERPOLATION = {}\n", interp));
@@ -85,7 +87,7 @@ pub fn write_oem(oem: &OEM) -> Result<String, BraheError> {
 
         // Ephemeris data lines
         for sv in &segment.states {
-            let epoch_str = format_ccsds_datetime(&sv.epoch);
+            let epoch_str = format_ccsds_datetime_in(&sv.epoch, &segment.metadata.time_system);
             // Convert m → km, m/s → km/s
             let x = sv.position[0] / 1000.0;
             let y = sv.position[1] / 1000.0;
@@ -115,7 +117,10 @@ pub fn write_oem(oem: &OEM) -> Result<String, BraheError> {
             out.push_str("\nCOVARIANCE_START\n");
             for cov in &segment.covariances {
                 if let Some(ref epoch) = cov.epoch {
-                    out.push_str(&format!("EPOCH = {}\n", format_ccsds_datetime(epoch)));
+                    out.push_str(&format!(
+                        "EPOCH = {}\n",
+                        format_ccsds_datetime_in(epoch, &segment.metadata.time_system)
+                    ));
                 }
                 if let Some(ref frame) = cov.cov_ref_frame {
                     out.push_str(&format!("COV_REF_FRAME = {}\n", frame));
@@ -163,7 +168,7 @@ pub fn write_omm(omm: &crate::ccsds::omm::OMM) -> Result<String, BraheError> {
     }
     out.push_str(&format!(
         "CREATION_DATE = {}\n",
-        format_ccsds_datetime(&omm.header.creation_date)
+        format_ccsds_datetime_in(&omm.header.creation_date, &CCSDSTimeSystem::UTC)
     ));
     out.push_str(&format!("ORIGINATOR = {}\n", omm.header.originator));
     if let Some(ref msg_id) = omm.header.message_id {
@@ -182,7 +187,7 @@ pub fn write_omm(omm: &crate::ccsds::omm::OMM) -> Result<String, BraheError> {
     if let Some(ref epoch) = omm.metadata.ref_frame_epoch {
         out.push_str(&format!(
             "REF_FRAME_EPOCH = {}\n",
-            format_ccsds_datetime(epoch)
+            format_ccsds_datetime_in(epoch, &omm.metadata.time_system)
         ));
     }
     out.push_str(&format!("TIME_SYSTEM = {}\n", omm.metadata.time_system));
@@ -198,7 +203,7 @@ pub fn write_omm(omm: &crate::ccsds::omm::OMM) -> Result<String, BraheError> {
     }
     out.push_str(&format!(
         "EPOCH = {}\n",
-        format_ccsds_datetime(&omm.mean_elements.epoch)
+        format_ccsds_datetime_in(&omm.mean_elements.epoch, &omm.metadata.time_system)
     ));
     if let Some(mm) = omm.mean_elements.mean_motion {
         out.push_str(&format!("MEAN_MOTION = {}\n", mm));
@@ -279,7 +284,10 @@ pub fn write_omm(omm: &crate::ccsds::omm::OMM) -> Result<String, BraheError> {
             out.push_str(&format!("COMMENT {}\n", comment));
         }
         if let Some(ref epoch) = cov.epoch {
-            out.push_str(&format!("EPOCH = {}\n", format_ccsds_datetime(epoch)));
+            out.push_str(&format!(
+                "EPOCH = {}\n",
+                format_ccsds_datetime_in(epoch, &omm.metadata.time_system)
+            ));
         }
         if let Some(ref frame) = cov.cov_ref_frame {
             out.push_str(&format!("COV_REF_FRAME = {}\n", frame));
@@ -315,7 +323,7 @@ pub fn write_opm(opm: &crate::ccsds::opm::OPM) -> Result<String, BraheError> {
     }
     out.push_str(&format!(
         "CREATION_DATE = {}\n",
-        format_ccsds_datetime(&opm.header.creation_date)
+        format_ccsds_datetime_in(&opm.header.creation_date, &CCSDSTimeSystem::UTC)
     ));
     out.push_str(&format!("ORIGINATOR = {}\n", opm.header.originator));
     if let Some(ref msg_id) = opm.header.message_id {
@@ -334,7 +342,7 @@ pub fn write_opm(opm: &crate::ccsds::opm::OPM) -> Result<String, BraheError> {
     if let Some(ref epoch) = opm.metadata.ref_frame_epoch {
         out.push_str(&format!(
             "REF_FRAME_EPOCH = {}\n",
-            format_ccsds_datetime(epoch)
+            format_ccsds_datetime_in(epoch, &opm.metadata.time_system)
         ));
     }
     out.push_str(&format!("TIME_SYSTEM = {}\n", opm.metadata.time_system));
@@ -345,7 +353,7 @@ pub fn write_opm(opm: &crate::ccsds::opm::OPM) -> Result<String, BraheError> {
     }
     out.push_str(&format!(
         "EPOCH = {}\n",
-        format_ccsds_datetime(&opm.state_vector.epoch)
+        format_ccsds_datetime_in(&opm.state_vector.epoch, &opm.metadata.time_system)
     ));
     // Position: m → km
     out.push_str(&format!("X = {:.6}\n", opm.state_vector.position[0] / 1e3));
@@ -401,7 +409,10 @@ pub fn write_opm(opm: &crate::ccsds::opm::OPM) -> Result<String, BraheError> {
             out.push_str(&format!("COMMENT {}\n", comment));
         }
         if let Some(ref epoch) = cov.epoch {
-            out.push_str(&format!("EPOCH = {}\n", format_ccsds_datetime(epoch)));
+            out.push_str(&format!(
+                "EPOCH = {}\n",
+                format_ccsds_datetime_in(epoch, &opm.metadata.time_system)
+            ));
         }
         if let Some(ref frame) = cov.cov_ref_frame {
             out.push_str(&format!("COV_REF_FRAME = {}\n", frame));
@@ -417,7 +428,7 @@ pub fn write_opm(opm: &crate::ccsds::opm::OPM) -> Result<String, BraheError> {
         }
         out.push_str(&format!(
             "MAN_EPOCH_IGNITION = {}\n",
-            format_ccsds_datetime(&man.epoch_ignition)
+            format_ccsds_datetime_in(&man.epoch_ignition, &opm.metadata.time_system)
         ));
         out.push_str(&format!("MAN_DURATION = {:.2}\n", man.duration));
         if let Some(dm) = man.delta_mass {
@@ -522,6 +533,8 @@ pub fn write_cdm(cdm: &crate::ccsds::cdm::CDM) -> Result<String, BraheError> {
     let kw_units = |out: &mut String, key: &str, val: &str, units: &str| {
         out.push_str(&format!("{:<34}= {:<40} [{}]\n", key, val, units));
     };
+    // CCSDS 508.0-B-1 subsection 6.2.3.4: all CDM time tags are UTC.
+    let utc = |e: &crate::time::Epoch| format_ccsds_datetime_in(e, &CCSDSTimeSystem::UTC);
 
     // Header
     kw(
@@ -535,11 +548,7 @@ pub fn write_cdm(cdm: &crate::ccsds::cdm::CDM) -> Result<String, BraheError> {
     if let Some(ref class) = cdm.header.classification {
         kw(&mut out, "CLASSIFICATION", class);
     }
-    kw(
-        &mut out,
-        "CREATION_DATE",
-        &format_ccsds_datetime(&cdm.header.creation_date),
-    );
+    kw(&mut out, "CREATION_DATE", &utc(&cdm.header.creation_date));
     kw(&mut out, "ORIGINATOR", &cdm.header.originator);
     if let Some(ref mf) = cdm.header.message_for {
         kw(&mut out, "MESSAGE_FOR", mf);
@@ -554,7 +563,7 @@ pub fn write_cdm(cdm: &crate::ccsds::cdm::CDM) -> Result<String, BraheError> {
     if let Some(ref cid) = rm.conjunction_id {
         kw(&mut out, "CONJUNCTION_ID", cid);
     }
-    kw(&mut out, "TCA", &format_ccsds_datetime(&rm.tca));
+    kw(&mut out, "TCA", &utc(&rm.tca));
     kw_units(
         &mut out,
         "MISS_DISTANCE",
@@ -589,10 +598,10 @@ pub fn write_cdm(cdm: &crate::ccsds::cdm::CDM) -> Result<String, BraheError> {
         kw_units(&mut out, "APPROACH_ANGLE", &format!("{}", v), "deg");
     }
     if let Some(ref e) = rm.start_screen_period {
-        kw(&mut out, "START_SCREEN_PERIOD", &format_ccsds_datetime(e));
+        kw(&mut out, "START_SCREEN_PERIOD", &utc(e));
     }
     if let Some(ref e) = rm.stop_screen_period {
-        kw(&mut out, "STOP_SCREEN_PERIOD", &format_ccsds_datetime(e));
+        kw(&mut out, "STOP_SCREEN_PERIOD", &utc(e));
     }
     if let Some(ref s) = rm.screen_type {
         kw(&mut out, "SCREEN_TYPE", s);
@@ -616,10 +625,10 @@ pub fn write_cdm(cdm: &crate::ccsds::cdm::CDM) -> Result<String, BraheError> {
         kw_units(&mut out, "SCREEN_VOLUME_Z", &format!("{}", v), "m");
     }
     if let Some(ref e) = rm.screen_entry_time {
-        kw(&mut out, "SCREEN_ENTRY_TIME", &format_ccsds_datetime(e));
+        kw(&mut out, "SCREEN_ENTRY_TIME", &utc(e));
     }
     if let Some(ref e) = rm.screen_exit_time {
-        kw(&mut out, "SCREEN_EXIT_TIME", &format_ccsds_datetime(e));
+        kw(&mut out, "SCREEN_EXIT_TIME", &utc(e));
     }
     if let Some(v) = rm.screen_pc_threshold {
         kw(&mut out, "SCREEN_PC_THRESHOLD", &format!("{:E}", v));
@@ -653,14 +662,10 @@ pub fn write_cdm(cdm: &crate::ccsds::cdm::CDM) -> Result<String, BraheError> {
         kw(&mut out, "PREVIOUS_MESSAGE_ID", s);
     }
     if let Some(ref e) = rm.previous_message_epoch {
-        kw(
-            &mut out,
-            "PREVIOUS_MESSAGE_EPOCH",
-            &format_ccsds_datetime(e),
-        );
+        kw(&mut out, "PREVIOUS_MESSAGE_EPOCH", &utc(e));
     }
     if let Some(ref e) = rm.next_message_epoch {
-        kw(&mut out, "NEXT_MESSAGE_EPOCH", &format_ccsds_datetime(e));
+        kw(&mut out, "NEXT_MESSAGE_EPOCH", &utc(e));
     }
 
     // Write object sections
@@ -745,10 +750,10 @@ pub fn write_cdm(cdm: &crate::ccsds::cdm::CDM) -> Result<String, BraheError> {
                 out.push_str(&format!("COMMENT {}\n", comment));
             }
             if let Some(ref e) = od.time_lastob_start {
-                kw(out, "TIME_LASTOB_START", &format_ccsds_datetime(e));
+                kw(out, "TIME_LASTOB_START", &utc(e));
             }
             if let Some(ref e) = od.time_lastob_end {
-                kw(out, "TIME_LASTOB_END", &format_ccsds_datetime(e));
+                kw(out, "TIME_LASTOB_END", &utc(e));
             }
             if let Some(v) = od.recommended_od_span {
                 kw_units(out, "RECOMMENDED_OD_SPAN", &format!("{:.2}", v), "d");
@@ -775,7 +780,7 @@ pub fn write_cdm(cdm: &crate::ccsds::cdm::CDM) -> Result<String, BraheError> {
                 kw(out, "WEIGHTED_RMS", &format!("{}", v));
             }
             if let Some(ref e) = od.od_epoch {
-                kw(out, "OD_EPOCH", &format_ccsds_datetime(e));
+                kw(out, "OD_EPOCH", &utc(e));
             }
         }
 
@@ -803,7 +808,7 @@ pub fn write_cdm(cdm: &crate::ccsds::cdm::CDM) -> Result<String, BraheError> {
                 kw(out, "OEB_PARENT_FRAME", v);
             }
             if let Some(ref e) = ap.oeb_parent_frame_epoch {
-                kw(out, "OEB_PARENT_FRAME_EPOCH", &format_ccsds_datetime(e));
+                kw(out, "OEB_PARENT_FRAME_EPOCH", &utc(e));
             }
             if let Some(v) = ap.oeb_q1 {
                 kw(out, "OEB_Q1", &format!("{}", v));

--- a/src/ccsds/xml/writer.rs
+++ b/src/ccsds/xml/writer.rs
@@ -3,8 +3,8 @@
  */
 
 use crate::ccsds::common::{
-    CCSDSCovariance, CCSDSSpacecraftParameters, CCSDSUserDefined, ODMHeader,
-    covariance_to_lower_triangular, format_ccsds_datetime,
+    CCSDSCovariance, CCSDSSpacecraftParameters, CCSDSTimeSystem, CCSDSUserDefined, ODMHeader,
+    covariance_to_lower_triangular, format_ccsds_datetime_in,
 };
 use crate::utils::errors::BraheError;
 
@@ -107,7 +107,7 @@ fn write_xml_header(out: &mut String, header: &ODMHeader, i1: &str, i2: &str) {
     out.push_str(&format!(
         "{}<CREATION_DATE>{}</CREATION_DATE>\n",
         i2,
-        format_ccsds_datetime(&header.creation_date)
+        format_ccsds_datetime_in(&header.creation_date, &CCSDSTimeSystem::UTC)
     ));
     out.push_str(&format!(
         "{}<ORIGINATOR>{}</ORIGINATOR>\n",
@@ -125,13 +125,19 @@ fn write_xml_header(out: &mut String, header: &ODMHeader, i1: &str, i2: &str) {
 }
 
 /// Write XML 6x6 covariance block (shared across OEM/OMM/OPM).
-fn write_xml_covariance(out: &mut String, cov: &CCSDSCovariance, i_block: &str, i_elem: &str) {
+fn write_xml_covariance(
+    out: &mut String,
+    cov: &CCSDSCovariance,
+    time_system: &CCSDSTimeSystem,
+    i_block: &str,
+    i_elem: &str,
+) {
     out.push_str(&format!("{}<covarianceMatrix>\n", i_block));
     if let Some(ref epoch) = cov.epoch {
         out.push_str(&format!(
             "{}<EPOCH>{}</EPOCH>\n",
             i_elem,
-            format_ccsds_datetime(epoch)
+            format_ccsds_datetime_in(epoch, time_system)
         ));
     }
     if let Some(ref frame) = cov.cov_ref_frame {
@@ -268,7 +274,7 @@ pub fn write_oem_xml(oem: &crate::ccsds::oem::OEM) -> Result<String, BraheError>
             out.push_str(&format!(
                 "{}<REF_FRAME_EPOCH>{}</REF_FRAME_EPOCH>\n",
                 i4,
-                format_ccsds_datetime(e)
+                format_ccsds_datetime_in(e, &segment.metadata.time_system)
             ));
         }
         out.push_str(&format!(
@@ -278,26 +284,26 @@ pub fn write_oem_xml(oem: &crate::ccsds::oem::OEM) -> Result<String, BraheError>
         out.push_str(&format!(
             "{}<START_TIME>{}</START_TIME>\n",
             i4,
-            format_ccsds_datetime(&segment.metadata.start_time)
+            format_ccsds_datetime_in(&segment.metadata.start_time, &segment.metadata.time_system)
         ));
         if let Some(ref t) = segment.metadata.useable_start_time {
             out.push_str(&format!(
                 "{}<USEABLE_START_TIME>{}</USEABLE_START_TIME>\n",
                 i4,
-                format_ccsds_datetime(t)
+                format_ccsds_datetime_in(t, &segment.metadata.time_system)
             ));
         }
         if let Some(ref t) = segment.metadata.useable_stop_time {
             out.push_str(&format!(
                 "{}<USEABLE_STOP_TIME>{}</USEABLE_STOP_TIME>\n",
                 i4,
-                format_ccsds_datetime(t)
+                format_ccsds_datetime_in(t, &segment.metadata.time_system)
             ));
         }
         out.push_str(&format!(
             "{}<STOP_TIME>{}</STOP_TIME>\n",
             i4,
-            format_ccsds_datetime(&segment.metadata.stop_time)
+            format_ccsds_datetime_in(&segment.metadata.stop_time, &segment.metadata.time_system)
         ));
         if let Some(ref interp) = segment.metadata.interpolation {
             out.push_str(&format!(
@@ -329,7 +335,7 @@ pub fn write_oem_xml(oem: &crate::ccsds::oem::OEM) -> Result<String, BraheError>
             out.push_str(&format!("{}<stateVector>\n", i4));
             out.push_str(&format!(
                 "        <EPOCH>{}</EPOCH>\n",
-                format_ccsds_datetime(&sv.epoch)
+                format_ccsds_datetime_in(&sv.epoch, &segment.metadata.time_system)
             ));
             // Position: m → km
             out.push_str(&format!("        <X>{}</X>\n", sv.position[0] / 1e3));
@@ -359,7 +365,7 @@ pub fn write_oem_xml(oem: &crate::ccsds::oem::OEM) -> Result<String, BraheError>
 
         // Covariance
         for cov in &segment.covariances {
-            write_xml_covariance(&mut out, cov, i4, "        ");
+            write_xml_covariance(&mut out, cov, &segment.metadata.time_system, i4, "        ");
         }
 
         out.push_str(&format!("{}</data>\n", i3));
@@ -427,7 +433,7 @@ pub fn write_omm_xml(omm: &crate::ccsds::omm::OMM) -> Result<String, BraheError>
         out.push_str(&format!(
             "{}<REF_FRAME_EPOCH>{}</REF_FRAME_EPOCH>\n",
             i4,
-            format_ccsds_datetime(e)
+            format_ccsds_datetime_in(e, &omm.metadata.time_system)
         ));
     }
     out.push_str(&format!(
@@ -451,7 +457,7 @@ pub fn write_omm_xml(omm: &crate::ccsds::omm::OMM) -> Result<String, BraheError>
     }
     out.push_str(&format!(
         "        <EPOCH>{}</EPOCH>\n",
-        format_ccsds_datetime(&omm.mean_elements.epoch)
+        format_ccsds_datetime_in(&omm.mean_elements.epoch, &omm.metadata.time_system)
     ));
     if let Some(mm) = omm.mean_elements.mean_motion {
         out.push_str(&format!("        <MEAN_MOTION>{}</MEAN_MOTION>\n", mm));
@@ -549,7 +555,7 @@ pub fn write_omm_xml(omm: &crate::ccsds::omm::OMM) -> Result<String, BraheError>
 
     // Covariance
     if let Some(ref cov) = omm.covariance {
-        write_xml_covariance(&mut out, cov, i4, "        ");
+        write_xml_covariance(&mut out, cov, &omm.metadata.time_system, i4, "        ");
     }
 
     out.push_str(&format!("{}</data>\n", i3));
@@ -621,7 +627,7 @@ pub fn write_opm_xml(opm: &crate::ccsds::opm::OPM) -> Result<String, BraheError>
         out.push_str(&format!(
             "{}<REF_FRAME_EPOCH>{}</REF_FRAME_EPOCH>\n",
             i4,
-            format_ccsds_datetime(e)
+            format_ccsds_datetime_in(e, &opm.metadata.time_system)
         ));
     }
     out.push_str(&format!(
@@ -640,7 +646,7 @@ pub fn write_opm_xml(opm: &crate::ccsds::opm::OPM) -> Result<String, BraheError>
     }
     out.push_str(&format!(
         "        <EPOCH>{}</EPOCH>\n",
-        format_ccsds_datetime(&opm.state_vector.epoch)
+        format_ccsds_datetime_in(&opm.state_vector.epoch, &opm.metadata.time_system)
     ));
     // Position: m → km
     out.push_str(&format!(
@@ -717,7 +723,7 @@ pub fn write_opm_xml(opm: &crate::ccsds::opm::OPM) -> Result<String, BraheError>
 
     // Covariance
     if let Some(ref cov) = opm.covariance {
-        write_xml_covariance(&mut out, cov, i4, "        ");
+        write_xml_covariance(&mut out, cov, &opm.metadata.time_system, i4, "        ");
     }
 
     // Maneuvers
@@ -728,7 +734,7 @@ pub fn write_opm_xml(opm: &crate::ccsds::opm::OPM) -> Result<String, BraheError>
         }
         out.push_str(&format!(
             "        <MAN_EPOCH_IGNITION>{}</MAN_EPOCH_IGNITION>\n",
-            format_ccsds_datetime(&man.epoch_ignition)
+            format_ccsds_datetime_in(&man.epoch_ignition, &opm.metadata.time_system)
         ));
         out.push_str(&format!(
             "        <MAN_DURATION>{:.2}</MAN_DURATION>\n",
@@ -777,7 +783,7 @@ pub fn write_opm_xml(opm: &crate::ccsds::opm::OPM) -> Result<String, BraheError>
 /// Write a CDM message to XML format.
 pub fn write_cdm_xml(cdm: &crate::ccsds::cdm::CDM) -> Result<String, BraheError> {
     use crate::ccsds::cdm::*;
-    use crate::ccsds::common::{covariance9x9_to_lower_triangular, format_ccsds_datetime};
+    use crate::ccsds::common::covariance9x9_to_lower_triangular;
 
     let mut out = String::new();
     let i1 = "  ";
@@ -810,7 +816,7 @@ pub fn write_cdm_xml(cdm: &crate::ccsds::cdm::CDM) -> Result<String, BraheError>
     out.push_str(&format!(
         "{}<CREATION_DATE>{}</CREATION_DATE>\n",
         i2,
-        format_ccsds_datetime(&cdm.header.creation_date)
+        format_ccsds_datetime_in(&cdm.header.creation_date, &CCSDSTimeSystem::UTC)
     ));
     out.push_str(&format!(
         "{}<ORIGINATOR>{}</ORIGINATOR>\n",
@@ -854,7 +860,7 @@ pub fn write_cdm_xml(cdm: &crate::ccsds::cdm::CDM) -> Result<String, BraheError>
     out.push_str(&format!(
         "{}<TCA>{}</TCA>\n",
         i3,
-        format_ccsds_datetime(&rm.tca)
+        format_ccsds_datetime_in(&rm.tca, &CCSDSTimeSystem::UTC)
     ));
     out.push_str(&format!(
         "{}<MISS_DISTANCE units=\"m\">{}</MISS_DISTANCE>\n",
@@ -927,14 +933,14 @@ pub fn write_cdm_xml(cdm: &crate::ccsds::cdm::CDM) -> Result<String, BraheError>
         out.push_str(&format!(
             "{}<START_SCREEN_PERIOD>{}</START_SCREEN_PERIOD>\n",
             i3,
-            format_ccsds_datetime(e)
+            format_ccsds_datetime_in(e, &CCSDSTimeSystem::UTC)
         ));
     }
     if let Some(ref e) = rm.stop_screen_period {
         out.push_str(&format!(
             "{}<STOP_SCREEN_PERIOD>{}</STOP_SCREEN_PERIOD>\n",
             i3,
-            format_ccsds_datetime(e)
+            format_ccsds_datetime_in(e, &CCSDSTimeSystem::UTC)
         ));
     }
     if let Some(ref s) = rm.screen_type {
@@ -985,14 +991,14 @@ pub fn write_cdm_xml(cdm: &crate::ccsds::cdm::CDM) -> Result<String, BraheError>
         out.push_str(&format!(
             "{}<SCREEN_ENTRY_TIME>{}</SCREEN_ENTRY_TIME>\n",
             i3,
-            format_ccsds_datetime(e)
+            format_ccsds_datetime_in(e, &CCSDSTimeSystem::UTC)
         ));
     }
     if let Some(ref e) = rm.screen_exit_time {
         out.push_str(&format!(
             "{}<SCREEN_EXIT_TIME>{}</SCREEN_EXIT_TIME>\n",
             i3,
-            format_ccsds_datetime(e)
+            format_ccsds_datetime_in(e, &CCSDSTimeSystem::UTC)
         ));
     }
     if let Some(v) = rm.screen_pc_threshold {
@@ -1066,14 +1072,14 @@ pub fn write_cdm_xml(cdm: &crate::ccsds::cdm::CDM) -> Result<String, BraheError>
         out.push_str(&format!(
             "{}<PREVIOUS_MESSAGE_EPOCH>{}</PREVIOUS_MESSAGE_EPOCH>\n",
             i3,
-            format_ccsds_datetime(e)
+            format_ccsds_datetime_in(e, &CCSDSTimeSystem::UTC)
         ));
     }
     if let Some(ref e) = rm.next_message_epoch {
         out.push_str(&format!(
             "{}<NEXT_MESSAGE_EPOCH>{}</NEXT_MESSAGE_EPOCH>\n",
             i3,
-            format_ccsds_datetime(e)
+            format_ccsds_datetime_in(e, &CCSDSTimeSystem::UTC)
         ));
     }
 
@@ -1384,13 +1390,13 @@ pub fn write_cdm_xml(cdm: &crate::ccsds::cdm::CDM) -> Result<String, BraheError>
             if let Some(ref e) = od.time_lastob_start {
                 out.push_str(&format!(
                     "        <TIME_LASTOB_START>{}</TIME_LASTOB_START>\n",
-                    format_ccsds_datetime(e)
+                    format_ccsds_datetime_in(e, &CCSDSTimeSystem::UTC)
                 ));
             }
             if let Some(ref e) = od.time_lastob_end {
                 out.push_str(&format!(
                     "        <TIME_LASTOB_END>{}</TIME_LASTOB_END>\n",
-                    format_ccsds_datetime(e)
+                    format_ccsds_datetime_in(e, &CCSDSTimeSystem::UTC)
                 ));
             }
             if let Some(v) = od.recommended_od_span {
@@ -1432,7 +1438,7 @@ pub fn write_cdm_xml(cdm: &crate::ccsds::cdm::CDM) -> Result<String, BraheError>
             if let Some(ref e) = od.od_epoch {
                 out.push_str(&format!(
                     "        <OD_EPOCH>{}</OD_EPOCH>\n",
-                    format_ccsds_datetime(e)
+                    format_ccsds_datetime_in(e, &CCSDSTimeSystem::UTC)
                 ));
             }
             out.push_str(&format!("{}</odParameters>\n", i4));
@@ -1483,7 +1489,7 @@ pub fn write_cdm_xml(cdm: &crate::ccsds::cdm::CDM) -> Result<String, BraheError>
             if let Some(ref e) = ap.oeb_parent_frame_epoch {
                 out.push_str(&format!(
                     "        <OEB_PARENT_FRAME_EPOCH>{}</OEB_PARENT_FRAME_EPOCH>\n",
-                    format_ccsds_datetime(e)
+                    format_ccsds_datetime_in(e, &CCSDSTimeSystem::UTC)
                 ));
             }
             if let Some(v) = ap.oeb_q1 {

--- a/tests/ccsds/test_time_system.py
+++ b/tests/ccsds/test_time_system.py
@@ -1,0 +1,90 @@
+"""Tests for CCSDS epoch time-system handling — parity with Rust tests in src/ccsds/common.rs."""
+
+import brahe  # noqa: F401
+from brahe.ccsds import OEM, OMM, OPM
+
+FORMATS = ["kvn", "xml", "json"]
+
+
+def test_write_oem_epochs_follow_the_declared_time_system(eop):
+    """Mirror of test_write_oem_epochs_follow_the_declared_time_system in Rust."""
+    oem = OEM.from_file("test_assets/ccsds/oem/OEMExample1.txt")
+    assert oem.segments[0].time_system == "UTC"
+    assert "START_TIME = 1996-12-18T12:00:00.331" in oem.to_string("kvn")
+
+    # Redeclaring TIME_SYSTEM moves the written epochs onto that scale.
+    oem.segments[0].time_system = "TAI"
+    assert "START_TIME = 1996-12-18T12:00:30.331" in oem.to_string("kvn")
+
+
+def test_write_omm_epochs_follow_the_declared_time_system(eop):
+    """The OMM EPOCH keyword follows the metadata TIME_SYSTEM."""
+    omm = OMM.from_file("test_assets/ccsds/omm/OMMExample2.txt")
+    assert omm.time_system == "UTC"
+    assert "EPOCH = 2007-03-05T10:34:41.4264" in omm.to_string("kvn")
+
+    omm.time_system = "TAI"
+    assert "EPOCH = 2007-03-05T10:35:14.4264" in omm.to_string("kvn")
+
+
+def test_write_opm_epochs_follow_the_declared_time_system(eop):
+    """The OPM EPOCH keyword follows the metadata TIME_SYSTEM."""
+    opm = OPM.from_file("test_assets/ccsds/opm/OPMExample1.txt")
+    assert opm.time_system == "UTC"
+    utc = opm.to_string("kvn")
+
+    opm.time_system = "TAI"
+    assert opm.to_string("kvn") != utc
+
+
+def test_writers_use_declared_time_system_not_epoch_time_system(eop):
+    """Mirror of test_writers_use_declared_time_system_not_epoch_time_system in Rust."""
+    oem = OEM.from_file("test_assets/ccsds/oem/OEMExample1.txt")
+
+    # The declared TIME_SYSTEM, not the stored epoch, decides the written value,
+    # so the epochs a message reports agree with the strings it writes.
+    for fmt in FORMATS:
+        written = oem.to_string(fmt)
+        assert OEM.from_str(written).segments[0].time_system == "UTC"
+    assert oem.to_dict()["segments"][0]["metadata"]["start_time"].startswith(
+        "1996-12-18T12:00:00"
+    )
+
+    oem.segments[0].time_system = "TAI"
+    assert oem.to_dict()["segments"][0]["metadata"]["start_time"].startswith(
+        "1996-12-18T12:00:30"
+    )
+
+
+def test_cdm_writes_time_tags_in_utc(eop):
+    """Python half of test_writers_use_declared_time_system_not_epoch_time_system."""
+    from brahe.ccsds import CDM
+
+    # CCSDS 508.0-B-1 subsection 6.2.3.4 fixes every CDM time tag to UTC, and
+    # PyCDM.__repr__ reports the same instant the writers emit.
+    cdm = CDM.from_file("test_assets/ccsds/cdm/CDMExample1.txt")
+
+    # Compared as written time codes: an Epoch carries sub-nanosecond
+    # representation noise that a CCSDS time code does not encode.
+    for fmt in FORMATS:
+        assert "2010-03-13T22:37:52.618" in CDM.from_str(cdm.to_string(fmt)).to_string(
+            "kvn"
+        )
+    assert "2010-03-13T22:37:52" in repr(cdm)
+
+
+def test_ref_frame_epoch_survives_a_non_utc_time_system(eop):
+    """Mirror of test_ref_frame_epoch_survives_a_non_utc_time_system in Rust."""
+    # REF_FRAME_EPOCH and START_TIME are read in the declared TIME_SYSTEM, but
+    # neither the KVN keyword order nor JSON key order guarantees the
+    # declaration comes first.
+    oem = OEM.from_file("test_assets/ccsds/oem/OEMExample1.txt")
+    oem.segments[0].time_system = "TAI"
+    start = oem.segments[0].start_time
+
+    for fmt in FORMATS:
+        reparsed = OEM.from_str(oem.to_string(fmt))
+        assert reparsed.segments[0].time_system == "TAI", (
+            f"{fmt} did not round-trip the declared time system"
+        )
+        assert reparsed.segments[0].start_time == start, f"{fmt} shifted START_TIME"


### PR DESCRIPTION
# Pull Request

## Description

CCSDS 502.0-B-3 subsection 7.5.11 fixes `CREATION_DATE` to UTC and ties every other time or epoch keyword to the message's `TIME_SYSTEM`; CCSDS 508.0-B-1 subsection 6.2.3.4 fixes every CDM time tag to UTC. A brahe `Epoch` carries its own time system, which for a user-constructed message need not be the one the metadata declares, and the writers formatted each epoch as stored. A message holding TAI epochs under `TIME_SYSTEM = UTC` was written with UTC in the metadata and TAI in the data — an error of the current leap-second count, silently produced and silently misread.

A new `format_ccsds_datetime_in` converts to the declared system before formatting, and the OEM, OMM, OPM, and CDM writers use it in all three encodings, along with the OMM-to-`GPRecord` conversion and the Python `to_dict` views so they report the same strings the writers emit. The five CCSDS time systems with no `TimeSystem` counterpart — `MET`, `MRT`, `SCLK`, `GMST`, `TDR` — are mission- or spacecraft-specific clocks with no fixed relationship to a physical time scale, so an epoch declared in one of those is written as stored.

## Changelog

### Fixed
- CCSDS OEM, OMM, OPM, and CDM writers now convert each epoch to the message's declared `TIME_SYSTEM` before formatting, per CCSDS 502.0-B-3 subsection 7.5.11 and CCSDS 508.0-B-1 subsection 6.2.3.4, instead of writing it in whichever time system the `Epoch` happened to carry. `CREATION_DATE` and all CDM time tags are written in UTC.

## Related Issue

Covers item 2 of #463.

## Note to Reviewers

`codecov/patch` initially failed here for the same reason as the PR below it: the sweep replaces the formatter at 81 call sites, many on epoch fields no stock fixture populates, so pre-existing gaps became patch misses. Rather than add a coverage-shaped test, the existing retag test was extended to populate every epoch field the writers can emit — `REF_FRAME_EPOCH` on the OMM and OPM, the covariance epoch, and the CDM message-linking epochs — and moved to an OPM fixture that actually carries maneuvers. Its claim is that retagging *any* epoch leaves output identical, so it should have covered those all along. Patch coverage went from 95.7% to 99.6%; the two lines still uncovered are arguments to `assert!` failure messages.


Tests exercise the helper directly, assert that retagging every epoch of an OEM, OMM, OPM, and CDM leaves KVN, XML, and JSON output byte identical, and assert that redeclaring `TIME_SYSTEM` moves the written epochs onto that scale. All three were confirmed to fail against the previous behaviour. Messages parsed from a file were already consistent, since the parsers build epochs in the declared system; the defect only bites user-constructed or programmatically retagged messages.
