### PR TITLE
Round-trip CCSDS comments through JSON

### DIFF
--- a/src/ccsds/json.rs
+++ b/src/ccsds/json.rs
@@ -50,7 +50,7 @@ pub fn parse_oem_json(content: &str) -> Result<crate::ccsds::oem::OEM, BraheErro
 
     // Header
     if let Some(header) = v.get("header") {
-        flatten_object(&mut kvn_lines, header);
+        flatten_block(&mut kvn_lines, header);
     }
 
     // Segments
@@ -59,9 +59,14 @@ pub fn parse_oem_json(content: &str) -> Result<crate::ccsds::oem::OEM, BraheErro
             // Metadata block
             kvn_lines.push("META_START".to_string());
             if let Some(meta) = seg.get("metadata") {
+                emit_json_comments(&mut kvn_lines, meta);
                 flatten_object_ordered(&mut kvn_lines, meta, &TIME_SYSTEM_FIRST);
             }
             kvn_lines.push("META_STOP".to_string());
+
+            // Data-section comments sit between META_STOP and the first
+            // ephemeris line.
+            emit_json_comments(&mut kvn_lines, seg);
 
             // State vectors (data lines)
             if let Some(Value::Array(states)) = seg.get("states") {
@@ -110,7 +115,10 @@ pub fn parse_oem_json(content: &str) -> Result<crate::ccsds::oem::OEM, BraheErro
                 kvn_lines.push("COVARIANCE_START".to_string());
                 for cov in covariances {
                     if let Some(obj) = cov.as_object() {
-                        // Epoch
+                        // EPOCH delimits one covariance from the next, so it
+                        // leads: comments emitted ahead of it would be flushed
+                        // into the preceding block. This is the order the KVN
+                        // writer uses.
                         if let Some(epoch_val) = obj
                             .get("EPOCH")
                             .or_else(|| obj.get("epoch"))
@@ -126,6 +134,7 @@ pub fn parse_oem_json(content: &str) -> Result<crate::ccsds::oem::OEM, BraheErro
                         {
                             kvn_lines.push(format!("COV_REF_FRAME = {}", frame));
                         }
+                        emit_json_comments(&mut kvn_lines, cov);
                         // Lower-triangular values
                         if let Some(Value::Array(values)) =
                             obj.get("VALUES").or_else(|| obj.get("values"))
@@ -180,6 +189,9 @@ pub fn write_oem_json(
     header.insert(key("ORIGINATOR", key_case), json!(&oem.header.originator));
     if let Some(ref msg_id) = oem.header.message_id {
         header.insert(key("MESSAGE_ID", key_case), json!(msg_id));
+    }
+    if !oem.header.comments.is_empty() {
+        header.insert("comments".into(), json!(oem.header.comments));
     }
     root.insert("header".into(), Value::Object(header));
 
@@ -245,6 +257,9 @@ pub fn write_oem_json(
         if let Some(deg) = seg.metadata.interpolation_degree {
             meta.insert(key("INTERPOLATION_DEGREE", key_case), json!(deg));
         }
+        if !seg.metadata.comments.is_empty() {
+            meta.insert("comments".into(), json!(seg.metadata.comments));
+        }
         seg_obj.insert("metadata".into(), Value::Object(meta));
 
         // States (convert m → km, m/s → km/s for CCSDS standard units)
@@ -271,6 +286,9 @@ pub fn write_oem_json(
             }
             states.push(Value::Object(state_obj));
         }
+        if !seg.comments.is_empty() {
+            seg_obj.insert("comments".into(), json!(seg.comments));
+        }
         seg_obj.insert("states".into(), Value::Array(states));
 
         // Covariances
@@ -286,6 +304,9 @@ pub fn write_oem_json(
                 }
                 if let Some(ref frame) = cov.cov_ref_frame {
                     cov_obj.insert(key("COV_REF_FRAME", key_case), json!(format!("{}", frame)));
+                }
+                if !cov.comments.is_empty() {
+                    cov_obj.insert("comments".into(), json!(cov.comments));
                 }
                 // Convert m² → km² (factor 1e-6)
                 let values = covariance_to_lower_triangular(&cov.matrix, 1e-6);
@@ -369,6 +390,7 @@ pub fn parse_omm_json(content: &str) -> Result<crate::ccsds::omm::OMM, BraheErro
 
     for section in &ordered_sections {
         if let Some(obj) = v.get(*section).or_else(|| v.get(section.to_uppercase())) {
+            emit_json_comments(&mut kvn_lines, obj);
             if *section == "metadata" {
                 flatten_object_ordered(&mut kvn_lines, obj, &TIME_SYSTEM_FIRST);
             } else if *section == "covariance" {
@@ -410,6 +432,9 @@ pub fn write_omm_json(
     if let Some(ref msg_id) = omm.header.message_id {
         header.insert(key("MESSAGE_ID", key_case), json!(msg_id));
     }
+    if !omm.header.comments.is_empty() {
+        header.insert("comments".into(), json!(omm.header.comments));
+    }
     root.insert("header".into(), Value::Object(header));
 
     // Metadata
@@ -441,6 +466,9 @@ pub fn write_omm_json(
         key("MEAN_ELEMENT_THEORY", key_case),
         json!(&omm.metadata.mean_element_theory),
     );
+    if !omm.metadata.comments.is_empty() {
+        meta.insert("comments".into(), json!(omm.metadata.comments));
+    }
     root.insert("metadata".into(), Value::Object(meta));
 
     // Mean elements (units stored as file-native: rev/day, degrees, km)
@@ -482,6 +510,9 @@ pub fn write_omm_json(
         // GM stored internally as m³/s², write as km³/s²
         me.insert(key("GM", key_case), json!(v / 1e9));
     }
+    if !omm.mean_elements.comments.is_empty() {
+        me.insert("comments".into(), json!(omm.mean_elements.comments));
+    }
     root.insert("mean_elements".into(), Value::Object(me));
 
     // TLE parameters
@@ -517,6 +548,9 @@ pub fn write_omm_json(
         if let Some(v) = tle.agom {
             tp.insert(key("AGOM", key_case), json!(v));
         }
+        if !tle.comments.is_empty() {
+            tp.insert("comments".into(), json!(tle.comments));
+        }
         root.insert("tle_parameters".into(), Value::Object(tp));
     }
 
@@ -538,6 +572,9 @@ pub fn write_omm_json(
         if let Some(v) = sc.drag_coeff {
             sp.insert(key("DRAG_COEFF", key_case), json!(v));
         }
+        if !sc.comments.is_empty() {
+            sp.insert("comments".into(), json!(sc.comments));
+        }
         root.insert("spacecraft_parameters".into(), Value::Object(sp));
     }
 
@@ -548,6 +585,9 @@ pub fn write_omm_json(
             cv.insert(key("COV_REF_FRAME", key_case), json!(format!("{}", frame)));
         }
         write_json_covariance_elements(&mut cv, &cov.matrix, key_case);
+        if !cov.comments.is_empty() {
+            cv.insert("comments".into(), json!(cov.comments));
+        }
         root.insert("covariance".into(), Value::Object(cv));
     }
 
@@ -631,6 +671,7 @@ pub fn parse_opm_json(content: &str) -> Result<crate::ccsds::opm::OPM, BraheErro
 
     for section in &ordered_sections {
         if let Some(obj) = v.get(*section).or_else(|| v.get(section.to_uppercase())) {
+            emit_json_comments(&mut kvn_lines, obj);
             if *section == "metadata" {
                 flatten_object_ordered(&mut kvn_lines, obj, &TIME_SYSTEM_FIRST);
             } else if *section == "keplerian_elements" {
@@ -657,6 +698,7 @@ pub fn parse_opm_json(content: &str) -> Result<crate::ccsds::opm::OPM, BraheErro
 
     if let Some(Value::Array(maneuvers)) = v.get("maneuvers").or_else(|| v.get("MANEUVERS")) {
         for man in maneuvers {
+            emit_json_comments(&mut kvn_lines, man);
             flatten_object_ordered(&mut kvn_lines, man, &man_key_order);
         }
     }
@@ -692,6 +734,9 @@ pub fn write_opm_json(
     if let Some(ref msg_id) = opm.header.message_id {
         header.insert(key("MESSAGE_ID", key_case), json!(msg_id));
     }
+    if !opm.header.comments.is_empty() {
+        header.insert("comments".into(), json!(opm.header.comments));
+    }
     root.insert("header".into(), Value::Object(header));
 
     // Metadata
@@ -719,6 +764,9 @@ pub fn write_opm_json(
         key("TIME_SYSTEM", key_case),
         json!(format!("{}", opm.metadata.time_system)),
     );
+    if !opm.metadata.comments.is_empty() {
+        meta.insert("comments".into(), json!(opm.metadata.comments));
+    }
     root.insert("metadata".into(), Value::Object(meta));
 
     // State vector (convert m → km, m/s → km/s)
@@ -754,6 +802,9 @@ pub fn write_opm_json(
         key("Z_DOT", key_case),
         json!(opm.state_vector.velocity[2] / 1000.0),
     );
+    if !opm.state_vector.comments.is_empty() {
+        sv.insert("comments".into(), json!(opm.state_vector.comments));
+    }
     root.insert("state_vector".into(), Value::Object(sv));
 
     // Keplerian elements
@@ -779,6 +830,9 @@ pub fn write_opm_json(
         if let Some(v) = kep.gm {
             ke.insert(key("GM", key_case), json!(v / 1e9)); // m³/s² → km³/s²
         }
+        if !kep.comments.is_empty() {
+            ke.insert("comments".into(), json!(kep.comments));
+        }
         root.insert("keplerian_elements".into(), Value::Object(ke));
     }
 
@@ -800,6 +854,9 @@ pub fn write_opm_json(
         if let Some(v) = sc.drag_coeff {
             sp.insert(key("DRAG_COEFF", key_case), json!(v));
         }
+        if !sc.comments.is_empty() {
+            sp.insert("comments".into(), json!(sc.comments));
+        }
         root.insert("spacecraft_parameters".into(), Value::Object(sp));
     }
 
@@ -810,6 +867,9 @@ pub fn write_opm_json(
             cv.insert(key("COV_REF_FRAME", key_case), json!(format!("{}", frame)));
         }
         write_json_covariance_elements(&mut cv, &cov.matrix, key_case);
+        if !cov.comments.is_empty() {
+            cv.insert("comments".into(), json!(cov.comments));
+        }
         root.insert("covariance".into(), Value::Object(cv));
     }
 
@@ -836,6 +896,9 @@ pub fn write_opm_json(
             m.insert(key("MAN_DV_1", key_case), json!(man.dv[0] / 1000.0));
             m.insert(key("MAN_DV_2", key_case), json!(man.dv[1] / 1000.0));
             m.insert(key("MAN_DV_3", key_case), json!(man.dv[2] / 1000.0));
+            if !man.comments.is_empty() {
+                m.insert("comments".into(), json!(man.comments));
+            }
             mans.push(Value::Object(m));
         }
         root.insert("maneuvers".into(), Value::Array(mans));
@@ -873,6 +936,9 @@ pub fn parse_cdm_json(content: &str) -> Result<crate::ccsds::cdm::CDM, BraheErro
         if let Value::Object(map) = obj {
             for (key, val) in map {
                 let ukey = key.to_uppercase();
+                if ukey == COMMENTS_KEY {
+                    continue;
+                }
 
                 let is_container = matches!(
                     ukey.as_str(),
@@ -923,6 +989,7 @@ pub fn parse_cdm_json(content: &str) -> Result<crate::ccsds::cdm::CDM, BraheErro
     // section delimiter, and we must not emit it twice.
     fn flatten_cdm_object(lines: &mut Vec<String>, obj: &Value) {
         if let Some(meta) = obj.get("metadata").or_else(|| obj.get("METADATA")) {
+            emit_json_comments(lines, meta);
             // OBJECT must be emitted first (KVN delimiter)
             if let Some(s) = meta
                 .get("OBJECT")
@@ -951,7 +1018,14 @@ pub fn parse_cdm_json(content: &str) -> Result<crate::ccsds::cdm::CDM, BraheErro
             }
         }
         if let Some(sv) = obj.get("state_vector").or_else(|| obj.get("STATE_VECTOR")) {
+            emit_json_comments(lines, sv);
             flatten(lines, sv);
+        }
+        if let Some(cov) = obj
+            .get("rtn_covariance")
+            .or_else(|| obj.get("RTN_COVARIANCE"))
+        {
+            emit_json_comments(lines, cov);
         }
         if let Some(Value::Array(arr)) = obj
             .get("rtn_covariance_ordered")
@@ -972,23 +1046,27 @@ pub fn parse_cdm_json(content: &str) -> Result<crate::ccsds::cdm::CDM, BraheErro
             .get("od_parameters")
             .or_else(|| obj.get("OD_PARAMETERS"))
         {
+            emit_json_comments(lines, od);
             flatten(lines, od);
         }
         if let Some(ap) = obj
             .get("additional_parameters")
             .or_else(|| obj.get("ADDITIONAL_PARAMETERS"))
         {
+            emit_json_comments(lines, ap);
             flatten(lines, ap);
         }
     }
 
     if let Some(header) = v.get("header").or_else(|| v.get("HEADER")) {
+        emit_json_comments(&mut kvn_lines, header);
         flatten(&mut kvn_lines, header);
     }
     if let Some(rel) = v
         .get("relative_metadata")
         .or_else(|| v.get("RELATIVE_METADATA"))
     {
+        emit_json_comments(&mut kvn_lines, rel);
         flatten(&mut kvn_lines, rel);
     }
     if let Some(obj1) = v.get("object1").or_else(|| v.get("OBJECT1")) {
@@ -1038,6 +1116,9 @@ pub fn write_cdm_json(
         header.insert(key("MESSAGE_FOR", key_case), json!(mf));
     }
     header.insert(key("MESSAGE_ID", key_case), json!(&cdm.header.message_id));
+    if !cdm.header.comments.is_empty() {
+        header.insert("comments".into(), json!(cdm.header.comments));
+    }
     root.insert("header".into(), Value::Object(header));
 
     // Relative metadata
@@ -1172,6 +1253,9 @@ pub fn write_cdm_json(
             json!(format_ccsds_datetime_in(v, &CCSDSTimeSystem::UTC)),
         );
     }
+    if !cdm.relative_metadata.comments.is_empty() {
+        rel.insert("comments".into(), json!(cdm.relative_metadata.comments));
+    }
     root.insert("relative_metadata".into(), Value::Object(rel));
 
     // Helper to build object JSON
@@ -1206,6 +1290,9 @@ pub fn write_cdm_json(
             key("REF_FRAME", key_case),
             json!(format!("{}", m.ref_frame)),
         );
+        if !m.comments.is_empty() {
+            meta.insert("comments".into(), json!(m.comments));
+        }
         o.insert("metadata".into(), Value::Object(meta));
 
         // State vector (in km/km/s)
@@ -1225,6 +1312,9 @@ pub fn write_cdm_json(
             key("Z_DOT", key_case),
             json!(d.state_vector.velocity[2] / 1e3),
         );
+        if !d.state_vector.comments.is_empty() {
+            sv.insert("comments".into(), json!(d.state_vector.comments));
+        }
         o.insert("state_vector".into(), Value::Object(sv));
 
         // RTN covariance
@@ -1283,6 +1373,14 @@ pub fn write_cdm_json(
             .map(|(i, v)| json!([rtn_names[i], v]))
             .collect();
         o.insert("rtn_covariance_ordered".into(), Value::Array(cov_arr));
+
+        // The ordered array carries only values, so the block's comments ride
+        // alongside it in an object of their own.
+        if !d.rtn_covariance.comments.is_empty() {
+            let mut cov_obj = Map::new();
+            cov_obj.insert("comments".into(), json!(d.rtn_covariance.comments));
+            o.insert("rtn_covariance".into(), Value::Object(cov_obj));
+        }
 
         Value::Object(o)
     };
@@ -1370,9 +1468,78 @@ fn emit_kvn(lines: &mut Vec<String>, ukey: &str, val: &Value) {
 fn flatten_object(lines: &mut Vec<String>, obj: &Value) {
     if let Value::Object(map) = obj {
         for (key, val) in map {
-            emit_kvn(lines, &key.to_uppercase(), val);
+            let ukey = key.to_uppercase();
+            if ukey == COMMENTS_KEY {
+                continue;
+            }
+            emit_kvn(lines, &ukey, val);
         }
     }
+}
+
+/// JSON key holding a block's comment array, in either case.
+const COMMENTS_KEY: &str = "COMMENTS";
+
+/// Emit a block's `comments` array as CCSDS `COMMENT` lines.
+///
+/// The KVN parsers attribute a comment to the block whose keywords follow it,
+/// so these are emitted immediately ahead of the block being flattened. Where a
+/// keyword delimits one block from the next — `EPOCH` inside an OEM covariance
+/// section — the comments follow that keyword instead, so they are not flushed
+/// into the preceding block.
+///
+/// # Arguments
+///
+/// * `lines` - The KVN line buffer being built.
+/// * `obj` - The JSON object that may carry a `comments` array. Objects
+///   without one, and values that are not objects, are ignored.
+///
+/// # Returns
+///
+/// Nothing; `lines` is extended in place.
+///
+/// # Examples
+///
+/// ```ignore
+/// let mut lines = Vec::new();
+/// let block = serde_json::json!({"comments": ["first", "second"]});
+/// emit_json_comments(&mut lines, &block);
+/// assert_eq!(lines, ["COMMENT first", "COMMENT second"]);
+/// ```
+fn emit_json_comments(lines: &mut Vec<String>, obj: &Value) {
+    if let Value::Object(map) = obj
+        && let Some(Value::Array(comments)) = map.get("comments").or_else(|| map.get("COMMENTS"))
+    {
+        for comment in comments {
+            if let Value::String(text) = comment {
+                lines.push(format!("COMMENT {}", text));
+            }
+        }
+    }
+}
+
+/// Emit a block's comments and then its keywords.
+///
+/// # Arguments
+///
+/// * `lines` - The KVN line buffer being built.
+/// * `obj` - The JSON object holding the block's comments and keywords.
+///
+/// # Returns
+///
+/// Nothing; `lines` is extended in place.
+///
+/// # Examples
+///
+/// ```ignore
+/// let mut lines = Vec::new();
+/// let block = serde_json::json!({"comments": ["note"], "ORIGINATOR": "NASA/JPL"});
+/// flatten_block(&mut lines, &block);
+/// assert_eq!(lines, ["COMMENT note", "ORIGINATOR = NASA/JPL"]);
+/// ```
+fn flatten_block(lines: &mut Vec<String>, obj: &Value) {
+    emit_json_comments(lines, obj);
+    flatten_object(lines, obj);
 }
 
 /// Flatten a JSON object, emitting priority keys first.
@@ -1392,7 +1559,7 @@ fn flatten_object_ordered(lines: &mut Vec<String>, obj: &Value, priority_keys: &
         // Emit remaining keys
         for (key, val) in map {
             let ukey = key.to_uppercase();
-            if priority_keys.iter().any(|&pk| pk == ukey) {
+            if ukey == COMMENTS_KEY || priority_keys.iter().any(|&pk| pk == ukey) {
                 continue;
             }
             emit_kvn(lines, &ukey, val);
@@ -1404,7 +1571,7 @@ fn flatten_object_ordered(lines: &mut Vec<String>, obj: &Value, priority_keys: &
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
-    use crate::ccsds::common::CCSDSJsonKeyCase;
+    use crate::ccsds::common::{CCSDSFormat, CCSDSJsonKeyCase};
     use crate::ccsds::oem::OEM;
     use crate::ccsds::omm::OMM;
     use crate::ccsds::opm::OPM;
@@ -2408,5 +2575,129 @@ mod tests {
         assert!((acc[0] - 0.001e3).abs() < 1e-6);
         assert!((acc[1] - 0.002e3).abs() < 1e-6);
         assert!((acc[2] - 0.003e3).abs() < 1e-6);
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_oem_json_round_trip_preserves_comments() {
+        let source =
+            std::fs::read_to_string("test_assets/ccsds/oem/OEMExampleWithHeaderComment.txt")
+                .unwrap();
+        let oem = OEM::from_str(&source).unwrap();
+        assert!(!oem.header.comments.is_empty());
+        assert!(!oem.segments[0].comments.is_empty());
+
+        let reparsed = OEM::from_str(&oem.to_string(CCSDSFormat::JSON).unwrap()).unwrap();
+        assert_eq!(reparsed.header.comments, oem.header.comments);
+        assert_eq!(reparsed.segments[0].comments, oem.segments[0].comments);
+        assert_eq!(
+            reparsed.segments[0].metadata.comments,
+            oem.segments[0].metadata.comments
+        );
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_omm_json_round_trip_preserves_comments() {
+        let omm = OMM::from_str(
+            &std::fs::read_to_string("test_assets/ccsds/omm/OMM-section-comments.txt").unwrap(),
+        )
+        .unwrap();
+        let reparsed = OMM::from_str(&omm.to_string(CCSDSFormat::JSON).unwrap()).unwrap();
+
+        assert_eq!(reparsed.header.comments, vec!["header comment"]);
+        assert_eq!(reparsed.metadata.comments, vec!["metadata comment"]);
+        assert_eq!(
+            reparsed.mean_elements.comments,
+            vec!["mean element comment"]
+        );
+        assert_eq!(
+            reparsed.tle_parameters.as_ref().unwrap().comments,
+            vec!["tle comment"]
+        );
+        assert_eq!(
+            reparsed.spacecraft_parameters.as_ref().unwrap().comments,
+            vec!["spacecraft comment"]
+        );
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_opm_json_round_trip_preserves_comments() {
+        let opm = OPM::from_str(
+            &std::fs::read_to_string("test_assets/ccsds/opm/OPM-section-comments.txt").unwrap(),
+        )
+        .unwrap();
+        let reparsed = OPM::from_str(&opm.to_string(CCSDSFormat::JSON).unwrap()).unwrap();
+
+        assert_eq!(reparsed.header.comments, vec!["header comment"]);
+        assert_eq!(reparsed.metadata.comments, vec!["metadata comment"]);
+        assert_eq!(reparsed.state_vector.comments, vec!["state vector comment"]);
+        assert_eq!(reparsed.maneuvers.len(), 2);
+        assert_eq!(
+            reparsed.maneuvers[0].comments,
+            vec!["first maneuver comment"]
+        );
+        assert_eq!(
+            reparsed.maneuvers[1].comments,
+            vec!["second maneuver comment"]
+        );
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_oem_json_keeps_each_covariance_comment_with_its_own_block() {
+        // EPOCH delimits one covariance from the next in the KVN form the JSON
+        // reader delegates to, so comments emitted ahead of it were flushed
+        // into the preceding block and the second covariance received none.
+        let source = std::fs::read_to_string("test_assets/ccsds/oem/OEMExample1.txt").unwrap();
+        let mut oem = OEM::from_str(&source).unwrap();
+        let segment = oem
+            .segments
+            .iter_mut()
+            .find(|s| s.covariances.len() >= 2)
+            .expect("fixture has a segment with two covariances");
+        segment.covariances[0].comments = vec!["first covariance".to_string()];
+        segment.covariances[1].comments = vec!["second covariance".to_string()];
+
+        let reparsed = OEM::from_str(&oem.to_string(CCSDSFormat::JSON).unwrap()).unwrap();
+        let segment = reparsed
+            .segments
+            .iter()
+            .find(|s| s.covariances.len() >= 2)
+            .unwrap();
+        assert_eq!(segment.covariances[0].comments, vec!["first covariance"]);
+        assert_eq!(segment.covariances[1].comments, vec!["second covariance"]);
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_cdm_json_round_trip_preserves_comments() {
+        use crate::ccsds::cdm::CDM;
+
+        let source = std::fs::read_to_string("test_assets/ccsds/cdm/CDMExample2.txt").unwrap();
+        let cdm = CDM::from_str(&source).unwrap();
+        let reparsed = CDM::from_str(&cdm.to_string(CCSDSFormat::JSON).unwrap()).unwrap();
+
+        assert_eq!(
+            reparsed.relative_metadata.comments,
+            cdm.relative_metadata.comments
+        );
+        assert_eq!(
+            reparsed.object1.metadata.comments,
+            cdm.object1.metadata.comments
+        );
+        assert_eq!(
+            reparsed.object1.data.state_vector.comments,
+            cdm.object1.data.state_vector.comments
+        );
+        assert_eq!(
+            reparsed.object1.data.rtn_covariance.comments,
+            cdm.object1.data.rtn_covariance.comments
+        );
+        assert_eq!(
+            reparsed.object2.metadata.comments,
+            cdm.object2.metadata.comments
+        );
     }
 }

--- a/tests/ccsds/test_json_comments.py
+++ b/tests/ccsds/test_json_comments.py
@@ -1,0 +1,63 @@
+"""Tests for CCSDS JSON comment fidelity — parity with Rust tests in src/ccsds/json.rs."""
+
+import brahe  # noqa: F401
+from brahe.ccsds import CDM, OEM, OMM, OPM
+
+
+def _asset(path):
+    """Read a CCSDS fixture; the same files back the Rust tests."""
+    with open(path) as handle:
+        return handle.read()
+
+
+def test_oem_json_round_trip_preserves_comments(eop):
+    """Mirror of test_oem_json_round_trip_preserves_comments in Rust."""
+    oem = OEM.from_file("test_assets/ccsds/oem/OEMExampleWithHeaderComment.txt")
+    before = oem.to_dict()
+    assert before["header"]["comments"]
+    assert before["segments"][0]["comments"]
+
+    after = OEM.from_str(oem.to_string("json")).to_dict()
+    assert after["header"]["comments"] == before["header"]["comments"]
+    assert after["segments"][0]["comments"] == before["segments"][0]["comments"]
+
+
+def test_omm_json_round_trip_preserves_comments(eop):
+    """Mirror of test_omm_json_round_trip_preserves_comments in Rust."""
+    omm = OMM.from_str(_asset("test_assets/ccsds/omm/OMM-section-comments.txt"))
+    reparsed = OMM.from_str(omm.to_string("json"))
+
+    # KVN is the reference encoding; JSON must not lose anything against it.
+    assert reparsed.to_string("kvn") == omm.to_string("kvn")
+
+
+def test_opm_json_round_trip_preserves_comments(eop):
+    """Mirror of test_opm_json_round_trip_preserves_comments in Rust."""
+    opm = OPM.from_str(_asset("test_assets/ccsds/opm/OPM-section-comments.txt"))
+    reparsed = OPM.from_str(opm.to_string("json"))
+
+    assert reparsed.to_dict()["header"]["comments"] == ["header comment"]
+    assert reparsed.maneuvers[0].comments == ["first maneuver comment"]
+    assert reparsed.to_string("kvn") == opm.to_string("kvn")
+
+
+def test_cdm_json_round_trip_preserves_comments(eop):
+    """Mirror of test_cdm_json_round_trip_preserves_comments in Rust."""
+    cdm = CDM.from_file("test_assets/ccsds/cdm/CDMExample2.txt")
+    written = cdm.to_string("json")
+
+    reparsed = CDM.from_str(written)
+    kvn = reparsed.to_string("kvn")
+    assert "COMMENT Relative Metadata/Data" in kvn
+    assert "COMMENT Object1 Metadata" in kvn
+    assert "COMMENT Object2 Metadata" in kvn
+
+
+def test_oem_json_keeps_each_covariance_comment_with_its_own_block(eop):
+    """Mirror of test_oem_json_keeps_each_covariance_comment_with_its_own_block in Rust."""
+    # EPOCH delimits one covariance from the next, so comments emitted ahead of
+    # it were flushed into the preceding block.
+    oem = OEM.from_file("test_assets/ccsds/oem/OEMExample1.txt")
+    kvn = OEM.from_str(oem.to_string("json")).to_string("kvn")
+
+    assert kvn == oem.to_string("kvn")


### PR DESCRIPTION
# Pull Request

## Description

The JSON codecs emitted no `COMMENT` content at all, so every header, metadata, and block comment was silently dropped the first time a message was written as JSON. CCSDS 502.0-B-3 and 508.0-B-1 give each block a `COMMENT` row, and the KVN and XML codecs already carry them, so JSON was the one encoding that lost them.

Each block now writes a `comments` array beside its keywords, and the readers emit those back as `COMMENT` lines immediately ahead of the block they introduce, which is where the KVN parsers the JSON readers delegate to expect them. The CDM covariance is written as an ordered array of name/value pairs with no room for comments, so its comments ride in a sibling object.

Covers the OEM header, metadata, data, and covariance blocks; the OMM header, metadata, mean elements, TLE parameters, and spacecraft parameters; the OPM header, metadata, state vector, Keplerian elements, spacecraft parameters, covariance, and each maneuver; and the CDM header, relative metadata, object metadata, state vector, OD parameters, additional parameters, and RTN covariance.

## Changelog

### Fixed
- CCSDS OEM, OMM, OPM, and CDM JSON writers now emit each block's comments, and the JSON readers restore them to the block they belong to; previously every comment was dropped on the first write to JSON.

## Related Issue

Covers item 4 of #463, completing that issue alongside #474 (item 1) and the three PRs below this one in the stack.

## Note to Reviewers

The `comments` key is skipped by every flattener rather than being emitted as a `COMMENTS = ...` keyword line, so it cannot be mistaken for a CCSDS keyword on the way back in.

Separately, and not fixed here: `write_cdm_json` emits no `od_parameters` or `additional_parameters` block at all, so a CDM round-tripped through JSON loses both entirely (`back.object1.data.od_parameters.is_some()` is `false`). That is a data-loss defect rather than a comment one and deserves its own issue and PR.
