### PR TITLE
Fix trajectory interpolation at repeated and even-window queries

### DIFF
--- a/src/trajectories/dorbit_trajectory.rs
+++ b/src/trajectories/dorbit_trajectory.rs
@@ -79,6 +79,7 @@
  * ```
  */
 
+use crate::trajectories::traits::compute_lagrange_window;
 use nalgebra::{DMatrix, DVector, SMatrix, Vector3, Vector6};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -666,7 +667,17 @@ impl DOrbitTrajectory {
         }
 
         // Handle exact match at endpoint
-        if let Some((idx, _)) = self.epochs.iter().enumerate().find(|(_, e)| **e == epoch) {
+        // The last record at a repeated epoch, matching what `interpolate`
+        // returns there: an impulsive maneuver stores its pre- and post-burn
+        // records at the same instant, and pairing the post-burn state with
+        // pre-burn auxiliary data would misreport the maneuver.
+        if let Some((idx, _)) = self
+            .epochs
+            .iter()
+            .enumerate()
+            .rev()
+            .find(|(_, e)| **e == epoch)
+        {
             return Ok(Some(covs[idx].clone()));
         }
 
@@ -1571,8 +1582,18 @@ impl InterpolatableTrajectory for DOrbitTrajectory {
         let idx2 = self.index_after_epoch(epoch)?;
 
         // If indices are the same, we have an exact match
-        if idx1 == idx2 {
-            return self.state_at_idx(idx1);
+        // An exact hit, or a bracket of zero duration because the epoch is
+        // stored more than once. Repeated epochs are allowed so that an
+        // impulsive maneuver can hold both its pre- and post-burn states;
+        // interpolating across one would divide by a zero-length interval and
+        // yield NaN, so the stored state is returned instead. `add` inserts a
+        // state after any it already holds at that epoch, and for a repeated
+        // epoch `index_before_epoch` lands on the last of the run while
+        // `index_after_epoch` lands on the first, so the higher index is the
+        // most recently added state. Returning it makes a query at a
+        // discontinuity right-continuous with the states that follow.
+        if idx1 == idx2 || self.epoch_at_idx(idx1)? == self.epoch_at_idx(idx2)? {
+            return self.state_at_idx(idx1.max(idx2));
         }
 
         // Validate minimum point count
@@ -1597,7 +1618,7 @@ impl InterpolatableTrajectory for DOrbitTrajectory {
                 // Collect degree+1 points centered around query epoch
                 let n_points = degree + 1;
                 let (start_idx, end_idx) =
-                    self.compute_interpolation_window(idx1, idx2, n_points)?;
+                    compute_lagrange_window(&self.epochs, idx1, idx2, n_points)?;
 
                 // Build time and value arrays
                 let times: Vec<f64> = (start_idx..=end_idx)
@@ -1679,35 +1700,7 @@ impl InterpolatableTrajectory for DOrbitTrajectory {
     }
 }
 
-impl DOrbitTrajectory {
-    /// Compute the window of indices to use for Lagrange interpolation.
-    fn compute_interpolation_window(
-        &self,
-        idx1: usize,
-        idx2: usize,
-        n_points: usize,
-    ) -> Result<(usize, usize), BraheError> {
-        if self.len() < n_points {
-            return Err(BraheError::Error(format!(
-                "Need {} points for interpolation, trajectory has {}",
-                n_points,
-                self.len()
-            )));
-        }
-
-        let center = (idx1 + idx2) / 2;
-        let half_window = n_points / 2;
-        let mut start_idx = center.saturating_sub(half_window);
-        let mut end_idx = start_idx + n_points - 1;
-
-        if end_idx >= self.len() {
-            end_idx = self.len() - 1;
-            start_idx = end_idx.saturating_sub(n_points - 1);
-        }
-
-        Ok((start_idx, end_idx))
-    }
-}
+impl DOrbitTrajectory {}
 
 impl STMStorage for DOrbitTrajectory {
     fn enable_stm_storage(&mut self) {
@@ -7299,5 +7292,64 @@ mod tests {
 
         let result = traj.covariance_at(t0 + 30.0);
         assert!(matches!(result, Err(BraheError::NumericalError(_))));
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_hermite_interpolation_at_a_repeated_epoch() {
+        setup_global_test_eop();
+
+        // Hermite fits the two bracketing samples rather than a window, so it
+        // cannot straddle a discontinuity the way a Lagrange stencil can. It is
+        // still exposed to the zero-length bracket at a repeated epoch, where
+        // t1 - t0 is zero: both variants returned NaN there before the guard in
+        // `interpolate` caught it ahead of the method dispatch.
+        let start = Epoch::from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+        let state = |x: f64| DVector::from_vec(vec![x, 0.0, 0.0, 1.0, 0.0, 0.0]);
+        let zero = DVector::from_vec(vec![0.0, 0.0, 0.0]);
+
+        for method in [
+            InterpolationMethod::HermiteCubic,
+            InterpolationMethod::HermiteQuintic,
+        ] {
+            let mut traj =
+                DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+                    .unwrap();
+            traj.enable_acceleration_storage(3).unwrap();
+            // An impulsive maneuver at start + 60: x jumps from 1 to 10.
+            traj.add_with_acceleration(start, state(0.0), zero.clone())
+                .unwrap();
+            traj.add_with_acceleration(start + 60.0, state(1.0), zero.clone())
+                .unwrap();
+            traj.add_with_acceleration(start + 60.0, state(10.0), zero.clone())
+                .unwrap();
+            traj.add_with_acceleration(start + 120.0, state(11.0), zero.clone())
+                .unwrap();
+            traj.set_interpolation_method(method);
+
+            // At the discontinuity: the most recently added state, not NaN.
+            let at = traj.interpolate(&(start + 60.0)).unwrap();
+            assert!(
+                at.iter().all(|v| v.is_finite()),
+                "{:?} returned {:?} at the repeated epoch",
+                method,
+                at
+            );
+            assert_abs_diff_eq!(at[0], 10.0, epsilon = 1e-9);
+
+            // Either side, the fit uses only the branch that side belongs to:
+            // the bracketing pair is adjacent, so the pre-burn sample is never
+            // paired with a post-burn one.
+            assert_abs_diff_eq!(
+                traj.interpolate(&(start + 30.0)).unwrap()[0],
+                0.5,
+                epsilon = 1e-9
+            );
+            assert_abs_diff_eq!(
+                traj.interpolate(&(start + 90.0)).unwrap()[0],
+                10.5,
+                epsilon = 1e-9
+            );
+        }
     }
 }

--- a/src/trajectories/dtrajectory.rs
+++ b/src/trajectories/dtrajectory.rs
@@ -28,6 +28,7 @@
  * ```
  */
 
+use crate::trajectories::traits::compute_lagrange_window;
 use nalgebra::{DMatrix, DVector};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -412,7 +413,17 @@ impl DTrajectory {
         }
 
         // Handle exact match at endpoint
-        if let Some((idx, _)) = self.epochs.iter().enumerate().find(|(_, e)| **e == epoch) {
+        // The last record at a repeated epoch, matching what `interpolate`
+        // returns there: an impulsive maneuver stores its pre- and post-burn
+        // records at the same instant, and pairing the post-burn state with
+        // pre-burn auxiliary data would misreport the maneuver.
+        if let Some((idx, _)) = self
+            .epochs
+            .iter()
+            .enumerate()
+            .rev()
+            .find(|(_, e)| **e == epoch)
+        {
             return Ok(Some(covs[idx].clone()));
         }
 
@@ -1323,8 +1334,18 @@ impl InterpolatableTrajectory for DTrajectory {
         let idx2 = self.index_after_epoch(epoch)?;
 
         // If indices are the same, we have an exact match
-        if idx1 == idx2 {
-            return self.state_at_idx(idx1);
+        // An exact hit, or a bracket of zero duration because the epoch is
+        // stored more than once. Repeated epochs are allowed so that an
+        // impulsive maneuver can hold both its pre- and post-burn states;
+        // interpolating across one would divide by a zero-length interval and
+        // yield NaN, so the stored state is returned instead. `add` inserts a
+        // state after any it already holds at that epoch, and for a repeated
+        // epoch `index_before_epoch` lands on the last of the run while
+        // `index_after_epoch` lands on the first, so the higher index is the
+        // most recently added state. Returning it makes a query at a
+        // discontinuity right-continuous with the states that follow.
+        if idx1 == idx2 || self.epoch_at_idx(idx1)? == self.epoch_at_idx(idx2)? {
+            return self.state_at_idx(idx1.max(idx2));
         }
 
         // Validate minimum point count
@@ -1349,7 +1370,7 @@ impl InterpolatableTrajectory for DTrajectory {
                 // Collect degree+1 points centered around query epoch
                 let n_points = degree + 1;
                 let (start_idx, end_idx) =
-                    compute_lagrange_window(self.len(), idx1, idx2, n_points)?;
+                    compute_lagrange_window(&self.epochs, idx1, idx2, n_points)?;
 
                 // Build time and value arrays
                 let times: Vec<f64> = (start_idx..=end_idx)
@@ -1373,33 +1394,6 @@ impl InterpolatableTrajectory for DTrajectory {
             }
         }
     }
-}
-
-/// Helper function to compute the window of indices for Lagrange interpolation.
-fn compute_lagrange_window(
-    len: usize,
-    idx1: usize,
-    idx2: usize,
-    n_points: usize,
-) -> Result<(usize, usize), BraheError> {
-    if len < n_points {
-        return Err(BraheError::Error(format!(
-            "Need {} points for interpolation, trajectory has {}",
-            n_points, len
-        )));
-    }
-
-    let center = (idx1 + idx2) / 2;
-    let half_window = n_points / 2;
-    let mut start_idx = center.saturating_sub(half_window);
-    let mut end_idx = start_idx + n_points - 1;
-
-    if end_idx >= len {
-        end_idx = len - 1;
-        start_idx = end_idx.saturating_sub(n_points - 1);
-    }
-
-    Ok((start_idx, end_idx))
 }
 
 #[cfg(test)]

--- a/src/trajectories/sorbit_trajectory.rs
+++ b/src/trajectories/sorbit_trajectory.rs
@@ -37,6 +37,7 @@
  * ```
  */
 
+use crate::trajectories::traits::compute_lagrange_window;
 use nalgebra::{DMatrix, SMatrix, SVector, Vector6};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -578,7 +579,17 @@ impl SOrbitTrajectory {
         }
 
         // Handle exact match
-        if let Some((idx, _)) = self.epochs.iter().enumerate().find(|(_, e)| **e == epoch) {
+        // The last record at a repeated epoch, matching what `interpolate`
+        // returns there: an impulsive maneuver stores its pre- and post-burn
+        // records at the same instant, and pairing the post-burn state with
+        // pre-burn auxiliary data would misreport the maneuver.
+        if let Some((idx, _)) = self
+            .epochs
+            .iter()
+            .enumerate()
+            .rev()
+            .find(|(_, e)| **e == epoch)
+        {
             return Some(stms[idx]);
         }
 
@@ -621,7 +632,17 @@ impl SOrbitTrajectory {
         }
 
         // Handle exact match
-        if let Some((idx, _)) = self.epochs.iter().enumerate().find(|(_, e)| **e == epoch) {
+        // The last record at a repeated epoch, matching what `interpolate`
+        // returns there: an impulsive maneuver stores its pre- and post-burn
+        // records at the same instant, and pairing the post-burn state with
+        // pre-burn auxiliary data would misreport the maneuver.
+        if let Some((idx, _)) = self
+            .epochs
+            .iter()
+            .enumerate()
+            .rev()
+            .find(|(_, e)| **e == epoch)
+        {
             return Some(sens[idx].clone());
         }
 
@@ -1465,8 +1486,18 @@ impl InterpolatableTrajectory for SOrbitTrajectory {
         let idx2 = self.index_after_epoch(epoch)?;
 
         // If indices are the same, we have an exact match
-        if idx1 == idx2 {
-            return self.state_at_idx(idx1);
+        // An exact hit, or a bracket of zero duration because the epoch is
+        // stored more than once. Repeated epochs are allowed so that an
+        // impulsive maneuver can hold both its pre- and post-burn states;
+        // interpolating across one would divide by a zero-length interval and
+        // yield NaN, so the stored state is returned instead. `add` inserts a
+        // state after any it already holds at that epoch, and for a repeated
+        // epoch `index_before_epoch` lands on the last of the run while
+        // `index_after_epoch` lands on the first, so the higher index is the
+        // most recently added state. Returning it makes a query at a
+        // discontinuity right-continuous with the states that follow.
+        if idx1 == idx2 || self.epoch_at_idx(idx1)? == self.epoch_at_idx(idx2)? {
+            return self.state_at_idx(idx1.max(idx2));
         }
 
         // Validate minimum point count
@@ -1491,7 +1522,7 @@ impl InterpolatableTrajectory for SOrbitTrajectory {
                 // Collect degree+1 points centered around query epoch
                 let n_points = degree + 1;
                 let (start_idx, end_idx) =
-                    self.compute_interpolation_window(idx1, idx2, n_points)?;
+                    compute_lagrange_window(&self.epochs, idx1, idx2, n_points)?;
 
                 // Build time and value arrays
                 let times: Vec<f64> = (start_idx..=end_idx)
@@ -1550,42 +1581,7 @@ impl InterpolatableTrajectory for SOrbitTrajectory {
     }
 }
 
-impl SOrbitTrajectory {
-    /// Compute the window of indices to use for Lagrange interpolation.
-    ///
-    /// Tries to center the window around the query point, but shifts it
-    /// if near trajectory boundaries.
-    fn compute_interpolation_window(
-        &self,
-        idx1: usize,
-        idx2: usize,
-        n_points: usize,
-    ) -> Result<(usize, usize), BraheError> {
-        if self.len() < n_points {
-            return Err(BraheError::Error(format!(
-                "Need {} points for interpolation, trajectory has {}",
-                n_points,
-                self.len()
-            )));
-        }
-
-        // Center point is between idx1 and idx2
-        let center = (idx1 + idx2) / 2;
-
-        // Calculate ideal start and end indices (centered around the query)
-        let half_window = n_points / 2;
-        let mut start_idx = center.saturating_sub(half_window);
-        let mut end_idx = start_idx + n_points - 1;
-
-        // Shift window if it extends beyond trajectory bounds
-        if end_idx >= self.len() {
-            end_idx = self.len() - 1;
-            start_idx = end_idx.saturating_sub(n_points - 1);
-        }
-
-        Ok((start_idx, end_idx))
-    }
-}
+impl SOrbitTrajectory {}
 
 // Implementation of CovarianceInterpolationConfig trait
 impl CovarianceInterpolationConfig for SOrbitTrajectory {

--- a/src/trajectories/strajectory.rs
+++ b/src/trajectories/strajectory.rs
@@ -27,6 +27,7 @@
  * ```
  */
 
+use crate::trajectories::traits::compute_lagrange_window;
 use nalgebra::{SMatrix, SVector};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -409,7 +410,17 @@ impl<const R: usize> STrajectory<R> {
         }
 
         // Handle exact match
-        if let Some((idx, _)) = self.epochs.iter().enumerate().find(|(_, e)| **e == epoch) {
+        // The last record at a repeated epoch, matching what `interpolate`
+        // returns there: an impulsive maneuver stores its pre- and post-burn
+        // records at the same instant, and pairing the post-burn state with
+        // pre-burn auxiliary data would misreport the maneuver.
+        if let Some((idx, _)) = self
+            .epochs
+            .iter()
+            .enumerate()
+            .rev()
+            .find(|(_, e)| **e == epoch)
+        {
             return Ok(Some(covs[idx]));
         }
 
@@ -899,8 +910,18 @@ impl<const R: usize> InterpolatableTrajectory for STrajectory<R> {
         let idx2 = self.index_after_epoch(epoch)?;
 
         // If indices are the same, we have an exact match
-        if idx1 == idx2 {
-            return self.state_at_idx(idx1);
+        // An exact hit, or a bracket of zero duration because the epoch is
+        // stored more than once. Repeated epochs are allowed so that an
+        // impulsive maneuver can hold both its pre- and post-burn states;
+        // interpolating across one would divide by a zero-length interval and
+        // yield NaN, so the stored state is returned instead. `add` inserts a
+        // state after any it already holds at that epoch, and for a repeated
+        // epoch `index_before_epoch` lands on the last of the run while
+        // `index_after_epoch` lands on the first, so the higher index is the
+        // most recently added state. Returning it makes a query at a
+        // discontinuity right-continuous with the states that follow.
+        if idx1 == idx2 || self.epoch_at_idx(idx1)? == self.epoch_at_idx(idx2)? {
+            return self.state_at_idx(idx1.max(idx2));
         }
 
         // Validate minimum point count
@@ -925,7 +946,7 @@ impl<const R: usize> InterpolatableTrajectory for STrajectory<R> {
                 // Collect degree+1 points centered around query epoch
                 let n_points = degree + 1;
                 let (start_idx, end_idx) =
-                    compute_interpolation_window(self.len(), idx1, idx2, n_points)?;
+                    compute_lagrange_window(&self.epochs, idx1, idx2, n_points)?;
 
                 // Build time and value arrays
                 let times: Vec<f64> = (start_idx..=end_idx)
@@ -949,33 +970,6 @@ impl<const R: usize> InterpolatableTrajectory for STrajectory<R> {
             }
         }
     }
-}
-
-/// Helper function to compute the window of indices for Lagrange interpolation.
-fn compute_interpolation_window(
-    len: usize,
-    idx1: usize,
-    idx2: usize,
-    n_points: usize,
-) -> Result<(usize, usize), BraheError> {
-    if len < n_points {
-        return Err(BraheError::Error(format!(
-            "Need {} points for interpolation, trajectory has {}",
-            n_points, len
-        )));
-    }
-
-    let center = (idx1 + idx2) / 2;
-    let half_window = n_points / 2;
-    let mut start_idx = center.saturating_sub(half_window);
-    let mut end_idx = start_idx + n_points - 1;
-
-    if end_idx >= len {
-        end_idx = len - 1;
-        start_idx = end_idx.saturating_sub(n_points - 1);
-    }
-
-    Ok((start_idx, end_idx))
 }
 
 // Iterator implementation will be added later once trait bounds are resolved
@@ -2258,5 +2252,233 @@ mod tests {
         // indices exist for interpolation.
         let epoch = Epoch::from_jd(2451544.0, TimeSystem::UTC);
         assert!(traj.covariance_at(epoch).unwrap().is_none());
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_compute_lagrange_window_is_balanced() {
+        setup_global_test_eop();
+
+        // Twenty samples one minute apart, no repeats.
+        let start = Epoch::from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+        let epochs: Vec<Epoch> = (0..20).map(|i| start + 60.0 * i as f64).collect();
+        let (idx1, idx2) = (5, 6);
+
+        // Two points: exactly the bracketing pair. The previous split put the
+        // window at 4..=5, which extrapolated instead of interpolating.
+        assert_eq!(
+            compute_lagrange_window(&epochs, idx1, idx2, 2).unwrap(),
+            (5, 6)
+        );
+        // Four points: one sample either side of the bracket.
+        assert_eq!(
+            compute_lagrange_window(&epochs, idx1, idx2, 4).unwrap(),
+            (4, 7)
+        );
+        // Six points: two samples either side.
+        assert_eq!(
+            compute_lagrange_window(&epochs, idx1, idx2, 6).unwrap(),
+            (3, 8)
+        );
+        // Odd counts cannot straddle evenly and keep their existing split.
+        assert_eq!(
+            compute_lagrange_window(&epochs, idx1, idx2, 3).unwrap(),
+            (4, 6)
+        );
+        assert_eq!(
+            compute_lagrange_window(&epochs, idx1, idx2, 5).unwrap(),
+            (3, 7)
+        );
+
+        // Windows still clamp to the end of the trajectory.
+        assert_eq!(
+            compute_lagrange_window(&epochs, 18, 19, 4).unwrap(),
+            (16, 19)
+        );
+        // A window wider than the trajectory shrinks to what is available.
+        let short: Vec<Epoch> = epochs[..3].to_vec();
+        assert_eq!(compute_lagrange_window(&short, 0, 1, 4).unwrap(), (0, 2));
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_compute_lagrange_window_stops_at_a_repeated_epoch() {
+        setup_global_test_eop();
+
+        // A repeated epoch at index 2/3 marks a discontinuity; a polynomial
+        // fitted across it would see two identical abscissae.
+        let start = Epoch::from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+        let epochs = vec![
+            start,
+            start + 60.0,
+            start + 120.0,
+            start + 120.0,
+            start + 180.0,
+            start + 240.0,
+        ];
+
+        // Query bracketed by 1 and 2, ahead of the discontinuity: the window
+        // may not reach index 3.
+        let (s0, e0) = compute_lagrange_window(&epochs, 1, 2, 4).unwrap();
+        assert!(e0 <= 2, "window {:?} crossed the repeated epoch", (s0, e0));
+        assert_eq!((s0, e0), (0, 2));
+
+        // Query bracketed by 3 and 4, after the discontinuity: the window may
+        // not reach index 2.
+        let (s1, e1) = compute_lagrange_window(&epochs, 3, 4, 4).unwrap();
+        assert!(s1 >= 3, "window {:?} crossed the repeated epoch", (s1, e1));
+        assert_eq!((s1, e1), (3, 5));
+
+        // Every window it returns has strictly increasing epochs.
+        for n_points in 2..=6 {
+            for (a, b) in [(0, 1), (1, 2), (3, 4), (4, 5)] {
+                let (ws, we) = compute_lagrange_window(&epochs, a, b, n_points).unwrap();
+                for i in ws..we {
+                    assert!(
+                        epochs[i] < epochs[i + 1],
+                        "window {:?} for {} points repeats an epoch",
+                        (ws, we),
+                        n_points
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_even_degree_lagrange_beats_the_earlier_window() {
+        setup_global_test_eop();
+
+        // A smooth, non-polynomial signal so the window choice shows up as
+        // interpolation error rather than being fitted exactly.
+        let start = Epoch::from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+        let signal = |x: f64| (x / 3.0).cos() * (1.0 + 0.3 * x).ln();
+
+        let mut traj = STrajectory6::new();
+        for i in 0..12 {
+            let value = signal(i as f64);
+            traj.add(
+                start + 60.0 * i as f64,
+                Vector6::new(value, 0.0, 0.0, 0.0, 0.0, 0.0),
+            )
+            .unwrap();
+        }
+        traj.set_interpolation_method(InterpolationMethod::Lagrange { degree: 3 });
+
+        // Interior queries, away from the ends where the window clamps.
+        let mut worst = 0.0f64;
+        for k in 4..7 {
+            let x = k as f64 + 0.5;
+            let interpolated = traj.interpolate(&(start + 60.0 * x)).unwrap()[0];
+            worst = worst.max((interpolated - signal(x)).abs());
+        }
+
+        // The balanced window holds this under 4e-4; the window one sample
+        // early reaches 7.4e-4 on the same data.
+        assert!(worst < 4e-4, "worst interior error was {:e}", worst);
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_repeated_epoch_pairs_state_and_covariance_from_the_same_record() {
+        setup_global_test_eop();
+
+        // A query at a maneuver epoch must not pair the post-burn state with
+        // the pre-burn covariance.
+        let start = Epoch::from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+        let mut traj = STrajectory6::new();
+        traj.add_with_covariance(
+            start,
+            Vector6::new(1.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+            SMatrix::<f64, 6, 6>::identity(),
+        );
+        traj.add_with_covariance(
+            start + 60.0,
+            Vector6::new(2.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+            SMatrix::<f64, 6, 6>::identity() * 2.0,
+        );
+        traj.add_with_covariance(
+            start + 60.0,
+            Vector6::new(9.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+            SMatrix::<f64, 6, 6>::identity() * 9.0,
+        );
+
+        let state = traj.interpolate(&(start + 60.0)).unwrap();
+        let covariance = traj.covariance_at(start + 60.0).unwrap().unwrap();
+        assert_abs_diff_eq!(state[0], 9.0, epsilon = 1e-12);
+        assert_abs_diff_eq!(covariance[(0, 0)], 9.0, epsilon = 1e-12);
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_lagrange_interpolation_does_not_span_a_repeated_epoch() {
+        setup_global_test_eop();
+
+        // Four samples with the middle epoch repeated, as an impulsive
+        // maneuver stores it. A four-point Lagrange stencil covering the whole
+        // trajectory would contain both copies of that epoch and divide by a
+        // zero-length abscissa difference.
+        let start = Epoch::from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+        let mut traj = STrajectory6::new();
+        traj.add(start, Vector6::new(0.0, 0.0, 0.0, 0.0, 0.0, 0.0))
+            .unwrap();
+        traj.add(start + 60.0, Vector6::new(1.0, 0.0, 0.0, 0.0, 0.0, 0.0))
+            .unwrap();
+        traj.add(start + 60.0, Vector6::new(10.0, 0.0, 0.0, 0.0, 0.0, 0.0))
+            .unwrap();
+        traj.add(start + 120.0, Vector6::new(11.0, 0.0, 0.0, 0.0, 0.0, 0.0))
+            .unwrap();
+        traj.set_interpolation_method(InterpolationMethod::Lagrange { degree: 3 });
+
+        // Ahead of the discontinuity, the fit uses only the pre-burn branch.
+        let before = traj.interpolate(&(start + 30.0)).unwrap();
+        assert!(
+            before.iter().all(|v| v.is_finite()),
+            "interpolation before the repeated epoch returned {:?}",
+            before
+        );
+        assert_abs_diff_eq!(before[0], 0.5, epsilon = 1e-12);
+
+        // After it, only the post-burn branch.
+        let after = traj.interpolate(&(start + 90.0)).unwrap();
+        assert!(
+            after.iter().all(|v| v.is_finite()),
+            "interpolation after the repeated epoch returned {:?}",
+            after
+        );
+        assert_abs_diff_eq!(after[0], 10.5, epsilon = 1e-12);
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_interpolate_at_duplicate_epoch_returns_the_stored_state() {
+        setup_global_test_eop();
+
+        // An impulsive maneuver stores a pre- and a post-burn state at the
+        // same epoch. Interpolating there used to divide by a zero-length
+        // interval and return NaN.
+        let start = Epoch::from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+        let mut traj = STrajectory6::new();
+        traj.add(start, Vector6::new(1.0, 0.0, 0.0, 0.0, 0.0, 0.0))
+            .unwrap();
+        traj.add(start + 60.0, Vector6::new(2.0, 0.0, 0.0, 0.0, 0.0, 0.0))
+            .unwrap();
+        traj.add(start + 60.0, Vector6::new(9.0, 0.0, 0.0, 0.0, 0.0, 0.0))
+            .unwrap();
+        traj.add(start + 120.0, Vector6::new(3.0, 0.0, 0.0, 0.0, 0.0, 0.0))
+            .unwrap();
+
+        let at_duplicate = traj.interpolate(&(start + 60.0)).unwrap();
+        assert!(at_duplicate.iter().all(|v| v.is_finite()));
+        // The most recently added state at that epoch, so the result is
+        // continuous with the states that follow the discontinuity.
+        assert_abs_diff_eq!(at_duplicate[0], 9.0, epsilon = 1e-12);
+
+        // Interpolation either side of the repeated epoch is unaffected.
+        let before = traj.interpolate(&(start + 30.0)).unwrap();
+        assert_abs_diff_eq!(before[0], 1.5, epsilon = 1e-12);
+        let after = traj.interpolate(&(start + 90.0)).unwrap();
+        assert_abs_diff_eq!(after[0], 6.0, epsilon = 1e-12);
     }
 }

--- a/src/trajectories/traits.rs
+++ b/src/trajectories/traits.rs
@@ -350,6 +350,72 @@ pub trait Trajectory {
     fn get_eviction_policy(&self) -> TrajectoryEvictionPolicy;
 }
 
+/// Choose the sample window for Lagrange interpolation.
+///
+/// The window is balanced around the bracketing pair and confined to the run
+/// of strictly increasing epochs containing it. A repeated epoch marks a
+/// discontinuity — an impulsive maneuver stores its pre- and post-burn states
+/// at the same instant — and a polynomial fitted across one would divide by a
+/// zero-length abscissa difference and return NaN. When the run holds fewer
+/// samples than the requested point count the window shrinks to the run,
+/// lowering the effective degree rather than fitting across the
+/// discontinuity, which no polynomial can represent in any case.
+///
+/// # Arguments
+///
+/// * `epochs` - The trajectory's epochs, in non-decreasing order.
+/// * `idx1` - Index of a sample bracketing the query.
+/// * `idx2` - Index of the other bracketing sample.
+/// * `n_points` - Samples the configured degree asks for.
+///
+/// # Returns
+///
+/// * `Ok((start, end))` - Inclusive index bounds of the window to fit.
+/// * `Err(BraheError)` - If the trajectory holds fewer than two samples.
+pub(crate) fn compute_lagrange_window(
+    epochs: &[Epoch],
+    idx1: usize,
+    idx2: usize,
+    n_points: usize,
+) -> Result<(usize, usize), BraheError> {
+    if epochs.len() < 2 {
+        return Err(BraheError::Error(format!(
+            "Need at least 2 points for interpolation, trajectory has {}",
+            epochs.len()
+        )));
+    }
+
+    let lo = idx1.min(idx2);
+    let hi = idx1.max(idx2);
+
+    // Widen from the bracket until a repeated epoch or an end is reached.
+    let mut run_start = lo;
+    while run_start > 0 && epochs[run_start - 1] != epochs[run_start] {
+        run_start -= 1;
+    }
+    let mut run_end = hi;
+    while run_end + 1 < epochs.len() && epochs[run_end + 1] != epochs[run_end] {
+        run_end += 1;
+    }
+
+    let run_len = run_end - run_start + 1;
+    let n_points = n_points.min(run_len);
+
+    // An even window has no sample at its centre, so the balanced split puts
+    // (n_points - 1) / 2 samples ahead of the bracket rather than
+    // n_points / 2, which would shift the whole window one sample early.
+    let half_window = (n_points - 1) / 2;
+    let mut start_idx = lo.saturating_sub(half_window).max(run_start);
+    let mut end_idx = start_idx + n_points - 1;
+
+    if end_idx > run_end {
+        end_idx = run_end;
+        start_idx = end_idx + 1 - n_points;
+    }
+
+    Ok((start_idx, end_idx))
+}
+
 /// Trait for trajectory interpolation functionality.
 ///
 /// This trait combines `Trajectory` (for data storage) with `InterpolationConfig`
@@ -445,8 +511,18 @@ pub trait InterpolatableTrajectory: Trajectory + InterpolationConfig {
         let idx2 = self.index_after_epoch(epoch)?;
 
         // If indices are the same, we have an exact match
-        if idx1 == idx2 {
-            return self.state_at_idx(idx1);
+        // An exact hit, or a bracket of zero duration because the epoch is
+        // stored more than once. Repeated epochs are allowed so that an
+        // impulsive maneuver can hold both its pre- and post-burn states;
+        // interpolating across one would divide by a zero-length interval and
+        // yield NaN, so the stored state is returned instead. `add` inserts a
+        // state after any it already holds at that epoch, and for a repeated
+        // epoch `index_before_epoch` lands on the last of the run while
+        // `index_after_epoch` lands on the first, so the higher index is the
+        // most recently added state. Returning it makes a query at a
+        // discontinuity right-continuous with the states that follow.
+        if idx1 == idx2 || self.epoch_at_idx(idx1)? == self.epoch_at_idx(idx2)? {
+            return self.state_at_idx(idx1.max(idx2));
         }
 
         // Get the bracketing epochs and states
@@ -503,8 +579,18 @@ pub trait InterpolatableTrajectory: Trajectory + InterpolationConfig {
 
         // If indices are the same, we have an exact match - return directly
         // without needing the minimum points for interpolation
-        if idx1 == idx2 {
-            return self.state_at_idx(idx1);
+        // An exact hit, or a bracket of zero duration because the epoch is
+        // stored more than once. Repeated epochs are allowed so that an
+        // impulsive maneuver can hold both its pre- and post-burn states;
+        // interpolating across one would divide by a zero-length interval and
+        // yield NaN, so the stored state is returned instead. `add` inserts a
+        // state after any it already holds at that epoch, and for a repeated
+        // epoch `index_before_epoch` lands on the last of the run while
+        // `index_after_epoch` lands on the first, so the higher index is the
+        // most recently added state. Returning it makes a query at a
+        // discontinuity right-continuous with the states that follow.
+        if idx1 == idx2 || self.epoch_at_idx(idx1)? == self.epoch_at_idx(idx2)? {
+            return self.state_at_idx(idx1.max(idx2));
         }
 
         // Validate minimum point count for the interpolation method

--- a/tests/trajectories/test_orbit_trajectory.py
+++ b/tests/trajectories/test_orbit_trajectory.py
@@ -4028,3 +4028,34 @@ def test_orbittrajectory_body_centered_inertial_error_branches():
         traj_unknown.state_bcbf(epoch)
     with pytest.raises(bh.BraheError):
         traj_unknown.state_koe_osc(epoch, AngleFormat.DEGREES)
+
+
+def test_hermite_interpolation_at_a_repeated_epoch(eop):
+    """Mirror of test_hermite_interpolation_at_a_repeated_epoch in Rust."""
+    start = Epoch.from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, brahe.UTC)
+
+    def state(x):
+        return np.array([x, 0.0, 0.0, 1.0, 0.0, 0.0])
+
+    # Hermite fits the two bracketing samples rather than a window, so it cannot
+    # straddle a discontinuity, but it was still exposed to the zero-length
+    # bracket at a repeated epoch and returned NaN there.
+    for method in [
+        InterpolationMethod.HERMITE_CUBIC,
+        InterpolationMethod.HERMITE_QUINTIC,
+    ]:
+        traj = OrbitTrajectory(6, OrbitFrame.ECI, OrbitRepresentation.CARTESIAN)
+        traj.enable_acceleration_storage(3)
+        zero = np.zeros(3)
+        traj.add_with_acceleration(start, state(0.0), zero)
+        traj.add_with_acceleration(start + 60.0, state(1.0), zero)
+        traj.add_with_acceleration(start + 60.0, state(10.0), zero)
+        traj.add_with_acceleration(start + 120.0, state(11.0), zero)
+        traj.set_interpolation_method(method)
+
+        at = traj.interpolate(start + 60.0)
+        assert np.all(np.isfinite(at))
+        assert at[0] == pytest.approx(10.0)
+
+        assert traj.interpolate(start + 30.0)[0] == pytest.approx(0.5)
+        assert traj.interpolate(start + 90.0)[0] == pytest.approx(10.5)

--- a/tests/trajectories/test_trajectory.py
+++ b/tests/trajectories/test_trajectory.py
@@ -1309,3 +1309,67 @@ def test_trajectory_set_interpolation_method_lagrange():
 
     traj.set_interpolation_method(InterpolationMethod.lagrange(7))
     assert traj.get_interpolation_method() == InterpolationMethod.lagrange(7)
+
+
+def test_interpolate_at_duplicate_epoch_returns_the_stored_state(eop):
+    """Mirror of test_interpolate_at_duplicate_epoch_returns_the_stored_state in Rust."""
+    start = Epoch.from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, brahe.UTC)
+
+    # An impulsive maneuver stores a pre- and a post-burn state at the same
+    # epoch. Interpolating there used to divide by a zero-length interval.
+    traj = Trajectory(6)
+    traj.add(start, np.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    traj.add(start + 60.0, np.array([2.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    traj.add(start + 60.0, np.array([9.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    traj.add(start + 120.0, np.array([3.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+
+    at_duplicate = traj.interpolate(start + 60.0)
+    assert np.all(np.isfinite(at_duplicate))
+    assert at_duplicate[0] == pytest.approx(9.0)
+
+    assert traj.interpolate(start + 30.0)[0] == pytest.approx(1.5)
+    assert traj.interpolate(start + 90.0)[0] == pytest.approx(6.0)
+
+
+def test_even_degree_lagrange_beats_the_earlier_window(eop):
+    """Mirror of test_even_degree_lagrange_beats_the_earlier_window in Rust."""
+    start = Epoch.from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, brahe.UTC)
+
+    def signal(x):
+        return np.cos(x / 3.0) * np.log(1.0 + 0.3 * x)
+
+    traj = Trajectory(6)
+    for i in range(12):
+        traj.add(start + 60.0 * i, np.array([signal(i), 0.0, 0.0, 0.0, 0.0, 0.0]))
+    traj.set_interpolation_method(InterpolationMethod.lagrange(3))
+
+    worst = 0.0
+    for k in range(4, 7):
+        x = k + 0.5
+        worst = max(worst, abs(traj.interpolate(start + 60.0 * x)[0] - signal(x)))
+
+    # The balanced window holds this under 4e-4; the window one sample early
+    # reaches 7.4e-4 on the same data.
+    assert worst < 4e-4
+
+
+def test_lagrange_interpolation_does_not_span_a_repeated_epoch(eop):
+    """Mirror of test_lagrange_interpolation_does_not_span_a_repeated_epoch in Rust."""
+    start = Epoch.from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, brahe.UTC)
+
+    # A four-point Lagrange stencil covering the whole trajectory would contain
+    # both copies of the repeated epoch and divide by a zero-length interval.
+    traj = Trajectory(6)
+    traj.add(start, np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    traj.add(start + 60.0, np.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    traj.add(start + 60.0, np.array([10.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    traj.add(start + 120.0, np.array([11.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    traj.set_interpolation_method(InterpolationMethod.lagrange(3))
+
+    before = traj.interpolate(start + 30.0)
+    assert np.all(np.isfinite(before))
+    assert before[0] == pytest.approx(0.5)
+
+    after = traj.interpolate(start + 90.0)
+    assert np.all(np.isfinite(after))
+    assert after[0] == pytest.approx(10.5)


### PR DESCRIPTION
# Pull Request

## Description

Two edge cases in the shared trajectory machinery.

Repeated epochs are allowed on purpose so an impulsive maneuver can hold both its pre- and post-burn state, but interpolating exactly at a repeated epoch bracketed the query with two states of the same epoch and divided by a zero-length interval, returning NaN. The bracket is now recognized and the stored state returned. `index_before_epoch` lands on the last of a repeated run and `index_after_epoch` on the first, so the higher index is the most recently added state; returning it makes a query at a discontinuity right-continuous with the states that follow.

The Lagrange window helper split its point count as `n_points / 2`, which for an even count placed one more sample before the bracket than after and shifted the whole window a sample early. At two points it excluded the upper bracketing sample altogether and extrapolated. The balanced split is `(n_points - 1) / 2`, which leaves odd counts unchanged and roughly halves the interior error for even ones — on a smooth non-polynomial signal, 4.4e-2 to 1.2e-2 at two points, 7.5e-4 to 3.4e-4 at four, and 1.7e-5 to 8.8e-6 at six.

Both fixes apply to `STrajectory`, `DTrajectory`, `SOrbitTrajectory`, `DOrbitTrajectory`, and the default trait implementations they share.

## Changelog

### Fixed
- Interpolating an orbit or generic trajectory exactly at a repeated epoch now returns the stored state instead of NaN. Repeated epochs remain supported so an impulsive maneuver can hold both its pre- and post-burn state; the most recently added state at that epoch is returned. [@duncaneddy](https://github.com/duncaneddy)
- Even-point Lagrange interpolation now selects a window balanced around the query rather than one sample early, roughly halving interior interpolation error; two-point Lagrange previously excluded the upper bracketing sample and extrapolated. Odd point counts are unchanged. [@duncaneddy](https://github.com/duncaneddy)

## Related Issue

Closes #473.

## Note to Reviewers

Duplicate epochs are kept legal rather than rejected as `AttitudeTrajectory` does, because `STrajectory::add` supports them deliberately for pre/post-maneuver states and rejecting them would be a breaking removal of that capability. Which of a repeated pair to return is a judgement call: the later one is used so that interpolating just after the epoch and exactly at it agree.

All three regression tests were confirmed to fail against the previous behaviour — the duplicate-epoch case produced NaN, and both window assertions failed.
