### PR TITLE
Run a Windows Python smoke subset on pull requests

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -37,16 +37,33 @@ jobs:
       - name: Wait for Rust tests to claim runners
         run: sleep 15
 
+  # Pull requests test the oldest supported Python (the declared floor in
+  # pyproject.toml) to catch breakage of the minimum-supported version. The full
+  # version matrix runs on push to main.
   test-python:
     needs: [delay-python]
     if: needs.delay-python.result == 'success'
     uses: ./.github/workflows/test_python.yml
     with:
-      # PR runs test only the oldest supported Python (the declared floor in pyproject.toml)
-      # across all 3 OSes to catch breakage of the minimum-supported version.
-      # The full matrix runs on push to main.
       python-versions: '["3.10"]'
       coverage-python-version: '3.10'
+      os-matrix: '["ubuntu-latest", "macos-latest"]'
+      python-test-scope: full
+    secrets: inherit
+
+  # Windows runs the smoke subset rather than the whole suite. It is roughly
+  # 1.8x slower than ubuntu, so the full run would set the critical path, while
+  # the subset covers every area with a recorded history of Windows-only Python
+  # failures. The full Windows suite still runs on push to main.
+  test-python-windows:
+    needs: [delay-python]
+    if: needs.delay-python.result == 'success'
+    uses: ./.github/workflows/test_python.yml
+    with:
+      python-versions: '["3.10"]'
+      coverage-python-version: 'none'
+      os-matrix: '["windows-latest"]'
+      python-test-scope: smoke
     secrets: inherit
 
   test-examples:
@@ -217,6 +234,7 @@ jobs:
       - test-rust
       - delay-python
       - test-python
+      - test-python-windows
       - test-examples
       - validate-rust-package
       - validate-python-package

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -16,6 +16,19 @@ on:
                 description: "BRAHE_NETWORK_MODE for the test steps."
                 type: string
                 default: "offline"
+            os-matrix:
+                description: "JSON array of runners for the test matrix."
+                type: string
+                default: '["ubuntu-latest", "macos-latest", "windows-latest"]'
+            python-test-scope:
+                description: >-
+                    `full` runs the whole suite. `smoke` runs only the path- and
+                    IO-sensitive directories listed in SMOKE_PATHS below.
+                    Switching scope is this one input, and the directory list is
+                    defined in a single place, so widening it is a one-line
+                    change.
+                type: string
+                default: "full"
 jobs:
     test-python:
         runs-on: ${{ matrix.os }}
@@ -24,9 +37,16 @@ jobs:
             id-token: write
         env:
             BRAHE_NETWORK_MODE: ${{ inputs.network_mode }}
+            # The smoke subset: CLI, cache/IO, and dataset handling. Commit
+            # 16755ce2 fixed Windows-only failures under tests/cli and commit
+            # e486a937 fixed cache-path handling, so this covers the areas with
+            # a recorded history of platform-specific Python failures. The rest
+            # of the suite is platform-independent computation already run on
+            # all three platforms by the Rust matrix.
+            SMOKE_PATHS: tests/cli tests/utils tests/eop tests/space_weather tests/datasets
         strategy:
             matrix:
-                os: [ubuntu-latest, macos-latest, windows-latest]
+                os: ${{ fromJSON(inputs.os-matrix) }}
                 python-version: ${{ fromJSON(inputs.python-versions) }}
                 rust-toolchain: [stable]
         steps:
@@ -100,7 +120,14 @@ jobs:
 
             -   name: Test with python ${{ matrix.python-version }}
                 if: matrix.os != 'ubuntu-latest' || matrix.python-version != inputs.coverage-python-version
-                run: uv run --frozen pytest tests/ -n auto --dist loadscope
+                shell: bash
+                run: |
+                    if [ "${{ inputs.python-test-scope }}" = "smoke" ]; then
+                        # shellcheck disable=SC2086
+                        uv run --frozen pytest $SMOKE_PATHS -n auto --dist loadscope
+                    else
+                        uv run --frozen pytest tests/ -n auto --dist loadscope
+                    fi
 
             -   name: Upload Python coverage to Codecov
                 if: matrix.os == 'ubuntu-latest' && matrix.python-version == inputs.coverage-python-version


### PR DESCRIPTION
# Pull Request

## Description

Windows Python is roughly 1.8x slower than ubuntu — 24-26 minutes against 13-14 — so running the full suite there sets the critical path for every pull request. This runs the subset that actually carries the platform risk instead:

`tests/cli`, `tests/utils`, `tests/eop`, `tests/space_weather`, `tests/datasets` — **402 of 3,534 tests**, collecting and passing in 1.7 s locally.

That selection is not arbitrary. It is where Windows-specific Python breakage has actually happened in this repository:

| Commit | Fixed | Location |
|---|---|---|
| `16755ce2` | Windows-only CI test failures | `tests/cli/test_eop.py`, `tests/cli/test_groundstations.py` |
| `e486a937` | cache-dir and write handling | `src/utils/cache.rs`, `src/datasets/horizons/client.rs` |

The remainder of the suite is platform-independent computation — orbits, coordinates, frames, propagators — which the Rust matrix already exercises on all three platforms, and `src/` contains no `cfg(windows)` blocks at all. Note also that the second commit above was a Windows *library* defect caught by the **Rust** suite, which this PR keeps running on Windows in full.

The full Windows Python suite still runs on push to `main`.

## Changelog

### Changed
- Pull requests run a Windows Python smoke subset covering command-line, cache, and dataset handling rather than the full suite, which continues to run when changes land on the main branch.

## Note to Reviewers

Scope is a `python-test-scope` workflow input taking `full` or `smoke`, not a hardcoded path, and the directory list is defined once as `SMOKE_PATHS`. Widening it later is a one-line change in a single place.

This was originally part of the `dev` branch topology work in #497. It has no dependency on that topology, so it is separated out here; #497 remains parked.

The accepted risk is explicit: a Windows-only Python failure outside those five directories would surface on merge to `main` rather than on the pull request. Given the history above, that risk sits in the platform-independent portion of the suite.
