### PR TITLE
Stop rebuilding the extension during dependency install

### DIFF
--- a/.github/workflows/docs_only.yml
+++ b/.github/workflows/docs_only.yml
@@ -30,6 +30,10 @@ jobs:
     env:
       RUST_TOOLCHAIN: stable
       BRAHE_NETWORK_MODE: offline
+      # The project is installed by the explicit build step below, not by
+      # `uv sync`. Without this, `uv run` would notice it missing and rebuild
+      # it, relocating the cost rather than removing it.
+      UV_NO_SYNC: "1"
     steps:
       - uses: actions/checkout@v7.0.1
         with:
@@ -68,7 +72,7 @@ jobs:
         run: uv python install 3.14
 
       - name: Install dependencies
-        run: uv sync --group docs --all-extras --frozen
+        run: uv sync --group docs --all-extras --frozen --no-install-project
 
       # Build Python extension
       - name: Build Python extension

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -132,6 +132,10 @@ jobs:
         env:
             TEST_SPACETRACK_USER: ${{ secrets.TEST_SPACETRACK_USER }}
             TEST_SPACETRACK_PASS: ${{ secrets.TEST_SPACETRACK_PASS }}
+            # The project is installed by the explicit build step below, not by
+            # `uv sync`. Without this, `uv run` would notice it missing and
+            # rebuild it, relocating the cost rather than removing it.
+            UV_NO_SYNC: "1"
         steps:
             -   name: Set up Rust toolchain
                 uses: actions-rust-lang/setup-rust-toolchain@v1.17.0
@@ -185,7 +189,11 @@ jobs:
                     key: star-catalogs-v1
 
             -   name: Install dependencies
-                run: uv sync --group test --all-extras --frozen --python ${{ matrix.python-version }}
+                # Dependencies only: uv builds the project under PEP 517
+                # isolation, in a temporary target directory it cannot share
+                # with the restored cargo cache, so letting it do so costs a
+                # full cold compile that the build step below then discards.
+                run: uv sync --group test --all-extras --frozen --no-install-project --python ${{ matrix.python-version }}
 
             -   name: Install cargo-llvm-cov
                 if: matrix.python-version == '3.10'

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -147,6 +147,10 @@ jobs:
     if: needs.check-skip.outputs.should_skip == 'false'
     env:
       RUST_TOOLCHAIN: stable
+      # The project is installed by the explicit build step below, not by
+      # `uv sync`. Without this, `uv run` would notice it missing and rebuild
+      # it, relocating the cost rather than removing it.
+      UV_NO_SYNC: "1"
     steps:
       - uses: actions/checkout@v7.0.1
 
@@ -174,7 +178,7 @@ jobs:
         run: uv python install 3.14
 
       - name: Install dependencies
-        run: uv sync --group docs --all-extras --frozen
+        run: uv sync --group docs --all-extras --frozen --no-install-project
 
       - name: Build Python extension
         run: uv pip install -e ".[plots]"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,7 +135,11 @@ jobs:
 
     - name: Install package and dependencies
       run: |
-        uv sync --group dev
+        # Dependencies only; the line below installs the project. Letting uv
+        # sync build it costs a full cold compile under PEP 517 isolation that
+        # this then discards. `generate_stubs.sh` calls `.venv/bin/...`
+        # directly rather than through `uv run`, so no sync setting is needed.
+        uv sync --group dev --no-install-project
         uv pip install -e .
 
     - name: Generate stubs

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -33,6 +33,10 @@ jobs:
     env:
       RUST_TOOLCHAIN: stable
       BRAHE_NETWORK_MODE: ${{ inputs.network_mode }}
+      # The project is installed by the explicit build step below, not by
+      # `uv sync`. Without this, `uv run` would notice it missing and rebuild
+      # it, relocating the cost rather than removing it.
+      UV_NO_SYNC: "1"
     steps:
       - uses: actions/checkout@v7.0.1
 
@@ -78,8 +82,12 @@ jobs:
       - name: Install Python 3.14
         run: uv python install 3.14
 
+      # Dependencies only: uv builds the project under PEP 517 isolation, in a
+      # temporary target directory it cannot share with the restored cargo
+      # cache, so letting it do so costs a full cold compile that the build
+      # step below then discards and redoes warm.
       - name: Install dependencies
-        run: uv sync --all-extras --frozen
+        run: uv sync --all-extras --frozen --no-install-project
 
       # Restored before "Setup test assets in cache" below so the repo's
       # test_assets/de440s.bsp always wins over a stale cached copy. One step

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -24,6 +24,11 @@ jobs:
             id-token: write
         env:
             BRAHE_NETWORK_MODE: ${{ inputs.network_mode }}
+            # The project is installed by the explicit build steps below, not by
+            # `uv sync`. Without this, `uv run` would notice it missing and
+            # rebuild it, relocating the cost rather than removing it — and on
+            # the coverage leg it could replace the instrumented build.
+            UV_NO_SYNC: "1"
         strategy:
             matrix:
                 os: [ubuntu-latest, macos-latest, windows-latest]
@@ -65,8 +70,14 @@ jobs:
             -   name: Install Python ${{ matrix.python-version }}
                 run: uv python install ${{ matrix.python-version }}
 
+            # Dependencies only. uv builds the project under PEP 517 isolation, in
+            # a temporary target directory it cannot share with the restored
+            # cargo cache, so letting it do so costs a full cold compile — about
+            # seven minutes — which the build step below then discards and
+            # redoes warm in about two. The 140 third-party packages install
+            # from the uv cache in well under a second either way.
             -   name: Install dependencies
-                run: uv sync --group test --all-extras --frozen --python ${{ matrix.python-version }}
+                run: uv sync --group test --all-extras --frozen --no-install-project --python ${{ matrix.python-version }}
 
             # ── Coverage-instrumented build (ubuntu + coverage-python-version only) ──
 

--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -26,6 +26,10 @@ jobs:
     env:
       RUST_TOOLCHAIN: stable
       BRAHE_NETWORK_MODE: offline
+      # The project is installed by the explicit build step below, not by
+      # `uv sync`. Without this, `uv run` would notice it missing and rebuild
+      # it, relocating the cost rather than removing it.
+      UV_NO_SYNC: "1"
     steps:
       - uses: actions/checkout@v7.0.1
         with:
@@ -122,7 +126,7 @@ jobs:
         run: uv python install 3.14
 
       - name: Install dependencies
-        run: uv sync --group docs --all-extras --frozen
+        run: uv sync --group docs --all-extras --frozen --no-install-project
 
       - name: Build Python extension
         run: uv pip install -e .

--- a/.github/workflows/warm_data_cache.yml
+++ b/.github/workflows/warm_data_cache.yml
@@ -20,6 +20,11 @@ jobs:
     warm-cache:
         runs-on: ubuntu-latest
         timeout-minutes: 60
+        env:
+            # The project is installed by the explicit build step below, not
+            # by `uv sync`. Without this, `uv run` would notice it missing and
+            # rebuild it, relocating the cost rather than removing it.
+            UV_NO_SYNC: "1"
         steps:
             -   uses: actions/checkout@v7.0.1
 
@@ -37,7 +42,7 @@ jobs:
                 run: uv python install 3.14
 
             -   name: Install dependencies
-                run: uv sync --all-extras --frozen
+                run: uv sync --all-extras --frozen --no-install-project
 
             -   name: Build Python extension
                 run: uv pip install -e ".[all]"


### PR DESCRIPTION
# Pull Request

## Description

Installing dependencies took about **seven minutes on every leg of the Python matrix**. The uv cache was not the cause — it hits, and the third-party packages install from it almost instantly. From a real job log:

```
Cache hit for: setup-uv-2-x86_64-unknown-linux-gnu-ubuntu-24.04-3.12.3-f4c2c75c...
Cache restored successfully

Building brahe @ file:///home/runner/work/brahe/brahe    20:44:53
Built   brahe @ file:///home/runner/work/brahe/brahe     20:51:53
Prepared 1 package in 6m 59s
Installed 140 packages in 345ms
```

**140 packages in 345 ms; one package in 6 minutes 59 seconds.** The time is `uv sync` compiling the brahe extension.

That build is then thrown away. uv builds the project under PEP 517 **build isolation**, in a temporary target directory it cannot share with the restored cargo cache, so it pays a full cold compile. The `Build extension` step immediately after recompiles the same extension *warm* in about two minutes. On the coverage leg the discard is explicit — that step opens with `cargo llvm-cov clean --workspace`.

So the job compiles the extension twice, and the slow one is the one nothing uses.

## Why both changes are needed

`--no-install-project` alone does not work. With the project deliberately absent after sync, `uv run` notices and installs it, relocating the cost instead of removing it. Measured directly:

| Command | Result |
|---|---|
| `uv run --frozen` | rebuilds — **126.16 s** |
| `uv run --no-sync` | **0.04 s** |

`--frozen` only pins the lockfile; `--no-sync` is what skips environment sync. Setting `UV_NO_SYNC` at the job level covers every `uv run` in the job rather than requiring each call site to remember.

## Verification

Clean room, cold cache, exactly the sequence the workflow now runs:

| Step | Time |
|---|---|
| `uv sync --group test --all-extras --frozen --no-install-project` | 6.9 s |
| Build extension (`uv pip install -e .`) | 126.6 s |
| `uv run` under `UV_NO_SYNC=1` | 0.16 s — no rebuild |
| Full suite | **3,532 passed, 2 xfailed** |

Expected saving is roughly 7 minutes per Python leg, on jobs currently running about 14.

## Changelog

### Fixed
- Continuous-integration jobs no longer compile the Rust extension twice. Dependency installation was building it under an isolation that could not reuse the cached compiler output, only for the following step to rebuild it.

## Note to Reviewers

**Missing caches remain safe.** This removes work rather than adding a cache dependency: a cold uv cache still downloads normally, and a cold cargo cache means the single remaining build is cold. Both degrade to current performance, never to failure.

**No matrix combination can reach the tests unbuilt.** The two build steps are gated on `A && B` and `!A || !B`, exact complements, so exactly one always runs.

**One deliberate behaviour change.** If a build step ever failed, `uv run` will now surface an `ImportError` rather than silently rebuilding and masking it. That seems the better failure mode, but it is a change worth being aware of.

**Coverage is protected, not just unaffected.** On the coverage leg, `maturin develop` builds under the `cargo llvm-cov` environment. Previously nothing prevented `uv run` from re-syncing and replacing that instrumented build with an uninstrumented one, which would have quietly understated Rust coverage. Today's logs show one build, so it was not happening; `UV_NO_SYNC` makes that a guarantee rather than a coincidence. Worth confirming Codecov reports unchanged numbers on this PR before merging.

## Scope: every workflow with the pattern

The redundant build was not confined to the Python matrix. All eight `uv sync` sites that precede an explicit extension build now skip it:

| Workflow | Notes |
|---|---|
| `test_python.yml` | Largest win — multiplied across the matrix |
| `test_examples.yml` | The one pre-build `uv run` seeds the Celestrak cache and imports no brahe module |
| `docs_only.yml`, `update_docs.yml` | Build immediately follows the sync |
| `pr_tests.yml` (`build-docs`) | Same pattern |
| `warm_data_cache.yml` | Same pattern |
| `integration_tests.yml` | Cleans right after syncing, then rebuilds instrumented — the discarded compile was entirely dead, and the job runs inside a retry budget |
| `release.yml` (`generate-stubs`) | Needs the flag but **not** `UV_NO_SYNC`: `generate_stubs.sh` calls `.venv/bin/...` directly rather than through `uv run` |

Each was checked for a `uv run` that needs `brahe` *before* its build step; none has one.

Deliberately **not** changed: `release.yml` still runs `uv sync --group dev` without `--frozen`, unlike every other workflow. That reproducibility question is real but separate from this performance fix, and conflating them would make both harder to reason about.
