### PR TITLE
Rename ReferenceFrame to CelestialFrame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,6 @@ Each release groups entries under the Keep a Changelog section headings in the o
 
 <!-- release notes start -->
 
-## [Unreleased]
-
-### Changed
-
-- **Breaking:** `ReferenceFrame` renamed to `CelestialFrame` in Rust and Python — the frame router, all frame-router functions, and every associated binding now use the new name.
-
 ## [1.7.0] - 2026-07-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Each release groups entries under the Keep a Changelog section headings in the o
 
 <!-- release notes start -->
 
+## [Unreleased]
+
+### Changed
+
+- **Breaking:** `ReferenceFrame` renamed to `CelestialFrame` in Rust and Python — the frame router, all frame-router functions, and every associated binding now use the new name.
+
 ## [1.7.0] - 2026-07-21
 
 ### Added

--- a/brahe/cli/transform.py
+++ b/brahe/cli/transform.py
@@ -15,7 +15,7 @@ class Frame(str, Enum):
     """Named reference frames accepted by the transform commands.
 
     Values mirror the strings understood by
-    [`ReferenceFrame.from_string`](../library_api/frames/router.md#brahe.ReferenceFrame.from_string).
+    [`CelestialFrame.from_string`](../library_api/frames/router.md#brahe.CelestialFrame.from_string).
     """
 
     ECI = "ECI"
@@ -42,14 +42,14 @@ class CartesianFrame(str, Enum):
     ECEF = "ECEF"
 
 
-def _resolve_frame(frame: Frame) -> "brahe.ReferenceFrame":
-    """Convert a CLI `Frame` value into a core `ReferenceFrame`.
+def _resolve_frame(frame: Frame) -> "brahe.CelestialFrame":
+    """Convert a CLI `Frame` value into a core `CelestialFrame`.
 
     Every `Frame` member mirrors a string accepted by
-    `ReferenceFrame.from_string`; Typer rejects any other value before this
+    `CelestialFrame.from_string`; Typer rejects any other value before this
     is reached.
     """
-    return brahe.ReferenceFrame.from_string(frame.value)
+    return brahe.CelestialFrame.from_string(frame.value)
 
 
 class StateRepresentation(str, Enum):

--- a/brahe/frames.py
+++ b/brahe/frames.py
@@ -31,7 +31,7 @@ Naming Conventions:
 """
 
 from brahe._brahe import (
-    ReferenceFrame,
+    CelestialFrame,
     # Reference frame router
     SynodicOrigin,
     # EME2000 <> GCRF transformations
@@ -122,7 +122,7 @@ from brahe._brahe import (
 )
 
 __all__ = [
-    "ReferenceFrame",
+    "CelestialFrame",
     # Reference frame router
     "SynodicOrigin",
     # EME2000 <> GCRF transformations

--- a/brahe/plots/synodic_3d.py
+++ b/brahe/plots/synodic_3d.py
@@ -49,9 +49,9 @@ def plot_synodic_3d(
             - line_width (float, optional): Line width
             - label (str, optional): Legend label
 
-        frame (str or ReferenceFrame, optional): Synodic frame to plot in.
-            Either ``'EMR'``, ``'SER'``, ``'GSE'``, a ``ReferenceFrame`` name
-            string, or a ``ReferenceFrame.Synodic(origin, primary, secondary)``.
+        frame (str or CelestialFrame, optional): Synodic frame to plot in.
+            Either ``'EMR'``, ``'SER'``, ``'GSE'``, a ``CelestialFrame`` name
+            string, or a ``CelestialFrame.Synodic(origin, primary, secondary)``.
             Default: ``'EMR'``
         reference_epoch (Epoch, optional): Epoch at which the primary and
             secondary body spheres are placed. Default: the first epoch of
@@ -81,8 +81,8 @@ def plot_synodic_3d(
         object: Generated figure (matplotlib.figure.Figure or plotly.graph_objects.Figure)
 
     Raises:
-        ValueError: If ``frame`` is not a recognized ``ReferenceFrame`` name,
-            or resolves to a ``ReferenceFrame`` that is not synodic.
+        ValueError: If ``frame`` is not a recognized ``CelestialFrame`` name,
+            or resolves to a ``CelestialFrame`` that is not synodic.
         TypeError: If a trajectory is not an OrbitTrajectory object.
 
     Example:
@@ -110,13 +110,13 @@ def plot_synodic_3d(
     validate_backend(backend)
 
     if isinstance(frame, str):
-        frame = bh.ReferenceFrame.from_string(frame)
+        frame = bh.CelestialFrame.from_string(frame)
     primary_id = frame.synodic_primary
     secondary_id = frame.synodic_secondary
     if primary_id is None:
         raise ValueError(
             f"{frame} is not a synodic frame. Use EMR/SER/GSE or "
-            "ReferenceFrame.Synodic(origin, primary, secondary)."
+            "CelestialFrame.Synodic(origin, primary, secondary)."
         )
 
     traj_groups = _normalize_trajectory_groups(trajectories)
@@ -136,7 +136,7 @@ def plot_synodic_3d(
         states = traj.to_matrix()
         xyz = np.array(
             [
-                bh.state_frame_to_frame(bh.ReferenceFrame.GCRF, frame, epc, s)[:3]
+                bh.state_frame_to_frame(bh.CelestialFrame.GCRF, frame, epc, s)[:3]
                 for epc, s in zip(epochs, states)
             ]
         )
@@ -159,7 +159,7 @@ def plot_synodic_3d(
             )
             continue
         pos = bh.position_frame_to_frame(
-            bh.ReferenceFrame.BodyCenteredICRF(naif_id),
+            bh.CelestialFrame.BodyCenteredICRF(naif_id),
             frame,
             reference_epoch,
             np.zeros(3),
@@ -337,7 +337,7 @@ def _synodic_3d_plotly(
 def plot_earth_moon_rotating_3d(trajectories, **kwargs) -> object:
     """Plot 3D trajectories in the Earth-Moon Rotating (EMR) frame.
 
-    Alias for ``plot_synodic_3d(trajectories, frame=ReferenceFrame.EMR, ...)``;
+    Alias for ``plot_synodic_3d(trajectories, frame=CelestialFrame.EMR, ...)``;
     accepts the same keyword arguments.
 
     Args:
@@ -367,4 +367,4 @@ def plot_earth_moon_rotating_3d(trajectories, **kwargs) -> object:
         ```
     """
     kwargs.pop("frame", None)
-    return plot_synodic_3d(trajectories, frame=bh.ReferenceFrame.EMR, **kwargs)
+    return plot_synodic_3d(trajectories, frame=bh.CelestialFrame.EMR, **kwargs)

--- a/crates/brahe-py/src/frames.rs
+++ b/crates/brahe-py/src/frames.rs
@@ -2905,7 +2905,7 @@ fn py_state_gse_to_gcrf<'py>(
 // Reference Frame Router
 // ============================================================================
 
-/// Origin choice for a generic synodic frame (`ReferenceFrame.Synodic`):
+/// Origin choice for a generic synodic frame (`CelestialFrame.Synodic`):
 /// `Primary`, `Secondary`, or the GM-weighted two-body `Barycenter`.
 #[pyclass(module = "brahe._brahe", eq, from_py_object)]
 #[pyo3(name = "SynodicOrigin")]
@@ -2967,101 +2967,101 @@ impl PySynodicOrigin {
 ///     import brahe as bh
 ///
 ///     epc = bh.Epoch.from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, bh.UTC)
-///     r = bh.rotation_frame_to_frame(bh.ReferenceFrame.MCI, bh.ReferenceFrame.MCMF, epc)
+///     r = bh.rotation_frame_to_frame(bh.CelestialFrame.MCI, bh.CelestialFrame.MCMF, epc)
 ///     ```
 #[pyclass(module = "brahe._brahe", eq, from_py_object)]
-#[pyo3(name = "ReferenceFrame")]
+#[pyo3(name = "CelestialFrame")]
 #[derive(Clone, PartialEq)]
-pub struct PyReferenceFrame {
-    pub(crate) frame: frames::ReferenceFrame,
+pub struct PyCelestialFrame {
+    pub(crate) frame: frames::CelestialFrame,
 }
 
 #[pymethods]
-impl PyReferenceFrame {
+impl PyCelestialFrame {
     /// Geocentric Celestial Reference Frame (ICRF-aligned, Earth-centered).
     #[classattr]
     #[allow(non_snake_case)]
     fn GCRF() -> Self {
-        PyReferenceFrame { frame: frames::ReferenceFrame::GCRF }
+        PyCelestialFrame { frame: frames::CelestialFrame::GCRF }
     }
 
     /// International Terrestrial Reference Frame (Earth-fixed).
     #[classattr]
     #[allow(non_snake_case)]
     fn ITRF() -> Self {
-        PyReferenceFrame { frame: frames::ReferenceFrame::ITRF }
+        PyCelestialFrame { frame: frames::CelestialFrame::ITRF }
     }
 
-    /// Alias for `ReferenceFrame.GCRF`: the Earth-Centered Inertial (ECI)
+    /// Alias for `CelestialFrame.GCRF`: the Earth-Centered Inertial (ECI)
     /// frame is realized as GCRF.
     #[classattr]
     #[allow(non_snake_case)]
     fn ECI() -> Self {
-        PyReferenceFrame { frame: frames::ReferenceFrame::ECI }
+        PyCelestialFrame { frame: frames::CelestialFrame::ECI }
     }
 
-    /// Alias for `ReferenceFrame.ITRF`: the Earth-Centered Earth-Fixed (ECEF)
+    /// Alias for `CelestialFrame.ITRF`: the Earth-Centered Earth-Fixed (ECEF)
     /// frame is realized as ITRF.
     #[classattr]
     #[allow(non_snake_case)]
     fn ECEF() -> Self {
-        PyReferenceFrame { frame: frames::ReferenceFrame::ECEF }
+        PyCelestialFrame { frame: frames::CelestialFrame::ECEF }
     }
 
     /// Earth Mean Equator and Equinox of J2000.0.
     #[classattr]
     #[allow(non_snake_case)]
     fn EME2000() -> Self {
-        PyReferenceFrame { frame: frames::ReferenceFrame::EME2000 }
+        PyCelestialFrame { frame: frames::CelestialFrame::EME2000 }
     }
 
     /// Lunar-Centered Inertial (ICRF-aligned, Moon-centered).
     #[classattr]
     #[allow(non_snake_case)]
     fn LCI() -> Self {
-        PyReferenceFrame { frame: frames::ReferenceFrame::LCI }
+        PyCelestialFrame { frame: frames::CelestialFrame::LCI }
     }
 
     /// Lunar-Fixed Principal Axis (DE440 `MOON_PA_DE440`).
     #[classattr]
     #[allow(non_snake_case)]
     fn LFPA() -> Self {
-        PyReferenceFrame { frame: frames::ReferenceFrame::LFPA }
+        PyCelestialFrame { frame: frames::CelestialFrame::LFPA }
     }
 
     /// Lunar-Fixed Mean Earth/polar-axis.
     #[classattr]
     #[allow(non_snake_case)]
     fn LFME() -> Self {
-        PyReferenceFrame { frame: frames::ReferenceFrame::LFME }
+        PyCelestialFrame { frame: frames::CelestialFrame::LFME }
     }
 
     /// Mars-Centered Inertial (ICRF-aligned, Mars-centered).
     #[classattr]
     #[allow(non_snake_case)]
     fn MCI() -> Self {
-        PyReferenceFrame { frame: frames::ReferenceFrame::MCI }
+        PyCelestialFrame { frame: frames::CelestialFrame::MCI }
     }
 
     /// Mars-Centered Mars-Fixed (IAU/WGCCRE Mars rotation model).
     #[classattr]
     #[allow(non_snake_case)]
     fn MCMF() -> Self {
-        PyReferenceFrame { frame: frames::ReferenceFrame::MCMF }
+        PyCelestialFrame { frame: frames::CelestialFrame::MCMF }
     }
 
     /// Earth-Moon Barycentric Inertial (ICRF-aligned).
     #[classattr]
     #[allow(non_snake_case)]
     fn EMBI() -> Self {
-        PyReferenceFrame { frame: frames::ReferenceFrame::EMBI }
+        PyCelestialFrame { frame: frames::CelestialFrame::EMBI }
     }
 
     /// Solar System Barycentric Inertial (ICRF-aligned).
     #[classattr]
     #[allow(non_snake_case)]
     fn SSBI() -> Self {
-        PyReferenceFrame { frame: frames::ReferenceFrame::SSBI }
+        PyCelestialFrame { frame: frames::CelestialFrame::SSBI }
     }
 
     /// Earth-Moon Rotating frame (NASA TP-20220014814): x̂ Earth→Moon, ẑ
@@ -3070,7 +3070,7 @@ impl PyReferenceFrame {
     #[classattr]
     #[allow(non_snake_case)]
     fn EMR() -> Self {
-        PyReferenceFrame { frame: frames::ReferenceFrame::EMR }
+        PyCelestialFrame { frame: frames::CelestialFrame::EMR }
     }
 
     /// Sun-Earth Rotating frame (NASA TP-20220014814): x̂ Sun→Earth, ẑ
@@ -3079,7 +3079,7 @@ impl PyReferenceFrame {
     #[classattr]
     #[allow(non_snake_case)]
     fn SER() -> Self {
-        PyReferenceFrame { frame: frames::ReferenceFrame::SER }
+        PyCelestialFrame { frame: frames::CelestialFrame::SER }
     }
 
     /// Geocentric Solar Ecliptic frame (NASA TP-20220014814): x̂ Earth→Sun,
@@ -3087,7 +3087,7 @@ impl PyReferenceFrame {
     #[classattr]
     #[allow(non_snake_case)]
     fn GSE() -> Self {
-        PyReferenceFrame { frame: frames::ReferenceFrame::GSE }
+        PyCelestialFrame { frame: frames::CelestialFrame::GSE }
     }
 
     /// ICRF-aligned axes centered on the given NAIF ID.
@@ -3096,11 +3096,11 @@ impl PyReferenceFrame {
     ///     naif_id (int): NAIF ID of the frame's center
     ///
     /// Returns:
-    ///     ReferenceFrame: ICRF-aligned frame centered on `naif_id`
+    ///     CelestialFrame: ICRF-aligned frame centered on `naif_id`
     #[staticmethod]
     #[allow(non_snake_case)]
     fn BodyCenteredICRF(naif_id: i32) -> Self {
-        PyReferenceFrame { frame: frames::ReferenceFrame::BodyCenteredICRF(naif_id) }
+        PyCelestialFrame { frame: frames::CelestialFrame::BodyCenteredICRF(naif_id) }
     }
 
     /// IAU/WGCCRE body-fixed frame of the given NAIF ID, centered on that
@@ -3110,11 +3110,11 @@ impl PyReferenceFrame {
     ///     naif_id (int): NAIF ID of the body (see `iau_rotation_model_ids` for the supported set)
     ///
     /// Returns:
-    ///     ReferenceFrame: IAU/WGCCRE body-fixed frame of `naif_id`
+    ///     CelestialFrame: IAU/WGCCRE body-fixed frame of `naif_id`
     #[staticmethod]
     #[allow(non_snake_case)]
     fn BodyFixedIAU(naif_id: i32) -> Self {
-        PyReferenceFrame { frame: frames::ReferenceFrame::BodyFixedIAU(naif_id) }
+        PyCelestialFrame { frame: frames::CelestialFrame::BodyFixedIAU(naif_id) }
     }
 
     /// Body-fixed frame evaluated from a loaded binary PCK's `frame_id`,
@@ -3125,11 +3125,11 @@ impl PyReferenceFrame {
     ///     frame_id (int): NAIF binary PCK frame class ID (e.g. 31008 for `MOON_PA_DE440`)
     ///
     /// Returns:
-    ///     ReferenceFrame: Body-fixed frame for `frame_id`, centered on `center`
+    ///     CelestialFrame: Body-fixed frame for `frame_id`, centered on `center`
     #[staticmethod]
     #[allow(non_snake_case)]
     fn BodyFixedPCK(center: i32, frame_id: i32) -> Self {
-        PyReferenceFrame { frame: frames::ReferenceFrame::BodyFixedPCK { center, frame_id } }
+        PyCelestialFrame { frame: frames::CelestialFrame::BodyFixedPCK { center, frame_id } }
     }
 
     /// Body-fixed frame evaluated from a user-registered rotation callback
@@ -3151,11 +3151,11 @@ impl PyReferenceFrame {
     ///     key (int): Registry key the frame's callbacks were registered under
     ///
     /// Returns:
-    ///     ReferenceFrame: Custom body-fixed frame for `key`, centered on `center`
+    ///     CelestialFrame: Custom body-fixed frame for `key`, centered on `center`
     #[staticmethod]
     #[allow(non_snake_case)]
     fn BodyFixedCustom(center: i32, key: u32) -> Self {
-        PyReferenceFrame { frame: frames::ReferenceFrame::BodyFixedCustom { center, key } }
+        PyCelestialFrame { frame: frames::CelestialFrame::BodyFixedCustom { center, key } }
     }
 
     /// Generic two-body synodic (rotating) frame: x̂ from `primary` toward
@@ -3179,12 +3179,12 @@ impl PyReferenceFrame {
     ///     secondary (int): NAIF ID of the secondary body
     ///
     /// Returns:
-    ///     ReferenceFrame: Generic synodic frame for the pair
+    ///     CelestialFrame: Generic synodic frame for the pair
     #[staticmethod]
     #[allow(non_snake_case)]
     fn Synodic(origin: PySynodicOrigin, primary: i32, secondary: i32) -> Self {
-        PyReferenceFrame {
-            frame: frames::ReferenceFrame::Synodic { origin: origin.origin, primary, secondary },
+        PyCelestialFrame {
+            frame: frames::CelestialFrame::Synodic { origin: origin.origin, primary, secondary },
         }
     }
 
@@ -3195,11 +3195,11 @@ impl PyReferenceFrame {
     #[getter]
     fn synodic_origin(&self) -> Option<PySynodicOrigin> {
         let origin = match self.frame {
-            frames::ReferenceFrame::Synodic { origin, .. } => origin,
-            frames::ReferenceFrame::EMR | frames::ReferenceFrame::SER => {
+            frames::CelestialFrame::Synodic { origin, .. } => origin,
+            frames::CelestialFrame::EMR | frames::CelestialFrame::SER => {
                 frames::SynodicOrigin::Barycenter
             }
-            frames::ReferenceFrame::GSE => frames::SynodicOrigin::Primary,
+            frames::CelestialFrame::GSE => frames::SynodicOrigin::Primary,
             _ => return None,
         };
         Some(PySynodicOrigin { origin })
@@ -3212,9 +3212,9 @@ impl PyReferenceFrame {
     #[getter]
     fn synodic_primary(&self) -> Option<i32> {
         match self.frame {
-            frames::ReferenceFrame::Synodic { primary, .. } => Some(primary),
-            frames::ReferenceFrame::EMR | frames::ReferenceFrame::GSE => Some(399),
-            frames::ReferenceFrame::SER => Some(10),
+            frames::CelestialFrame::Synodic { primary, .. } => Some(primary),
+            frames::CelestialFrame::EMR | frames::CelestialFrame::GSE => Some(399),
+            frames::CelestialFrame::SER => Some(10),
             _ => None,
         }
     }
@@ -3226,15 +3226,15 @@ impl PyReferenceFrame {
     #[getter]
     fn synodic_secondary(&self) -> Option<i32> {
         match self.frame {
-            frames::ReferenceFrame::Synodic { secondary, .. } => Some(secondary),
-            frames::ReferenceFrame::EMR => Some(301),
-            frames::ReferenceFrame::SER => Some(399),
-            frames::ReferenceFrame::GSE => Some(10),
+            frames::CelestialFrame::Synodic { secondary, .. } => Some(secondary),
+            frames::CelestialFrame::EMR => Some(301),
+            frames::CelestialFrame::SER => Some(399),
+            frames::CelestialFrame::GSE => Some(10),
             _ => None,
         }
     }
 
-    /// Parses a `ReferenceFrame` from its string representation (named
+    /// Parses a `CelestialFrame` from its string representation (named
     /// variants only, case-insensitive), plus the common aliases `"ECI"`
     /// (-> `GCRF`) and `"ECEF"` (-> `ITRF`).
     ///
@@ -3242,7 +3242,7 @@ impl PyReferenceFrame {
     ///     s (str): String representation of the reference frame
     ///
     /// Returns:
-    ///     ReferenceFrame: Parsed reference frame
+    ///     CelestialFrame: Parsed reference frame
     ///
     /// Raises:
     ///     ValueError: If `s` is not a recognized reference frame name
@@ -3251,12 +3251,12 @@ impl PyReferenceFrame {
     ///     ```python
     ///     import brahe as bh
     ///
-    ///     assert bh.ReferenceFrame.from_string("ECI") == bh.ReferenceFrame.GCRF
+    ///     assert bh.CelestialFrame.from_string("ECI") == bh.CelestialFrame.GCRF
     ///     ```
     #[staticmethod]
     fn from_string(s: &str) -> PyResult<Self> {
-        s.parse::<frames::ReferenceFrame>()
-            .map(|frame| PyReferenceFrame { frame })
+        s.parse::<frames::CelestialFrame>()
+            .map(|frame| PyCelestialFrame { frame })
             .map_err(|e| exceptions::PyValueError::new_err(e.to_string()))
     }
 
@@ -3265,7 +3265,7 @@ impl PyReferenceFrame {
     }
 
     fn __repr__(&self) -> String {
-        format!("ReferenceFrame.{}", self.frame)
+        format!("CelestialFrame.{}", self.frame)
     }
 }
 
@@ -3279,8 +3279,8 @@ impl PyReferenceFrame {
 /// of those frames still queries SPK.
 ///
 /// Args:
-///     from_frame (ReferenceFrame): Source reference frame
-///     to_frame (ReferenceFrame): Target reference frame
+///     from_frame (CelestialFrame): Source reference frame
+///     to_frame (CelestialFrame): Target reference frame
 ///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
 ///         one matrix per epoch.
 ///
@@ -3296,15 +3296,15 @@ impl PyReferenceFrame {
 ///     import brahe as bh
 ///
 ///     epc = bh.Epoch.from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, bh.UTC)
-///     r = bh.rotation_frame_to_frame(bh.ReferenceFrame.MCI, bh.ReferenceFrame.MCMF, epc)
+///     r = bh.rotation_frame_to_frame(bh.CelestialFrame.MCI, bh.CelestialFrame.MCMF, epc)
 ///     ```
 #[pyfunction]
 #[pyo3(text_signature = "(from_frame, to_frame, epc)")]
 #[pyo3(name = "rotation_frame_to_frame")]
 fn py_rotation_frame_to_frame<'py>(
     py: Python<'py>,
-    from_frame: PyReferenceFrame,
-    to_frame: PyReferenceFrame,
+    from_frame: PyCelestialFrame,
+    to_frame: PyCelestialFrame,
     epc: &Bound<'py, PyAny>,
 ) -> PyResult<Bound<'py, PyAny>> {
     let (from, to) = (from_frame.frame, to_frame.frame);
@@ -3318,7 +3318,7 @@ fn py_rotation_frame_to_frame<'py>(
 
 /// Registers (or replaces) a user-defined body-fixed frame under `key`.
 ///
-/// The frame becomes usable as `ReferenceFrame.BodyFixedCustom(center, key)`
+/// The frame becomes usable as `CelestialFrame.BodyFixedCustom(center, key)`
 /// in every frame-router function. `rotation` must be a callable taking an
 /// `Epoch` and returning a 3x3 rotation matrix (ICRF -> body-fixed, i.e.
 /// `v_body = R @ v_icrf`) as a numpy array or nested list. If `omega` is
@@ -3332,7 +3332,7 @@ fn py_rotation_frame_to_frame<'py>(
 ///
 /// Args:
 ///     key (int): Identifier to register the frame under; the same value is
-///         passed to `ReferenceFrame.BodyFixedCustom`.
+///         passed to `CelestialFrame.BodyFixedCustom`.
 ///     rotation (callable): Callable `Epoch -> 3x3 array` returning the
 ///         ICRF -> body-fixed rotation matrix.
 ///     omega (callable, optional): Callable `Epoch -> length-3 array`
@@ -3351,7 +3351,7 @@ fn py_rotation_frame_to_frame<'py>(
 ///         return np.array([[c, s, 0.0], [-s, c, 0.0], [0.0, 0.0, 1.0]])
 ///
 ///     bh.register_custom_frame(42, spin)
-///     frame = bh.ReferenceFrame.BodyFixedCustom(-20001, 42)
+///     frame = bh.CelestialFrame.BodyFixedCustom(-20001, 42)
 ///     ```
 #[pyfunction]
 #[pyo3(text_signature = "(key, rotation, omega=None)")]
@@ -3416,8 +3416,8 @@ fn py_unregister_custom_frame(key: u32) -> bool {
 /// those frames is not SPK-free.
 ///
 /// Args:
-///     from_frame (ReferenceFrame): Source reference frame
-///     to_frame (ReferenceFrame): Target reference frame
+///     from_frame (CelestialFrame): Source reference frame
+///     to_frame (CelestialFrame): Target reference frame
 ///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x (numpy.ndarray or list): Cartesian position in `from_frame` axes/center (m), shape `(3,)`, or a batch
@@ -3445,7 +3445,7 @@ fn py_unregister_custom_frame(key: u32) -> bool {
 ///
 ///     epc = bh.Epoch.from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, bh.UTC)
 ///     x_gcrf = [bh.R_EARTH + 500e3, 0.0, 0.0]
-///     x_itrf = bh.position_frame_to_frame(bh.ReferenceFrame.GCRF, bh.ReferenceFrame.ITRF, epc, x_gcrf)
+///     x_itrf = bh.position_frame_to_frame(bh.CelestialFrame.GCRF, bh.CelestialFrame.ITRF, epc, x_gcrf)
 ///     ```
 #[pyfunction]
 #[pyo3(signature = (from_frame, to_frame, epc, x, axis=-1))]
@@ -3453,8 +3453,8 @@ fn py_unregister_custom_frame(key: u32) -> bool {
 #[pyo3(name = "position_frame_to_frame")]
 fn py_position_frame_to_frame<'py>(
     py: Python<'py>,
-    from_frame: PyReferenceFrame,
-    to_frame: PyReferenceFrame,
+    from_frame: PyCelestialFrame,
+    to_frame: PyCelestialFrame,
     epc: &Bound<'py, PyAny>,
     x: &Bound<'py, PyAny>,
     axis: isize,
@@ -3484,8 +3484,8 @@ fn py_position_frame_to_frame<'py>(
 /// like GCRF <-> GSE.
 ///
 /// Args:
-///     from_frame (ReferenceFrame): Source reference frame
-///     to_frame (ReferenceFrame): Target reference frame
+///     from_frame (CelestialFrame): Source reference frame
+///     to_frame (CelestialFrame): Target reference frame
 ///     epc (Epoch or Sequence[Epoch]): Epoch instant for computation of the transformation. A sequence evaluates
 ///         one epoch per vector (or broadcasts a single vector across all epochs).
 ///     x (numpy.ndarray or list): Cartesian state in `from_frame` axes/center `[position (m), velocity (m/s)]`, shape `(6,)`, or a batch
@@ -3511,7 +3511,7 @@ fn py_position_frame_to_frame<'py>(
 ///
 ///     epc = bh.Epoch.from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, bh.UTC)
 ///     x_gcrf = [1e8, -2e8, 5e7, 1.0e3, -2.0e3, 0.5e3]
-///     x_lfpa = bh.state_frame_to_frame(bh.ReferenceFrame.GCRF, bh.ReferenceFrame.LFPA, epc, x_gcrf)
+///     x_lfpa = bh.state_frame_to_frame(bh.CelestialFrame.GCRF, bh.CelestialFrame.LFPA, epc, x_gcrf)
 ///     ```
 #[pyfunction]
 #[pyo3(signature = (from_frame, to_frame, epc, x, axis=-1))]
@@ -3519,8 +3519,8 @@ fn py_position_frame_to_frame<'py>(
 #[pyo3(name = "state_frame_to_frame")]
 fn py_state_frame_to_frame<'py>(
     py: Python<'py>,
-    from_frame: PyReferenceFrame,
-    to_frame: PyReferenceFrame,
+    from_frame: PyCelestialFrame,
+    to_frame: PyCelestialFrame,
     epc: &Bound<'py, PyAny>,
     x: &Bound<'py, PyAny>,
     axis: isize,

--- a/crates/brahe-py/src/lib.rs
+++ b/crates/brahe-py/src/lib.rs
@@ -960,7 +960,7 @@ pub fn _brahe(py: Python<'_>, module: &Bound<'_, PyModule>) -> PyResult<()> {
 
     // Reference frame router
     module.add_class::<PySynodicOrigin>()?;
-    module.add_class::<PyReferenceFrame>()?;
+    module.add_class::<PyCelestialFrame>()?;
     module.add_function(wrap_pyfunction!(py_rotation_frame_to_frame, module)?)?;
     module.add_function(wrap_pyfunction!(py_register_custom_frame, module)?)?;
     module.add_function(wrap_pyfunction!(py_unregister_custom_frame, module)?)?;

--- a/crates/brahe-py/src/propagators.rs
+++ b/crates/brahe-py/src/propagators.rs
@@ -619,7 +619,7 @@ impl PySGPPropagator {
     /// frame, converting from the source's native central-body frame.
     ///
     /// Args:
-    ///     frame (ReferenceFrame): Reference frame to express the state in.
+    ///     frame (CelestialFrame): Reference frame to express the state in.
     ///     epoch (Epoch): Target epoch for state computation.
     ///
     /// Returns:
@@ -628,7 +628,7 @@ impl PySGPPropagator {
     pub fn state_in_frame<'a>(
         &self,
         py: Python<'a>,
-        frame: &PyReferenceFrame,
+        frame: &PyCelestialFrame,
         epoch: &PyEpoch,
     ) -> PyResult<Bound<'a, PyArray<f64, Ix1>>> {
         let state = SOrbitStateProvider::state_in_frame(&self.propagator, frame.frame, epoch.obj)?;
@@ -844,7 +844,7 @@ impl PySGPPropagator {
     /// central-body frame.
     ///
     /// Args:
-    ///     frame (ReferenceFrame): The reference frame to express the states in.
+    ///     frame (CelestialFrame): The reference frame to express the states in.
     ///     epochs (list[Epoch]): List of epochs for state computation.
     ///
     /// Returns:
@@ -853,7 +853,7 @@ impl PySGPPropagator {
     pub fn states_in_frame<'a>(
         &self,
         py: Python<'a>,
-        frame: &PyReferenceFrame,
+        frame: &PyCelestialFrame,
         epochs: Vec<PyRef<PyEpoch>>,
     ) -> PyResult<Vec<Bound<'a, PyArray<f64, Ix1>>>> {
         let epoch_vec: Vec<_> = epochs.iter().map(|e| e.obj).collect();
@@ -2882,7 +2882,7 @@ impl PyKeplerianPropagator {
     /// inertial frame).
     ///
     /// Args:
-    ///     frame (ReferenceFrame): Reference frame to express the state in.
+    ///     frame (CelestialFrame): Reference frame to express the state in.
     ///     epoch (Epoch): Target epoch for state computation.
     ///
     /// Returns:
@@ -2891,7 +2891,7 @@ impl PyKeplerianPropagator {
     pub fn state_in_frame<'a>(
         &self,
         py: Python<'a>,
-        frame: &PyReferenceFrame,
+        frame: &PyCelestialFrame,
         epoch: PyRef<PyEpoch>,
     ) -> PyResult<Bound<'a, PyArray<f64, Ix1>>> {
         let state = self.propagator.state_in_frame(frame.frame, epoch.obj)?;
@@ -3127,7 +3127,7 @@ impl PyKeplerianPropagator {
     /// central-body frame.
     ///
     /// Args:
-    ///     frame (ReferenceFrame): The reference frame to express the states in.
+    ///     frame (CelestialFrame): The reference frame to express the states in.
     ///     epochs (list[Epoch]): List of epochs for state computation.
     ///
     /// Returns:
@@ -3136,7 +3136,7 @@ impl PyKeplerianPropagator {
     pub fn states_in_frame<'a>(
         &self,
         py: Python<'a>,
-        frame: &PyReferenceFrame,
+        frame: &PyCelestialFrame,
         epochs: Vec<PyRef<PyEpoch>>,
     ) -> PyResult<Vec<Bound<'a, PyArray<f64, Ix1>>>> {
         let epoch_vec: Vec<_> = epochs.iter().map(|e| e.obj).collect();
@@ -5251,7 +5251,7 @@ impl PyCentralBody {
     ///     gm (float): Gravitational parameter. Units: (m^3/s^2)
     ///     radius (float, optional): Mean or equatorial radius, if known. Units: (m)
     ///     omega (numpy.ndarray or list, optional): Body-fixed axial spin vector, if known. Units: (rad/s)
-    ///     fixed_frame (ReferenceFrame, optional): Body-fixed reference frame, required for
+    ///     fixed_frame (CelestialFrame, optional): Body-fixed reference frame, required for
     ///         spherical-harmonic gravity and body-fixed rotations.
     ///
     /// Returns:
@@ -5265,7 +5265,7 @@ impl PyCentralBody {
         gm: f64,
         radius: Option<f64>,
         omega: Option<Bound<'_, PyAny>>,
-        fixed_frame: Option<PyReferenceFrame>,
+        fixed_frame: Option<PyCelestialFrame>,
     ) -> PyResult<Self> {
         let omega_vec = match omega {
             Some(o) => Some(pyany_to_svector::<3>(&o)?),
@@ -5343,10 +5343,10 @@ impl PyCentralBody {
     /// ICRF-aligned inertial reference frame centered on this body.
     ///
     /// Returns:
-    ///     ReferenceFrame: `GCRF` for `Earth`, `LCI` for `Moon`, `MCI` for `Mars`, `EMBI`
+    ///     CelestialFrame: `GCRF` for `Earth`, `LCI` for `Moon`, `MCI` for `Mars`, `EMBI`
     ///     for `EMB`, `SSBI` for `SSB`, and `BodyCenteredICRF(naif_id)` for `Custom` bodies.
-    fn inertial_frame(&self) -> PyReferenceFrame {
-        PyReferenceFrame {
+    fn inertial_frame(&self) -> PyCelestialFrame {
+        PyCelestialFrame {
             frame: self.body.inertial_frame(),
         }
     }
@@ -5354,12 +5354,12 @@ impl PyCentralBody {
     /// Body-fixed reference frame of this body, if one is defined.
     ///
     /// Returns:
-    ///     ReferenceFrame or None: `ITRF` for `Earth`, `LFPA` for `Moon`, `MCMF` for `Mars`,
+    ///     CelestialFrame or None: `ITRF` for `Earth`, `LFPA` for `Moon`, `MCMF` for `Mars`,
     ///     `None` for `EMB`/`SSB`, and `custom.fixed_frame` for `Custom` bodies.
-    fn fixed_frame(&self) -> Option<PyReferenceFrame> {
+    fn fixed_frame(&self) -> Option<PyCelestialFrame> {
         self.body
             .fixed_frame()
-            .map(|frame| PyReferenceFrame { frame })
+            .map(|frame| PyCelestialFrame { frame })
     }
 
     /// Whether this central body is a barycenter (`EMB` or `SSB`).
@@ -5853,13 +5853,13 @@ impl PyThirdBody {
     /// Mars).
     ///
     /// Returns:
-    ///     ReferenceFrame | None: Body-fixed frame, or None for the
+    ///     CelestialFrame | None: Body-fixed frame, or None for the
     ///         barycenter variants, Custom bodies, and bodies without a
     ///         rotation model.
-    fn body_fixed_frame(&self) -> Option<PyReferenceFrame> {
+    fn body_fixed_frame(&self) -> Option<PyCelestialFrame> {
         self.body
             .body_fixed_frame()
-            .map(|f| PyReferenceFrame { frame: f })
+            .map(|f| PyCelestialFrame { frame: f })
     }
 
     fn __repr__(&self) -> String {
@@ -7361,7 +7361,7 @@ impl PyNumericalOrbitPropagator {
     /// propagator.
     ///
     /// Args:
-    ///     frame (ReferenceFrame): Reference frame to express the state in.
+    ///     frame (CelestialFrame): Reference frame to express the state in.
     ///     epoch (Epoch): Target epoch for state computation.
     ///
     /// Returns:
@@ -7373,7 +7373,7 @@ impl PyNumericalOrbitPropagator {
     pub fn state_in_frame<'a>(
         &self,
         py: Python<'a>,
-        frame: &PyReferenceFrame,
+        frame: &PyCelestialFrame,
         epoch: &PyEpoch,
     ) -> PyResult<Bound<'a, PyArray<f64, Ix1>>> {
         let state = self
@@ -7604,7 +7604,7 @@ impl PyNumericalOrbitPropagator {
     /// central-body frame.
     ///
     /// Args:
-    ///     frame (ReferenceFrame): The reference frame to express the states in.
+    ///     frame (CelestialFrame): The reference frame to express the states in.
     ///     epochs (list[Epoch]): List of epochs for state computation.
     ///
     /// Returns:
@@ -7613,7 +7613,7 @@ impl PyNumericalOrbitPropagator {
     pub fn states_in_frame<'a>(
         &self,
         py: Python<'a>,
-        frame: &PyReferenceFrame,
+        frame: &PyCelestialFrame,
         epochs: Vec<PyRef<PyEpoch>>,
     ) -> PyResult<Vec<Bound<'a, PyArray<f64, Ix1>>>> {
         let epoch_vec: Vec<_> = epochs.iter().map(|e| e.obj).collect();

--- a/crates/brahe-py/src/trajectories.rs
+++ b/crates/brahe-py/src/trajectories.rs
@@ -2021,7 +2021,7 @@ impl PyOrbitalTrajectory {
     /// frame, converting from the source's native central-body frame.
     ///
     /// Args:
-    ///     frame (ReferenceFrame): Reference frame to express the state in.
+    ///     frame (CelestialFrame): Reference frame to express the state in.
     ///     epoch (Epoch): Target epoch for state computation.
     ///
     /// Returns:
@@ -2030,7 +2030,7 @@ impl PyOrbitalTrajectory {
     pub fn state_in_frame<'a>(
         &self,
         py: Python<'a>,
-        frame: &PyReferenceFrame,
+        frame: &PyCelestialFrame,
         epoch: &PyEpoch,
     ) -> PyResult<Bound<'a, PyArray<f64, Ix1>>> {
         let state = DOrbitStateProvider::state_in_frame(&self.trajectory, frame.frame, epoch.obj)?;

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,12 @@ Each release groups entries under the Keep a Changelog section headings in the o
 
 <!-- release notes start -->
 
+## [Unreleased]
+
+### Changed
+
+- **Breaking:** `ReferenceFrame` renamed to `CelestialFrame` in Rust and Python — the frame router, all frame-router functions, and every associated binding now use the new name.
+
 ## [1.7.0] - 2026-07-21
 
 ### Added

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,12 +9,6 @@ Each release groups entries under the Keep a Changelog section headings in the o
 
 <!-- release notes start -->
 
-## [Unreleased]
-
-### Changed
-
-- **Breaking:** `ReferenceFrame` renamed to `CelestialFrame` in Rust and Python — the frame router, all frame-router functions, and every associated binding now use the new name. [@duncaneddy](https://github.com/duncaneddy) ([#507](https://github.com/duncaneddy/brahe/pull/507))
-
 ## [1.7.0] - 2026-07-21
 
 ### Added

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,7 +13,7 @@ Each release groups entries under the Keep a Changelog section headings in the o
 
 ### Changed
 
-- **Breaking:** `ReferenceFrame` renamed to `CelestialFrame` in Rust and Python — the frame router, all frame-router functions, and every associated binding now use the new name.
+- **Breaking:** `ReferenceFrame` renamed to `CelestialFrame` in Rust and Python — the frame router, all frame-router functions, and every associated binding now use the new name. [@duncaneddy](https://github.com/duncaneddy) ([#507](https://github.com/duncaneddy/brahe/pull/507))
 
 ## [1.7.0] - 2026-07-21
 

--- a/docs/examples/dawn_ceres_orbit.md
+++ b/docs/examples/dawn_ceres_orbit.md
@@ -75,8 +75,8 @@ equator on the ICRF equator - the standard IAU orientation convention
 ([Archinal et al., 2018](https://doi.org/10.1007/s10569-017-9805-5)) - since
 $\hat{z}_{\text{ICRF}} \times \hat{p}$ is perpendicular to both poles, hence
 lies in both equatorial planes: the line of nodes. Once registered under an
-integer key, `ReferenceFrame.BodyFixedCustom(naif_id, key)` is usable
-anywhere a [`ReferenceFrame`](../library_api/frames/router.md#referenceframe) is accepted:
+integer key, `CelestialFrame.BodyFixedCustom(naif_id, key)` is usable
+anywhere a [`CelestialFrame`](../library_api/frames/router.md#celestialframe) is accepted:
 
 ``` python
 --8<-- "./examples/examples/dawn_ceres_orbit.py:body_fixed_frame"

--- a/docs/learn/frames/frame_transformations.md
+++ b/docs/learn/frames/frame_transformations.md
@@ -1,6 +1,6 @@
 # Reference Frame Router
 
-`ReferenceFrame` is a single enum spanning every reference frame in Brahe &mdash; Earth-centered, lunar, Martian, barycentric, and generic NAIF-ID variants &mdash; and three router functions (`rotation_frame_to_frame`, `position_frame_to_frame`, `state_frame_to_frame`) that convert between *any* two of them. The router is the frame machinery underlying multibody numerical propagation; see [Cislunar and Lunar Propagation](../orbit_propagation/numerical_propagation/cislunar_lunar_propagation.md) and [Propagation Around Other Central Bodies](../orbit_propagation/numerical_propagation/other_central_bodies.md) for the propagation side.
+`CelestialFrame` is a single enum spanning every reference frame in Brahe &mdash; Earth-centered, lunar, Martian, barycentric, and generic NAIF-ID variants &mdash; and three router functions (`rotation_frame_to_frame`, `position_frame_to_frame`, `state_frame_to_frame`) that convert between *any* two of them. The router is the frame machinery underlying multibody numerical propagation; see [Cislunar and Lunar Propagation](../orbit_propagation/numerical_propagation/cislunar_lunar_propagation.md) and [Propagation Around Other Central Bodies](../orbit_propagation/numerical_propagation/other_central_bodies.md) for the propagation side.
 
 ## Available Frames
 

--- a/docs/learn/frames/index.md
+++ b/docs/learn/frames/index.md
@@ -34,7 +34,7 @@ Brahe also supports Moon- and Mars-fixed frames for multibody propagation and re
 - **MCMF (Mars-Centered Mars-Fixed)**: Mars-fixed frame, evaluated from the IAU/WGCCRE rotation model
 - **EMR / SER / GSE (Earth-Moon Rotating / Sun-Earth Rotating / Geocentric Solar Ecliptic)**: synodic frames that rotate with the line between two primary bodies
 
-See [Lunar Reference Frames](lunar_frames.md), [Mars Reference Frames](mars_frames.md), and [Synodic Reference Frames](synodic_frames.md) for details, and [Reference Frame Router](frame_transformations.md) for the `ReferenceFrame` router that converts between any two frames (including generic NAIF-ID variants for bodies without a dedicated named frame). Central-body propagation is covered in [Cislunar and Lunar Propagation](../orbit_propagation/numerical_propagation/cislunar_lunar_propagation.md) and [Propagation Around Other Central Bodies](../orbit_propagation/numerical_propagation/other_central_bodies.md).
+See [Lunar Reference Frames](lunar_frames.md), [Mars Reference Frames](mars_frames.md), and [Synodic Reference Frames](synodic_frames.md) for details, and [Reference Frame Router](frame_transformations.md) for the `CelestialFrame` router that converts between any two frames (including generic NAIF-ID variants for bodies without a dedicated named frame). Central-body propagation is covered in [Cislunar and Lunar Propagation](../orbit_propagation/numerical_propagation/cislunar_lunar_propagation.md) and [Propagation Around Other Central Bodies](../orbit_propagation/numerical_propagation/other_central_bodies.md).
 
 ## Available Transformations
 

--- a/docs/learn/frames/lunar_frames.md
+++ b/docs/learn/frames/lunar_frames.md
@@ -42,7 +42,7 @@ For propagating an orbit about the Moon and reporting it in the LFPA frame, see 
 ## See Also
 
 - [Mars Reference Frames](mars_frames.md) - MCI/MCMF frames
-- [Reference Frame Router](frame_transformations.md) - `ReferenceFrame`, kernel requirements, and cross-frame conversion
+- [Reference Frame Router](frame_transformations.md) - `CelestialFrame`, kernel requirements, and cross-frame conversion
 - [Cislunar and Lunar Propagation](../orbit_propagation/numerical_propagation/cislunar_lunar_propagation.md) - lunar force-model defaults and a worked propagation example
 - [Lunar Frames API Reference](../../library_api/frames/lunar.md)
 

--- a/docs/learn/frames/mars_frames.md
+++ b/docs/learn/frames/mars_frames.md
@@ -25,7 +25,7 @@ For propagating an orbit about Mars and reporting it in the MCMF frame, see [Pro
 ## See Also
 
 - [Lunar Reference Frames](lunar_frames.md) - LCI/LFPA/LFME frames
-- [Reference Frame Router](frame_transformations.md) - `ReferenceFrame`, kernel requirements, and cross-frame conversion
+- [Reference Frame Router](frame_transformations.md) - `CelestialFrame`, kernel requirements, and cross-frame conversion
 - [Propagation Around Other Central Bodies](../orbit_propagation/numerical_propagation/other_central_bodies.md) - Mars force-model defaults and a worked propagation example
 - [Mars Frames API Reference](../../library_api/frames/mars.md)
 

--- a/docs/learn/frames/synodic_frames.md
+++ b/docs/learn/frames/synodic_frames.md
@@ -26,7 +26,7 @@ Origin: Earth center. $\hat{\boldsymbol{x}}$ points from the Earth to the Sun �
 
 ## Generic Synodic Frames
 
-EMR, SER, and GSE are named instances of a generic two-body synodic frame, `ReferenceFrame.Synodic(origin, primary, secondary)`. `origin` is a `SynodicOrigin` (`Primary`, `Secondary`, or `Barycenter`); `primary` and `secondary` are the NAIF IDs of the two bodies, and any NAIF ID is accepted for any origin. For a `Barycenter` origin, the pair is encoded into a synthetic negative center ID as `primary * 1000 + secondary`. Both bodies must have packaged $GM$ constants. IDs outside that range still work but produce a different encoding that no longer maps back to a synthetic center — this surfaces as an SPK/GM lookup error at transform time rather than a silent collision. The axis construction is identical to the formula above, with $\boldsymbol{r}_{12}$ and $\boldsymbol{v}_{12}$ taken between `primary` and `secondary`.
+EMR, SER, and GSE are named instances of a generic two-body synodic frame, `CelestialFrame.Synodic(origin, primary, secondary)`. `origin` is a `SynodicOrigin` (`Primary`, `Secondary`, or `Barycenter`); `primary` and `secondary` are the NAIF IDs of the two bodies, and any NAIF ID is accepted for any origin. For a `Barycenter` origin, the pair is encoded into a synthetic negative center ID as `primary * 1000 + secondary`. Both bodies must have packaged $GM$ constants. IDs outside that range still work but produce a different encoding that no longer maps back to a synthetic center — this surfaces as an SPK/GM lookup error at transform time rather than a silent collision. The axis construction is identical to the formula above, with $\boldsymbol{r}_{12}$ and $\boldsymbol{v}_{12}$ taken between `primary` and `secondary`.
 
 The three named frames are equivalent to these generic configurations:
 
@@ -76,12 +76,12 @@ The generic frame has no dedicated `rotation_gcrf_to_synodic`-style functions; i
 | GCRF &rarr; GSE | [`rotation_gcrf_to_gse`](../../library_api/frames/synodic.md#brahe.rotation_gcrf_to_gse), [`position_gcrf_to_gse`](../../library_api/frames/synodic.md#brahe.position_gcrf_to_gse), [`state_gcrf_to_gse`](../../library_api/frames/synodic.md#brahe.state_gcrf_to_gse) |
 | GSE &rarr; GCRF | [`rotation_gse_to_gcrf`](../../library_api/frames/synodic.md#brahe.rotation_gse_to_gcrf), [`position_gse_to_gcrf`](../../library_api/frames/synodic.md#brahe.position_gse_to_gcrf), [`state_gse_to_gcrf`](../../library_api/frames/synodic.md#brahe.state_gse_to_gcrf) |
 
-All three frames are also available through the frame router as `ReferenceFrame.EMR`, `ReferenceFrame.SER`, and `ReferenceFrame.GSE`, usable in `rotation_frame_to_frame`, `position_frame_to_frame`, `state_frame_to_frame`, and every provider's `state_in_frame`/`states_in_frame`. The `de440s` SPK kernel is auto-loaded on first use.
+All three frames are also available through the frame router as `CelestialFrame.EMR`, `CelestialFrame.SER`, and `CelestialFrame.GSE`, usable in `rotation_frame_to_frame`, `position_frame_to_frame`, `state_frame_to_frame`, and every provider's `state_in_frame`/`states_in_frame`. The `de440s` SPK kernel is auto-loaded on first use.
 
 ## See Also
 
 - [Lunar Reference Frames](lunar_frames.md) - LCI/LFPA/LFME frames
-- [Reference Frame Router](frame_transformations.md) - `ReferenceFrame`, kernel requirements, and cross-frame conversion
+- [Reference Frame Router](frame_transformations.md) - `CelestialFrame`, kernel requirements, and cross-frame conversion
 - [Synodic Frames API Reference](../../library_api/frames/synodic.md)
 
 [^tp]: Folta, D., Bosanac, N., Elliott, I., Mann, L., Mesarch, R., & Rosales, J. (2022). [*Astrodynamics Convention and Modeling Reference for Lunar, Cislunar, and Libration Point Orbits*, NASA/TP-20220014814](https://ntrs.nasa.gov/api/citations/20220014814/downloads/NASA%20TP%2020220014814%20final.pdf), §2.5 and §4.6.

--- a/docs/learn/orbit_propagation/numerical_propagation/cislunar_lunar_propagation.md
+++ b/docs/learn/orbit_propagation/numerical_propagation/cislunar_lunar_propagation.md
@@ -7,7 +7,7 @@
 | `Moon` | 301 | `LCI` | `LFPA` |
 | `EMB` | 3 | `EMBI` | none |
 
-The propagator integrates in the central body's inertial frame (`LCI` for `Moon`, `EMBI` for `EMB`). `state_in_frame(frame, epoch)` converts the integrated state into any [`ReferenceFrame`](../../frames/frame_transformations.md), routing directly from the integration frame: for a Moon-centered propagator, `state_in_frame(ReferenceFrame.LCI, epoch)` is the identity (no SPK round trip), and `state_in_frame(ReferenceFrame.LFPA, epoch)` gives the Moon-fixed state without first converting to Earth-centered `GCRF`. `state_bci(epoch)` returns the raw body-centered inertial state without conversion, and `state_bcbf(epoch)` returns the body-centered body-fixed state (`LFPA` for `Moon`; `EMB` has no body-fixed frame and returns an error).
+The propagator integrates in the central body's inertial frame (`LCI` for `Moon`, `EMBI` for `EMB`). `state_in_frame(frame, epoch)` converts the integrated state into any [`CelestialFrame`](../../frames/frame_transformations.md), routing directly from the integration frame: for a Moon-centered propagator, `state_in_frame(CelestialFrame.LCI, epoch)` is the identity (no SPK round trip), and `state_in_frame(CelestialFrame.LFPA, epoch)` gives the Moon-fixed state without first converting to Earth-centered `GCRF`. `state_bci(epoch)` returns the raw body-centered inertial state without conversion, and `state_bcbf(epoch)` returns the body-centered body-fixed state (`LFPA` for `Moon`; `EMB` has no body-fixed frame and returns an error).
 
 ## Force-Model Defaults
 

--- a/docs/learn/orbit_propagation/numerical_propagation/other_central_bodies.md
+++ b/docs/learn/orbit_propagation/numerical_propagation/other_central_bodies.md
@@ -63,7 +63,7 @@ A custom body that has no SPICE orientation kernel and no compiled-in IAU model 
 - `omega` is an optional second callback function: it receives an `Epoch` and returns the frame's angular velocity vector (rad/s), used for the exact velocity transport term. When omitted, the angular velocity is derived numerically by central differencing of `rotation`.
 - `key` is an arbitrary integer handle that names the registered callback. It does **not** need to match (and is unrelated to) the central body's NAIF ID; the body's NAIF ID appears separately as the `center` of the frame variant.
 
-Reference the registered frame as `ReferenceFrame.BodyFixedCustom(center, key)`, using the same `key`, and set it as the custom body's `fixed_frame`. This enables support for user-defined orientation models, enabling the framework to extend to additional bodies without needing hard-coded support for them in the library. See [Generic NAIF-ID Variants](../../frames/frame_transformations.md#generic-naif-id-variants) for the frame-router side.
+Reference the registered frame as `CelestialFrame.BodyFixedCustom(center, key)`, using the same `key`, and set it as the custom body's `fixed_frame`. This enables support for user-defined orientation models, enabling the framework to extend to additional bodies without needing hard-coded support for them in the library. See [Generic NAIF-ID Variants](../../frames/frame_transformations.md#generic-naif-id-variants) for the frame-router side.
 
 ### Example: Registering a Custom Body-Fixed Frame
 
@@ -96,6 +96,6 @@ The example below registers a uniform spin state for an uncatalogued body (self-
 
 - [Cislunar and Lunar Propagation](cislunar_lunar_propagation.md) - `Moon`/`EMB` central bodies and barycenter third-body physics
 - [Mars Reference Frames](../../frames/mars_frames.md) - MCI/MCMF frame definitions
-- [Reference Frame Router](../../frames/frame_transformations.md) - `ReferenceFrame`, `BodyFixedCustom`, and `register_custom_frame`
+- [Reference Frame Router](../../frames/frame_transformations.md) - `CelestialFrame`, `BodyFixedCustom`, and `register_custom_frame`
 - [Force Models](force_models.md) - Building a `ForceModelConfig` from individual force terms
 - [Force Model Configuration API Reference](../../../library_api/propagators/force_model_config.md)

--- a/docs/learn/plots/synodic_plots.md
+++ b/docs/learn/plots/synodic_plots.md
@@ -1,6 +1,6 @@
 # Synodic Frame Trajectory Plots
 
-`plot_synodic_3d` renders 3D trajectories in a synodic (two-body rotating) frame: EMR (Earth-Moon Rotating), SER (Sun-Earth Rotating), GSE (Geocentric Solar Ecliptic), or a generic `ReferenceFrame.Synodic(origin, primary, secondary)`. Each input trajectory is converted to ECI and then transformed per-epoch into the requested frame via `state_frame_to_frame`. The frame's primary and secondary bodies are drawn as textured spheres at a single reference epoch, since a synodic frame keeps both bodies on the x-axis at all times.
+`plot_synodic_3d` renders 3D trajectories in a synodic (two-body rotating) frame: EMR (Earth-Moon Rotating), SER (Sun-Earth Rotating), GSE (Geocentric Solar Ecliptic), or a generic `CelestialFrame.Synodic(origin, primary, secondary)`. Each input trajectory is converted to ECI and then transformed per-epoch into the requested frame via `state_frame_to_frame`. The frame's primary and secondary bodies are drawn as textured spheres at a single reference epoch, since a synodic frame keeps both bodies on the x-axis at all times.
 
 `plot_earth_moon_rotating_3d` is an alias for `plot_synodic_3d(trajectories, frame="EMR", ...)`; it accepts the same keyword arguments.
 
@@ -13,8 +13,8 @@
 The `frame` parameter accepts:
 
 - A frame alias string: `'EMR'`, `'SER'`, or `'GSE'`
-- Any other `ReferenceFrame` name string accepted by `ReferenceFrame.from_string`
-- A `ReferenceFrame.Synodic(origin, primary, secondary)` instance for a custom two-body pair
+- Any other `CelestialFrame` name string accepted by `CelestialFrame.from_string`
+- A `CelestialFrame.Synodic(origin, primary, secondary)` instance for a custom two-body pair
 
 See [Synodic Reference Frames](../frames/synodic_frames.md) for the axis construction and physical definition of each frame. Passing a non-synodic frame raises `ValueError`.
 

--- a/docs/library_api/frames/index.md
+++ b/docs/library_api/frames/index.md
@@ -30,4 +30,4 @@ Transformations between GCRF and the synodic EMR, SER, and GSE frames.
 
 ### [Reference Frame Router](router.md)
 
-`ReferenceFrame` and the generic `rotation_frame_to_frame`/`position_frame_to_frame`/`state_frame_to_frame` functions, which convert between any two supported frames, including generic NAIF-ID variants for bodies without a dedicated named frame.
+`CelestialFrame` and the generic `rotation_frame_to_frame`/`position_frame_to_frame`/`state_frame_to_frame` functions, which convert between any two supported frames, including generic NAIF-ID variants for bodies without a dedicated named frame.

--- a/docs/library_api/frames/router.md
+++ b/docs/library_api/frames/router.md
@@ -1,13 +1,13 @@
 # Reference Frame Router
 
-`ReferenceFrame` and the generic `rotation_frame_to_frame`/`position_frame_to_frame`/`state_frame_to_frame` functions convert between any two supported reference frames, including generic NAIF-ID variants for bodies without a dedicated named frame.
+`CelestialFrame` and the generic `rotation_frame_to_frame`/`position_frame_to_frame`/`state_frame_to_frame` functions convert between any two supported reference frames, including generic NAIF-ID variants for bodies without a dedicated named frame.
 
 !!! note
     For conceptual explanations and the full frame/kernel-requirement tables, see [Reference Frame Router](../../learn/frames/frame_transformations.md) in the Learn section. For central-body propagation defaults, see [Cislunar and Lunar Propagation](../../learn/orbit_propagation/numerical_propagation/cislunar_lunar_propagation.md) and [Propagation Around Other Central Bodies](../../learn/orbit_propagation/numerical_propagation/other_central_bodies.md).
 
-## ReferenceFrame
+## CelestialFrame
 
-::: brahe.ReferenceFrame
+::: brahe.CelestialFrame
 
 ## Router Functions
 

--- a/docs/library_api/frames/synodic.md
+++ b/docs/library_api/frames/synodic.md
@@ -49,7 +49,7 @@ Transformations between GCRF and the Earth-Moon Rotating (EMR), Sun-Earth Rotati
 
 ## SynodicOrigin
 
-Origin choice for the generic [`ReferenceFrame.Synodic`](router.md) constructor.
+Origin choice for the generic [`CelestialFrame.Synodic`](router.md) constructor.
 
 ::: brahe.SynodicOrigin
 

--- a/examples/examples/dawn_ceres_orbit.py
+++ b/examples/examples/dawn_ceres_orbit.py
@@ -123,7 +123,7 @@ def ceres_omega(epc=None):
 # The `1` is an arbitrarily chosen registry key for this custom frame; it
 # just needs to be unique among registered custom frames.
 bh.register_custom_frame(1, ceres_rotation, ceres_omega)
-ceres_fixed = bh.ReferenceFrame.BodyFixedCustom(CERES_NAIF_ID, 1)
+ceres_fixed = bh.CelestialFrame.BodyFixedCustom(CERES_NAIF_ID, 1)
 # --8<-- [end:body_fixed_frame]
 
 # --8<-- [start:force_model]

--- a/examples/examples/earth_moon_free_return.py
+++ b/examples/examples/earth_moon_free_return.py
@@ -277,7 +277,7 @@ i_perilune = int(np.argmin(moon_dists))
 reference_epoch = sample_epochs[i_perilune]
 
 emr_states = np.array(
-    [prop.state_in_frame(bh.ReferenceFrame.EMR, e) for e in sample_epochs]
+    [prop.state_in_frame(bh.CelestialFrame.EMR, e) for e in sample_epochs]
 )
 emr_xyz_km = emr_states[:, :3] / 1e3
 emr_vel = emr_states[:, 3:6]
@@ -291,8 +291,8 @@ def _emr_body_xy_km(naif_id):
     """Body position in the EMR frame at the perilune epoch [km]."""
     return (
         bh.position_frame_to_frame(
-            bh.ReferenceFrame.BodyCenteredICRF(naif_id),
-            bh.ReferenceFrame.EMR,
+            bh.CelestialFrame.BodyCenteredICRF(naif_id),
+            bh.CelestialFrame.EMR,
             reference_epoch,
             np.zeros(3),
         )

--- a/examples/frames/custom_frame.py
+++ b/examples/frames/custom_frame.py
@@ -41,8 +41,8 @@ def omega(epc):
 
 bh.register_custom_frame(KEY, rotation, omega)
 
-inertial = bh.ReferenceFrame.BodyCenteredICRF(CENTER)
-fixed = bh.ReferenceFrame.BodyFixedCustom(CENTER, KEY)
+inertial = bh.CelestialFrame.BodyCenteredICRF(CENTER)
+fixed = bh.CelestialFrame.BodyFixedCustom(CENTER, KEY)
 
 # Convert an inertial state about the body into its body-fixed frame. Both
 # frames share the same center, so no ephemeris kernel is needed.

--- a/examples/frames/custom_frame.rs
+++ b/examples/frames/custom_frame.rs
@@ -35,8 +35,8 @@ fn main() {
 
     bh::register_custom_frame(KEY, rotation, Some(Box::new(omega)));
 
-    let inertial = bh::ReferenceFrame::BodyCenteredICRF(CENTER);
-    let fixed = bh::ReferenceFrame::BodyFixedCustom {
+    let inertial = bh::CelestialFrame::BodyCenteredICRF(CENTER);
+    let fixed = bh::CelestialFrame::BodyFixedCustom {
         center: CENTER,
         key: KEY,
     };

--- a/examples/frames/frame_router.py
+++ b/examples/frames/frame_router.py
@@ -23,13 +23,13 @@ x_gcrf = bh.state_koe_to_eci(oe, bh.AngleFormat.DEGREES)
 # state_frame_to_frame routes through ICRF and re-centers Earth -> Moon, so the
 # same physical state is now expressed relative to the Moon.
 x_lci = bh.state_frame_to_frame(
-    bh.ReferenceFrame.GCRF, bh.ReferenceFrame.LCI, epc, x_gcrf
+    bh.CelestialFrame.GCRF, bh.CelestialFrame.LCI, epc, x_gcrf
 )
 
 # rotation_frame_to_frame returns only the 3x3 axis rotation (no re-centering);
 # GCRF -> MCMF uses the compiled-in WGCCRE Mars model and needs no kernel.
 r_gcrf_to_mcmf = bh.rotation_frame_to_frame(
-    bh.ReferenceFrame.GCRF, bh.ReferenceFrame.MCMF, epc
+    bh.CelestialFrame.GCRF, bh.CelestialFrame.MCMF, epc
 )
 
 print(f"Epoch: {epc}")

--- a/examples/frames/frame_router.rs
+++ b/examples/frames/frame_router.rs
@@ -19,14 +19,14 @@ fn main() {
     // state_frame_to_frame routes through ICRF and re-centers Earth -> Moon, so
     // the same physical state is now expressed relative to the Moon.
     let x_lci =
-        bh::state_frame_to_frame(bh::ReferenceFrame::GCRF, bh::ReferenceFrame::LCI, epc, x_gcrf)
+        bh::state_frame_to_frame(bh::CelestialFrame::GCRF, bh::CelestialFrame::LCI, epc, x_gcrf)
             .unwrap();
 
     // rotation_frame_to_frame returns only the 3x3 axis rotation (no
     // re-centering); GCRF -> MCMF uses the compiled-in WGCCRE Mars model and
     // needs no kernel.
     let r_gcrf_to_mcmf =
-        bh::rotation_frame_to_frame(bh::ReferenceFrame::GCRF, bh::ReferenceFrame::MCMF, epc)
+        bh::rotation_frame_to_frame(bh::CelestialFrame::GCRF, bh::CelestialFrame::MCMF, epc)
             .unwrap();
 
     println!("Epoch: {}", epc);

--- a/examples/frames/generic_synodic_frame.py
+++ b/examples/frames/generic_synodic_frame.py
@@ -18,7 +18,7 @@ epc = bh.Epoch.from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, bh.TimeSystem.UTC)
 # A generic Synodic frame isn't limited to the named EMR/SER/GSE instances:
 # any two SPK-covered bodies work as the primary/secondary pair. Here the
 # Sun-Mars barycenter defines a Sun-Mars rotating frame.
-frame = bh.ReferenceFrame.Synodic(bh.SynodicOrigin.Barycenter, 10, 4)
+frame = bh.CelestialFrame.Synodic(bh.SynodicOrigin.Barycenter, 10, 4)
 
 # A LEO state in GCRF, transformed into the Sun-Mars rotating frame through
 # the frame router.
@@ -26,7 +26,7 @@ x_gcrf = bh.state_koe_to_eci(
     np.array([bh.R_EARTH + 500e3, 0.001, 97.8, 15.0, 30.0, 45.0]),
     bh.AngleFormat.DEGREES,
 )
-x_syn = bh.state_frame_to_frame(bh.ReferenceFrame.GCRF, frame, epc, x_gcrf)
+x_syn = bh.state_frame_to_frame(bh.CelestialFrame.GCRF, frame, epc, x_gcrf)
 
 print(f"Epoch: {epc}")
 print(f"GCRF state (km): {np.array2string(x_gcrf[:3] / 1e3, precision=3)}")
@@ -38,7 +38,7 @@ assert frame.synodic_primary == 10
 assert frame.synodic_secondary == 4
 
 # Round-tripping back to GCRF recovers the original state.
-x_back = bh.state_frame_to_frame(frame, bh.ReferenceFrame.GCRF, epc, x_syn)
+x_back = bh.state_frame_to_frame(frame, bh.CelestialFrame.GCRF, epc, x_syn)
 np.testing.assert_allclose(x_back, x_gcrf, atol=1e-6)
 
 print("\nExample validated successfully!")

--- a/examples/frames/generic_synodic_frame.rs
+++ b/examples/frames/generic_synodic_frame.rs
@@ -15,7 +15,7 @@ fn main() {
     // A generic Synodic frame isn't limited to the named EMR/SER/GSE
     // instances: any two SPK-covered bodies work as the primary/secondary
     // pair. Here the Sun-Mars barycenter defines a Sun-Mars rotating frame.
-    let frame = bh::ReferenceFrame::Synodic {
+    let frame = bh::CelestialFrame::Synodic {
         origin: bh::SynodicOrigin::Barycenter,
         primary: 10,
         secondary: 4,
@@ -25,7 +25,7 @@ fn main() {
     // through the frame router.
     let oe = na::SVector::<f64, 6>::new(bh::R_EARTH + 500e3, 0.001, 97.8, 15.0, 30.0, 45.0);
     let x_gcrf = bh::state_koe_to_eci(oe, bh::AngleFormat::Degrees);
-    let x_syn = bh::state_frame_to_frame(bh::ReferenceFrame::GCRF, frame, epc, x_gcrf).unwrap();
+    let x_syn = bh::state_frame_to_frame(bh::CelestialFrame::GCRF, frame, epc, x_gcrf).unwrap();
 
     println!("Epoch: {}", epc);
     println!(
@@ -45,7 +45,7 @@ fn main() {
     // frame's origin is ~1e11 m from Earth, so the absolute tolerance is
     // scaled to the position magnitude rather than held at GCRF-local
     // precision.
-    let x_back = bh::state_frame_to_frame(frame, bh::ReferenceFrame::GCRF, epc, x_syn).unwrap();
+    let x_back = bh::state_frame_to_frame(frame, bh::CelestialFrame::GCRF, epc, x_syn).unwrap();
     assert!((x_back - x_gcrf).norm() < 1e-6 * x_gcrf.norm());
 
     println!("\nExample validated successfully!");

--- a/examples/numerical_propagation/lunar_orbit.py
+++ b/examples/numerical_propagation/lunar_orbit.py
@@ -57,8 +57,8 @@ prop.propagate_to(final_epoch)
 # state_in_frame routes the propagator's native LCI state through the
 # reference frame router into any other supported frame. LFPA is the Moon-
 # fixed, DE440 principal-axis frame.
-x0_lfpa = prop.state_in_frame(bh.ReferenceFrame.LFPA, epoch)
-xf_lfpa = prop.state_in_frame(bh.ReferenceFrame.LFPA, final_epoch)
+x0_lfpa = prop.state_in_frame(bh.CelestialFrame.LFPA, epoch)
+xf_lfpa = prop.state_in_frame(bh.CelestialFrame.LFPA, final_epoch)
 
 print(f"Initial epoch: {epoch}")
 print(f"Final epoch:   {final_epoch}")

--- a/examples/numerical_propagation/lunar_orbit.rs
+++ b/examples/numerical_propagation/lunar_orbit.rs
@@ -51,9 +51,9 @@ fn main() {
     // state_in_frame routes the propagator's native LCI state through the
     // reference frame router into any other supported frame. LFPA is the
     // Moon-fixed, DE440 principal-axis frame.
-    let x0_lfpa = prop.state_in_frame(bh::ReferenceFrame::LFPA, epoch).unwrap();
+    let x0_lfpa = prop.state_in_frame(bh::CelestialFrame::LFPA, epoch).unwrap();
     let xf_lfpa = prop
-        .state_in_frame(bh::ReferenceFrame::LFPA, final_epoch)
+        .state_in_frame(bh::CelestialFrame::LFPA, final_epoch)
         .unwrap();
 
     println!("Initial epoch: {}", epoch);

--- a/examples/numerical_propagation/mars_orbit.py
+++ b/examples/numerical_propagation/mars_orbit.py
@@ -56,8 +56,8 @@ prop.propagate_to(final_epoch)
 # state_in_frame routes the propagator's native MCI state through the
 # reference frame router into any other supported frame. MCMF is the
 # Mars-fixed, IAU/WGCCRE body-fixed frame.
-x0_mcmf = prop.state_in_frame(bh.ReferenceFrame.MCMF, epoch)
-xf_mcmf = prop.state_in_frame(bh.ReferenceFrame.MCMF, final_epoch)
+x0_mcmf = prop.state_in_frame(bh.CelestialFrame.MCMF, epoch)
+xf_mcmf = prop.state_in_frame(bh.CelestialFrame.MCMF, final_epoch)
 
 print(f"Initial epoch: {epoch}")
 print(f"Final epoch:   {final_epoch}")

--- a/examples/numerical_propagation/mars_orbit.rs
+++ b/examples/numerical_propagation/mars_orbit.rs
@@ -50,9 +50,9 @@ fn main() {
     // state_in_frame routes the propagator's native MCI state through the
     // reference frame router into any other supported frame. MCMF is the
     // Mars-fixed, IAU/WGCCRE body-fixed frame.
-    let x0_mcmf = prop.state_in_frame(bh::ReferenceFrame::MCMF, epoch).unwrap();
+    let x0_mcmf = prop.state_in_frame(bh::CelestialFrame::MCMF, epoch).unwrap();
     let xf_mcmf = prop
-        .state_in_frame(bh::ReferenceFrame::MCMF, final_epoch)
+        .state_in_frame(bh::CelestialFrame::MCMF, final_epoch)
         .unwrap();
 
     println!("Initial epoch: {}", epoch);

--- a/src/coordinates/cartesian.rs
+++ b/src/coordinates/cartesian.rs
@@ -895,7 +895,7 @@ mod tests {
         // a fixed_frame resolves its pole through that frame (rule 3). Using
         // BodyFixedIAU(499) as the fixed frame reuses Mars's pole, so a round
         // trip must recover the elements.
-        use crate::frames::ReferenceFrame;
+        use crate::frames::CelestialFrame;
         use crate::propagators::{CentralBody, CustomBody};
 
         let body = CentralBody::Custom(CustomBody {
@@ -904,7 +904,7 @@ mod tests {
             gm: crate::constants::GM_MARS,
             radius: Some(R_MARS),
             omega: None,
-            fixed_frame: Some(ReferenceFrame::BodyFixedIAU(499)),
+            fixed_frame: Some(CelestialFrame::BodyFixedIAU(499)),
         });
 
         let osc = vector6_from_array([R_MARS + 300e3, 0.01, 80.0, 30.0, 45.0, 10.0]);

--- a/src/frames/custom.rs
+++ b/src/frames/custom.rs
@@ -2,7 +2,7 @@
  * User-defined body-fixed frame registry.
  *
  * Lets applications plug an arbitrary orientation model into the frame
- * router as [`ReferenceFrame::BodyFixedCustom`](super::ReferenceFrame):
+ * router as [`CelestialFrame::BodyFixedCustom`](super::CelestialFrame):
  * a rotation callback mapping an [`Epoch`] to the ICRF→body-fixed DCM,
  * optionally paired with an angular-velocity callback for the velocity
  * transport term. This supports orientation models the crate does not
@@ -16,7 +16,7 @@
  *
  * Frames are registered process-wide under a caller-chosen `u32` key,
  * following the crate's global-provider pattern (EOP, gravity, SPICE
- * registries), which keeps [`ReferenceFrame`](super::ReferenceFrame)
+ * registries), which keeps [`CelestialFrame`](super::CelestialFrame)
  * `Copy`/serializable — the enum stores only the key.
  */
 
@@ -54,7 +54,7 @@ const OMEGA_DIFF_STEP: f64 = 1.0;
 /// Registers (or replaces) a user-defined body-fixed frame under `key`.
 ///
 /// The frame becomes usable as
-/// [`ReferenceFrame::BodyFixedCustom`](super::ReferenceFrame) in every
+/// [`CelestialFrame::BodyFixedCustom`](super::CelestialFrame) in every
 /// router function. `rotation` must return the DCM rotating ICRF-axis
 /// vectors into the body-fixed frame (`v_body = R * v_icrf`). If `omega`
 /// is `None`, the angular velocity used for the velocity transport term
@@ -62,14 +62,14 @@ const OMEGA_DIFF_STEP: f64 = 1.0;
 ///
 /// # Arguments
 /// - `key`: Caller-chosen identifier the frame is registered under; the
-///   same value used in `ReferenceFrame::BodyFixedCustom { key, .. }`
+///   same value used in `CelestialFrame::BodyFixedCustom { key, .. }`
 /// - `rotation`: Callback returning the ICRF→body-fixed DCM at an epoch
 /// - `omega`: Optional callback returning the frame's angular velocity in
 ///   the body-fixed frame. Units: (rad/s)
 ///
 /// # Examples
 /// ```
-/// use brahe::frames::{register_custom_frame, ReferenceFrame, rotation_frame_to_frame};
+/// use brahe::frames::{register_custom_frame, CelestialFrame, rotation_frame_to_frame};
 /// use brahe::math::SMatrix3;
 /// use brahe::time::{Epoch, TimeSystem};
 ///
@@ -85,8 +85,8 @@ const OMEGA_DIFF_STEP: f64 = 1.0;
 ///     None,
 /// );
 ///
-/// let frame = ReferenceFrame::BodyFixedCustom { center: -20001, key: 42 };
-/// let r = rotation_frame_to_frame(ReferenceFrame::GCRF, frame, t0 + 100.0).unwrap();
+/// let frame = CelestialFrame::BodyFixedCustom { center: -20001, key: 42 };
+/// let r = rotation_frame_to_frame(CelestialFrame::GCRF, frame, t0 + 100.0).unwrap();
 /// ```
 pub fn register_custom_frame<R>(key: u32, rotation: R, omega: Option<Box<CustomFrameOmega>>)
 where

--- a/src/frames/emb.rs
+++ b/src/frames/emb.rs
@@ -6,7 +6,7 @@ Both frames share the ICRF orientation, so the transformation is a pure
 translation by the Earth's barycentric state from the loaded DE ephemeris:
 positions differ by the Earth→EMB offset and velocities by its time
 derivative. The EMBI origin is the Earth-Moon barycenter (NAIF ID 3); see
-[`crate::frames::ReferenceFrame::EMBI`].
+[`crate::frames::CelestialFrame::EMBI`].
 
 These helpers express states for and from EMB-centered propagation (e.g.
 [`crate::propagators::ForceModelConfig::cislunar_default`]).

--- a/src/frames/transform.rs
+++ b/src/frames/transform.rs
@@ -1281,7 +1281,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reference_frame_from_str_aliases() {
+    fn test_celestial_frame_from_str_aliases() {
         assert_eq!(
             "ECI".parse::<CelestialFrame>().unwrap(),
             CelestialFrame::GCRF
@@ -1305,7 +1305,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reference_frame_from_str_rejects_parameterized_variants() {
+    fn test_celestial_frame_from_str_rejects_parameterized_variants() {
         // The generic variants' own Display output is not a valid FromStr
         // input -- they must be constructed directly, per the FromStr
         // doc comment.
@@ -1368,7 +1368,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reference_frame_display() {
+    fn test_celestial_frame_display() {
         assert_eq!(CelestialFrame::GCRF.to_string(), "GCRF");
         assert_eq!(CelestialFrame::LFPA.to_string(), "LFPA");
         assert_eq!(
@@ -1390,7 +1390,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reference_frame_display_from_str_roundtrip() {
+    fn test_celestial_frame_display_from_str_roundtrip() {
         let frames = [
             CelestialFrame::GCRF,
             CelestialFrame::ITRF,
@@ -1409,7 +1409,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reference_frame_center_naif_id() {
+    fn test_celestial_frame_center_naif_id() {
         assert_eq!(CelestialFrame::GCRF.center_naif_id(), 399);
         assert_eq!(CelestialFrame::ITRF.center_naif_id(), 399);
         assert_eq!(CelestialFrame::EME2000.center_naif_id(), 399);
@@ -1433,7 +1433,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reference_frame_serde_roundtrip() {
+    fn test_celestial_frame_serde_roundtrip() {
         let frames = [
             CelestialFrame::GCRF,
             CelestialFrame::LFPA,
@@ -1643,7 +1643,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reference_frame_display_and_center_body_fixed_custom() {
+    fn test_celestial_frame_display_and_center_body_fixed_custom() {
         // The BodyFixedCustom Display and center_naif_id arms are not covered by
         // the other Display/center tests.
         let f = CelestialFrame::BodyFixedCustom {

--- a/src/frames/transform.rs
+++ b/src/frames/transform.rs
@@ -1,7 +1,7 @@
 /*!
  * Centralized reference frame router.
  *
- * This module defines [`ReferenceFrame`], an enum spanning every reference
+ * This module defines [`CelestialFrame`], an enum spanning every reference
  * frame implemented elsewhere in [`crate::frames`], and a small set of
  * router functions (`rotation_frame_to_frame`, `position_frame_to_frame`,
  * `state_frame_to_frame`) that convert between *any* two frames in the
@@ -16,9 +16,9 @@
  * 1. **Orientation**: the state is rotated from the source frame's axes
  *    into ICRF axes (still centered on the source frame's origin), using
  *    the exact pairwise rotation/transport-velocity transform for that
- *    frame. [`ReferenceFrame::GCRF`], [`ReferenceFrame::LCI`],
- *    [`ReferenceFrame::MCI`], [`ReferenceFrame::EMBI`],
- *    [`ReferenceFrame::SSBI`], and [`ReferenceFrame::BodyCenteredICRF`] are
+ *    frame. [`CelestialFrame::GCRF`], [`CelestialFrame::LCI`],
+ *    [`CelestialFrame::MCI`], [`CelestialFrame::EMBI`],
+ *    [`CelestialFrame::SSBI`], and [`CelestialFrame::BodyCenteredICRF`] are
  *    already ICRF-aligned (this crate treats GCRF, LCI, MCI, and the ICRF
  *    as equivalent axes, consistent with [`crate::frames::lunar`] and
  *    [`crate::frames::mars`]), so this step is the identity for them.
@@ -80,7 +80,7 @@ use super::lunar::{rotation_lci_to_lfme, rotation_lci_to_lfpa};
 use super::mars::rotation_mci_to_mcmf;
 
 /// Brahe-internal synthetic center ID for the Sun-Earth barycenter, the
-/// origin of [`ReferenceFrame::SER`]. The SEB has no catalogued NAIF ID
+/// origin of [`CelestialFrame::SER`]. The SEB has no catalogued NAIF ID
 /// or SPK segment; the ID is negative following NAIF's convention for
 /// non-catalogued objects (magnitude mnemonic: Sun 10, Earth 399). It is
 /// never passed to SPK — `center_offset_state` computes the barycenter
@@ -89,11 +89,11 @@ use super::mars::rotation_mci_to_mcmf;
 ///
 /// All center IDs at or below -1_000_000_000 are reserved for synthetic
 /// synodic barycenters encoded by [`synodic_barycenter_id`] (of which this
-/// constant is one instance); see [`ReferenceFrame::BodyFixedCustom`] for
+/// constant is one instance); see [`CelestialFrame::BodyFixedCustom`] for
 /// why a self-assigned center in that range is not rejected.
 pub const SUN_EARTH_BARYCENTER_ID: i32 = -1_000_010_399;
 
-/// Origin choice for a generic [`ReferenceFrame::Synodic`] frame.
+/// Origin choice for a generic [`CelestialFrame::Synodic`] frame.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum SynodicOrigin {
     /// Centered on the primary body.
@@ -112,7 +112,7 @@ pub enum SynodicOrigin {
 /// [`SUN_EARTH_BARYCENTER_ID`] is this encoding evaluated at `(10, 399)`.
 ///
 /// The full range at or below -1_000_000_000 is reserved for these synthetic
-/// barycenters; see [`ReferenceFrame::BodyFixedCustom`] for why a
+/// barycenters; see [`CelestialFrame::BodyFixedCustom`] for why a
 /// user-registered custom frame is nonetheless allowed to self-assign a
 /// center in that range.
 ///
@@ -176,12 +176,12 @@ fn synthetic_barycenter_pair(center: i32) -> Option<(i32, i32)> {
 /// - `Synodic { origin, primary, secondary }`: a generic two-body synodic
 ///   (rotating) frame for an arbitrary primary/secondary pair, of which
 ///   `EMR`/`SER`/`GSE` are specific configurations (see
-///   [`ReferenceFrame::Synodic`]).
+///   [`CelestialFrame::Synodic`]).
 ///
 /// See the module-level documentation for the full center table and the
 /// hub-and-spoke conversion design.
 #[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
-pub enum ReferenceFrame {
+pub enum CelestialFrame {
     /// Geocentric Celestial Reference Frame (ICRF-aligned, Earth-centered).
     GCRF,
     /// International Terrestrial Reference Frame (Earth-fixed).
@@ -273,14 +273,14 @@ pub enum ReferenceFrame {
     },
 }
 
-impl ReferenceFrame {
-    /// Alias for [`ReferenceFrame::GCRF`]: the crate's Earth-Centered
+impl CelestialFrame {
+    /// Alias for [`CelestialFrame::GCRF`]: the crate's Earth-Centered
     /// Inertial (ECI) frame is realized as GCRF.
-    pub const ECI: ReferenceFrame = ReferenceFrame::GCRF;
+    pub const ECI: CelestialFrame = CelestialFrame::GCRF;
 
-    /// Alias for [`ReferenceFrame::ITRF`]: the crate's Earth-Centered
+    /// Alias for [`CelestialFrame::ITRF`]: the crate's Earth-Centered
     /// Earth-Fixed (ECEF) frame is realized as ITRF.
-    pub const ECEF: ReferenceFrame = ReferenceFrame::ITRF;
+    pub const ECEF: CelestialFrame = CelestialFrame::ITRF;
 
     /// NAIF ID of this frame's origin.
     ///
@@ -292,28 +292,28 @@ impl ReferenceFrame {
     ///
     /// # Examples:
     /// ```
-    /// use brahe::frames::ReferenceFrame;
+    /// use brahe::frames::CelestialFrame;
     ///
-    /// assert_eq!(ReferenceFrame::GCRF.center_naif_id(), 399);
-    /// assert_eq!(ReferenceFrame::LCI.center_naif_id(), 301);
+    /// assert_eq!(CelestialFrame::GCRF.center_naif_id(), 399);
+    /// assert_eq!(CelestialFrame::LCI.center_naif_id(), 301);
     /// ```
     pub fn center_naif_id(&self) -> i32 {
         match self {
-            ReferenceFrame::GCRF | ReferenceFrame::ITRF | ReferenceFrame::EME2000 => {
+            CelestialFrame::GCRF | CelestialFrame::ITRF | CelestialFrame::EME2000 => {
                 NAIFId::Earth.id()
             }
-            ReferenceFrame::LCI | ReferenceFrame::LFPA | ReferenceFrame::LFME => NAIFId::Moon.id(),
-            ReferenceFrame::MCI | ReferenceFrame::MCMF => NAIFId::Mars.id(),
-            ReferenceFrame::EMBI => NAIFId::EarthMoonBarycenter.id(),
-            ReferenceFrame::SSBI => NAIFId::SolarSystemBarycenter.id(),
-            ReferenceFrame::EMR => NAIFId::EarthMoonBarycenter.id(),
-            ReferenceFrame::SER => SUN_EARTH_BARYCENTER_ID,
-            ReferenceFrame::GSE => NAIFId::Earth.id(),
-            ReferenceFrame::BodyCenteredICRF(id) => *id,
-            ReferenceFrame::BodyFixedIAU(id) => *id,
-            ReferenceFrame::BodyFixedPCK { center, .. } => *center,
-            ReferenceFrame::BodyFixedCustom { center, .. } => *center,
-            ReferenceFrame::Synodic {
+            CelestialFrame::LCI | CelestialFrame::LFPA | CelestialFrame::LFME => NAIFId::Moon.id(),
+            CelestialFrame::MCI | CelestialFrame::MCMF => NAIFId::Mars.id(),
+            CelestialFrame::EMBI => NAIFId::EarthMoonBarycenter.id(),
+            CelestialFrame::SSBI => NAIFId::SolarSystemBarycenter.id(),
+            CelestialFrame::EMR => NAIFId::EarthMoonBarycenter.id(),
+            CelestialFrame::SER => SUN_EARTH_BARYCENTER_ID,
+            CelestialFrame::GSE => NAIFId::Earth.id(),
+            CelestialFrame::BodyCenteredICRF(id) => *id,
+            CelestialFrame::BodyFixedIAU(id) => *id,
+            CelestialFrame::BodyFixedPCK { center, .. } => *center,
+            CelestialFrame::BodyFixedCustom { center, .. } => *center,
+            CelestialFrame::Synodic {
                 origin,
                 primary,
                 secondary,
@@ -331,38 +331,38 @@ impl ReferenceFrame {
     /// otherwise.
     fn state_to_icrf_axes(&self, epc: Epoch, x: SVector6) -> Result<SVector6, BraheError> {
         match self {
-            ReferenceFrame::GCRF
-            | ReferenceFrame::LCI
-            | ReferenceFrame::MCI
-            | ReferenceFrame::EMBI
-            | ReferenceFrame::SSBI
-            | ReferenceFrame::BodyCenteredICRF(_) => Ok(x),
-            ReferenceFrame::ITRF => Ok(super::gcrf_itrf::state_itrf_to_gcrf(epc, x)),
-            ReferenceFrame::EME2000 => Ok(super::eme_2000::state_eme2000_to_gcrf(x)),
-            ReferenceFrame::LFPA => Ok(super::lunar::state_lfpa_to_lci(epc, x)),
-            ReferenceFrame::LFME => Ok(super::lunar::state_lfme_to_lci(epc, x)),
-            ReferenceFrame::MCMF => Ok(super::mars::state_mcmf_to_mci(epc, x)),
-            ReferenceFrame::EMR => {
+            CelestialFrame::GCRF
+            | CelestialFrame::LCI
+            | CelestialFrame::MCI
+            | CelestialFrame::EMBI
+            | CelestialFrame::SSBI
+            | CelestialFrame::BodyCenteredICRF(_) => Ok(x),
+            CelestialFrame::ITRF => Ok(super::gcrf_itrf::state_itrf_to_gcrf(epc, x)),
+            CelestialFrame::EME2000 => Ok(super::eme_2000::state_eme2000_to_gcrf(x)),
+            CelestialFrame::LFPA => Ok(super::lunar::state_lfpa_to_lci(epc, x)),
+            CelestialFrame::LFME => Ok(super::lunar::state_lfme_to_lci(epc, x)),
+            CelestialFrame::MCMF => Ok(super::mars::state_mcmf_to_mci(epc, x)),
+            CelestialFrame::EMR => {
                 let (s, s_dot) = super::synodic::emr_axes(epc)?;
                 Ok(super::synodic::state_synodic_to_inertial(&s, &s_dot, x))
             }
-            ReferenceFrame::SER => {
+            CelestialFrame::SER => {
                 let (s, s_dot) = super::synodic::ser_axes(epc)?;
                 Ok(super::synodic::state_synodic_to_inertial(&s, &s_dot, x))
             }
-            ReferenceFrame::GSE => {
+            CelestialFrame::GSE => {
                 let (s, s_dot) = super::synodic::gse_axes(epc)?;
                 Ok(super::synodic::state_synodic_to_inertial(&s, &s_dot, x))
             }
-            ReferenceFrame::BodyFixedIAU(id) => state_iau_body_to_icrf(*id, epc, x),
-            ReferenceFrame::BodyFixedPCK { frame_id, .. } => {
+            CelestialFrame::BodyFixedIAU(id) => state_iau_body_to_icrf(*id, epc, x),
+            CelestialFrame::BodyFixedPCK { frame_id, .. } => {
                 state_pck_body_to_icrf(*frame_id, epc, x)
             }
-            ReferenceFrame::BodyFixedCustom { key, .. } => {
+            CelestialFrame::BodyFixedCustom { key, .. } => {
                 let (r_mat, omega) = super::custom::custom_frame_rotation_and_omega(*key, epc)?;
                 Ok(state_rotating_to_icrf(r_mat, omega, x))
             }
-            ReferenceFrame::Synodic {
+            CelestialFrame::Synodic {
                 primary, secondary, ..
             } => {
                 let (s, s_dot) = super::synodic::generic_synodic_axes(epc, *primary, *secondary)?;
@@ -373,47 +373,47 @@ impl ReferenceFrame {
 
     /// Rotates an ICRF-axis state (already translated to this frame's
     /// origin) into this frame's own axes. Inverse of
-    /// [`ReferenceFrame::state_to_icrf_axes`].
+    /// [`CelestialFrame::state_to_icrf_axes`].
     fn state_from_icrf_axes(&self, epc: Epoch, x_icrf: SVector6) -> Result<SVector6, BraheError> {
         match self {
-            ReferenceFrame::GCRF
-            | ReferenceFrame::LCI
-            | ReferenceFrame::MCI
-            | ReferenceFrame::EMBI
-            | ReferenceFrame::SSBI
-            | ReferenceFrame::BodyCenteredICRF(_) => Ok(x_icrf),
-            ReferenceFrame::ITRF => Ok(super::gcrf_itrf::state_gcrf_to_itrf(epc, x_icrf)),
-            ReferenceFrame::EME2000 => Ok(super::eme_2000::state_gcrf_to_eme2000(x_icrf)),
-            ReferenceFrame::LFPA => Ok(super::lunar::state_lci_to_lfpa(epc, x_icrf)),
-            ReferenceFrame::LFME => Ok(super::lunar::state_lci_to_lfme(epc, x_icrf)),
-            ReferenceFrame::MCMF => Ok(super::mars::state_mci_to_mcmf(epc, x_icrf)),
-            ReferenceFrame::EMR => {
+            CelestialFrame::GCRF
+            | CelestialFrame::LCI
+            | CelestialFrame::MCI
+            | CelestialFrame::EMBI
+            | CelestialFrame::SSBI
+            | CelestialFrame::BodyCenteredICRF(_) => Ok(x_icrf),
+            CelestialFrame::ITRF => Ok(super::gcrf_itrf::state_gcrf_to_itrf(epc, x_icrf)),
+            CelestialFrame::EME2000 => Ok(super::eme_2000::state_gcrf_to_eme2000(x_icrf)),
+            CelestialFrame::LFPA => Ok(super::lunar::state_lci_to_lfpa(epc, x_icrf)),
+            CelestialFrame::LFME => Ok(super::lunar::state_lci_to_lfme(epc, x_icrf)),
+            CelestialFrame::MCMF => Ok(super::mars::state_mci_to_mcmf(epc, x_icrf)),
+            CelestialFrame::EMR => {
                 let (s, s_dot) = super::synodic::emr_axes(epc)?;
                 Ok(super::synodic::state_inertial_to_synodic(
                     &s, &s_dot, x_icrf,
                 ))
             }
-            ReferenceFrame::SER => {
+            CelestialFrame::SER => {
                 let (s, s_dot) = super::synodic::ser_axes(epc)?;
                 Ok(super::synodic::state_inertial_to_synodic(
                     &s, &s_dot, x_icrf,
                 ))
             }
-            ReferenceFrame::GSE => {
+            CelestialFrame::GSE => {
                 let (s, s_dot) = super::synodic::gse_axes(epc)?;
                 Ok(super::synodic::state_inertial_to_synodic(
                     &s, &s_dot, x_icrf,
                 ))
             }
-            ReferenceFrame::BodyFixedIAU(id) => state_icrf_to_iau_body(*id, epc, x_icrf),
-            ReferenceFrame::BodyFixedPCK { frame_id, .. } => {
+            CelestialFrame::BodyFixedIAU(id) => state_icrf_to_iau_body(*id, epc, x_icrf),
+            CelestialFrame::BodyFixedPCK { frame_id, .. } => {
                 state_icrf_to_pck_body(*frame_id, epc, x_icrf)
             }
-            ReferenceFrame::BodyFixedCustom { key, .. } => {
+            CelestialFrame::BodyFixedCustom { key, .. } => {
                 let (r_mat, omega) = super::custom::custom_frame_rotation_and_omega(*key, epc)?;
                 Ok(state_icrf_to_rotating(r_mat, omega, x_icrf))
             }
-            ReferenceFrame::Synodic {
+            CelestialFrame::Synodic {
                 primary, secondary, ..
             } => {
                 let (s, s_dot) = super::synodic::generic_synodic_axes(epc, *primary, *secondary)?;
@@ -425,31 +425,31 @@ impl ReferenceFrame {
     }
 }
 
-impl fmt::Display for ReferenceFrame {
+impl fmt::Display for CelestialFrame {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            ReferenceFrame::GCRF => write!(f, "GCRF"),
-            ReferenceFrame::ITRF => write!(f, "ITRF"),
-            ReferenceFrame::EME2000 => write!(f, "EME2000"),
-            ReferenceFrame::LCI => write!(f, "LCI"),
-            ReferenceFrame::LFPA => write!(f, "LFPA"),
-            ReferenceFrame::LFME => write!(f, "LFME"),
-            ReferenceFrame::MCI => write!(f, "MCI"),
-            ReferenceFrame::MCMF => write!(f, "MCMF"),
-            ReferenceFrame::EMBI => write!(f, "EMBI"),
-            ReferenceFrame::SSBI => write!(f, "SSBI"),
-            ReferenceFrame::EMR => write!(f, "EMR"),
-            ReferenceFrame::SER => write!(f, "SER"),
-            ReferenceFrame::GSE => write!(f, "GSE"),
-            ReferenceFrame::BodyCenteredICRF(id) => write!(f, "BodyCenteredICRF({})", id),
-            ReferenceFrame::BodyFixedIAU(id) => write!(f, "BodyFixedIAU({})", id),
-            ReferenceFrame::BodyFixedPCK { center, frame_id } => {
+            CelestialFrame::GCRF => write!(f, "GCRF"),
+            CelestialFrame::ITRF => write!(f, "ITRF"),
+            CelestialFrame::EME2000 => write!(f, "EME2000"),
+            CelestialFrame::LCI => write!(f, "LCI"),
+            CelestialFrame::LFPA => write!(f, "LFPA"),
+            CelestialFrame::LFME => write!(f, "LFME"),
+            CelestialFrame::MCI => write!(f, "MCI"),
+            CelestialFrame::MCMF => write!(f, "MCMF"),
+            CelestialFrame::EMBI => write!(f, "EMBI"),
+            CelestialFrame::SSBI => write!(f, "SSBI"),
+            CelestialFrame::EMR => write!(f, "EMR"),
+            CelestialFrame::SER => write!(f, "SER"),
+            CelestialFrame::GSE => write!(f, "GSE"),
+            CelestialFrame::BodyCenteredICRF(id) => write!(f, "BodyCenteredICRF({})", id),
+            CelestialFrame::BodyFixedIAU(id) => write!(f, "BodyFixedIAU({})", id),
+            CelestialFrame::BodyFixedPCK { center, frame_id } => {
                 write!(f, "BodyFixedPCK(center={}, frame_id={})", center, frame_id)
             }
-            ReferenceFrame::BodyFixedCustom { center, key } => {
+            CelestialFrame::BodyFixedCustom { center, key } => {
                 write!(f, "BodyFixedCustom(center={}, key={})", center, key)
             }
-            ReferenceFrame::Synodic {
+            CelestialFrame::Synodic {
                 origin,
                 primary,
                 secondary,
@@ -462,34 +462,34 @@ impl fmt::Display for ReferenceFrame {
     }
 }
 
-impl FromStr for ReferenceFrame {
+impl FromStr for CelestialFrame {
     type Err = BraheError;
 
-    /// Parses a [`ReferenceFrame`] from its [`Display`](fmt::Display)
+    /// Parses a [`CelestialFrame`] from its [`Display`](fmt::Display)
     /// representation (named variants only, case-insensitive), plus the
-    /// common aliases `"ECI"` (-> [`ReferenceFrame::GCRF`]) and `"ECEF"`
-    /// (-> [`ReferenceFrame::ITRF`]).
+    /// common aliases `"ECI"` (-> [`CelestialFrame::GCRF`]) and `"ECEF"`
+    /// (-> [`CelestialFrame::ITRF`]).
     ///
     /// The generic variants (`BodyCenteredICRF`, `BodyFixedIAU`,
     /// `BodyFixedPCK`, `BodyFixedCustom`, `Synodic`) are not parseable from
     /// a string; construct them directly.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_ascii_uppercase().as_str() {
-            "ECI" => Ok(ReferenceFrame::GCRF),
-            "ECEF" => Ok(ReferenceFrame::ITRF),
-            "GCRF" => Ok(ReferenceFrame::GCRF),
-            "ITRF" => Ok(ReferenceFrame::ITRF),
-            "EME2000" => Ok(ReferenceFrame::EME2000),
-            "LCI" => Ok(ReferenceFrame::LCI),
-            "LFPA" => Ok(ReferenceFrame::LFPA),
-            "LFME" => Ok(ReferenceFrame::LFME),
-            "MCI" => Ok(ReferenceFrame::MCI),
-            "MCMF" => Ok(ReferenceFrame::MCMF),
-            "EMBI" => Ok(ReferenceFrame::EMBI),
-            "SSBI" => Ok(ReferenceFrame::SSBI),
-            "EMR" => Ok(ReferenceFrame::EMR),
-            "SER" => Ok(ReferenceFrame::SER),
-            "GSE" => Ok(ReferenceFrame::GSE),
+            "ECI" => Ok(CelestialFrame::GCRF),
+            "ECEF" => Ok(CelestialFrame::ITRF),
+            "GCRF" => Ok(CelestialFrame::GCRF),
+            "ITRF" => Ok(CelestialFrame::ITRF),
+            "EME2000" => Ok(CelestialFrame::EME2000),
+            "LCI" => Ok(CelestialFrame::LCI),
+            "LFPA" => Ok(CelestialFrame::LFPA),
+            "LFME" => Ok(CelestialFrame::LFME),
+            "MCI" => Ok(CelestialFrame::MCI),
+            "MCMF" => Ok(CelestialFrame::MCMF),
+            "EMBI" => Ok(CelestialFrame::EMBI),
+            "SSBI" => Ok(CelestialFrame::SSBI),
+            "EMR" => Ok(CelestialFrame::EMR),
+            "SER" => Ok(CelestialFrame::SER),
+            "GSE" => Ok(CelestialFrame::GSE),
             _ => Err(BraheError::ParseError(format!(
                 "Unknown reference frame '{}'. Supported: GCRF (alias ECI), ITRF (alias ECEF), \
                  EME2000, LCI, LFPA, LFME, MCI, MCMF, EMBI, SSBI, EMR, SER, GSE",
@@ -591,7 +591,7 @@ pub(crate) fn apply_state_rotating_to_icrf(
 /// Rotates an ICRF-axis state into the IAU/WGCCRE body-fixed frame of
 /// `naif_id`, including the velocity transport term induced by the
 /// body's rotation. Generic form of [`super::mars::state_mci_to_mcmf`],
-/// parameterized over `naif_id` for use by [`ReferenceFrame::BodyFixedIAU`].
+/// parameterized over `naif_id` for use by [`CelestialFrame::BodyFixedIAU`].
 fn state_icrf_to_iau_body(
     naif_id: i32,
     epc: Epoch,
@@ -626,7 +626,7 @@ fn state_iau_body_to_icrf(
 /// PCK `frame_id`, including the velocity transport term induced by the
 /// frame's rotation. This is a general SPICE-PCK-backed transformation,
 /// parameterized over `frame_id` for use by
-/// [`ReferenceFrame::BodyFixedPCK`]. Unlike the lunar-specific helpers
+/// [`CelestialFrame::BodyFixedPCK`]. Unlike the lunar-specific helpers
 /// (e.g. [`super::lunar::state_lci_to_lfpa`]), this does not auto-load any
 /// PCK — the caller's kernel must already be loaded (see
 /// [`crate::spice::pck_rotation_matrix`]).
@@ -662,30 +662,30 @@ fn state_pck_body_to_icrf(
 
 /// Rotation matrix from ICRF axes to `frame`'s own axes at `epc`. Identity
 /// for ICRF-aligned frames.
-fn icrf_to_frame_dcm(frame: ReferenceFrame, epc: Epoch) -> Result<SMatrix3, BraheError> {
+fn icrf_to_frame_dcm(frame: CelestialFrame, epc: Epoch) -> Result<SMatrix3, BraheError> {
     match frame {
-        ReferenceFrame::GCRF
-        | ReferenceFrame::LCI
-        | ReferenceFrame::MCI
-        | ReferenceFrame::EMBI
-        | ReferenceFrame::SSBI
-        | ReferenceFrame::BodyCenteredICRF(_) => Ok(SMatrix3::identity()),
-        ReferenceFrame::ITRF => Ok(rotation_gcrf_to_itrf(epc)),
-        ReferenceFrame::EME2000 => Ok(rotation_gcrf_to_eme2000()),
-        ReferenceFrame::LFPA => Ok(rotation_lci_to_lfpa(epc)),
-        ReferenceFrame::LFME => Ok(rotation_lci_to_lfme(epc)),
-        ReferenceFrame::MCMF => Ok(rotation_mci_to_mcmf(epc)),
-        ReferenceFrame::EMR => Ok(super::synodic::emr_axes(epc)?.0),
-        ReferenceFrame::SER => Ok(super::synodic::ser_axes(epc)?.0),
-        ReferenceFrame::GSE => Ok(super::synodic::gse_axes(epc)?.0),
-        ReferenceFrame::BodyFixedIAU(id) => rotation_icrf_to_body_fixed_iau(id, epc),
-        ReferenceFrame::BodyFixedPCK { frame_id, .. } => {
+        CelestialFrame::GCRF
+        | CelestialFrame::LCI
+        | CelestialFrame::MCI
+        | CelestialFrame::EMBI
+        | CelestialFrame::SSBI
+        | CelestialFrame::BodyCenteredICRF(_) => Ok(SMatrix3::identity()),
+        CelestialFrame::ITRF => Ok(rotation_gcrf_to_itrf(epc)),
+        CelestialFrame::EME2000 => Ok(rotation_gcrf_to_eme2000()),
+        CelestialFrame::LFPA => Ok(rotation_lci_to_lfpa(epc)),
+        CelestialFrame::LFME => Ok(rotation_lci_to_lfme(epc)),
+        CelestialFrame::MCMF => Ok(rotation_mci_to_mcmf(epc)),
+        CelestialFrame::EMR => Ok(super::synodic::emr_axes(epc)?.0),
+        CelestialFrame::SER => Ok(super::synodic::ser_axes(epc)?.0),
+        CelestialFrame::GSE => Ok(super::synodic::gse_axes(epc)?.0),
+        CelestialFrame::BodyFixedIAU(id) => rotation_icrf_to_body_fixed_iau(id, epc),
+        CelestialFrame::BodyFixedPCK { frame_id, .. } => {
             crate::spice::pck_rotation_matrix(frame_id, epc).map(|r| r.to_matrix())
         }
-        ReferenceFrame::BodyFixedCustom { key, .. } => {
+        CelestialFrame::BodyFixedCustom { key, .. } => {
             super::custom::custom_frame_rotation(key, epc)
         }
-        ReferenceFrame::Synodic {
+        CelestialFrame::Synodic {
             primary, secondary, ..
         } => Ok(super::synodic::generic_synodic_axes(epc, primary, secondary)?.0),
     }
@@ -712,15 +712,15 @@ fn icrf_to_frame_dcm(frame: ReferenceFrame, epc: Epoch) -> Result<SMatrix3, Brah
 ///
 /// # Examples:
 /// ```
-/// use brahe::frames::{ReferenceFrame, rotation_frame_to_frame};
+/// use brahe::frames::{CelestialFrame, rotation_frame_to_frame};
 /// use brahe::time::{Epoch, TimeSystem};
 ///
 /// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
-/// let r = rotation_frame_to_frame(ReferenceFrame::MCI, ReferenceFrame::MCMF, epc).unwrap();
+/// let r = rotation_frame_to_frame(CelestialFrame::MCI, CelestialFrame::MCMF, epc).unwrap();
 /// ```
 pub fn rotation_frame_to_frame(
-    from: ReferenceFrame,
-    to: ReferenceFrame,
+    from: CelestialFrame,
+    to: CelestialFrame,
     epc: Epoch,
 ) -> Result<SMatrix3, BraheError> {
     if from == to {
@@ -751,18 +751,18 @@ pub fn rotation_frame_to_frame(
 /// # Examples:
 /// ```no_run
 /// use brahe::constants::R_EARTH;
-/// use brahe::frames::{ReferenceFrame, position_frame_to_frame};
+/// use brahe::frames::{CelestialFrame, position_frame_to_frame};
 /// use brahe::time::{Epoch, TimeSystem};
 /// use nalgebra::Vector3;
 ///
 /// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
 /// let x_gcrf = Vector3::new(R_EARTH + 500e3, 0.0, 0.0);
 /// let x_itrf =
-///     position_frame_to_frame(ReferenceFrame::GCRF, ReferenceFrame::ITRF, epc, x_gcrf).unwrap();
+///     position_frame_to_frame(CelestialFrame::GCRF, CelestialFrame::ITRF, epc, x_gcrf).unwrap();
 /// ```
 pub fn position_frame_to_frame(
-    from: ReferenceFrame,
-    to: ReferenceFrame,
+    from: CelestialFrame,
+    to: CelestialFrame,
     epc: Epoch,
     x: Vector3<f64>,
 ) -> Result<Vector3<f64>, BraheError> {
@@ -797,16 +797,16 @@ struct FramePairContext {
 /// # Examples
 ///
 /// ```ignore
-/// use brahe::frames::ReferenceFrame;
+/// use brahe::frames::CelestialFrame;
 /// use brahe::time::{Epoch, TimeSystem};
 ///
 /// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
-/// let c = frame_pair_context(ReferenceFrame::GCRF, ReferenceFrame::ITRF, epc).unwrap();
+/// let c = frame_pair_context(CelestialFrame::GCRF, CelestialFrame::ITRF, epc).unwrap();
 /// // c.offset is None because both frames share the Earth center
 /// ```
 fn frame_pair_context(
-    from: ReferenceFrame,
-    to: ReferenceFrame,
+    from: CelestialFrame,
+    to: CelestialFrame,
     epc: Epoch,
 ) -> Result<FramePairContext, BraheError> {
     let r_from = icrf_to_frame_dcm(from, epc)?;
@@ -836,12 +836,12 @@ fn frame_pair_context(
 /// # Examples
 ///
 /// ```ignore
-/// use brahe::frames::ReferenceFrame;
+/// use brahe::frames::CelestialFrame;
 /// use brahe::time::{Epoch, TimeSystem};
 /// use nalgebra::Vector3;
 ///
 /// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
-/// let c = frame_pair_context(ReferenceFrame::GCRF, ReferenceFrame::ITRF, epc).unwrap();
+/// let c = frame_pair_context(CelestialFrame::GCRF, CelestialFrame::ITRF, epc).unwrap();
 /// let x_itrf = apply_position_frame_pair(&c, &Vector3::new(7.0e6, 0.0, 0.0));
 /// ```
 fn apply_position_frame_pair(c: &FramePairContext, x: &Vector3<f64>) -> Vector3<f64> {
@@ -879,18 +879,18 @@ fn apply_position_frame_pair(c: &FramePairContext, x: &Vector3<f64>) -> Vector3<
 /// # Examples:
 /// ```no_run
 /// use brahe::constants::R_MOON;
-/// use brahe::frames::{ReferenceFrame, state_frame_to_frame};
+/// use brahe::frames::{CelestialFrame, state_frame_to_frame};
 /// use brahe::math::vector6_from_array;
 /// use brahe::time::{Epoch, TimeSystem};
 ///
 /// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
 /// let x_gcrf = vector6_from_array([1e8, -2e8, 5e7, 1.0e3, -2.0e3, 0.5e3]);
 /// let x_lfpa =
-///     state_frame_to_frame(ReferenceFrame::GCRF, ReferenceFrame::LFPA, epc, x_gcrf).unwrap();
+///     state_frame_to_frame(CelestialFrame::GCRF, CelestialFrame::LFPA, epc, x_gcrf).unwrap();
 /// ```
 pub fn state_frame_to_frame(
-    from: ReferenceFrame,
-    to: ReferenceFrame,
+    from: CelestialFrame,
+    to: CelestialFrame,
     epc: Epoch,
     x: SVector6,
 ) -> Result<SVector6, BraheError> {
@@ -922,17 +922,17 @@ pub fn state_frame_to_frame(
 ///
 /// # Examples:
 /// ```
-/// use brahe::frames::{ReferenceFrame, rotations_frame_to_frame};
+/// use brahe::frames::{CelestialFrame, rotations_frame_to_frame};
 /// use brahe::time::{Epoch, TimeSystem};
 ///
 /// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
 /// let epochs = vec![epc, epc + 60.0];
-/// let r = rotations_frame_to_frame(ReferenceFrame::MCI, ReferenceFrame::MCMF, &epochs).unwrap();
+/// let r = rotations_frame_to_frame(CelestialFrame::MCI, CelestialFrame::MCMF, &epochs).unwrap();
 /// assert_eq!(r.len(), 2);
 /// ```
 pub fn rotations_frame_to_frame(
-    from: ReferenceFrame,
-    to: ReferenceFrame,
+    from: CelestialFrame,
+    to: CelestialFrame,
     epochs: &[Epoch],
 ) -> Result<Vec<SMatrix3>, BraheError> {
     try_batch_map(|epc| rotation_frame_to_frame(from, to, *epc), epochs)
@@ -962,7 +962,7 @@ pub fn rotations_frame_to_frame(
 /// use brahe::eop::*;
 /// use brahe::constants::R_EARTH;
 /// use brahe::vector3_from_array;
-/// use brahe::frames::{ReferenceFrame, positions_frame_to_frame};
+/// use brahe::frames::{CelestialFrame, positions_frame_to_frame};
 /// use brahe::time::{Epoch, TimeSystem};
 ///
 /// let eop = FileEOPProvider::from_default_file(EOPType::StandardBulletinA, true, EOPExtrapolation::Zero).unwrap();
@@ -970,12 +970,12 @@ pub fn rotations_frame_to_frame(
 ///
 /// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
 /// let positions = vec![vector3_from_array([R_EARTH + 500e3, 0.0, 0.0]); 3];
-/// let x_itrf = positions_frame_to_frame(ReferenceFrame::GCRF, ReferenceFrame::ITRF, &[epc], &positions).unwrap();
+/// let x_itrf = positions_frame_to_frame(CelestialFrame::GCRF, CelestialFrame::ITRF, &[epc], &positions).unwrap();
 /// assert_eq!(x_itrf.len(), 3);
 /// ```
 pub fn positions_frame_to_frame(
-    from: ReferenceFrame,
-    to: ReferenceFrame,
+    from: CelestialFrame,
+    to: CelestialFrame,
     epochs: &[Epoch],
     x: &[Vector3<f64>],
 ) -> Result<Vec<Vector3<f64>>, BraheError> {
@@ -1018,7 +1018,7 @@ pub fn positions_frame_to_frame(
 /// use brahe::constants::R_EARTH;
 /// use brahe::vector6_from_array;
 /// use brahe::orbits::perigee_velocity;
-/// use brahe::frames::{ReferenceFrame, states_frame_to_frame};
+/// use brahe::frames::{CelestialFrame, states_frame_to_frame};
 /// use brahe::time::{Epoch, TimeSystem};
 ///
 /// let eop = FileEOPProvider::from_default_file(EOPType::StandardBulletinA, true, EOPExtrapolation::Zero).unwrap();
@@ -1027,12 +1027,12 @@ pub fn positions_frame_to_frame(
 /// let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
 /// let v = perigee_velocity(R_EARTH + 500e3, 0.0);
 /// let states = vec![vector6_from_array([R_EARTH + 500e3, 0.0, 0.0, 0.0, v, 0.0]); 3];
-/// let x_itrf = states_frame_to_frame(ReferenceFrame::GCRF, ReferenceFrame::ITRF, &[epc], &states).unwrap();
+/// let x_itrf = states_frame_to_frame(CelestialFrame::GCRF, CelestialFrame::ITRF, &[epc], &states).unwrap();
 /// assert_eq!(x_itrf.len(), 3);
 /// ```
 pub fn states_frame_to_frame(
-    from: ReferenceFrame,
-    to: ReferenceFrame,
+    from: CelestialFrame,
+    to: CelestialFrame,
     epochs: &[Epoch],
     x: &[SVector6],
 ) -> Result<Vec<SVector6>, BraheError> {
@@ -1127,7 +1127,7 @@ mod tests {
             DEGREES,
         );
         let via_router =
-            state_frame_to_frame(ReferenceFrame::GCRF, ReferenceFrame::ITRF, epc, x).unwrap();
+            state_frame_to_frame(CelestialFrame::GCRF, CelestialFrame::ITRF, epc, x).unwrap();
         let pairwise = crate::frames::state_gcrf_to_itrf(epc, x);
         for i in 0..6 {
             // bit-identical: same-center path must not touch SPK
@@ -1143,7 +1143,7 @@ mod tests {
         let x = vector6_from_array([1e8, -2e8, 5e7, 1.0e3, -2.0e3, 0.5e3]);
 
         let via_router =
-            state_frame_to_frame(ReferenceFrame::GCRF, ReferenceFrame::LCI, epc, x).unwrap();
+            state_frame_to_frame(CelestialFrame::GCRF, CelestialFrame::LCI, epc, x).unwrap();
         let pairwise = crate::frames::state_eci_to_lci(epc, x);
         for i in 0..6 {
             assert_abs_diff_eq!(via_router[i], pairwise[i], epsilon = 1e-9);
@@ -1151,14 +1151,14 @@ mod tests {
 
         let x_lci = via_router;
         let via_router_lfpa =
-            state_frame_to_frame(ReferenceFrame::LCI, ReferenceFrame::LFPA, epc, x_lci).unwrap();
+            state_frame_to_frame(CelestialFrame::LCI, CelestialFrame::LFPA, epc, x_lci).unwrap();
         let pairwise_lfpa = crate::frames::state_lci_to_lfpa(epc, x_lci);
         for i in 0..6 {
             assert_eq!(via_router_lfpa[i], pairwise_lfpa[i]); // same-center, bit-identical
         }
 
         let via_router_composed =
-            state_frame_to_frame(ReferenceFrame::GCRF, ReferenceFrame::LFPA, epc, x).unwrap();
+            state_frame_to_frame(CelestialFrame::GCRF, CelestialFrame::LFPA, epc, x).unwrap();
         let composed =
             crate::frames::state_lci_to_lfpa(epc, crate::frames::state_eci_to_lci(epc, x));
         for i in 0..6 {
@@ -1175,19 +1175,19 @@ mod tests {
 
         for (frame, pairwise) in [
             (
-                ReferenceFrame::EMR,
+                CelestialFrame::EMR,
                 crate::frames::state_gcrf_to_emr(epc, x).unwrap(),
             ),
             (
-                ReferenceFrame::SER,
+                CelestialFrame::SER,
                 crate::frames::state_gcrf_to_ser(epc, x).unwrap(),
             ),
             (
-                ReferenceFrame::GSE,
+                CelestialFrame::GSE,
                 crate::frames::state_gcrf_to_gse(epc, x).unwrap(),
             ),
         ] {
-            let via_router = state_frame_to_frame(ReferenceFrame::GCRF, frame, epc, x).unwrap();
+            let via_router = state_frame_to_frame(CelestialFrame::GCRF, frame, epc, x).unwrap();
             for i in 0..6 {
                 assert_abs_diff_eq!(via_router[i], pairwise[i], epsilon = 1e-9);
             }
@@ -1202,8 +1202,8 @@ mod tests {
         setup_global_test_spice();
         let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
         let x_moon_emr = state_frame_to_frame(
-            ReferenceFrame::LCI,
-            ReferenceFrame::EMR,
+            CelestialFrame::LCI,
+            CelestialFrame::EMR,
             epc,
             SVector6::zeros(),
         )
@@ -1218,20 +1218,20 @@ mod tests {
     #[test]
     fn test_synodic_frame_parse_and_display() {
         for (s, f) in [
-            ("EMR", ReferenceFrame::EMR),
-            ("SER", ReferenceFrame::SER),
-            ("GSE", ReferenceFrame::GSE),
-            ("emr", ReferenceFrame::EMR),
+            ("EMR", CelestialFrame::EMR),
+            ("SER", CelestialFrame::SER),
+            ("GSE", CelestialFrame::GSE),
+            ("emr", CelestialFrame::EMR),
         ] {
-            assert_eq!(s.parse::<ReferenceFrame>().unwrap(), f);
+            assert_eq!(s.parse::<CelestialFrame>().unwrap(), f);
         }
-        assert_eq!(ReferenceFrame::EMR.to_string(), "EMR");
-        assert_eq!(ReferenceFrame::SER.to_string(), "SER");
-        assert_eq!(ReferenceFrame::GSE.to_string(), "GSE");
-        assert_eq!(ReferenceFrame::EMR.center_naif_id(), 3);
-        assert_eq!(ReferenceFrame::GSE.center_naif_id(), 399);
+        assert_eq!(CelestialFrame::EMR.to_string(), "EMR");
+        assert_eq!(CelestialFrame::SER.to_string(), "SER");
+        assert_eq!(CelestialFrame::GSE.to_string(), "GSE");
+        assert_eq!(CelestialFrame::EMR.center_naif_id(), 3);
+        assert_eq!(CelestialFrame::GSE.center_naif_id(), 399);
         assert_eq!(
-            ReferenceFrame::SER.center_naif_id(),
+            CelestialFrame::SER.center_naif_id(),
             SUN_EARTH_BARYCENTER_ID
         );
     }
@@ -1242,19 +1242,19 @@ mod tests {
         setup_global_test_eop();
         setup_global_test_spice();
         let frames = [
-            ReferenceFrame::GCRF,
-            ReferenceFrame::ITRF,
-            ReferenceFrame::EME2000,
-            ReferenceFrame::LCI,
-            ReferenceFrame::LFPA,
-            ReferenceFrame::LFME,
-            ReferenceFrame::MCI,
-            ReferenceFrame::MCMF,
-            ReferenceFrame::EMBI,
-            ReferenceFrame::SSBI,
-            ReferenceFrame::EMR,
-            ReferenceFrame::SER,
-            ReferenceFrame::GSE,
+            CelestialFrame::GCRF,
+            CelestialFrame::ITRF,
+            CelestialFrame::EME2000,
+            CelestialFrame::LCI,
+            CelestialFrame::LFPA,
+            CelestialFrame::LFME,
+            CelestialFrame::MCI,
+            CelestialFrame::MCMF,
+            CelestialFrame::EMBI,
+            CelestialFrame::SSBI,
+            CelestialFrame::EMR,
+            CelestialFrame::SER,
+            CelestialFrame::GSE,
         ];
         let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
         let x = vector6_from_array([1e8, -2e8, 5e7, 1.0e3, -2.0e3, 0.5e3]);
@@ -1283,25 +1283,25 @@ mod tests {
     #[test]
     fn test_reference_frame_from_str_aliases() {
         assert_eq!(
-            "ECI".parse::<ReferenceFrame>().unwrap(),
-            ReferenceFrame::GCRF
+            "ECI".parse::<CelestialFrame>().unwrap(),
+            CelestialFrame::GCRF
         );
         assert_eq!(
-            "ECEF".parse::<ReferenceFrame>().unwrap(),
-            ReferenceFrame::ITRF
+            "ECEF".parse::<CelestialFrame>().unwrap(),
+            CelestialFrame::ITRF
         );
         // Associated-constant aliases mirror the string aliases.
-        assert_eq!(ReferenceFrame::ECI, ReferenceFrame::GCRF);
-        assert_eq!(ReferenceFrame::ECEF, ReferenceFrame::ITRF);
+        assert_eq!(CelestialFrame::ECI, CelestialFrame::GCRF);
+        assert_eq!(CelestialFrame::ECEF, CelestialFrame::ITRF);
         assert_eq!(
-            "LFPA".parse::<ReferenceFrame>().unwrap(),
-            ReferenceFrame::LFPA
+            "LFPA".parse::<CelestialFrame>().unwrap(),
+            CelestialFrame::LFPA
         );
         assert_eq!(
-            "eci".parse::<ReferenceFrame>().unwrap(),
-            ReferenceFrame::GCRF
+            "eci".parse::<CelestialFrame>().unwrap(),
+            CelestialFrame::GCRF
         );
-        assert!("bogus".parse::<ReferenceFrame>().is_err());
+        assert!("bogus".parse::<CelestialFrame>().is_err());
     }
 
     #[test]
@@ -1310,26 +1310,26 @@ mod tests {
         // input -- they must be constructed directly, per the FromStr
         // doc comment.
         for s in [
-            ReferenceFrame::BodyCenteredICRF(4).to_string(),
-            ReferenceFrame::BodyFixedIAU(499).to_string(),
-            ReferenceFrame::BodyFixedPCK {
+            CelestialFrame::BodyCenteredICRF(4).to_string(),
+            CelestialFrame::BodyFixedIAU(499).to_string(),
+            CelestialFrame::BodyFixedPCK {
                 center: 301,
                 frame_id: 31008,
             }
             .to_string(),
-            ReferenceFrame::BodyFixedCustom {
+            CelestialFrame::BodyFixedCustom {
                 center: -20001,
                 key: 7,
             }
             .to_string(),
-            ReferenceFrame::Synodic {
+            CelestialFrame::Synodic {
                 origin: SynodicOrigin::Barycenter,
                 primary: 399,
                 secondary: 301,
             }
             .to_string(),
         ] {
-            let err = s.parse::<ReferenceFrame>().unwrap_err().to_string();
+            let err = s.parse::<CelestialFrame>().unwrap_err().to_string();
             assert!(err.contains(&s), "error should name the input '{s}': {err}");
         }
     }
@@ -1337,10 +1337,10 @@ mod tests {
     #[test]
     fn test_generic_variants_equal_named() {
         let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
-        let a = rotation_frame_to_frame(ReferenceFrame::MCI, ReferenceFrame::MCMF, epc).unwrap();
+        let a = rotation_frame_to_frame(CelestialFrame::MCI, CelestialFrame::MCMF, epc).unwrap();
         let b = rotation_frame_to_frame(
-            ReferenceFrame::BodyCenteredICRF(4),
-            ReferenceFrame::BodyFixedIAU(499),
+            CelestialFrame::BodyCenteredICRF(4),
+            CelestialFrame::BodyFixedIAU(499),
             epc,
         )
         .unwrap();
@@ -1359,8 +1359,8 @@ mod tests {
         // the embedded IAU/WGCCRE table.
         let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
         let r = rotation_frame_to_frame(
-            ReferenceFrame::BodyFixedIAU(999999),
-            ReferenceFrame::BodyFixedIAU(999999),
+            CelestialFrame::BodyFixedIAU(999999),
+            CelestialFrame::BodyFixedIAU(999999),
             epc,
         )
         .unwrap();
@@ -1369,18 +1369,18 @@ mod tests {
 
     #[test]
     fn test_reference_frame_display() {
-        assert_eq!(ReferenceFrame::GCRF.to_string(), "GCRF");
-        assert_eq!(ReferenceFrame::LFPA.to_string(), "LFPA");
+        assert_eq!(CelestialFrame::GCRF.to_string(), "GCRF");
+        assert_eq!(CelestialFrame::LFPA.to_string(), "LFPA");
         assert_eq!(
-            ReferenceFrame::BodyCenteredICRF(4).to_string(),
+            CelestialFrame::BodyCenteredICRF(4).to_string(),
             "BodyCenteredICRF(4)"
         );
         assert_eq!(
-            ReferenceFrame::BodyFixedIAU(599).to_string(),
+            CelestialFrame::BodyFixedIAU(599).to_string(),
             "BodyFixedIAU(599)"
         );
         assert_eq!(
-            ReferenceFrame::BodyFixedPCK {
+            CelestialFrame::BodyFixedPCK {
                 center: 301,
                 frame_id: 31008
             }
@@ -1392,38 +1392,38 @@ mod tests {
     #[test]
     fn test_reference_frame_display_from_str_roundtrip() {
         let frames = [
-            ReferenceFrame::GCRF,
-            ReferenceFrame::ITRF,
-            ReferenceFrame::EME2000,
-            ReferenceFrame::LCI,
-            ReferenceFrame::LFPA,
-            ReferenceFrame::LFME,
-            ReferenceFrame::MCI,
-            ReferenceFrame::MCMF,
-            ReferenceFrame::EMBI,
-            ReferenceFrame::SSBI,
+            CelestialFrame::GCRF,
+            CelestialFrame::ITRF,
+            CelestialFrame::EME2000,
+            CelestialFrame::LCI,
+            CelestialFrame::LFPA,
+            CelestialFrame::LFME,
+            CelestialFrame::MCI,
+            CelestialFrame::MCMF,
+            CelestialFrame::EMBI,
+            CelestialFrame::SSBI,
         ];
         for f in frames {
-            assert_eq!(f.to_string().parse::<ReferenceFrame>().unwrap(), f);
+            assert_eq!(f.to_string().parse::<CelestialFrame>().unwrap(), f);
         }
     }
 
     #[test]
     fn test_reference_frame_center_naif_id() {
-        assert_eq!(ReferenceFrame::GCRF.center_naif_id(), 399);
-        assert_eq!(ReferenceFrame::ITRF.center_naif_id(), 399);
-        assert_eq!(ReferenceFrame::EME2000.center_naif_id(), 399);
-        assert_eq!(ReferenceFrame::LCI.center_naif_id(), 301);
-        assert_eq!(ReferenceFrame::LFPA.center_naif_id(), 301);
-        assert_eq!(ReferenceFrame::LFME.center_naif_id(), 301);
-        assert_eq!(ReferenceFrame::MCI.center_naif_id(), 499);
-        assert_eq!(ReferenceFrame::MCMF.center_naif_id(), 499);
-        assert_eq!(ReferenceFrame::EMBI.center_naif_id(), 3);
-        assert_eq!(ReferenceFrame::SSBI.center_naif_id(), 0);
-        assert_eq!(ReferenceFrame::BodyCenteredICRF(599).center_naif_id(), 599);
-        assert_eq!(ReferenceFrame::BodyFixedIAU(499).center_naif_id(), 499);
+        assert_eq!(CelestialFrame::GCRF.center_naif_id(), 399);
+        assert_eq!(CelestialFrame::ITRF.center_naif_id(), 399);
+        assert_eq!(CelestialFrame::EME2000.center_naif_id(), 399);
+        assert_eq!(CelestialFrame::LCI.center_naif_id(), 301);
+        assert_eq!(CelestialFrame::LFPA.center_naif_id(), 301);
+        assert_eq!(CelestialFrame::LFME.center_naif_id(), 301);
+        assert_eq!(CelestialFrame::MCI.center_naif_id(), 499);
+        assert_eq!(CelestialFrame::MCMF.center_naif_id(), 499);
+        assert_eq!(CelestialFrame::EMBI.center_naif_id(), 3);
+        assert_eq!(CelestialFrame::SSBI.center_naif_id(), 0);
+        assert_eq!(CelestialFrame::BodyCenteredICRF(599).center_naif_id(), 599);
+        assert_eq!(CelestialFrame::BodyFixedIAU(499).center_naif_id(), 499);
         assert_eq!(
-            ReferenceFrame::BodyFixedPCK {
+            CelestialFrame::BodyFixedPCK {
                 center: 301,
                 frame_id: 31008
             }
@@ -1435,18 +1435,18 @@ mod tests {
     #[test]
     fn test_reference_frame_serde_roundtrip() {
         let frames = [
-            ReferenceFrame::GCRF,
-            ReferenceFrame::LFPA,
-            ReferenceFrame::BodyCenteredICRF(4),
-            ReferenceFrame::BodyFixedIAU(499),
-            ReferenceFrame::BodyFixedPCK {
+            CelestialFrame::GCRF,
+            CelestialFrame::LFPA,
+            CelestialFrame::BodyCenteredICRF(4),
+            CelestialFrame::BodyFixedIAU(499),
+            CelestialFrame::BodyFixedPCK {
                 center: 301,
                 frame_id: 31008,
             },
         ];
         for f in frames {
             let json = serde_json::to_string(&f).unwrap();
-            let back: ReferenceFrame = serde_json::from_str(&json).unwrap();
+            let back: CelestialFrame = serde_json::from_str(&json).unwrap();
             assert_eq!(back, f);
         }
     }
@@ -1456,7 +1456,7 @@ mod tests {
         let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
         let x = Vector3::new(1.0, 2.0, 3.0);
         let out =
-            position_frame_to_frame(ReferenceFrame::GCRF, ReferenceFrame::GCRF, epc, x).unwrap();
+            position_frame_to_frame(CelestialFrame::GCRF, CelestialFrame::GCRF, epc, x).unwrap();
         assert_eq!(out, x);
     }
 
@@ -1467,7 +1467,7 @@ mod tests {
         let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
         let x = Vector3::new(R_EARTH + 500e3, 1e5, 2e5);
         let via_router =
-            position_frame_to_frame(ReferenceFrame::GCRF, ReferenceFrame::ITRF, epc, x).unwrap();
+            position_frame_to_frame(CelestialFrame::GCRF, CelestialFrame::ITRF, epc, x).unwrap();
         let pairwise = crate::frames::position_gcrf_to_itrf(epc, x);
         for i in 0..3 {
             assert_eq!(via_router[i], pairwise[i]);
@@ -1494,8 +1494,8 @@ mod tests {
             None,
         );
         // Same (self-assigned) center as the source frame: rotation-only.
-        let inertial = ReferenceFrame::BodyCenteredICRF(-20001);
-        let fixed = ReferenceFrame::BodyFixedCustom {
+        let inertial = CelestialFrame::BodyCenteredICRF(-20001);
+        let fixed = CelestialFrame::BodyFixedCustom {
             center: -20001,
             key: 777,
         };
@@ -1528,7 +1528,7 @@ mod tests {
         }
 
         // Unregistered key surfaces an actionable error through the router.
-        let missing = ReferenceFrame::BodyFixedCustom {
+        let missing = CelestialFrame::BodyFixedCustom {
             center: -20001,
             key: 778,
         };
@@ -1543,7 +1543,7 @@ mod tests {
         // rotation: rotation_frame_to_frame never touches SPK or EOP here.
         let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
         let r =
-            rotation_frame_to_frame(ReferenceFrame::GCRF, ReferenceFrame::EME2000, epc).unwrap();
+            rotation_frame_to_frame(CelestialFrame::GCRF, CelestialFrame::EME2000, epc).unwrap();
         let pairwise = crate::frames::rotation_gcrf_to_eme2000();
         for i in 0..3 {
             for j in 0..3 {
@@ -1552,7 +1552,7 @@ mod tests {
         }
         // Inverse composes back to the identity.
         let r_inv =
-            rotation_frame_to_frame(ReferenceFrame::EME2000, ReferenceFrame::GCRF, epc).unwrap();
+            rotation_frame_to_frame(CelestialFrame::EME2000, CelestialFrame::GCRF, epc).unwrap();
         let should_be_identity = r_inv * r;
         for i in 0..3 {
             for j in 0..3 {
@@ -1572,7 +1572,7 @@ mod tests {
         let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
         let x = vector6_from_array([R_EARTH + 500e3, 1e5, 2e5, 1.0, 7.5e3, 0.5e3]);
         let via_router =
-            state_frame_to_frame(ReferenceFrame::GCRF, ReferenceFrame::EME2000, epc, x).unwrap();
+            state_frame_to_frame(CelestialFrame::GCRF, CelestialFrame::EME2000, epc, x).unwrap();
         let pairwise = crate::frames::state_gcrf_to_eme2000(x);
         for i in 0..6 {
             assert_eq!(via_router[i], pairwise[i]);
@@ -1581,8 +1581,8 @@ mod tests {
         // orthogonality residual of the constant `bias_eme2000` rotation
         // (B^T*B - I ~ 4e-15) amplified by the ~6.9e6 m position magnitude.
         let back = state_frame_to_frame(
-            ReferenceFrame::EME2000,
-            ReferenceFrame::GCRF,
+            CelestialFrame::EME2000,
+            CelestialFrame::GCRF,
             epc,
             via_router,
         )
@@ -1598,8 +1598,8 @@ mod tests {
         // rotation-only + transport-velocity path (IAU analytic model). Exercises
         // state_icrf_to_iau_body / state_iau_body_to_icrf and the position path.
         let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
-        let icrf = ReferenceFrame::BodyCenteredICRF(599);
-        let fixed = ReferenceFrame::BodyFixedIAU(599);
+        let icrf = CelestialFrame::BodyCenteredICRF(599);
+        let fixed = CelestialFrame::BodyFixedIAU(599);
         let x = vector6_from_array([7.0e7, -2.0e7, 3.0e7, 10.0, 25.0, -5.0]);
 
         let x_fixed = state_frame_to_frame(icrf, fixed, epc, x).unwrap();
@@ -1624,8 +1624,8 @@ mod tests {
         let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
         assert!(
             rotation_frame_to_frame(
-                ReferenceFrame::BodyCenteredICRF(999999),
-                ReferenceFrame::BodyFixedIAU(999999),
+                CelestialFrame::BodyCenteredICRF(999999),
+                CelestialFrame::BodyFixedIAU(999999),
                 epc
             )
             .is_err()
@@ -1633,8 +1633,8 @@ mod tests {
         let x = vector6_from_array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
         assert!(
             state_frame_to_frame(
-                ReferenceFrame::BodyCenteredICRF(999999),
-                ReferenceFrame::BodyFixedIAU(999999),
+                CelestialFrame::BodyCenteredICRF(999999),
+                CelestialFrame::BodyFixedIAU(999999),
                 epc,
                 x
             )
@@ -1646,7 +1646,7 @@ mod tests {
     fn test_reference_frame_display_and_center_body_fixed_custom() {
         // The BodyFixedCustom Display and center_naif_id arms are not covered by
         // the other Display/center tests.
-        let f = ReferenceFrame::BodyFixedCustom {
+        let f = CelestialFrame::BodyFixedCustom {
             center: -20001,
             key: 7,
         };
@@ -1675,8 +1675,8 @@ mod tests {
             crate::constants::JD_J2000 + 500.0 / crate::constants::SECONDS_PER_DAY,
             TimeSystem::TDB,
         );
-        let center = ReferenceFrame::BodyCenteredICRF(-30001);
-        let fixed = ReferenceFrame::BodyFixedPCK {
+        let center = CelestialFrame::BodyCenteredICRF(-30001);
+        let fixed = CelestialFrame::BodyFixedPCK {
             center: -30001,
             frame_id,
         };
@@ -1711,14 +1711,14 @@ mod tests {
         let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
         let x = vector6_from_array([1e8, -2e8, 5e7, 1.0e3, -2.0e3, 0.5e3]);
         let via_iau = state_frame_to_frame(
-            ReferenceFrame::GCRF,
-            ReferenceFrame::BodyFixedIAU(499),
+            CelestialFrame::GCRF,
+            CelestialFrame::BodyFixedIAU(499),
             epc,
             x,
         )
         .unwrap();
         let via_mcmf =
-            state_frame_to_frame(ReferenceFrame::GCRF, ReferenceFrame::MCMF, epc, x).unwrap();
+            state_frame_to_frame(CelestialFrame::GCRF, CelestialFrame::MCMF, epc, x).unwrap();
         for i in 0..6 {
             assert_abs_diff_eq!(via_iau[i], via_mcmf[i], epsilon = 1e-9);
         }
@@ -1751,7 +1751,7 @@ mod tests {
         // round trip for a Moon-centered (399, 301) pair.
         setup_global_test_spice();
         let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
-        let frame = ReferenceFrame::Synodic {
+        let frame = CelestialFrame::Synodic {
             origin: SynodicOrigin::Secondary,
             primary: 399,
             secondary: 301,
@@ -1763,15 +1763,15 @@ mod tests {
         // secondary body defines the frame's center.
         let x_moon_gcrf = spk_state(NAIFId::Moon, NAIFId::Earth, epc).unwrap();
         let x_moon_syn =
-            state_frame_to_frame(ReferenceFrame::GCRF, frame, epc, x_moon_gcrf).unwrap();
+            state_frame_to_frame(CelestialFrame::GCRF, frame, epc, x_moon_gcrf).unwrap();
         for i in 0..3 {
             assert_abs_diff_eq!(x_moon_syn[i], 0.0, epsilon = 1e-3);
         }
 
         // Round trip through GCRF recovers an arbitrary input state.
         let x = vector6_from_array([1.0e8, -2.0e8, 5.0e7, 1.0e3, -2.0e3, 0.5e3]);
-        let x_syn = state_frame_to_frame(ReferenceFrame::GCRF, frame, epc, x).unwrap();
-        let x_back = state_frame_to_frame(frame, ReferenceFrame::GCRF, epc, x_syn).unwrap();
+        let x_syn = state_frame_to_frame(CelestialFrame::GCRF, frame, epc, x).unwrap();
+        let x_back = state_frame_to_frame(frame, CelestialFrame::GCRF, epc, x_syn).unwrap();
         for i in 0..3 {
             assert_abs_diff_eq!(x_back[i], x[i], epsilon = 1e-3);
         }
@@ -1791,8 +1791,8 @@ mod tests {
         );
         let cases = [
             (
-                ReferenceFrame::EMR,
-                ReferenceFrame::Synodic {
+                CelestialFrame::EMR,
+                CelestialFrame::Synodic {
                     origin: SynodicOrigin::Barycenter,
                     primary: 399,
                     secondary: 301,
@@ -1810,8 +1810,8 @@ mod tests {
                 1.0,
             ),
             (
-                ReferenceFrame::SER,
-                ReferenceFrame::Synodic {
+                CelestialFrame::SER,
+                CelestialFrame::Synodic {
                     origin: SynodicOrigin::Barycenter,
                     primary: 10,
                     secondary: 399,
@@ -1823,8 +1823,8 @@ mod tests {
                 1e-6,
             ),
             (
-                ReferenceFrame::GSE,
-                ReferenceFrame::Synodic {
+                CelestialFrame::GSE,
+                CelestialFrame::Synodic {
                     origin: SynodicOrigin::Primary,
                     primary: 399,
                     secondary: 10,
@@ -1835,10 +1835,10 @@ mod tests {
             ),
         ];
         for (named, generic, eps) in cases {
-            let x_named = state_frame_to_frame(ReferenceFrame::GCRF, named, epc, x).unwrap();
-            let x_generic = state_frame_to_frame(ReferenceFrame::GCRF, generic, epc, x).unwrap();
+            let x_named = state_frame_to_frame(CelestialFrame::GCRF, named, epc, x).unwrap();
+            let x_generic = state_frame_to_frame(CelestialFrame::GCRF, generic, epc, x).unwrap();
             assert_abs_diff_eq!(x_named, x_generic, epsilon = eps);
-            let x_rt = state_frame_to_frame(generic, ReferenceFrame::GCRF, epc, x_generic).unwrap();
+            let x_rt = state_frame_to_frame(generic, CelestialFrame::GCRF, epc, x_generic).unwrap();
             // Looser than the cross-comparison above: this is a pure
             // floating-point roundoff check on the generic frame's own
             // round trip (two SPK state queries plus the barycenter
@@ -1853,14 +1853,14 @@ mod tests {
     fn test_synodic_novel_pair_sun_mars() {
         setup_global_test_eop();
         let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
-        let frame = ReferenceFrame::Synodic {
+        let frame = CelestialFrame::Synodic {
             origin: SynodicOrigin::Barycenter,
             primary: 10,
             secondary: 4,
         };
         // Mars (barycenter 4) sits on the +x axis of the Sun-Mars synodic frame.
         let x_mars_icrf = center_offset_state(frame.center_naif_id(), 4, epc).unwrap();
-        let r = rotation_frame_to_frame(ReferenceFrame::SSBI, frame, epc).unwrap();
+        let r = rotation_frame_to_frame(CelestialFrame::SSBI, frame, epc).unwrap();
         let p = r * x_mars_icrf.fixed_rows::<3>(0).into_owned();
         assert!(p[0] > 0.0);
         assert_abs_diff_eq!(p[1], 0.0, epsilon = 1e-3);
@@ -1870,8 +1870,8 @@ mod tests {
             vector6_from_array([R_EARTH + 500e3, 1e-3, 97.8, 75.0, 25.0, 45.0]),
             DEGREES,
         );
-        let x_syn = state_frame_to_frame(ReferenceFrame::GCRF, frame, epc, x).unwrap();
-        let x_back = state_frame_to_frame(frame, ReferenceFrame::GCRF, epc, x_syn).unwrap();
+        let x_syn = state_frame_to_frame(CelestialFrame::GCRF, frame, epc, x).unwrap();
+        let x_back = state_frame_to_frame(frame, CelestialFrame::GCRF, epc, x_syn).unwrap();
         assert_abs_diff_eq!(x_back, x, epsilon = 1e-4);
     }
 
@@ -1881,19 +1881,19 @@ mod tests {
         setup_global_test_eop();
         let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
         // Jupiter-Europa barycenter: Europa (502) has no packaged GM.
-        let frame = ReferenceFrame::Synodic {
+        let frame = CelestialFrame::Synodic {
             origin: SynodicOrigin::Barycenter,
             primary: 599,
             secondary: 502,
         };
         let x = SVector6::new(1e7, 0.0, 0.0, 0.0, 1e3, 0.0);
-        assert!(state_frame_to_frame(ReferenceFrame::GCRF, frame, epc, x).is_err());
+        assert!(state_frame_to_frame(CelestialFrame::GCRF, frame, epc, x).is_err());
     }
 
     #[test]
     #[parallel]
     fn test_synodic_display() {
-        let f = ReferenceFrame::Synodic {
+        let f = CelestialFrame::Synodic {
             origin: SynodicOrigin::Barycenter,
             primary: 399,
             secondary: 301,
@@ -1924,10 +1924,10 @@ mod tests {
             .collect();
 
         let pairs = [
-            (ReferenceFrame::GCRF, ReferenceFrame::ITRF),
-            (ReferenceFrame::GCRF, ReferenceFrame::LFPA),
-            (ReferenceFrame::GCRF, ReferenceFrame::EMR),
-            (ReferenceFrame::ITRF, ReferenceFrame::MCMF),
+            (CelestialFrame::GCRF, CelestialFrame::ITRF),
+            (CelestialFrame::GCRF, CelestialFrame::LFPA),
+            (CelestialFrame::GCRF, CelestialFrame::EMR),
+            (CelestialFrame::ITRF, CelestialFrame::MCMF),
         ];
         for (from, to) in pairs {
             let rot = rotations_frame_to_frame(from, to, &epochs).unwrap();
@@ -1961,16 +1961,16 @@ mod tests {
 
         // Identity pair broadcasts without evaluation
         let same = positions_frame_to_frame(
-            ReferenceFrame::GCRF,
-            ReferenceFrame::GCRF,
+            CelestialFrame::GCRF,
+            CelestialFrame::GCRF,
             &epochs,
             &positions,
         )
         .unwrap();
         assert_eq!(same, positions);
         let same = states_frame_to_frame(
-            ReferenceFrame::LCI,
-            ReferenceFrame::LCI,
+            CelestialFrame::LCI,
+            CelestialFrame::LCI,
             &epochs[..1],
             &states,
         )
@@ -1979,8 +1979,8 @@ mod tests {
 
         // One position, many epochs
         let one = positions_frame_to_frame(
-            ReferenceFrame::ITRF,
-            ReferenceFrame::GCRF,
+            CelestialFrame::ITRF,
+            CelestialFrame::GCRF,
             &epochs,
             &positions[..1],
         )
@@ -1989,8 +1989,8 @@ mod tests {
             assert_eq!(
                 one[i],
                 position_frame_to_frame(
-                    ReferenceFrame::ITRF,
-                    ReferenceFrame::GCRF,
+                    CelestialFrame::ITRF,
+                    CelestialFrame::GCRF,
                     epochs[i],
                     positions[0]
                 )
@@ -2001,8 +2001,8 @@ mod tests {
         // Errors: broadcast mismatch and unsupported body
         assert!(
             states_frame_to_frame(
-                ReferenceFrame::GCRF,
-                ReferenceFrame::ITRF,
+                CelestialFrame::GCRF,
+                CelestialFrame::ITRF,
                 &epochs[..2],
                 &states
             )
@@ -2010,16 +2010,16 @@ mod tests {
         );
         assert!(
             rotations_frame_to_frame(
-                ReferenceFrame::GCRF,
-                ReferenceFrame::BodyFixedIAU(-1234),
+                CelestialFrame::GCRF,
+                CelestialFrame::BodyFixedIAU(-1234),
                 &epochs
             )
             .is_err()
         );
         assert!(
             positions_frame_to_frame(
-                ReferenceFrame::GCRF,
-                ReferenceFrame::ITRF,
+                CelestialFrame::GCRF,
+                CelestialFrame::ITRF,
                 &epochs[..1],
                 &[]
             )

--- a/src/orbit_dynamics/third_body.rs
+++ b/src/orbit_dynamics/third_body.rs
@@ -638,7 +638,7 @@ pub fn accel_third_body_field_for_body<P: IntoPosition>(
                     gravity, body
                 ))
             })?;
-            crate::frames::rotation_frame_to_frame(crate::frames::ReferenceFrame::GCRF, frame, epc)?
+            crate::frames::rotation_frame_to_frame(crate::frames::CelestialFrame::GCRF, frame, epc)?
         }
     };
 
@@ -1760,8 +1760,8 @@ mod tests {
         let central = CentralBody::EMB;
 
         let r_i2b = crate::frames::rotation_frame_to_frame(
-            crate::frames::ReferenceFrame::GCRF,
-            crate::frames::ReferenceFrame::ITRF,
+            crate::frames::CelestialFrame::GCRF,
+            crate::frames::CelestialFrame::ITRF,
             epc,
         )
         .unwrap();
@@ -1816,8 +1816,8 @@ mod tests {
         let r_object = Vector3::new(1.0e8, 5.0e7, 2.0e7);
 
         let r_i2b = crate::frames::rotation_frame_to_frame(
-            crate::frames::ReferenceFrame::GCRF,
-            crate::frames::ReferenceFrame::ITRF,
+            crate::frames::CelestialFrame::GCRF,
+            crate::frames::CelestialFrame::ITRF,
             epc,
         )
         .unwrap();
@@ -1865,8 +1865,8 @@ mod tests {
         let r_object = Vector3::new(R_EARTH + 500e3, 0.0, 0.0);
 
         let r_i2b = crate::frames::rotation_frame_to_frame(
-            crate::frames::ReferenceFrame::GCRF,
-            crate::frames::ReferenceFrame::LFPA,
+            crate::frames::CelestialFrame::GCRF,
+            crate::frames::CelestialFrame::LFPA,
             epc,
         )
         .unwrap();
@@ -1927,8 +1927,8 @@ mod tests {
         let r_object = Vector3::new(R_EARTH + 500e3, 0.0, 0.0);
 
         let r_i2b = crate::frames::rotation_frame_to_frame(
-            crate::frames::ReferenceFrame::GCRF,
-            crate::frames::ReferenceFrame::LFPA,
+            crate::frames::CelestialFrame::GCRF,
+            crate::frames::CelestialFrame::LFPA,
             epc,
         )
         .unwrap();
@@ -2045,8 +2045,8 @@ mod tests {
 
         // Internal variant with explicitly resolved resources
         let r_i2b = crate::frames::rotation_frame_to_frame(
-            crate::frames::ReferenceFrame::GCRF,
-            crate::frames::ReferenceFrame::ITRF,
+            crate::frames::CelestialFrame::GCRF,
+            crate::frames::CelestialFrame::ITRF,
             epc,
         )
         .unwrap();
@@ -2163,8 +2163,8 @@ mod tests {
         let epc = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
         let r = Vector3::new(3.8e8, 0.0, 0.0);
         let r_i2b = crate::frames::rotation_frame_to_frame(
-            crate::frames::ReferenceFrame::GCRF,
-            crate::frames::ReferenceFrame::ITRF,
+            crate::frames::CelestialFrame::GCRF,
+            crate::frames::CelestialFrame::ITRF,
             epc,
         )
         .unwrap();

--- a/src/propagators/central_body.rs
+++ b/src/propagators/central_body.rs
@@ -41,7 +41,7 @@ use crate::constants::{
     GM_SATURN, GM_SUN, GM_URANUS, GM_VENUS, OMEGA_EARTH, OMEGA_MARS, OMEGA_MOON, R_EARTH, R_MARS,
     R_MOON, R_SUN,
 };
-use crate::frames::{ReferenceFrame, iau_rotation_model_ids};
+use crate::frames::{CelestialFrame, iau_rotation_model_ids};
 use crate::utils::BraheError;
 
 /// A user-defined central body, for propagation about a body without a
@@ -65,7 +65,7 @@ pub struct CustomBody {
     /// will surface an SPK lookup error unless a kernel covering that ID
     /// is loaded, and a body-fixed frame can be supplied without any
     /// ephemeris via [`crate::frames::register_custom_frame`] and
-    /// [`crate::frames::ReferenceFrame::BodyFixedCustom`].
+    /// [`crate::frames::CelestialFrame::BodyFixedCustom`].
     pub naif_id: i32,
     /// Gravitational parameter. Units: (m^3/s^2)
     pub gm: f64,
@@ -80,7 +80,7 @@ pub struct CustomBody {
     /// Body-fixed reference frame, required for spherical-harmonic
     /// gravity and body-fixed rotations. `None` if no rotation model is
     /// available.
-    pub fixed_frame: Option<ReferenceFrame>,
+    pub fixed_frame: Option<CelestialFrame>,
 }
 
 /// The central body an orbit is propagated relative to.
@@ -225,18 +225,18 @@ impl CentralBody {
     /// # Examples
     /// ```
     /// use brahe::propagators::CentralBody;
-    /// use brahe::frames::ReferenceFrame;
+    /// use brahe::frames::CelestialFrame;
     ///
-    /// assert_eq!(CentralBody::Moon.inertial_frame(), ReferenceFrame::LCI);
+    /// assert_eq!(CentralBody::Moon.inertial_frame(), CelestialFrame::LCI);
     /// ```
-    pub fn inertial_frame(&self) -> ReferenceFrame {
+    pub fn inertial_frame(&self) -> CelestialFrame {
         match self {
-            CentralBody::Earth => ReferenceFrame::GCRF,
-            CentralBody::Moon => ReferenceFrame::LCI,
-            CentralBody::Mars => ReferenceFrame::MCI,
-            CentralBody::EMB => ReferenceFrame::EMBI,
-            CentralBody::SSB => ReferenceFrame::SSBI,
-            CentralBody::Custom(c) => ReferenceFrame::BodyCenteredICRF(c.naif_id),
+            CentralBody::Earth => CelestialFrame::GCRF,
+            CentralBody::Moon => CelestialFrame::LCI,
+            CentralBody::Mars => CelestialFrame::MCI,
+            CentralBody::EMB => CelestialFrame::EMBI,
+            CentralBody::SSB => CelestialFrame::SSBI,
+            CentralBody::Custom(c) => CelestialFrame::BodyCenteredICRF(c.naif_id),
         }
     }
 
@@ -250,16 +250,16 @@ impl CentralBody {
     /// # Examples
     /// ```
     /// use brahe::propagators::CentralBody;
-    /// use brahe::frames::ReferenceFrame;
+    /// use brahe::frames::CelestialFrame;
     ///
-    /// assert_eq!(CentralBody::Moon.fixed_frame(), Some(ReferenceFrame::LFPA));
+    /// assert_eq!(CentralBody::Moon.fixed_frame(), Some(CelestialFrame::LFPA));
     /// assert_eq!(CentralBody::EMB.fixed_frame(), None);
     /// ```
-    pub fn fixed_frame(&self) -> Option<ReferenceFrame> {
+    pub fn fixed_frame(&self) -> Option<CelestialFrame> {
         match self {
-            CentralBody::Earth => Some(ReferenceFrame::ITRF),
-            CentralBody::Moon => Some(ReferenceFrame::LFPA),
-            CentralBody::Mars => Some(ReferenceFrame::MCMF),
+            CentralBody::Earth => Some(CelestialFrame::ITRF),
+            CentralBody::Moon => Some(CelestialFrame::LFPA),
+            CentralBody::Mars => Some(CelestialFrame::MCMF),
             CentralBody::EMB => None,
             CentralBody::SSB => None,
             CentralBody::Custom(c) => c.fixed_frame,
@@ -326,7 +326,7 @@ impl CentralBody {
     /// | 606     | Titan     | 8.978137095521046e12 (`BODY606_GM`)   | (2575.15, 2574.78, 2574.47), mean       | 2,574,800.0 |
     ///
     /// Every `Custom` entry's `fixed_frame` is
-    /// `Some(ReferenceFrame::BodyFixedIAU(naif_id))` when `naif_id` is
+    /// `Some(CelestialFrame::BodyFixedIAU(naif_id))` when `naif_id` is
     /// in [`iau_rotation_model_ids`] (true for every body in the table
     /// above), and `None` otherwise. `omega` is always `None` — set it
     /// directly on the returned `CustomBody` if a force model needs it.
@@ -349,7 +349,7 @@ impl CentralBody {
     pub fn from_naif_id(naif_id: i32) -> Result<CentralBody, BraheError> {
         let custom = |name: &str, naif_id: i32, gm: f64, radius: f64| -> CentralBody {
             let fixed_frame = if iau_rotation_model_ids().contains(&naif_id) {
-                Some(ReferenceFrame::BodyFixedIAU(naif_id))
+                Some(CelestialFrame::BodyFixedIAU(naif_id))
             } else {
                 None
             };
@@ -428,9 +428,9 @@ mod tests {
         assert_eq!(CentralBody::Mars.naif_id(), 499);
         assert_eq!(CentralBody::EMB.gm(), 0.0);
         assert!(CentralBody::SSB.is_barycenter());
-        assert_eq!(CentralBody::Moon.fixed_frame(), Some(ReferenceFrame::LFPA));
+        assert_eq!(CentralBody::Moon.fixed_frame(), Some(CelestialFrame::LFPA));
         assert_eq!(CentralBody::EMB.fixed_frame(), None);
-        assert_eq!(CentralBody::Moon.inertial_frame(), ReferenceFrame::LCI);
+        assert_eq!(CentralBody::Moon.inertial_frame(), CelestialFrame::LCI);
     }
 
     #[test]
@@ -441,7 +441,7 @@ mod tests {
             CentralBody::Custom(c) => {
                 assert_eq!(c.naif_id, 602);
                 assert!(c.gm > 7.0e9 && c.gm < 7.4e9);
-                assert_eq!(c.fixed_frame, Some(ReferenceFrame::BodyFixedIAU(602)));
+                assert_eq!(c.fixed_frame, Some(CelestialFrame::BodyFixedIAU(602)));
             }
             _ => panic!("expected Custom"),
         }
@@ -474,13 +474,13 @@ mod tests {
             CentralBody::Earth.omega_vector(),
             Some(Vector3::new(0.0, 0.0, OMEGA_EARTH))
         );
-        assert_eq!(CentralBody::Mars.fixed_frame(), Some(ReferenceFrame::MCMF));
-        assert_eq!(CentralBody::Mars.inertial_frame(), ReferenceFrame::MCI);
+        assert_eq!(CentralBody::Mars.fixed_frame(), Some(CelestialFrame::MCMF));
+        assert_eq!(CentralBody::Mars.inertial_frame(), CelestialFrame::MCI);
         assert_eq!(CentralBody::Earth.radius(), Some(R_EARTH));
         assert_eq!(CentralBody::SSB.radius(), None);
         assert_eq!(CentralBody::SSB.omega_vector(), None);
-        assert_eq!(CentralBody::EMB.inertial_frame(), ReferenceFrame::EMBI);
-        assert_eq!(CentralBody::SSB.inertial_frame(), ReferenceFrame::SSBI);
+        assert_eq!(CentralBody::EMB.inertial_frame(), CelestialFrame::EMBI);
+        assert_eq!(CentralBody::SSB.inertial_frame(), CelestialFrame::SSBI);
     }
 
     #[test]
@@ -526,15 +526,15 @@ mod tests {
         assert_eq!(CentralBody::EMB.omega_vector(), None);
         assert_eq!(CentralBody::SSB.omega_vector(), None);
         // inertial_frame
-        assert_eq!(CentralBody::Earth.inertial_frame(), ReferenceFrame::GCRF);
-        assert_eq!(CentralBody::Moon.inertial_frame(), ReferenceFrame::LCI);
-        assert_eq!(CentralBody::Mars.inertial_frame(), ReferenceFrame::MCI);
-        assert_eq!(CentralBody::EMB.inertial_frame(), ReferenceFrame::EMBI);
-        assert_eq!(CentralBody::SSB.inertial_frame(), ReferenceFrame::SSBI);
+        assert_eq!(CentralBody::Earth.inertial_frame(), CelestialFrame::GCRF);
+        assert_eq!(CentralBody::Moon.inertial_frame(), CelestialFrame::LCI);
+        assert_eq!(CentralBody::Mars.inertial_frame(), CelestialFrame::MCI);
+        assert_eq!(CentralBody::EMB.inertial_frame(), CelestialFrame::EMBI);
+        assert_eq!(CentralBody::SSB.inertial_frame(), CelestialFrame::SSBI);
         // fixed_frame
-        assert_eq!(CentralBody::Earth.fixed_frame(), Some(ReferenceFrame::ITRF));
-        assert_eq!(CentralBody::Moon.fixed_frame(), Some(ReferenceFrame::LFPA));
-        assert_eq!(CentralBody::Mars.fixed_frame(), Some(ReferenceFrame::MCMF));
+        assert_eq!(CentralBody::Earth.fixed_frame(), Some(CelestialFrame::ITRF));
+        assert_eq!(CentralBody::Moon.fixed_frame(), Some(CelestialFrame::LFPA));
+        assert_eq!(CentralBody::Mars.fixed_frame(), Some(CelestialFrame::MCMF));
         assert_eq!(CentralBody::EMB.fixed_frame(), None);
         assert_eq!(CentralBody::SSB.fixed_frame(), None);
         // is_barycenter
@@ -568,14 +568,14 @@ mod tests {
             gm: 1.0,
             radius: Some(2.0),
             omega: Some(Vector3::new(0.0, 0.0, 3.0)),
-            fixed_frame: Some(ReferenceFrame::BodyFixedIAU(-42)),
+            fixed_frame: Some(CelestialFrame::BodyFixedIAU(-42)),
         });
         assert_eq!(body.gm(), 1.0);
         assert_eq!(body.radius(), Some(2.0));
         assert_eq!(body.naif_id(), -42);
         assert_eq!(body.omega_vector(), Some(Vector3::new(0.0, 0.0, 3.0)));
-        assert_eq!(body.inertial_frame(), ReferenceFrame::BodyCenteredICRF(-42));
-        assert_eq!(body.fixed_frame(), Some(ReferenceFrame::BodyFixedIAU(-42)));
+        assert_eq!(body.inertial_frame(), CelestialFrame::BodyCenteredICRF(-42));
+        assert_eq!(body.fixed_frame(), Some(CelestialFrame::BodyFixedIAU(-42)));
         assert!(!body.is_barycenter());
     }
 
@@ -586,7 +586,7 @@ mod tests {
             assert_eq!(body.naif_id(), id);
             assert_eq!(
                 body.fixed_frame(),
-                Some(ReferenceFrame::BodyFixedIAU(id)),
+                Some(CelestialFrame::BodyFixedIAU(id)),
                 "naif_id {id} should have a BodyFixedIAU frame"
             );
             assert!(body.gm() > 0.0);

--- a/src/propagators/dnumerical_orbit_propagator.rs
+++ b/src/propagators/dnumerical_orbit_propagator.rs
@@ -16,7 +16,7 @@ use nalgebra::{DMatrix, DVector, Vector3, Vector6};
 
 use crate::earth_models::{density_harris_priester, density_nrlmsise00};
 use crate::frames::{
-    ReferenceFrame, earth_rotation, rotation_eci_to_ecef, rotation_frame_to_frame,
+    CelestialFrame, earth_rotation, rotation_eci_to_ecef, rotation_frame_to_frame,
     rotation_lci_to_lfpa, rotation_mci_to_mcmf, state_frame_to_frame,
 };
 use crate::integrators::traits::DIntegrator;
@@ -3569,7 +3569,7 @@ impl DOrbitStateProvider for DNumericalOrbitPropagator {
     /// * `Err(BraheError)` - If the state cannot be computed or the frame conversion fails
     fn state_in_frame(
         &self,
-        frame: ReferenceFrame,
+        frame: CelestialFrame,
         epoch: Epoch,
     ) -> Result<Vector6<f64>, BraheError> {
         let x = self.state_central_inertial(epoch)?;
@@ -14130,7 +14130,7 @@ mod tests {
         }
         let x_lci = prop
             .trajectory()
-            .state_in_frame(ReferenceFrame::LCI, epoch0)
+            .state_in_frame(CelestialFrame::LCI, epoch0)
             .unwrap();
         for i in 0..6 {
             assert_abs_diff_eq!(x_lci[i], x_bci_traj[i], epsilon = 0.0);
@@ -14205,7 +14205,7 @@ mod tests {
 
         let (prop, epoch0, _x0) = lunar_point_mass_propagator_at_epoch0();
 
-        let x_lci = prop.state_in_frame(ReferenceFrame::LCI, epoch0).unwrap();
+        let x_lci = prop.state_in_frame(CelestialFrame::LCI, epoch0).unwrap();
         let x_central = prop.state_central_inertial(epoch0).unwrap();
 
         assert_eq!(x_lci, x_central);
@@ -14240,7 +14240,7 @@ mod tests {
         )
         .unwrap();
 
-        let x_in_frame = prop.state_in_frame(ReferenceFrame::ITRF, epoch).unwrap();
+        let x_in_frame = prop.state_in_frame(CelestialFrame::ITRF, epoch).unwrap();
         let x_ecef = prop.state_ecef(epoch).unwrap();
 
         for i in 0..6 {

--- a/src/propagators/force_model_config.rs
+++ b/src/propagators/force_model_config.rs
@@ -2037,19 +2037,19 @@ impl ThirdBody {
     /// MCMF for Mars, IAU frames for the other planet centers).
     ///
     /// # Returns
-    /// - `Some(ReferenceFrame)` when the body has a known body-fixed frame
+    /// - `Some(CelestialFrame)` when the body has a known body-fixed frame
     /// - `None` for the `*Barycenter` variants, `Custom` bodies, and bodies
     ///   without a rotation model
     ///
     /// # Examples
     /// ```
-    /// use brahe::frames::ReferenceFrame;
+    /// use brahe::frames::CelestialFrame;
     /// use brahe::propagators::force_model_config::ThirdBody;
     ///
-    /// assert_eq!(ThirdBody::Earth.body_fixed_frame(), Some(ReferenceFrame::ITRF));
+    /// assert_eq!(ThirdBody::Earth.body_fixed_frame(), Some(CelestialFrame::ITRF));
     /// assert_eq!(ThirdBody::NeptuneBarycenter.body_fixed_frame(), None);
     /// ```
-    pub fn body_fixed_frame(&self) -> Option<crate::frames::ReferenceFrame> {
+    pub fn body_fixed_frame(&self) -> Option<crate::frames::CelestialFrame> {
         self.as_central_body().and_then(|cb| cb.fixed_frame())
     }
 }
@@ -3008,21 +3008,21 @@ mod tests {
     #[test]
     #[serial_test::parallel]
     fn test_third_body_as_central_body_and_fixed_frame() {
-        use crate::frames::ReferenceFrame;
+        use crate::frames::CelestialFrame;
         assert_eq!(ThirdBody::Earth.as_central_body(), Some(CentralBody::Earth));
         assert_eq!(ThirdBody::Moon.as_central_body(), Some(CentralBody::Moon));
         assert_eq!(ThirdBody::Mars.as_central_body(), Some(CentralBody::Mars));
         assert_eq!(
             ThirdBody::Earth.body_fixed_frame(),
-            Some(ReferenceFrame::ITRF)
+            Some(CelestialFrame::ITRF)
         );
         assert_eq!(
             ThirdBody::Moon.body_fixed_frame(),
-            Some(ReferenceFrame::LFPA)
+            Some(CelestialFrame::LFPA)
         );
         assert_eq!(
             ThirdBody::Mars.body_fixed_frame(),
-            Some(ReferenceFrame::MCMF)
+            Some(CelestialFrame::MCMF)
         );
         // Planet centers resolve through from_naif_id (IAU frames)
         assert!(ThirdBody::Jupiter.body_fixed_frame().is_some());
@@ -3528,7 +3528,7 @@ mod tests {
             gm: 0.0,
             radius: None,
             omega: None,
-            fixed_frame: Some(crate::frames::ReferenceFrame::BodyFixedIAU(-1)),
+            fixed_frame: Some(crate::frames::CelestialFrame::BodyFixedIAU(-1)),
         });
         let config = ForceModelConfig {
             central_body: custom,

--- a/src/propagators/keplerian_propagator.rs
+++ b/src/propagators/keplerian_propagator.rs
@@ -679,12 +679,12 @@ impl DOrbitStateProvider for KeplerianPropagator {
     /// body's inertial frame) into `frame` via the reference frame router.
     fn state_in_frame(
         &self,
-        frame: crate::frames::ReferenceFrame,
+        frame: crate::frames::CelestialFrame,
         epoch: Epoch,
     ) -> Result<Vector6<f64>, BraheError> {
         let x_gcrf = self.state_gcrf(epoch)?;
         crate::frames::state_frame_to_frame(
-            crate::frames::ReferenceFrame::GCRF,
+            crate::frames::CelestialFrame::GCRF,
             frame,
             epoch,
             x_gcrf,
@@ -757,7 +757,7 @@ mod tests {
     use super::*;
     use crate::DEGREES;
     use crate::coordinates::state_eci_to_koe;
-    use crate::frames::ReferenceFrame;
+    use crate::frames::CelestialFrame;
     use crate::orbits::keplerian::orbital_period;
     use crate::time::{Epoch, TimeSystem};
     use crate::utils::testing::setup_global_test_eop;
@@ -1630,12 +1630,12 @@ mod tests {
 
         let epochs = vec![epoch, epoch + 60.0, epoch + 120.0];
         let states = propagator
-            .states_in_frame(ReferenceFrame::GCRF, &epochs)
+            .states_in_frame(CelestialFrame::GCRF, &epochs)
             .unwrap();
         assert_eq!(states.len(), 3);
         for (i, epc) in epochs.iter().enumerate() {
             let single = propagator
-                .state_in_frame(ReferenceFrame::GCRF, *epc)
+                .state_in_frame(CelestialFrame::GCRF, *epc)
                 .unwrap();
             for j in 0..6 {
                 assert_eq!(states[i][j], single[j]);

--- a/src/propagators/sgp_propagator.rs
+++ b/src/propagators/sgp_propagator.rs
@@ -2444,12 +2444,12 @@ impl SOrbitStateProvider for SGPPropagator {
     /// body's inertial frame) into `frame` via the reference frame router.
     fn state_in_frame(
         &self,
-        frame: crate::frames::ReferenceFrame,
+        frame: crate::frames::CelestialFrame,
         epoch: Epoch,
     ) -> Result<Vector6<f64>, BraheError> {
         let x_gcrf = self.state_gcrf(epoch)?;
         crate::frames::state_frame_to_frame(
-            crate::frames::ReferenceFrame::GCRF,
+            crate::frames::CelestialFrame::GCRF,
             frame,
             epoch,
             x_gcrf,
@@ -2542,7 +2542,7 @@ impl crate::utils::DOrbitStateProvider for SGPPropagator {
 
     fn state_in_frame(
         &self,
-        frame: crate::frames::ReferenceFrame,
+        frame: crate::frames::CelestialFrame,
         epoch: Epoch,
     ) -> Result<Vector6<f64>, BraheError> {
         <Self as SOrbitStateProvider>::state_in_frame(self, frame, epoch)
@@ -4096,7 +4096,7 @@ mod tests {
         // SGPPropagator is Earth-centered: state_bci is its GCRF state,
         // state_bcbf its ITRF state, and state_in_frame converts from GCRF
         // via the reference frame router.
-        use crate::frames::ReferenceFrame;
+        use crate::frames::CelestialFrame;
         use approx::assert_abs_diff_eq;
         setup_global_test_eop();
 
@@ -4115,7 +4115,7 @@ mod tests {
             assert_abs_diff_eq!(bcbf[i], itrf[i], epsilon = 0.0);
         }
 
-        let in_itrf = prop.state_in_frame(ReferenceFrame::ITRF, epoch).unwrap();
+        let in_itrf = prop.state_in_frame(CelestialFrame::ITRF, epoch).unwrap();
         for i in 0..6 {
             assert_abs_diff_eq!(in_itrf[i], itrf[i], epsilon = 1e-6);
         }

--- a/src/trajectories/dorbit_trajectory.rs
+++ b/src/trajectories/dorbit_trajectory.rs
@@ -2052,7 +2052,7 @@ impl DOrbitTrajectory {
                                 self.try_convert_orbital_preserving_additional(&s, |orbital| {
                                     crate::frames::state_frame_to_frame(
                                         native,
-                                        crate::frames::ReferenceFrame::GCRF,
+                                        crate::frames::CelestialFrame::GCRF,
                                         e,
                                         orbital,
                                     )
@@ -2165,7 +2165,7 @@ impl DOrbitTrajectory {
                                 self.try_convert_orbital_preserving_additional(&s, |orbital| {
                                     crate::frames::state_frame_to_frame(
                                         native,
-                                        crate::frames::ReferenceFrame::GCRF,
+                                        crate::frames::CelestialFrame::GCRF,
                                         e,
                                         orbital,
                                     )
@@ -2279,7 +2279,7 @@ impl DOrbitTrajectory {
                                 self.try_convert_orbital_preserving_additional(&s, |orbital| {
                                     crate::frames::state_frame_to_frame(
                                         native,
-                                        crate::frames::ReferenceFrame::ITRF,
+                                        crate::frames::CelestialFrame::ITRF,
                                         e,
                                         orbital,
                                     )
@@ -2394,7 +2394,7 @@ impl DOrbitTrajectory {
                                 self.try_convert_orbital_preserving_additional(&s, |orbital| {
                                     crate::frames::state_frame_to_frame(
                                         native,
-                                        crate::frames::ReferenceFrame::ITRF,
+                                        crate::frames::CelestialFrame::ITRF,
                                         e,
                                         orbital,
                                     )
@@ -2509,7 +2509,7 @@ impl DOrbitTrajectory {
                                 self.try_convert_orbital_preserving_additional(&s, |orbital| {
                                     crate::frames::state_frame_to_frame(
                                         native,
-                                        crate::frames::ReferenceFrame::EME2000,
+                                        crate::frames::CelestialFrame::EME2000,
                                         e,
                                         orbital,
                                     )
@@ -2924,7 +2924,7 @@ impl DOrbitStateProvider for DOrbitTrajectory {
     /// Earth round trip for `BodyCenteredInertial` trajectories).
     fn state_in_frame(
         &self,
-        frame: crate::frames::ReferenceFrame,
+        frame: crate::frames::CelestialFrame,
         epoch: Epoch,
     ) -> Result<Vector6<f64>, BraheError> {
         let x = self.state_bci(epoch)?;
@@ -2932,7 +2932,7 @@ impl DOrbitStateProvider for DOrbitTrajectory {
             OrbitFrame::BodyCenteredInertial(center) => {
                 crate::trajectories::traits::bci_reference_frame(center)
             }
-            _ => crate::frames::ReferenceFrame::GCRF,
+            _ => crate::frames::CelestialFrame::GCRF,
         };
         crate::frames::state_frame_to_frame(native, frame, epoch, x)
     }
@@ -2949,7 +2949,7 @@ impl DOrbitStateProvider for DOrbitTrajectory {
                 let x = self.bci_native_cartesian(center, state)?;
                 return crate::frames::state_frame_to_frame(
                     crate::trajectories::traits::bci_reference_frame(center),
-                    crate::frames::ReferenceFrame::GCRF,
+                    crate::frames::CelestialFrame::GCRF,
                     epoch,
                     x,
                 );
@@ -3001,7 +3001,7 @@ impl DOrbitStateProvider for DOrbitTrajectory {
                 let x = self.bci_native_cartesian(center, state)?;
                 return crate::frames::state_frame_to_frame(
                     crate::trajectories::traits::bci_reference_frame(center),
-                    crate::frames::ReferenceFrame::GCRF,
+                    crate::frames::CelestialFrame::GCRF,
                     epoch,
                     x,
                 );
@@ -3053,7 +3053,7 @@ impl DOrbitStateProvider for DOrbitTrajectory {
                 let x = self.bci_native_cartesian(center, state)?;
                 return crate::frames::state_frame_to_frame(
                     crate::trajectories::traits::bci_reference_frame(center),
-                    crate::frames::ReferenceFrame::ITRF,
+                    crate::frames::CelestialFrame::ITRF,
                     epoch,
                     x,
                 );
@@ -3116,7 +3116,7 @@ impl DOrbitStateProvider for DOrbitTrajectory {
                 let x = self.bci_native_cartesian(center, state)?;
                 return crate::frames::state_frame_to_frame(
                     crate::trajectories::traits::bci_reference_frame(center),
-                    crate::frames::ReferenceFrame::ITRF,
+                    crate::frames::CelestialFrame::ITRF,
                     epoch,
                     x,
                 );
@@ -3179,7 +3179,7 @@ impl DOrbitStateProvider for DOrbitTrajectory {
                 let x = self.bci_native_cartesian(center, state)?;
                 return crate::frames::state_frame_to_frame(
                     crate::trajectories::traits::bci_reference_frame(center),
-                    crate::frames::ReferenceFrame::EME2000,
+                    crate::frames::CelestialFrame::EME2000,
                     epoch,
                     x,
                 );
@@ -6457,7 +6457,7 @@ mod tests {
         // the batch to_gcrf/to_ecef/to_itrf/to_eme2000, each checked against
         // the equivalent Earth pairwise conversion of state_eci; covariance
         // passes through unchanged (ICRF-aligned axes).
-        use crate::frames::ReferenceFrame;
+        use crate::frames::CelestialFrame;
         setup_global_test_eop();
         crate::utils::testing::setup_global_test_spice();
         // Load the lunar PCK explicitly: this module's tests run after the
@@ -6546,7 +6546,7 @@ mod tests {
                 .unwrap();
         let state_e = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
         traj_e.add(epoch, state_e).unwrap();
-        let in_itrf = traj_e.state_in_frame(ReferenceFrame::ITRF, epoch).unwrap();
+        let in_itrf = traj_e.state_in_frame(CelestialFrame::ITRF, epoch).unwrap();
         let itrf_e = traj_e.state_itrf(epoch).unwrap();
         for i in 0..6 {
             assert_abs_diff_eq!(in_itrf[i], itrf_e[i], epsilon = 1e-6);
@@ -6641,7 +6641,7 @@ mod tests {
         // re-centers through SPK (LCI sample + Moon offset), and the batch
         // to_eci matches state_eci per epoch. Earth-frame trajectories keep
         // Earth semantics: state_bci == state_gcrf.
-        use crate::frames::ReferenceFrame;
+        use crate::frames::CelestialFrame;
         setup_global_test_eop();
         crate::utils::testing::setup_global_test_spice();
 
@@ -6660,7 +6660,7 @@ mod tests {
         for i in 0..6 {
             assert_abs_diff_eq!(bci[i], state[i], epsilon = 0.0);
         }
-        let in_lci = traj.state_in_frame(ReferenceFrame::LCI, epoch).unwrap();
+        let in_lci = traj.state_in_frame(CelestialFrame::LCI, epoch).unwrap();
         for i in 0..6 {
             assert_abs_diff_eq!(in_lci[i], bci[i], epsilon = 0.0);
         }

--- a/src/trajectories/sorbit_trajectory.rs
+++ b/src/trajectories/sorbit_trajectory.rs
@@ -1751,7 +1751,7 @@ impl OrbitalTrajectory for SOrbitTrajectory {
                         for (e, s) in self.into_iter() {
                             let converted = crate::frames::state_frame_to_frame(
                                 native,
-                                crate::frames::ReferenceFrame::GCRF,
+                                crate::frames::CelestialFrame::GCRF,
                                 e,
                                 s,
                             )?;
@@ -1848,7 +1848,7 @@ impl OrbitalTrajectory for SOrbitTrajectory {
                         for (e, s) in self.into_iter() {
                             let converted = crate::frames::state_frame_to_frame(
                                 native,
-                                crate::frames::ReferenceFrame::GCRF,
+                                crate::frames::CelestialFrame::GCRF,
                                 e,
                                 s,
                             )?;
@@ -1945,7 +1945,7 @@ impl OrbitalTrajectory for SOrbitTrajectory {
                         for (e, s) in self.into_iter() {
                             let converted = crate::frames::state_frame_to_frame(
                                 native,
-                                crate::frames::ReferenceFrame::ITRF,
+                                crate::frames::CelestialFrame::ITRF,
                                 e,
                                 s,
                             )?;
@@ -2039,7 +2039,7 @@ impl OrbitalTrajectory for SOrbitTrajectory {
                         for (e, s) in self.into_iter() {
                             let converted = crate::frames::state_frame_to_frame(
                                 native,
-                                crate::frames::ReferenceFrame::ITRF,
+                                crate::frames::CelestialFrame::ITRF,
                                 e,
                                 s,
                             )?;
@@ -2132,7 +2132,7 @@ impl OrbitalTrajectory for SOrbitTrajectory {
                         for (e, s) in self.into_iter() {
                             let converted = crate::frames::state_frame_to_frame(
                                 native,
-                                crate::frames::ReferenceFrame::EME2000,
+                                crate::frames::CelestialFrame::EME2000,
                                 e,
                                 s,
                             )?;
@@ -2383,7 +2383,7 @@ impl SOrbitStateProvider for SOrbitTrajectory {
     /// Earth round trip for `BodyCenteredInertial` trajectories).
     fn state_in_frame(
         &self,
-        frame: crate::frames::ReferenceFrame,
+        frame: crate::frames::CelestialFrame,
         epoch: Epoch,
     ) -> Result<Vector6<f64>, BraheError> {
         let x = self.state_bci(epoch)?;
@@ -2391,7 +2391,7 @@ impl SOrbitStateProvider for SOrbitTrajectory {
             OrbitFrame::BodyCenteredInertial(center) => {
                 crate::trajectories::traits::bci_reference_frame(center)
             }
-            _ => crate::frames::ReferenceFrame::GCRF,
+            _ => crate::frames::CelestialFrame::GCRF,
         };
         crate::frames::state_frame_to_frame(native, frame, epoch, x)
     }
@@ -2405,7 +2405,7 @@ impl SOrbitStateProvider for SOrbitTrajectory {
                 let x = self.bci_native_cartesian(center, state)?;
                 return crate::frames::state_frame_to_frame(
                     crate::trajectories::traits::bci_reference_frame(center),
-                    crate::frames::ReferenceFrame::GCRF,
+                    crate::frames::CelestialFrame::GCRF,
                     epoch,
                     x,
                 );
@@ -2454,7 +2454,7 @@ impl SOrbitStateProvider for SOrbitTrajectory {
                 let x = self.bci_native_cartesian(center, state)?;
                 return crate::frames::state_frame_to_frame(
                     crate::trajectories::traits::bci_reference_frame(center),
-                    crate::frames::ReferenceFrame::GCRF,
+                    crate::frames::CelestialFrame::GCRF,
                     epoch,
                     x,
                 );
@@ -2503,7 +2503,7 @@ impl SOrbitStateProvider for SOrbitTrajectory {
                 let x = self.bci_native_cartesian(center, state)?;
                 return crate::frames::state_frame_to_frame(
                     crate::trajectories::traits::bci_reference_frame(center),
-                    crate::frames::ReferenceFrame::ITRF,
+                    crate::frames::CelestialFrame::ITRF,
                     epoch,
                     x,
                 );
@@ -2563,7 +2563,7 @@ impl SOrbitStateProvider for SOrbitTrajectory {
                 let x = self.bci_native_cartesian(center, state)?;
                 return crate::frames::state_frame_to_frame(
                     crate::trajectories::traits::bci_reference_frame(center),
-                    crate::frames::ReferenceFrame::ITRF,
+                    crate::frames::CelestialFrame::ITRF,
                     epoch,
                     x,
                 );
@@ -2623,7 +2623,7 @@ impl SOrbitStateProvider for SOrbitTrajectory {
                 let x = self.bci_native_cartesian(center, state)?;
                 return crate::frames::state_frame_to_frame(
                     crate::trajectories::traits::bci_reference_frame(center),
-                    crate::frames::ReferenceFrame::EME2000,
+                    crate::frames::CelestialFrame::EME2000,
                     epoch,
                     x,
                 );
@@ -3031,7 +3031,7 @@ mod tests {
         // BCI(301) arms: provider trait accessors, state_eci/gcrf/ecef/itrf/
         // eme2000/koe_osc, all five to_* batch conversions, and covariance
         // passthrough. Mirrors the DOrbitTrajectory BCI tests.
-        use crate::frames::ReferenceFrame;
+        use crate::frames::CelestialFrame;
         setup_global_test_eop();
         crate::utils::testing::setup_global_test_spice();
         // Load the lunar PCK explicitly: this module's tests run after the
@@ -3053,7 +3053,7 @@ mod tests {
 
         // Trait accessors: raw sample in BCI; LCI target is the identity.
         let bci = traj.state_bci(epoch).unwrap();
-        let in_lci = traj.state_in_frame(ReferenceFrame::LCI, epoch).unwrap();
+        let in_lci = traj.state_in_frame(CelestialFrame::LCI, epoch).unwrap();
         for i in 0..6 {
             assert_abs_diff_eq!(bci[i], state[i], epsilon = 0.0);
             assert_abs_diff_eq!(in_lci[i], state[i], epsilon = 0.0);
@@ -3167,7 +3167,7 @@ mod tests {
         let itrf_e = traj_e.state_itrf(epoch).unwrap();
         let bci_e = traj_e.state_bci(epoch).unwrap();
         let bcbf_e = traj_e.state_bcbf(epoch).unwrap();
-        let in_itrf_e = traj_e.state_in_frame(ReferenceFrame::ITRF, epoch).unwrap();
+        let in_itrf_e = traj_e.state_in_frame(CelestialFrame::ITRF, epoch).unwrap();
         for i in 0..6 {
             assert_abs_diff_eq!(bci_e[i], gcrf_e[i], epsilon = 0.0);
             assert_abs_diff_eq!(bcbf_e[i], itrf_e[i], epsilon = 0.0);

--- a/src/trajectories/traits.rs
+++ b/src/trajectories/traits.rs
@@ -33,15 +33,15 @@ pub enum TrajectoryEvictionPolicy {
 /// used to convert `OrbitFrame::BodyCenteredInertial(center)` trajectory
 /// samples (named frames for the bodies that have them, generic
 /// `BodyCenteredICRF` otherwise).
-pub(crate) fn bci_reference_frame(center: i32) -> crate::frames::ReferenceFrame {
-    use crate::frames::ReferenceFrame;
+pub(crate) fn bci_reference_frame(center: i32) -> crate::frames::CelestialFrame {
+    use crate::frames::CelestialFrame;
     match center {
-        399 => ReferenceFrame::GCRF,
-        301 => ReferenceFrame::LCI,
-        499 => ReferenceFrame::MCI,
-        3 => ReferenceFrame::EMBI,
-        0 => ReferenceFrame::SSBI,
-        id => ReferenceFrame::BodyCenteredICRF(id),
+        399 => CelestialFrame::GCRF,
+        301 => CelestialFrame::LCI,
+        499 => CelestialFrame::MCI,
+        3 => CelestialFrame::EMBI,
+        0 => CelestialFrame::SSBI,
+        id => CelestialFrame::BodyCenteredICRF(id),
     }
 }
 
@@ -49,14 +49,14 @@ pub(crate) fn bci_reference_frame(center: i32) -> crate::frames::ReferenceFrame 
 /// (mirrors `CentralBody::fixed_frame`): `ITRF` for Earth, `LFPA` for the
 /// Moon, `MCMF` for Mars, the compiled-in IAU/WGCCRE frame for bodies in the
 /// embedded rotation table, and `None` for barycenters and unknown bodies.
-pub(crate) fn bci_fixed_frame(center: i32) -> Option<crate::frames::ReferenceFrame> {
-    use crate::frames::ReferenceFrame;
+pub(crate) fn bci_fixed_frame(center: i32) -> Option<crate::frames::CelestialFrame> {
+    use crate::frames::CelestialFrame;
     match center {
-        399 => Some(ReferenceFrame::ITRF),
-        301 => Some(ReferenceFrame::LFPA),
-        499 => Some(ReferenceFrame::MCMF),
+        399 => Some(CelestialFrame::ITRF),
+        301 => Some(CelestialFrame::LFPA),
+        499 => Some(CelestialFrame::MCMF),
         id if crate::frames::iau_rotation_model_ids().contains(&id) => {
-            Some(ReferenceFrame::BodyFixedIAU(id))
+            Some(CelestialFrame::BodyFixedIAU(id))
         }
         _ => None,
     }

--- a/src/utils/state_providers.rs
+++ b/src/utils/state_providers.rs
@@ -24,7 +24,7 @@
 use nalgebra::{DMatrix, DVector, SMatrix, Vector6};
 
 use crate::constants::AngleFormat;
-use crate::frames::ReferenceFrame;
+use crate::frames::CelestialFrame;
 use crate::orbits::{MeanElementMethod, state_koe_osc_to_mean};
 use crate::time::Epoch;
 use crate::utils::errors::BraheError;
@@ -275,7 +275,7 @@ pub trait SOrbitStateProvider: SStateProvider {
     /// * `Err(BraheError)` - If the state cannot be computed or the frame conversion fails
     fn state_in_frame(
         &self,
-        frame: ReferenceFrame,
+        frame: CelestialFrame,
         epoch: Epoch,
     ) -> Result<Vector6<f64>, BraheError>;
 
@@ -426,7 +426,7 @@ pub trait SOrbitStateProvider: SStateProvider {
     /// * `Err(BraheError)` - If any state cannot be computed
     fn states_in_frame(
         &self,
-        frame: ReferenceFrame,
+        frame: CelestialFrame,
         epochs: &[Epoch],
     ) -> Result<Vec<Vector6<f64>>, BraheError> {
         epochs
@@ -588,7 +588,7 @@ pub trait DOrbitStateProvider: DStateProvider {
     /// * `Err(BraheError)` - If the state cannot be computed or the frame conversion fails
     fn state_in_frame(
         &self,
-        frame: ReferenceFrame,
+        frame: CelestialFrame,
         epoch: Epoch,
     ) -> Result<Vector6<f64>, BraheError>;
 
@@ -739,7 +739,7 @@ pub trait DOrbitStateProvider: DStateProvider {
     /// * `Err(BraheError)` - If any state cannot be computed
     fn states_in_frame(
         &self,
-        frame: ReferenceFrame,
+        frame: CelestialFrame,
         epochs: &[Epoch],
     ) -> Result<Vec<Vector6<f64>>, BraheError> {
         epochs
@@ -1136,7 +1136,7 @@ mod tests {
         // KeplerianPropagator is Earth-centered: state_bci is its GCRF
         // state, state_bcbf its ITRF state, and state_in_frame converts
         // from GCRF via the reference frame router.
-        use crate::frames::ReferenceFrame;
+        use crate::frames::CelestialFrame;
         use crate::utils::testing::setup_global_test_eop;
         use approx::assert_abs_diff_eq;
         setup_global_test_eop();
@@ -1156,7 +1156,7 @@ mod tests {
             assert_abs_diff_eq!(bcbf[i], itrf[i], epsilon = 0.0);
         }
 
-        let in_itrf = prop.state_in_frame(ReferenceFrame::ITRF, epoch).unwrap();
+        let in_itrf = prop.state_in_frame(CelestialFrame::ITRF, epoch).unwrap();
         for i in 0..6 {
             assert_abs_diff_eq!(in_itrf[i], itrf[i], epsilon = 1e-6);
         }

--- a/tests/plots/test_synodic_3d.py
+++ b/tests/plots/test_synodic_3d.py
@@ -35,7 +35,7 @@ def test_plot_earth_moon_rotating_3d(leo_trajectory, naif_cache_setup):
 
 def test_plot_synodic_3d_rejects_non_synodic_frame(leo_trajectory):
     with pytest.raises(ValueError):
-        bh.plot_synodic_3d([leo_trajectory], frame=bh.ReferenceFrame.GCRF)
+        bh.plot_synodic_3d([leo_trajectory], frame=bh.CelestialFrame.GCRF)
 
 
 def test_plot_synodic_3d_rejects_non_trajectory():

--- a/tests/propagators/test_force_model_config.py
+++ b/tests/propagators/test_force_model_config.py
@@ -162,15 +162,15 @@ def test_centralbody_all_builtin_accessors():
     assert CentralBody.EMB.omega_vector() is None
     assert CentralBody.SSB.omega_vector() is None
     # inertial_frame
-    assert CentralBody.Earth.inertial_frame() == brahe.ReferenceFrame.GCRF
-    assert CentralBody.Moon.inertial_frame() == brahe.ReferenceFrame.LCI
-    assert CentralBody.Mars.inertial_frame() == brahe.ReferenceFrame.MCI
-    assert CentralBody.EMB.inertial_frame() == brahe.ReferenceFrame.EMBI
-    assert CentralBody.SSB.inertial_frame() == brahe.ReferenceFrame.SSBI
+    assert CentralBody.Earth.inertial_frame() == brahe.CelestialFrame.GCRF
+    assert CentralBody.Moon.inertial_frame() == brahe.CelestialFrame.LCI
+    assert CentralBody.Mars.inertial_frame() == brahe.CelestialFrame.MCI
+    assert CentralBody.EMB.inertial_frame() == brahe.CelestialFrame.EMBI
+    assert CentralBody.SSB.inertial_frame() == brahe.CelestialFrame.SSBI
     # fixed_frame
-    assert CentralBody.Earth.fixed_frame() == brahe.ReferenceFrame.ITRF
-    assert CentralBody.Moon.fixed_frame() == brahe.ReferenceFrame.LFPA
-    assert CentralBody.Mars.fixed_frame() == brahe.ReferenceFrame.MCMF
+    assert CentralBody.Earth.fixed_frame() == brahe.CelestialFrame.ITRF
+    assert CentralBody.Moon.fixed_frame() == brahe.CelestialFrame.LFPA
+    assert CentralBody.Mars.fixed_frame() == brahe.CelestialFrame.MCMF
     assert CentralBody.EMB.fixed_frame() is None
     assert CentralBody.SSB.fixed_frame() is None
     # is_barycenter
@@ -799,9 +799,9 @@ def test_force_model_third_bodies_coercion():
 
 
 def test_third_body_body_fixed_frame():
-    assert brahe.ThirdBody.EARTH.body_fixed_frame() == brahe.ReferenceFrame.ITRF
-    assert brahe.ThirdBody.MOON.body_fixed_frame() == brahe.ReferenceFrame.LFPA
-    assert brahe.ThirdBody.MARS.body_fixed_frame() == brahe.ReferenceFrame.MCMF
+    assert brahe.ThirdBody.EARTH.body_fixed_frame() == brahe.CelestialFrame.ITRF
+    assert brahe.ThirdBody.MOON.body_fixed_frame() == brahe.CelestialFrame.LFPA
+    assert brahe.ThirdBody.MARS.body_fixed_frame() == brahe.CelestialFrame.MCMF
     assert brahe.ThirdBody.MARS_BARYCENTER.body_fixed_frame() is None
 
 

--- a/tests/propagators/test_keplerian_propagator.py
+++ b/tests/propagators/test_keplerian_propagator.py
@@ -661,7 +661,7 @@ def test_keplerianpropagator_bci_bcbf_in_frame():
     Mirrors test_keplerian_propagator_bci_bcbf_in_frame."""
     import numpy as np
 
-    from brahe import ReferenceFrame
+    from brahe import CelestialFrame
 
     epoch = Epoch.from_jd(TEST_EPOCH_JD, TimeSystem.UTC)
     propagator = KeplerianPropagator.from_keplerian(
@@ -678,7 +678,7 @@ def test_keplerianpropagator_bci_bcbf_in_frame():
         propagator.state_bcbf(epoch), propagator.state_itrf(epoch)
     )
     np.testing.assert_allclose(
-        propagator.state_in_frame(ReferenceFrame.ITRF, epoch),
+        propagator.state_in_frame(CelestialFrame.ITRF, epoch),
         propagator.state_itrf(epoch),
         atol=1e-6,
     )
@@ -1297,7 +1297,7 @@ def test_state_provider_states_itrf():
 def test_state_provider_states_bci_bcbf_in_frame():
     """Test StateProvider states_bci(), states_bcbf(), states_in_frame()
     batch methods."""
-    from brahe import ReferenceFrame
+    from brahe import CelestialFrame
 
     epoch = Epoch.from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, TimeSystem.UTC)
     elements = np.array([6878e3, 0.01, 45.0, 15.0, 30.0, 60.0])
@@ -1322,11 +1322,11 @@ def test_state_provider_states_bci_bcbf_in_frame():
     for i, epc in enumerate(epochs):
         np.testing.assert_array_equal(states_bcbf[i], prop.state_bcbf(epc))
 
-    states_itrf = prop.states_in_frame(ReferenceFrame.ITRF, epochs)
+    states_itrf = prop.states_in_frame(CelestialFrame.ITRF, epochs)
     assert len(states_itrf) == 3
     for i, epc in enumerate(epochs):
         np.testing.assert_array_equal(
-            states_itrf[i], prop.state_in_frame(ReferenceFrame.ITRF, epc)
+            states_itrf[i], prop.state_in_frame(CelestialFrame.ITRF, epc)
         )
 
 

--- a/tests/propagators/test_numerical_orbit_propagator.py
+++ b/tests/propagators/test_numerical_orbit_propagator.py
@@ -14,6 +14,7 @@ from brahe import (
     R_EARTH,
     R_MOON,
     AngleFormat,
+    CelestialFrame,
     CentralBody,
     Epoch,
     ForceModelConfig,
@@ -23,7 +24,6 @@ from brahe import (
     NumericalOrbitPropagator,
     NumericalPropagationConfig,
     OrbitFrame,
-    ReferenceFrame,
     TimeSystem,
     VariationalConfig,
     orbital_period,
@@ -1288,10 +1288,10 @@ def test_numericalorbitpropagator_dorbitstateprovider_states_bci_bcbf_in_frame(
         single = prop.state_bcbf(epochs[i])
         np.testing.assert_allclose(state, single, rtol=1e-10)
 
-    states_itrf = prop.states_in_frame(ReferenceFrame.ITRF, epochs)
+    states_itrf = prop.states_in_frame(CelestialFrame.ITRF, epochs)
     assert len(states_itrf) == 5
     for i, state in enumerate(states_itrf):
-        single = prop.state_in_frame(ReferenceFrame.ITRF, epochs[i])
+        single = prop.state_in_frame(CelestialFrame.ITRF, epochs[i])
         np.testing.assert_allclose(state, single, rtol=1e-10)
 
 
@@ -6119,7 +6119,7 @@ class TestNumericalOrbitPropagatorCentralBodyStateAccessors:
         )
         prop.propagate_to(epoch + 60.0)
 
-        x_itrf = prop.state_in_frame(ReferenceFrame.ITRF, epoch)
+        x_itrf = prop.state_in_frame(CelestialFrame.ITRF, epoch)
         x_ecef = prop.state_ecef(epoch)
         assert np.allclose(x_itrf, x_ecef, atol=1e-9)
 
@@ -6154,7 +6154,7 @@ class TestNumericalOrbitPropagatorCentralBodyStateAccessors:
         # Provider trait accessors are frame-aware on the trajectory too.
         np.testing.assert_array_equal(traj.state_bci(epoch), prop.state_bci(epoch))
         np.testing.assert_array_equal(
-            traj.state_in_frame(ReferenceFrame.LCI, epoch), traj.state_bci(epoch)
+            traj.state_in_frame(CelestialFrame.LCI, epoch), traj.state_bci(epoch)
         )
         np.testing.assert_allclose(
             traj.state_bcbf(epoch), prop.state_bcbf(epoch), atol=1e-6
@@ -6213,7 +6213,7 @@ class TestNumericalOrbitPropagatorCentralBodyStateAccessors:
             None,
         )
 
-        x_lci = prop.state_in_frame(ReferenceFrame.LCI, epoch)
+        x_lci = prop.state_in_frame(CelestialFrame.LCI, epoch)
         x_central = prop.state_bci(epoch)
         assert np.array_equal(x_lci, x_central)
 

--- a/tests/propagators/test_sgp_propagator.py
+++ b/tests/propagators/test_sgp_propagator.py
@@ -1793,11 +1793,11 @@ class TestSGPPropagatorAdditionalMethods:
         for i, epoch in enumerate(epochs):
             np.testing.assert_array_equal(states_bcbf[i], prop.state_bcbf(epoch))
 
-        states_itrf = prop.states_in_frame(brahe.ReferenceFrame.ITRF, epochs)
+        states_itrf = prop.states_in_frame(brahe.CelestialFrame.ITRF, epochs)
         assert len(states_itrf) == 3
         for i, epoch in enumerate(epochs):
             np.testing.assert_array_equal(
-                states_itrf[i], prop.state_in_frame(brahe.ReferenceFrame.ITRF, epoch)
+                states_itrf[i], prop.state_in_frame(brahe.CelestialFrame.ITRF, epoch)
             )
 
 
@@ -1814,7 +1814,7 @@ def test_sgppropagator_bci_bcbf_in_frame(iss_tle):
     np.testing.assert_array_equal(prop.state_bci(epoch), prop.state_gcrf(epoch))
     np.testing.assert_array_equal(prop.state_bcbf(epoch), prop.state_itrf(epoch))
     np.testing.assert_allclose(
-        prop.state_in_frame(brahe.ReferenceFrame.ITRF, epoch),
+        prop.state_in_frame(brahe.CelestialFrame.ITRF, epoch),
         prop.state_itrf(epoch),
         atol=1e-6,
     )

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -895,10 +895,10 @@ def test_state_eci_to_lci_roundtrip():
 
 
 def test_reference_frame_synodic_attrs():
-    assert brahe.ReferenceFrame.from_string("EMR") == brahe.ReferenceFrame.EMR
-    assert brahe.ReferenceFrame.from_string("ser") == brahe.ReferenceFrame.SER
-    assert brahe.ReferenceFrame.from_string("GSE") == brahe.ReferenceFrame.GSE
-    assert str(brahe.ReferenceFrame.EMR) == "EMR"
+    assert brahe.CelestialFrame.from_string("EMR") == brahe.CelestialFrame.EMR
+    assert brahe.CelestialFrame.from_string("ser") == brahe.CelestialFrame.SER
+    assert brahe.CelestialFrame.from_string("GSE") == brahe.CelestialFrame.GSE
+    assert str(brahe.CelestialFrame.EMR) == "EMR"
 
 
 def test_state_gcrf_to_emr_moon_on_x_axis():
@@ -977,12 +977,12 @@ def test_synodic_router_matches_pairwise():
     epc = brahe.Epoch.from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, brahe.UTC)
     x = np.array([1e8, -2e8, 5e7, 1.0e3, -2.0e3, 0.5e3])
     for frame, pairwise in [
-        (brahe.ReferenceFrame.EMR, brahe.state_gcrf_to_emr(epc, x)),
-        (brahe.ReferenceFrame.SER, brahe.state_gcrf_to_ser(epc, x)),
-        (brahe.ReferenceFrame.GSE, brahe.state_gcrf_to_gse(epc, x)),
+        (brahe.CelestialFrame.EMR, brahe.state_gcrf_to_emr(epc, x)),
+        (brahe.CelestialFrame.SER, brahe.state_gcrf_to_ser(epc, x)),
+        (brahe.CelestialFrame.GSE, brahe.state_gcrf_to_gse(epc, x)),
     ]:
         via_router = brahe.state_frame_to_frame(
-            brahe.ReferenceFrame.GCRF, frame, epc, x
+            brahe.CelestialFrame.GCRF, frame, epc, x
         )
         np.testing.assert_allclose(via_router, pairwise, atol=1e-9)
 
@@ -993,7 +993,7 @@ def test_synodic_origin_enum():
 
 
 def test_reference_frame_synodic_constructor():
-    frame = brahe.ReferenceFrame.Synodic(brahe.SynodicOrigin.Barycenter, 399, 301)
+    frame = brahe.CelestialFrame.Synodic(brahe.SynodicOrigin.Barycenter, 399, 301)
     assert frame.synodic_primary == 399
     assert frame.synodic_secondary == 301
     assert frame.synodic_origin == brahe.SynodicOrigin.Barycenter
@@ -1003,7 +1003,7 @@ def test_reference_frame_synodic_constructor():
 def test_reference_frame_synodic_large_ids_construct():
     # Any NAIF ID is accepted at construction time, even for a Barycenter
     # origin outside 0..=999 (no longer validated).
-    frame = brahe.ReferenceFrame.Synodic(brahe.SynodicOrigin.Barycenter, 399, 1301)
+    frame = brahe.CelestialFrame.Synodic(brahe.SynodicOrigin.Barycenter, 399, 1301)
     assert frame.synodic_primary == 399
     assert frame.synodic_secondary == 1301
     assert frame.synodic_origin == brahe.SynodicOrigin.Barycenter
@@ -1018,38 +1018,38 @@ def test_reference_frame_synodic_large_ids_construct():
         brahe.AngleFormat.DEGREES,
     )
     with pytest.raises(RuntimeError):
-        brahe.state_frame_to_frame(brahe.ReferenceFrame.GCRF, frame, epc, x)
+        brahe.state_frame_to_frame(brahe.CelestialFrame.GCRF, frame, epc, x)
 
 
 def test_reference_frame_synodic_non_barycenter_allows_arbitrary_ids():
-    frame = brahe.ReferenceFrame.Synodic(brahe.SynodicOrigin.Primary, 499, 401)
+    frame = brahe.CelestialFrame.Synodic(brahe.SynodicOrigin.Primary, 499, 401)
     assert frame.synodic_primary == 499
     assert frame.synodic_secondary == 401
     assert frame.synodic_origin == brahe.SynodicOrigin.Primary
 
-    frame = brahe.ReferenceFrame.Synodic(brahe.SynodicOrigin.Secondary, 10, 2000001)
+    frame = brahe.CelestialFrame.Synodic(brahe.SynodicOrigin.Secondary, 10, 2000001)
     assert frame.synodic_primary == 10
     assert frame.synodic_secondary == 2000001
     assert frame.synodic_origin == brahe.SynodicOrigin.Secondary
 
 
 def test_reference_frame_synodic_accessors_named_frames():
-    assert brahe.ReferenceFrame.EMR.synodic_primary == 399
-    assert brahe.ReferenceFrame.EMR.synodic_secondary == 301
-    assert brahe.ReferenceFrame.SER.synodic_primary == 10
-    assert brahe.ReferenceFrame.GSE.synodic_secondary == 10
-    assert brahe.ReferenceFrame.GCRF.synodic_primary is None
+    assert brahe.CelestialFrame.EMR.synodic_primary == 399
+    assert brahe.CelestialFrame.EMR.synodic_secondary == 301
+    assert brahe.CelestialFrame.SER.synodic_primary == 10
+    assert brahe.CelestialFrame.GSE.synodic_secondary == 10
+    assert brahe.CelestialFrame.GCRF.synodic_primary is None
 
 
 def test_synodic_matches_emr_state_transform():
     epc = brahe.Epoch.from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, brahe.UTC)
     oe = np.array([brahe.R_EARTH + 500e3, 1e-3, 97.8, 75.0, 25.0, 45.0])
     x = brahe.state_koe_to_eci(oe, brahe.AngleFormat.DEGREES)
-    generic = brahe.ReferenceFrame.Synodic(brahe.SynodicOrigin.Barycenter, 399, 301)
+    generic = brahe.CelestialFrame.Synodic(brahe.SynodicOrigin.Barycenter, 399, 301)
     x_named = brahe.state_frame_to_frame(
-        brahe.ReferenceFrame.GCRF, brahe.ReferenceFrame.EMR, epc, x
+        brahe.CelestialFrame.GCRF, brahe.CelestialFrame.EMR, epc, x
     )
-    x_generic = brahe.state_frame_to_frame(brahe.ReferenceFrame.GCRF, generic, epc, x)
+    x_generic = brahe.state_frame_to_frame(brahe.CelestialFrame.GCRF, generic, epc, x)
     # EMR is an analytic barycenter, the generic router resolves the same
     # pair via SPK; the ~0.1 m barycenter discrepancy is expected (mirrors
     # the Rust equivalence test in src/frames/transform.rs).
@@ -1061,7 +1061,7 @@ def test_router_lci_to_emr():
     # land on EMR's +x_hat axis with zero transverse velocity.
     epc = brahe.Epoch.from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, brahe.UTC)
     x_moon_emr = brahe.state_frame_to_frame(
-        brahe.ReferenceFrame.LCI, brahe.ReferenceFrame.EMR, epc, np.zeros(6)
+        brahe.CelestialFrame.LCI, brahe.CelestialFrame.EMR, epc, np.zeros(6)
     )
     assert 3.4e8 < x_moon_emr[0] < 4.1e8
     assert x_moon_emr[1] == approx(0.0, abs=1e-3)
@@ -1070,16 +1070,16 @@ def test_router_lci_to_emr():
     assert x_moon_emr[5] == approx(0.0, abs=1e-6)
 
 
-# ReferenceFrame router tests
+# CelestialFrame router tests
 
 
 def test_reference_frame_from_string_aliases():
-    assert brahe.ReferenceFrame.from_string("ECI") == brahe.ReferenceFrame.GCRF
-    assert brahe.ReferenceFrame.from_string("ECEF") == brahe.ReferenceFrame.ITRF
-    assert brahe.ReferenceFrame.from_string("eci") == brahe.ReferenceFrame.GCRF
-    assert brahe.ReferenceFrame.from_string("LFPA") == brahe.ReferenceFrame.LFPA
+    assert brahe.CelestialFrame.from_string("ECI") == brahe.CelestialFrame.GCRF
+    assert brahe.CelestialFrame.from_string("ECEF") == brahe.CelestialFrame.ITRF
+    assert brahe.CelestialFrame.from_string("eci") == brahe.CelestialFrame.GCRF
+    assert brahe.CelestialFrame.from_string("LFPA") == brahe.CelestialFrame.LFPA
     with pytest.raises(ValueError):
-        brahe.ReferenceFrame.from_string("bogus")
+        brahe.CelestialFrame.from_string("bogus")
 
 
 def test_body_fixed_custom_frame_round_trip():
@@ -1095,8 +1095,8 @@ def test_body_fixed_custom_frame_round_trip():
         return np.array([[c, s, 0.0], [-s, c, 0.0], [0.0, 0.0, 1.0]])
 
     brahe.register_custom_frame(1042, spin)
-    inertial = brahe.ReferenceFrame.BodyCenteredICRF(-20001)
-    fixed = brahe.ReferenceFrame.BodyFixedCustom(-20001, 1042)
+    inertial = brahe.CelestialFrame.BodyCenteredICRF(-20001)
+    fixed = brahe.CelestialFrame.BodyFixedCustom(-20001, 1042)
 
     epc = t0 + 600.0
     x = np.array([7.0e5, -2.0e5, 3.0e5, 10.0, 25.0, -5.0])
@@ -1128,8 +1128,8 @@ def test_body_fixed_custom_frame_explicit_omega():
         return np.array([[c, s, 0.0], [-s, c, 0.0], [0.0, 0.0, 1.0]])
 
     brahe.register_custom_frame(1043, spin, lambda epc: np.array([0.0, 0.0, rate]))
-    inertial = brahe.ReferenceFrame.BodyCenteredICRF(-20002)
-    fixed = brahe.ReferenceFrame.BodyFixedCustom(-20002, 1043)
+    inertial = brahe.CelestialFrame.BodyCenteredICRF(-20002)
+    fixed = brahe.CelestialFrame.BodyFixedCustom(-20002, 1043)
 
     epc = t0 + 300.0
     x = np.array([7.0e5, -2.0e5, 3.0e5, 10.0, 25.0, -5.0])
@@ -1150,31 +1150,31 @@ def test_body_fixed_custom_allows_reserved_barycenter_range_center():
     to a custom body-fixed frame is not rejected: real user-defined bodies
     and loaded kernels may need any negative ID, and colliding with an
     actual synodic-barycenter ID is astronomically unlikely in practice."""
-    frame = brahe.ReferenceFrame.BodyFixedCustom(-1_000_000_000, 1044)
+    frame = brahe.CelestialFrame.BodyFixedCustom(-1_000_000_000, 1044)
     assert str(frame) == "BodyFixedCustom(center=-1000000000, key=1044)"
-    frame2 = brahe.ReferenceFrame.BodyFixedCustom(-1_000_010_399, 1044)
+    frame2 = brahe.CelestialFrame.BodyFixedCustom(-1_000_010_399, 1044)
     assert str(frame2) == "BodyFixedCustom(center=-1000010399, key=1044)"
 
 
 def test_reference_frame_class_aliases():
     """ECI/ECEF class attributes alias GCRF/ITRF."""
-    assert brahe.ReferenceFrame.ECI == brahe.ReferenceFrame.GCRF
-    assert brahe.ReferenceFrame.ECEF == brahe.ReferenceFrame.ITRF
+    assert brahe.CelestialFrame.ECI == brahe.CelestialFrame.GCRF
+    assert brahe.CelestialFrame.ECEF == brahe.CelestialFrame.ITRF
 
 
 def test_reference_frame_str():
-    assert str(brahe.ReferenceFrame.GCRF) == "GCRF"
-    assert str(brahe.ReferenceFrame.LFPA) == "LFPA"
+    assert str(brahe.CelestialFrame.GCRF) == "GCRF"
+    assert str(brahe.CelestialFrame.LFPA) == "LFPA"
 
 
 def test_reference_frame_generic_variants_equal_named():
     epc = brahe.Epoch.from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, brahe.UTC)
     a = brahe.rotation_frame_to_frame(
-        brahe.ReferenceFrame.MCI, brahe.ReferenceFrame.MCMF, epc
+        brahe.CelestialFrame.MCI, brahe.CelestialFrame.MCMF, epc
     )
     b = brahe.rotation_frame_to_frame(
-        brahe.ReferenceFrame.BodyCenteredICRF(4),
-        brahe.ReferenceFrame.BodyFixedIAU(499),
+        brahe.CelestialFrame.BodyCenteredICRF(4),
+        brahe.CelestialFrame.BodyFixedIAU(499),
         epc,
     )
     np.testing.assert_array_equal(a, b)
@@ -1188,10 +1188,10 @@ def test_body_fixed_pck_generic_variant_equals_lfpa():
     brahe.rotation_lci_to_lfpa(epc)
 
     via_lfpa = brahe.state_frame_to_frame(
-        brahe.ReferenceFrame.GCRF, brahe.ReferenceFrame.LFPA, epc, x
+        brahe.CelestialFrame.GCRF, brahe.CelestialFrame.LFPA, epc, x
     )
     via_pck = brahe.state_frame_to_frame(
-        brahe.ReferenceFrame.GCRF, brahe.ReferenceFrame.BodyFixedPCK(301, 31008), epc, x
+        brahe.CelestialFrame.GCRF, brahe.CelestialFrame.BodyFixedPCK(301, 31008), epc, x
     )
     np.testing.assert_array_equal(via_pck, via_lfpa)
 
@@ -1199,7 +1199,7 @@ def test_body_fixed_pck_generic_variant_equals_lfpa():
 def test_rotation_frame_to_frame_same_frame_is_identity():
     epc = brahe.Epoch.from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, brahe.UTC)
     r = brahe.rotation_frame_to_frame(
-        brahe.ReferenceFrame.GCRF, brahe.ReferenceFrame.GCRF, epc
+        brahe.CelestialFrame.GCRF, brahe.CelestialFrame.GCRF, epc
     )
     np.testing.assert_array_equal(r, np.eye(3))
 
@@ -1208,7 +1208,7 @@ def test_position_frame_to_frame_same_frame_is_identity():
     epc = brahe.Epoch.from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, brahe.UTC)
     x = np.array([1.0, 2.0, 3.0])
     out = brahe.position_frame_to_frame(
-        brahe.ReferenceFrame.GCRF, brahe.ReferenceFrame.GCRF, epc, x
+        brahe.CelestialFrame.GCRF, brahe.CelestialFrame.GCRF, epc, x
     )
     np.testing.assert_array_equal(out, x)
 
@@ -1219,7 +1219,7 @@ def test_router_matches_pairwise_gcrf_itrf(eop):
     x = brahe.state_koe_to_eci(oe, brahe.AngleFormat.DEGREES)
 
     via_router = brahe.state_frame_to_frame(
-        brahe.ReferenceFrame.GCRF, brahe.ReferenceFrame.ITRF, epc, x
+        brahe.CelestialFrame.GCRF, brahe.CelestialFrame.ITRF, epc, x
     )
     pairwise = brahe.state_gcrf_to_itrf(epc, x)
     np.testing.assert_array_equal(via_router, pairwise)
@@ -1230,20 +1230,20 @@ def test_router_matches_pairwise_eci_lci_and_lfpa():
     x = np.array([1e8, -2e8, 5e7, 1.0e3, -2.0e3, 0.5e3])
 
     via_router = brahe.state_frame_to_frame(
-        brahe.ReferenceFrame.GCRF, brahe.ReferenceFrame.LCI, epc, x
+        brahe.CelestialFrame.GCRF, brahe.CelestialFrame.LCI, epc, x
     )
     pairwise = brahe.state_eci_to_lci(epc, x)
     np.testing.assert_allclose(via_router, pairwise, atol=1e-9)
 
     x_lci = via_router
     via_router_lfpa = brahe.state_frame_to_frame(
-        brahe.ReferenceFrame.LCI, brahe.ReferenceFrame.LFPA, epc, x_lci
+        brahe.CelestialFrame.LCI, brahe.CelestialFrame.LFPA, epc, x_lci
     )
     pairwise_lfpa = brahe.state_lci_to_lfpa(epc, x_lci)
     np.testing.assert_array_equal(via_router_lfpa, pairwise_lfpa)  # bit-identical
 
     via_router_composed = brahe.state_frame_to_frame(
-        brahe.ReferenceFrame.GCRF, brahe.ReferenceFrame.LFPA, epc, x
+        brahe.CelestialFrame.GCRF, brahe.CelestialFrame.LFPA, epc, x
     )
     composed = brahe.state_lci_to_lfpa(epc, brahe.state_eci_to_lci(epc, x))
     np.testing.assert_allclose(via_router_composed, composed, atol=1e-9)
@@ -1251,16 +1251,16 @@ def test_router_matches_pairwise_eci_lci_and_lfpa():
 
 def test_router_roundtrip_all_pairs(eop):
     frames = [
-        brahe.ReferenceFrame.GCRF,
-        brahe.ReferenceFrame.ITRF,
-        brahe.ReferenceFrame.EME2000,
-        brahe.ReferenceFrame.LCI,
-        brahe.ReferenceFrame.LFPA,
-        brahe.ReferenceFrame.LFME,
-        brahe.ReferenceFrame.MCI,
-        brahe.ReferenceFrame.MCMF,
-        brahe.ReferenceFrame.EMBI,
-        brahe.ReferenceFrame.SSBI,
+        brahe.CelestialFrame.GCRF,
+        brahe.CelestialFrame.ITRF,
+        brahe.CelestialFrame.EME2000,
+        brahe.CelestialFrame.LCI,
+        brahe.CelestialFrame.LFPA,
+        brahe.CelestialFrame.LFME,
+        brahe.CelestialFrame.MCI,
+        brahe.CelestialFrame.MCMF,
+        brahe.CelestialFrame.EMBI,
+        brahe.CelestialFrame.SSBI,
     ]
     epc = brahe.Epoch.from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, brahe.UTC)
     x = np.array([1e8, -2e8, 5e7, 1.0e3, -2.0e3, 0.5e3])
@@ -1281,10 +1281,10 @@ def test_state_frame_to_frame_roundtrip_lci(eop):
     epc = brahe.Epoch.from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, brahe.UTC)
     x = np.array([1e8, -2e8, 5e7, 1.0e3, -2.0e3, 0.5e3])
     y = brahe.state_frame_to_frame(
-        brahe.ReferenceFrame.GCRF, brahe.ReferenceFrame.LCI, epc, x
+        brahe.CelestialFrame.GCRF, brahe.CelestialFrame.LCI, epc, x
     )
     x2 = brahe.state_frame_to_frame(
-        brahe.ReferenceFrame.LCI, brahe.ReferenceFrame.GCRF, epc, y
+        brahe.CelestialFrame.LCI, brahe.CelestialFrame.GCRF, epc, y
     )
     np.testing.assert_allclose(x2, x, atol=1e-4)
 
@@ -1298,10 +1298,10 @@ def test_body_fixed_iau_translation_auto_loads_satellite_kernel():
     epc = brahe.Epoch.from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, brahe.UTC)
     x = np.array([1e8, -2e8, 5e7, 1.0e3, -2.0e3, 0.5e3])
     via_iau = brahe.state_frame_to_frame(
-        brahe.ReferenceFrame.GCRF, brahe.ReferenceFrame.BodyFixedIAU(499), epc, x
+        brahe.CelestialFrame.GCRF, brahe.CelestialFrame.BodyFixedIAU(499), epc, x
     )
     via_mcmf = brahe.state_frame_to_frame(
-        brahe.ReferenceFrame.GCRF, brahe.ReferenceFrame.MCMF, epc, x
+        brahe.CelestialFrame.GCRF, brahe.CelestialFrame.MCMF, epc, x
     )
     np.testing.assert_allclose(via_iau, via_mcmf, atol=1e-9)
 
@@ -1316,11 +1316,11 @@ def test_rotation_frame_to_frame_same_center_eme2000():
     is a same-center, EOP-free constant bias rotation."""
     epc = brahe.Epoch.from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, brahe.UTC)
     r = brahe.rotation_frame_to_frame(
-        brahe.ReferenceFrame.GCRF, brahe.ReferenceFrame.EME2000, epc
+        brahe.CelestialFrame.GCRF, brahe.CelestialFrame.EME2000, epc
     )
     np.testing.assert_array_equal(r, brahe.rotation_gcrf_to_eme2000())
     r_inv = brahe.rotation_frame_to_frame(
-        brahe.ReferenceFrame.EME2000, brahe.ReferenceFrame.GCRF, epc
+        brahe.CelestialFrame.EME2000, brahe.CelestialFrame.GCRF, epc
     )
     np.testing.assert_allclose(r_inv @ r, np.eye(3), atol=1e-12)
 
@@ -1331,11 +1331,11 @@ def test_state_frame_to_frame_same_center_eme2000_no_spk():
     epc = brahe.Epoch.from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, brahe.UTC)
     x = np.array([brahe.R_EARTH + 500e3, 1e5, 2e5, 1.0, 7.5e3, 0.5e3])
     via_router = brahe.state_frame_to_frame(
-        brahe.ReferenceFrame.GCRF, brahe.ReferenceFrame.EME2000, epc, x
+        brahe.CelestialFrame.GCRF, brahe.CelestialFrame.EME2000, epc, x
     )
     np.testing.assert_array_equal(via_router, brahe.state_gcrf_to_eme2000(x))
     back = brahe.state_frame_to_frame(
-        brahe.ReferenceFrame.EME2000, brahe.ReferenceFrame.GCRF, epc, via_router
+        brahe.CelestialFrame.EME2000, brahe.CelestialFrame.GCRF, epc, via_router
     )
     np.testing.assert_allclose(back, x, atol=1e-6)
 
@@ -1345,8 +1345,8 @@ def test_router_body_fixed_iau_same_center_no_kernels():
     BodyCenteredICRF(id) <-> BodyFixedIAU(id) is a same-center, kernel-free
     rotation-only + transport path (IAU analytic model)."""
     epc = brahe.Epoch.from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, brahe.UTC)
-    icrf = brahe.ReferenceFrame.BodyCenteredICRF(599)
-    fixed = brahe.ReferenceFrame.BodyFixedIAU(599)
+    icrf = brahe.CelestialFrame.BodyCenteredICRF(599)
+    fixed = brahe.CelestialFrame.BodyFixedIAU(599)
     x = np.array([7.0e7, -2.0e7, 3.0e7, 10.0, 25.0, -5.0])
 
     x_fixed = brahe.state_frame_to_frame(icrf, fixed, epc, x)
@@ -1365,8 +1365,8 @@ def test_router_errors_on_unsupported_iau_body():
     epc = brahe.Epoch.from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, brahe.UTC)
     with pytest.raises(RuntimeError):
         brahe.rotation_frame_to_frame(
-            brahe.ReferenceFrame.BodyCenteredICRF(999999),
-            brahe.ReferenceFrame.BodyFixedIAU(999999),
+            brahe.CelestialFrame.BodyCenteredICRF(999999),
+            brahe.CelestialFrame.BodyFixedIAU(999999),
             epc,
         )
 
@@ -1533,7 +1533,7 @@ def test_batch_frame_router(eop):
         ]
     )
     positions = states[:, :3]
-    RF = brahe.ReferenceFrame
+    RF = brahe.CelestialFrame
     for src, dst in [
         (RF.GCRF, RF.ITRF),
         (RF.GCRF, RF.LFPA),

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -894,7 +894,7 @@ def test_state_eci_to_lci_roundtrip():
 # ---------------------------------------------------------------------------
 
 
-def test_reference_frame_synodic_attrs():
+def test_celestial_frame_synodic_attrs():
     assert brahe.CelestialFrame.from_string("EMR") == brahe.CelestialFrame.EMR
     assert brahe.CelestialFrame.from_string("ser") == brahe.CelestialFrame.SER
     assert brahe.CelestialFrame.from_string("GSE") == brahe.CelestialFrame.GSE
@@ -992,7 +992,7 @@ def test_synodic_origin_enum():
     assert str(brahe.SynodicOrigin.Barycenter) == "Barycenter"
 
 
-def test_reference_frame_synodic_constructor():
+def test_celestial_frame_synodic_constructor():
     frame = brahe.CelestialFrame.Synodic(brahe.SynodicOrigin.Barycenter, 399, 301)
     assert frame.synodic_primary == 399
     assert frame.synodic_secondary == 301
@@ -1000,7 +1000,7 @@ def test_reference_frame_synodic_constructor():
     assert "Synodic" in str(frame)
 
 
-def test_reference_frame_synodic_large_ids_construct():
+def test_celestial_frame_synodic_large_ids_construct():
     # Any NAIF ID is accepted at construction time, even for a Barycenter
     # origin outside 0..=999 (no longer validated).
     frame = brahe.CelestialFrame.Synodic(brahe.SynodicOrigin.Barycenter, 399, 1301)
@@ -1021,7 +1021,7 @@ def test_reference_frame_synodic_large_ids_construct():
         brahe.state_frame_to_frame(brahe.CelestialFrame.GCRF, frame, epc, x)
 
 
-def test_reference_frame_synodic_non_barycenter_allows_arbitrary_ids():
+def test_celestial_frame_synodic_non_barycenter_allows_arbitrary_ids():
     frame = brahe.CelestialFrame.Synodic(brahe.SynodicOrigin.Primary, 499, 401)
     assert frame.synodic_primary == 499
     assert frame.synodic_secondary == 401
@@ -1033,7 +1033,7 @@ def test_reference_frame_synodic_non_barycenter_allows_arbitrary_ids():
     assert frame.synodic_origin == brahe.SynodicOrigin.Secondary
 
 
-def test_reference_frame_synodic_accessors_named_frames():
+def test_celestial_frame_synodic_accessors_named_frames():
     assert brahe.CelestialFrame.EMR.synodic_primary == 399
     assert brahe.CelestialFrame.EMR.synodic_secondary == 301
     assert brahe.CelestialFrame.SER.synodic_primary == 10
@@ -1073,7 +1073,7 @@ def test_router_lci_to_emr():
 # CelestialFrame router tests
 
 
-def test_reference_frame_from_string_aliases():
+def test_celestial_frame_from_string_aliases():
     assert brahe.CelestialFrame.from_string("ECI") == brahe.CelestialFrame.GCRF
     assert brahe.CelestialFrame.from_string("ECEF") == brahe.CelestialFrame.ITRF
     assert brahe.CelestialFrame.from_string("eci") == brahe.CelestialFrame.GCRF
@@ -1156,18 +1156,18 @@ def test_body_fixed_custom_allows_reserved_barycenter_range_center():
     assert str(frame2) == "BodyFixedCustom(center=-1000010399, key=1044)"
 
 
-def test_reference_frame_class_aliases():
+def test_celestial_frame_class_aliases():
     """ECI/ECEF class attributes alias GCRF/ITRF."""
     assert brahe.CelestialFrame.ECI == brahe.CelestialFrame.GCRF
     assert brahe.CelestialFrame.ECEF == brahe.CelestialFrame.ITRF
 
 
-def test_reference_frame_str():
+def test_celestial_frame_str():
     assert str(brahe.CelestialFrame.GCRF) == "GCRF"
     assert str(brahe.CelestialFrame.LFPA) == "LFPA"
 
 
-def test_reference_frame_generic_variants_equal_named():
+def test_celestial_frame_generic_variants_equal_named():
     epc = brahe.Epoch.from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, brahe.UTC)
     a = brahe.rotation_frame_to_frame(
         brahe.CelestialFrame.MCI, brahe.CelestialFrame.MCMF, epc

--- a/tests/trajectories/test_orbit_trajectory.py
+++ b/tests/trajectories/test_orbit_trajectory.py
@@ -3945,7 +3945,7 @@ def test_orbittrajectory_body_centered_inertial_providers(naif_cache_setup):
 
     np.testing.assert_array_equal(traj.state_bci(epoch), state)
     np.testing.assert_array_equal(
-        traj.state_in_frame(bh.ReferenceFrame.LCI, epoch), state
+        traj.state_in_frame(bh.CelestialFrame.LCI, epoch), state
     )
 
     offset = bh.spk_state(301, 399, epoch)


### PR DESCRIPTION
# Pull Request

## Description

Renames `ReferenceFrame` to `CelestialFrame` across the Rust core, Python bindings, type stubs, tests, examples, and documentation. This is a pure mechanical token rename with no behavior changes and no deprecation alias, and it is the root of a stack that a follow-up frame-foundations PR will build on.

## Changelog

### Changed
- **Breaking:** `ReferenceFrame` renamed to `CelestialFrame` in Rust and Python — the frame router, all frame-router functions, and every associated binding now use the new name. The `ReferenceFrame` name now denotes the new unified supertype introduced in [#508](https://github.com/duncaneddy/brahe/pull/508) spanning celestial, orbit-relative, and body frames, so code using `ReferenceFrame::GCRF` becomes `CelestialFrame::GCRF`.

## Note to Reviewers
Mechanical rename verified by a zero-occurrence sweep for `ReferenceFrame` across `src`, `crates`, `tests`, `brahe`, `examples`, and `docs` (excluding the changelog's historical entries, which legitimately name the old token). `just check` (Rust + Python tests with coverage, clippy, format, stubs, docs) passes clean.

