### PR TITLE
Stop the SpaceTrack mock from advertising a reusable connection

### DIFF
--- a/tests/spacetrack/test_spacetrack.py
+++ b/tests/spacetrack/test_spacetrack.py
@@ -473,7 +473,12 @@ class TestSpaceTrackClientMethods:
 
 
 def _serve_slowly(port, delay):
-    """Answer every request with an empty JSON list after `delay` seconds."""
+    """Answer every request with an empty JSON list after `delay` seconds.
+
+    The handler closes the socket after each response, so it must advertise
+    `Connection: close`. Without it the client pools the connection and sends
+    its next request on a socket the server has already abandoned.
+    """
 
     class Handler(BaseHTTPRequestHandler):
         def _reply(self):
@@ -482,6 +487,7 @@ def _serve_slowly(port, delay):
             self.send_response(200)
             self.send_header("Content-Type", "application/json")
             self.send_header("Content-Length", str(len(payload)))
+            self.send_header("Connection", "close")
             self.end_headers()
             self.wfile.write(payload)
 


### PR DESCRIPTION
# Pull Request

## Description

`tests/spacetrack/test_spacetrack.py::TestSpaceTrackClientGil::test_query_releases_gil` failed intermittently on loaded macOS runners with `SpaceTrack query request failed: io: Peer disconnected`. The cause is in the test's mock server, not in the client.

`SpaceTrackClient.query_raw` authenticates before querying, so it issues two requests through one pooled `ureq::Agent`: `POST /ajaxauth/login`, then the query `GET`. The mock replied `HTTP/1.0 200 OK` with a `Content-Length` and no `Connection` header, then closed the socket, which is what Python's `BaseHTTPRequestHandler` does after every HTTP/1.0 response. ureq marks a connection non-reusable only when the response carries `Connection: close` (`ureq-proto/src/client/recvresp.rs:74`) or the body is close-delimited, and a `Content-Length` makes the body length-delimited even for HTTP/1.0, so neither applied and the socket went back into the pool (`ureq/src/run.rs:610`). The pool's liveness probe then either noticed the server's FIN or briefly considered the socket reusable (`ureq/src/pool.rs:125`, `:263`), which is why the query — always the second request on that agent, and the only one exposed to the reuse — failed only under load.

Sending `Connection: close` makes the mock describe the socket behaviour it actually has, so the client opens a fresh connection for the query. The `errors == []` assertion is kept: with a truthful mock the query genuinely succeeds, and that assertion is what would catch a regression.

## Changelog

### Fixed
- Fixed an intermittent failure in the SpaceTrack GIL test, whose mock server closed each connection while advertising a reusable one, causing the client to send the query on a socket the server had already abandoned.

## Related Issue

Closes #506

## Note to Reviewers

Verified with a reproduction that drives the real client against a server differing only in that header, with the close delayed so the losing race is deterministic. Without the header the client opens 1 TCP connection and fails; with it, 2 connections and success. The Celestrak fixture has the same HTTP/1.0-plus-`Content-Length` shape, but measurably does not reuse the connection (2 connections even with a 5 s close delay), so it is left alone.

Two pre-existing issues in the fixture are out of scope here and unrelated to this failure: the port is chosen by binding and releasing a probe socket before the child binds it, leaving a small bind race under `pytest -n auto`; and the worker thread records only `BraheError`, so another exception type would escape without appearing in `errors`.
