### PR TITLE
Reject XML characters the ODM writers cannot encode

### DIFF
--- a/src/ccsds/xml/writer.rs
+++ b/src/ccsds/xml/writer.rs
@@ -62,6 +62,93 @@ fn escape_xml_attribute(s: &str) -> String {
     escape_xml_text(s).replace('"', "&quot;")
 }
 
+/// Test a character against the XML 1.0 `Char` production.
+///
+/// XML 1.0 subsection 2.2 admits `#x9`, `#xA`, `#xD`, and the ranges
+/// `[#x20-#xD7FF]`, `[#xE000-#xFFFD]`, and `[#x10000-#x10FFFF]`. The remaining
+/// C0 controls, `U+FFFE`, and `U+FFFF` cannot appear in a document at all, and
+/// unlike the markup delimiters they cannot be rescued by escaping: the
+/// numeric character reference for such a character is equally forbidden.
+///
+/// # Arguments
+///
+/// * `c` - The character to test.
+///
+/// # Returns
+///
+/// * `bool` - `true` when XML 1.0 permits the character in a document.
+///
+/// # Examples
+///
+/// ```ignore
+/// assert!(is_xml_char('\t'));
+/// assert!(!is_xml_char('\u{1}'));
+/// ```
+fn is_xml_char(c: char) -> bool {
+    matches!(c,
+        '\u{9}' | '\u{A}' | '\u{D}'
+        | '\u{20}'..='\u{D7FF}'
+        | '\u{E000}'..='\u{FFFD}'
+        | '\u{10000}'..='\u{10FFFF}'
+    )
+}
+
+/// Reject a document carrying a character XML 1.0 forbids.
+///
+/// CCSDS 502.0-B-3 subsection 8.2 fixes the XML version at 1.0 and subsection
+/// 8.13.5 defines every ODM text value as the XML Schema `string` type, so a
+/// value carrying a character outside the `Char` production has no valid
+/// representation and the message cannot be written. The check runs over the
+/// assembled document rather than each value, which covers every emission
+/// site: element content, attribute values, and the element names the
+/// user-defined block builds from its keys.
+///
+/// # Arguments
+///
+/// * `msg_type` - The CCSDS message type named in the error (e.g. "OPM")
+/// * `document` - The assembled XML document.
+///
+/// # Returns
+///
+/// * `Result<(), BraheError>` - `Ok` when every character is writable, or an
+///   `Error` naming the element and the offending code point.
+///
+/// # Examples
+///
+/// ```ignore
+/// assert!(validate_xml_characters("OPM", "<ORIGINATOR>GSOC</ORIGINATOR>").is_ok());
+/// assert!(validate_xml_characters("OPM", "<ORIGINATOR>GS\u{1}C</ORIGINATOR>").is_err());
+/// ```
+fn validate_xml_characters(msg_type: &str, document: &str) -> Result<(), BraheError> {
+    let Some((index, c)) = document.char_indices().find(|(_, c)| !is_xml_char(*c)) else {
+        return Ok(());
+    };
+
+    // The offending character sits inside the element opened most recently, so
+    // the enclosing tag name is the CCSDS keyword to name in the error. A
+    // character that interrupts the name rather than following it leaves only
+    // a prefix, since the rest of the name cannot be printed.
+    let tag = document[..index]
+        .rfind('<')
+        .map(|open| &document[open + 1..index])
+        .unwrap_or_default();
+    let element: String = tag
+        .chars()
+        .take_while(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.' | ':'))
+        .collect();
+    let located = if element.len() == tag.len() {
+        format!("XML element name beginning '{}'", element)
+    } else {
+        format!("XML element '{}'", element)
+    };
+
+    Err(BraheError::Error(format!(
+        "CCSDS {}: {} contains U+{:04X}, which XML 1.0 forbids in any document; \
+         the character has no XML representation and must be removed before writing",
+        msg_type, located, c as u32
+    )))
+}
+
 /// XML covariance element names (6x6 lower-triangular, 21 elements).
 const COV_NAMES: [&str; 21] = [
     "CX_X",
@@ -391,6 +478,8 @@ pub fn write_oem_xml(oem: &crate::ccsds::oem::OEM) -> Result<String, BraheError>
     out.push_str(&format!("{}</body>\n", i1));
     out.push_str("</oem>\n");
 
+    validate_xml_characters("OEM", &out)?;
+
     Ok(out)
 }
 
@@ -591,6 +680,8 @@ pub fn write_omm_xml(omm: &crate::ccsds::omm::OMM) -> Result<String, BraheError>
 
     out.push_str(&format!("{}</body>\n", i1));
     out.push_str("</omm>\n");
+
+    validate_xml_characters("OMM", &out)?;
 
     Ok(out)
 }
@@ -806,6 +897,8 @@ pub fn write_opm_xml(opm: &crate::ccsds::opm::OPM) -> Result<String, BraheError>
 
     out.push_str(&format!("{}</body>\n", i1));
     out.push_str("</opm>\n");
+
+    validate_xml_characters("OPM", &out)?;
 
     Ok(out)
 }
@@ -1802,6 +1895,8 @@ pub fn write_cdm_xml(cdm: &crate::ccsds::cdm::CDM) -> Result<String, BraheError>
     out.push_str(&format!("{}</body>\n", i1));
     out.push_str("</cdm>\n");
 
+    validate_xml_characters("CDM", &out)?;
+
     Ok(out)
 }
 
@@ -1820,6 +1915,9 @@ mod tests {
 
     /// The same text once escaped for element content.
     const MARKUP_ESCAPED: &str = "R&amp;D &lt;ops&gt; \"quoted\"";
+
+    /// Free text carrying U+0001, which XML 1.0 forbids in any document.
+    const FORBIDDEN: &str = "GSOC\u{1}LAB";
 
     #[test]
     #[serial_test::parallel]
@@ -2036,5 +2134,129 @@ mod tests {
 
         // Nothing raw leaked into any of them.
         assert!(!xml.contains("R&D <ops>"));
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_write_oem_xml_rejects_forbidden_characters() {
+        let content = std::fs::read_to_string("test_assets/ccsds/oem/OEMExample1.txt").unwrap();
+        let mut oem = OEM::from_str(&content).unwrap();
+        oem.header.originator = FORBIDDEN.to_string();
+
+        let msg = oem.to_string(CCSDSFormat::XML).unwrap_err().to_string();
+        assert!(msg.contains("OEM"), "{}", msg);
+        assert!(msg.contains("ORIGINATOR"), "{}", msg);
+        assert!(msg.contains("U+0001"), "{}", msg);
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_write_omm_xml_rejects_forbidden_characters() {
+        let content = std::fs::read_to_string("test_assets/ccsds/omm/OMMExample2.txt").unwrap();
+        let mut omm = OMM::from_str(&content).unwrap();
+        omm.metadata.object_name = FORBIDDEN.to_string();
+
+        let msg = omm.to_string(CCSDSFormat::XML).unwrap_err().to_string();
+        assert!(msg.contains("OMM"), "{}", msg);
+        assert!(msg.contains("OBJECT_NAME"), "{}", msg);
+        assert!(msg.contains("U+0001"), "{}", msg);
+
+        // A user-defined parameter reaches the document as an attribute value
+        // and as part of an element name, neither of which the element-content
+        // escaping touches.
+        let mut omm = OMM::from_str(&content).unwrap();
+        omm.user_defined = Some(crate::ccsds::common::CCSDSUserDefined {
+            parameters: std::collections::HashMap::from([(
+                "EARTH_MODEL".to_string(),
+                FORBIDDEN.to_string(),
+            )]),
+        });
+        let msg = omm.to_string(CCSDSFormat::XML).unwrap_err().to_string();
+        assert!(msg.contains("USER_DEFINED_EARTH_MODEL"), "{}", msg);
+        assert!(msg.contains("U+0001"), "{}", msg);
+
+        let mut omm = OMM::from_str(&content).unwrap();
+        omm.user_defined = Some(crate::ccsds::common::CCSDSUserDefined {
+            parameters: std::collections::HashMap::from([(
+                FORBIDDEN.to_string(),
+                "value".to_string(),
+            )]),
+        });
+        let msg = omm.to_string(CCSDSFormat::XML).unwrap_err().to_string();
+        assert!(msg.contains("USER_DEFINED_GSOC"), "{}", msg);
+        assert!(msg.contains("U+0001"), "{}", msg);
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_write_opm_xml_rejects_forbidden_characters() {
+        let content = std::fs::read_to_string("test_assets/ccsds/opm/OPMExample1.txt").unwrap();
+        let mut opm = OPM::from_str(&content).unwrap();
+        opm.metadata.comments = vec![FORBIDDEN.to_string()];
+
+        let msg = opm.to_string(CCSDSFormat::XML).unwrap_err().to_string();
+        assert!(msg.contains("OPM"), "{}", msg);
+        assert!(msg.contains("COMMENT"), "{}", msg);
+        assert!(msg.contains("U+0001"), "{}", msg);
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_write_cdm_xml_rejects_forbidden_characters() {
+        let content = std::fs::read_to_string("test_assets/ccsds/cdm/CDMExample1.txt").unwrap();
+        let mut cdm = CDM::from_str(&content).unwrap();
+        cdm.object1.metadata.object_name = FORBIDDEN.to_string();
+
+        let msg = cdm.to_string(CCSDSFormat::XML).unwrap_err().to_string();
+        assert!(msg.contains("CDM"), "{}", msg);
+        assert!(msg.contains("OBJECT_NAME"), "{}", msg);
+        assert!(msg.contains("U+0001"), "{}", msg);
+    }
+
+    #[test]
+    #[serial_test::parallel]
+    fn test_write_xml_follows_the_xml_char_production() {
+        // XML 1.0 subsection 2.2 admits #x9, #xA, #xD, and the ranges
+        // [#x20-#xD7FF], [#xE000-#xFFFD], and [#x10000-#x10FFFF]; everything
+        // else is forbidden outright.
+        let content = std::fs::read_to_string("test_assets/ccsds/opm/OPMExample1.txt").unwrap();
+        let write_with_originator = |c: char| {
+            let mut opm = OPM::from_str(&content).unwrap();
+            opm.header.originator = format!("GSOC{}LAB", c);
+            opm.to_string(CCSDSFormat::XML)
+        };
+
+        for c in [
+            '\t',
+            '\n',
+            '\r',
+            ' ',
+            '\u{D7FF}',
+            '\u{E000}',
+            '\u{FFFD}',
+            '\u{10000}',
+            '\u{1FFFE}',
+            '\u{10FFFF}',
+        ] {
+            let xml = write_with_originator(c)
+                .unwrap_or_else(|e| panic!("U+{:04X} should be written: {}", c as u32, e));
+            assert!(
+                xml.contains(&format!("<ORIGINATOR>GSOC{}LAB</ORIGINATOR>", c)),
+                "U+{:04X} missing from output",
+                c as u32
+            );
+        }
+
+        for c in [
+            '\u{0}', '\u{8}', '\u{B}', '\u{C}', '\u{E}', '\u{1F}', '\u{FFFE}', '\u{FFFF}',
+        ] {
+            let err = write_with_originator(c)
+                .expect_err(&format!("U+{:04X} should be rejected", c as u32));
+            assert!(
+                err.to_string().contains(&format!("U+{:04X}", c as u32)),
+                "{}",
+                err
+            );
+        }
     }
 }

--- a/tests/ccsds/test_xml_writer.py
+++ b/tests/ccsds/test_xml_writer.py
@@ -1,6 +1,10 @@
 """Tests for CCSDS XML writing — parity with Rust tests in src/ccsds/xml/writer.rs."""
 
-import brahe  # noqa: F401
+import xml.etree.ElementTree as ET
+
+import pytest
+
+import brahe
 from brahe.ccsds import CDM, OEM, OMM, OPM
 
 # Free text exercising every character that terminates XML markup.
@@ -9,18 +13,26 @@ MARKUP = 'R&D <ops> "quoted"'
 # The same text once escaped for element content.
 MARKUP_ESCAPED = 'R&amp;D &lt;ops&gt; "quoted"'
 
+# Free text carrying U+0001, which XML 1.0 forbids in any document.
+FORBIDDEN = "GSOC\u0001LAB"
 
-def _with_markup_originator(path):
-    """Read a KVN fixture and replace its ORIGINATOR with XML-hostile text."""
+
+def _with_originator(path, value):
+    """Read a KVN fixture and replace its ORIGINATOR with the given text."""
     lines = []
     with open(path) as f:
         source = f.read()
     for line in source.splitlines():
         if line.split("=")[0].strip() == "ORIGINATOR":
-            lines.append(f"ORIGINATOR = {MARKUP}")
+            lines.append(f"ORIGINATOR = {value}")
         else:
             lines.append(line)
     return "\n".join(lines) + "\n"
+
+
+def _with_markup_originator(path):
+    """Read a KVN fixture and replace its ORIGINATOR with XML-hostile text."""
+    return _with_originator(path, MARKUP)
 
 
 def test_write_oem_xml_escapes_free_text(eop):
@@ -57,3 +69,76 @@ def test_write_cdm_xml_escapes_free_text(eop):
     xml = cdm.to_string("xml")
     assert f"<ORIGINATOR>{MARKUP_ESCAPED}</ORIGINATOR>" in xml
     assert CDM.from_str(xml).originator == MARKUP
+
+
+@pytest.mark.parametrize(
+    "cls,path,message_type",
+    [
+        (OEM, "test_assets/ccsds/oem/OEMExample1.txt", "OEM"),
+        (OMM, "test_assets/ccsds/omm/OMMExample2.txt", "OMM"),
+        (OPM, "test_assets/ccsds/opm/OPMExample1.txt", "OPM"),
+        (CDM, "test_assets/ccsds/cdm/CDMExample1.txt", "CDM"),
+    ],
+)
+def test_write_xml_rejects_forbidden_characters(eop, cls, path, message_type):
+    """Mirror of test_write_<msg>_xml_rejects_forbidden_characters in Rust."""
+    message = cls.from_str(_with_originator(path, FORBIDDEN))
+
+    with pytest.raises(brahe.BraheError) as excinfo:
+        message.to_string("xml")
+
+    assert message_type in str(excinfo.value)
+    assert "ORIGINATOR" in str(excinfo.value)
+    assert "U+0001" in str(excinfo.value)
+
+
+def test_write_omm_xml_rejects_forbidden_user_defined_value(eop):
+    """Mirror of the user-defined half of the Rust OMM rejection test."""
+    source = _with_originator("test_assets/ccsds/omm/OMMExample2.txt", "NOAA/USA")
+    source += f"USER_DEFINED_EARTH_MODEL = {FORBIDDEN}\n"
+
+    with pytest.raises(brahe.BraheError) as excinfo:
+        OMM.from_str(source).to_string("xml")
+
+    assert "USER_DEFINED_EARTH_MODEL" in str(excinfo.value)
+    assert "U+0001" in str(excinfo.value)
+
+
+def test_write_omm_xml_rejects_forbidden_user_defined_key(eop):
+    """Mirror of the user-defined key half of the Rust OMM rejection test."""
+    source = _with_originator("test_assets/ccsds/omm/OMMExample2.txt", "NOAA/USA")
+    source += f"USER_DEFINED_{FORBIDDEN} = value\n"
+
+    with pytest.raises(brahe.BraheError) as excinfo:
+        OMM.from_str(source).to_string("xml")
+
+    assert "USER_DEFINED_GSOC" in str(excinfo.value)
+    assert "U+0001" in str(excinfo.value)
+
+
+def test_write_xml_follows_the_xml_char_production(eop):
+    """Mirror of test_write_xml_follows_the_xml_char_production in Rust."""
+    path = "test_assets/ccsds/opm/OPMExample1.txt"
+
+    # A line break cannot travel through a KVN value, so the Rust test covers
+    # the #xA and #xD bounds.
+    for c in [
+        "\t",
+        " ",
+        "\ud7ff",
+        "\ue000",
+        "\ufffd",
+        "\U00010000",
+        "\U0001fffe",
+        "\U0010ffff",
+    ]:
+        opm = OPM.from_str(_with_originator(path, "GSOC" + c + "LAB"))
+        xml = opm.to_string("xml")
+        assert f"<ORIGINATOR>GSOC{c}LAB</ORIGINATOR>" in xml
+        ET.fromstring(xml)
+
+    for c in ["\x00", "\x08", "\x0b", "\x0c", "\x0e", "\x1f", "\ufffe", "\uffff"]:
+        opm = OPM.from_str(_with_originator(path, "GSOC" + c + "LAB"))
+        with pytest.raises(brahe.BraheError) as excinfo:
+            opm.to_string("xml")
+        assert f"U+{ord(c):04X}" in str(excinfo.value)


### PR DESCRIPTION
# Pull Request

## Description

The CCSDS XML writers escaped the markup delimiters but passed through characters that XML 1.0 forbids outright. The `Char` production in subsection 2.2 admits `#x9`, `#xA`, `#xD`, and the ranges `[#x20-#xD7FF]`, `[#xE000-#xFFFD]`, and `[#x10000-#x10FFFF]`; the remaining C0 controls, `U+FFFE`, and `U+FFFF` cannot appear in a document at all, and unlike the delimiters they cannot be rescued by escaping, because the numeric character reference for such a character is equally forbidden. CCSDS 502.0-B-3 subsection 8.13.5 defines every ODM text value as the XML Schema `string` type and subsection 8.2 fixes the version at 1.0, so such a value has no valid representation and the message cannot be written. Nothing on the write path rejected it, so `to_string(CCSDSFormat::XML)` returned `Ok` with a document that no conforming parser will read; brahe read it back only because quick-xml does not enforce the character range. The value reaches the writer by reading a KVN file, where subsection 7.5.2 places no restriction on free text.

`is_xml_char` states the `Char` production and `validate_xml_characters` runs it over the assembled document at the end of `write_oem_xml`, `write_omm_xml`, `write_opm_xml`, and `write_cdm_xml`, returning a `BraheError` naming the enclosing element and the offending code point. Validating the document rather than each value at its escape site covers element content, attribute values, and the element names the user-defined block builds from its keys — the last of which no escaping helper touches. KVN and JSON keep no such check, since KVN carries the character verbatim and JSON encodes it as a unicode escape, which makes XML the only encoding that cannot represent it.

## Changelog

### Fixed
- CCSDS ODM and CDM XML writing now rejects text carrying a character XML 1.0 forbids (the C0 controls other than tab, line feed, and carriage return, along with `U+FFFE` and `U+FFFF`) with an error naming the element and code point, instead of emitting a document that no conforming XML parser will read

## Related Issue

Closes #493

## Note to Reviewers

The reproduction from the issue now raises for every message type:

```
CCSDS OPM: XML element 'ORIGINATOR' contains U+0001, which XML 1.0 forbids in any document; the character has no XML representation and must be removed before writing
```

`just test-rust` (5512 passed), `just test-python` (3618 passed), `just lint`, `just format-check`, `just stubs`, and `just docs` are all clean, and the new lines carry full line coverage in `lcov.info`.

Unrelated to this change, `just test-python` fails locally with `not found *.profraw files` whenever the target directory holds an uninstrumented extension from an earlier `just test-python-fast`, because `cargo llvm-cov clean --workspace` does not remove `libbrahe_py.dylib` and maturin then reuses it. `cargo clean -p brahe-py` clears it. Left alone here as out of scope.
