### PR TITLE
Invert time system offset when building epochs

### DIFF
--- a/src/time/conversions.rs
+++ b/src/time/conversions.rs
@@ -517,7 +517,17 @@ pub fn time_system_offset(
 /// - `time_system`: Time system the date is expressed in
 ///
 /// # Returns
-/// - Offset that must be added to the date to obtain TAI. Units: [s]
+/// - `f64`: Offset that must be added to the date to obtain TAI. Units: [s]
+///
+/// # Examples
+/// ```ignore
+/// // 2022-04-01 01:02:33.4 GPS, with the offset evaluated at the instant
+/// // rather than at the start of the minute.
+/// let jd = 2459670.5;
+/// let fd = (1.0 * 3600.0 + 2.0 * 60.0) / SECONDS_PER_DAY;
+/// let offset = tai_offset_for_datetime(jd, fd, 33.4, TimeSystem::GPS);
+/// assert_eq!(offset, 19.0);
+/// ```
 pub(crate) fn tai_offset_for_datetime(
     jd: f64,
     fd: f64,

--- a/src/time/conversions.rs
+++ b/src/time/conversions.rs
@@ -489,6 +489,74 @@ pub fn time_system_offset(
     offset
 }
 
+/// Compute the offset in seconds from a Gregorian date given in `time_system`
+/// to TAI, consistent with the reverse TAI to `time_system` conversion.
+///
+/// [`time_system_offset`] evaluates its models at whichever instant it is
+/// handed. Reading an epoch converts the stored TAI instant into the requested
+/// system and so evaluates them at that TAI instant, while asking for the
+/// offset with the source and destination swapped evaluates them at the
+/// instant expressed in `time_system`. For UT1, TDB, TCB, and TCG those models
+/// vary with time, so the two evaluations disagree and the swapped call is not
+/// the inverse of the read. This function refines the swapped call until it is:
+/// the returned offset `dt` satisfies
+/// `time_system_offset(jd, fd + (seconds + dt) / 86400, TAI, time_system) == -dt`.
+///
+/// The remaining systems are returned unrefined. TAI, GPS, TT, BDT, and GST
+/// sit at a fixed offset from TAI that does not depend on the instant, so the
+/// swapped call already answers exactly. UTC is held back so that its
+/// leap-second lookup stays anchored on `fd`, resolving a `seconds` of 60 on a
+/// leap-second day to the leap second rather than to midnight of the following
+/// day. Refining UTC would additionally require the TAI to UTC direction to
+/// agree with it, which it does not in the pre-1972 rate-offset regime.
+///
+/// # Arguments
+/// - `jd`: Julian date of the start of the requested minute, expressed in `time_system`
+/// - `fd`: Fractional day locating the start of the requested minute within `jd`
+/// - `seconds`: Seconds elapsed since the start of that minute. Units: [s]
+/// - `time_system`: Time system the date is expressed in
+///
+/// # Returns
+/// - Offset that must be added to the date to obtain TAI. Units: [s]
+pub(crate) fn tai_offset_for_datetime(
+    jd: f64,
+    fd: f64,
+    seconds: f64,
+    time_system: TimeSystem,
+) -> f64 {
+    let mut offset = time_system_offset(jd, fd, time_system, TimeSystem::TAI);
+
+    match time_system {
+        TimeSystem::UT1 | TimeSystem::TDB | TimeSystem::TCB | TimeSystem::TCG => {
+            // Every model involved varies by less than 3e-8 seconds per second,
+            // so each pass shrinks the residual by at least that factor and two
+            // are enough to reach the resolution of an f64 offset. The third is
+            // there to let the loop exit on an exact fixed point.
+            let fd = fd + seconds / SECONDS_PER_DAY;
+            for _ in 0..3 {
+                let refined = -time_system_offset(
+                    jd,
+                    fd + offset / SECONDS_PER_DAY,
+                    TimeSystem::TAI,
+                    time_system,
+                );
+                if refined == offset {
+                    break;
+                }
+                offset = refined;
+            }
+        }
+        TimeSystem::TAI
+        | TimeSystem::UTC
+        | TimeSystem::GPS
+        | TimeSystem::TT
+        | TimeSystem::BDT
+        | TimeSystem::GST => {}
+    }
+
+    offset
+}
+
 /// Compute the offset between two time systems at a given Modified Julian Date.
 ///
 /// The offset (in seconds) is computed as:

--- a/src/time/epoch.rs
+++ b/src/time/epoch.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::constants::{AngleFormat, GPS_ZERO, JD_J2000, MJD_ZERO, SECONDS_PER_DAY, UNIX_EPOCH_JD};
 use crate::math::linalg::split_float;
-use crate::time::conversions::time_system_offset;
+use crate::time::conversions::{tai_offset_for_datetime, time_system_offset};
 use crate::time::time_types::TimeSystem;
 
 const NANOSECONDS_PER_SECOND_INT: u64 = 1_000_000_000;
@@ -276,7 +276,7 @@ impl Epoch {
     /// - `hour`: Hour of day
     /// - `minute`: Minute of day
     /// - `second`: Second of day
-    /// - `nanoseconds`: Picoseconds into day
+    /// - `nanoseconds`: Nanoseconds into the second
     /// - `time_system`: Time system the input time specification is given in
     ///
     /// # Returns
@@ -326,33 +326,34 @@ impl Epoch {
             );
         }
 
-        // Get time system offset based on days and fractional days using SOFA
-        let time_system_offset = time_system_offset(jd, fd, time_system, TimeSystem::TAI);
+        // Offset to TAI, evaluated so that it inverts the conversion performed
+        // when the epoch is read back in `time_system`.
+        let time_system_offset = tai_offset_for_datetime(
+            jd,
+            fd,
+            second + nanoseconds / NANOSECONDS_PER_SECOND_FLOAT,
+            time_system,
+        );
 
         // Get whole seconds and fractional seconds part of offset
         let (woffset, foffset) = split_float(time_system_offset);
 
-        // Parse jd and fd separate whole and fractional days
-        let (wjd, fjd) = split_float(jd);
-        let (wfd, ffd) = split_float(fd);
-
-        // Covert fractional days into total seconds while retaining fractional part
-        let (ws, fs) = split_float((fjd + ffd) * SECONDS_PER_DAY);
-
-        // Aggregate Component pieces
-        let mut days = (wjd + wfd) as u64; // This will always be positive
-
-        let seconds: u32 = if (ws + woffset + f64::trunc(second)) >= 0.0 {
-            (ws + woffset + f64::trunc(second)) as u32
-        } else {
-            days -= 1;
-            (SECONDS_PER_DAY + (ws + woffset + f64::trunc(second))) as u32
-        };
+        // `iauDtf2d` reports the Julian date of the requested calendar day,
+        // which always falls on a half day, and the time of day separately.
+        // Recovering the time of day from that fraction costs up to a
+        // hundredth of a nanosecond, so the whole seconds from the start of
+        // the Julian day are formed from the integer fields directly.
+        let days = f64::trunc(jd) as u64;
+        let seconds = (SECONDS_PER_DAY / 2.0) as i64
+            + hour as i64 * 3600
+            + minute as i64 * 60
+            + woffset as i64
+            + f64::trunc(second) as i64;
 
         let nanoseconds =
-            nanoseconds + (fs + foffset + f64::fract(second)) * NANOSECONDS_PER_SECOND_FLOAT;
+            nanoseconds + (foffset + f64::fract(second)) * NANOSECONDS_PER_SECOND_FLOAT;
 
-        let (d, s, ns) = align_epoch_data(days, seconds as i64, nanoseconds);
+        let (d, s, ns) = align_epoch_data(days, seconds, nanoseconds);
 
         Epoch {
             time_system,
@@ -801,14 +802,27 @@ impl Epoch {
         (jd, fd)
     }
 
-    /// As [`Epoch::get_jdfd`], additionally returning the offset in seconds
-    /// applied to reach `time_system` from the internal TAI storage.
+    /// As [`Epoch::get_jdfd`], additionally returning the offset applied to
+    /// reach `time_system` from the internal TAI storage.
     ///
     /// Callers that need the sub-second part of the epoch in `time_system`
     /// need this offset: the internal nanosecond counter is expressed in TAI,
-    /// and for UT1, TDB, TCB, and TCG the offset is not a whole number of
-    /// seconds, so the counter is not the target system's nanoseconds into
-    /// the second.
+    /// and the offset is not in general a whole number of seconds — TT, UT1,
+    /// TDB, TCB, and TCG all carry a sub-second part — so the counter is not
+    /// the target system's nanoseconds into the second.
+    ///
+    /// # Arguments
+    /// - `time_system`: Time system the returned date is expressed in
+    ///
+    /// # Returns
+    /// - `jd`: Julian date, in whole days
+    /// - `fd`: Fractional day locating the epoch within `jd`, expressed in `time_system`
+    /// - `offset`: Offset added to the internal TAI storage to reach `time_system`. Units: [s]
+    ///
+    /// # Examples
+    /// ```ignore
+    /// let (jd, fd, offset) = epoch.get_jdfd_offset(TimeSystem::UTC);
+    /// ```
     fn get_jdfd_offset(&self, time_system: TimeSystem) -> (f64, f64, f64) {
         // Get JD / FD from Epoch
         let jd = self.days as f64;
@@ -837,7 +851,7 @@ impl Epoch {
     /// - `hour`: Hour of day
     /// - `minute`: Minute of day
     /// - `second`: Second of day
-    /// - `nanoseconds`: Picoseconds into day
+    /// - `nanoseconds`: Nanoseconds into the second
     ///
     /// # Example
     /// ```
@@ -859,8 +873,27 @@ impl Epoch {
         &self,
         time_system: TimeSystem,
     ) -> (u32, u8, u8, u8, u8, f64, f64) {
-        // Get JD / FD from Epoch
-        let (jd, fd, offset) = self.get_jdfd_offset(time_system);
+        let (_, _, offset) = self.get_jdfd_offset(time_system);
+
+        // Split the epoch in `time_system` into a whole second and the
+        // nanoseconds into it. The stored counter is expressed in TAI, so only
+        // the sub-second part of the offset moves it; the whole seconds shift
+        // the second count.
+        let (offset_seconds, offset_subseconds) = split_float(offset);
+        let (days, seconds, nanoseconds) = align_epoch_data(
+            self.days,
+            self.seconds as i64 + offset_seconds as i64,
+            self.nanoseconds
+                + self.nanoseconds_kc
+                + offset_subseconds * NANOSECONDS_PER_SECOND_FLOAT,
+        );
+
+        // `iauD2dtf` is handed the whole second alone. Its rounding therefore
+        // cannot carry into the following second and displace the reported
+        // date from the stored instant, which is what recovering the
+        // nanoseconds through a fractional day would risk: the fractional day
+        // resolves the counter only to roughly a hundredth of a nanosecond.
+        let fd = seconds as f64 / SECONDS_PER_DAY;
 
         let mut iy: i32 = 0;
         let mut im: i32 = 0;
@@ -870,8 +903,8 @@ impl Epoch {
         unsafe {
             rsofa::iauD2dtf(
                 CString::new(time_system.to_string()).unwrap().as_ptr() as *const c_char,
-                9,
-                jd,
+                0,
+                days as f64,
                 fd,
                 &mut iy,
                 &mut im,
@@ -880,31 +913,6 @@ impl Epoch {
             );
         }
 
-        // `iauD2dtf` was asked for nine decimal places, so `ihmsf[3]` is whole
-        // nanoseconds, already rounded. The internal counter holds the same
-        // quantity at full precision, so it is the better source — but it is
-        // expressed in the internal TAI storage, and for UT1, TDB, TCB, and TCG
-        // the offset to `time_system` is not a whole number of seconds. Only
-        // the sub-second part of the offset moves the nanosecond field; the
-        // whole seconds are already in the calendar fields `iauD2dtf` returned.
-        let offset_subsecond_ns = (offset - offset.trunc()) * NANOSECONDS_PER_SECOND_FLOAT;
-        let mut ns = (self.nanoseconds + self.nanoseconds_kc + offset_subsecond_ns)
-            .rem_euclid(NANOSECONDS_PER_SECOND_FLOAT);
-
-        // Nanoseconds-into-day arithmetic quantizes the counter to roughly
-        // 0.01 ns, so an epoch built on a whole second can be stored just below
-        // the boundary (999999999.985). `iauD2dtf` rounds that up and carries
-        // into the next second, which is the second it reported, so the counter
-        // has to be re-expressed against it. Previously the two were combined by
-        // adding the counter's fractional part to `ihmsf[3]`, which
-        // double-counted the rounding and reported a nanosecond that is not
-        // there; a date read and rewritten accumulated one per cycle.
-        let whole = ihmsf[3] as f64;
-        if ns - whole > NANOSECONDS_PER_SECOND_FLOAT / 2.0 {
-            ns = (ns - NANOSECONDS_PER_SECOND_FLOAT).max(0.0);
-        } else if whole - ns > NANOSECONDS_PER_SECOND_FLOAT / 2.0 {
-            ns += NANOSECONDS_PER_SECOND_FLOAT;
-        }
         (
             iy as u32,
             im as u8,
@@ -912,7 +920,7 @@ impl Epoch {
             ihmsf[0] as u8,
             ihmsf[1] as u8,
             ihmsf[2] as f64,
-            ns,
+            nanoseconds,
         )
     }
 
@@ -929,7 +937,7 @@ impl Epoch {
     /// - `hour`: Hour of day
     /// - `minute`: Minute of day
     /// - `second`: Second of day
-    /// - `nanoseconds`: Picoseconds into day
+    /// - `nanoseconds`: Nanoseconds into the second
     ///
     /// # Example
     /// ```
@@ -2178,10 +2186,40 @@ mod tests {
 
         let epc = Epoch::from_datetime(2020, 2, 3, 4, 5, 6.0, 0.0, TimeSystem::GPS);
 
-        assert_eq!(
-            format!("{:?}", epc),
-            "Epoch<2458882, 57924, 999999999.9927241, 0, GPS>"
-        )
+        assert_eq!(format!("{:?}", epc), "Epoch<2458882, 57925, 0, 0, GPS>")
+    }
+
+    #[test]
+    #[parallel]
+    fn test_from_datetime_reaches_the_same_epoch_from_either_spelling_of_a_second() {
+        setup_global_test_eop();
+
+        // A whole second, and the second before it carrying a full nanosecond
+        // count, are the same instant. Both spellings must build the same
+        // epoch, report the same date, and return to it when rebuilt from what
+        // they report.
+        for ts in [
+            TimeSystem::GPS,
+            TimeSystem::UTC,
+            TimeSystem::UT1,
+            TimeSystem::TDB,
+        ] {
+            let whole = Epoch::from_datetime(2020, 2, 3, 4, 5, 6.0, 0.0, ts);
+            let carried = Epoch::from_datetime(2020, 2, 3, 4, 5, 5.0, 1.0e9, ts);
+
+            assert_abs_diff_eq!(whole - carried, 0.0, epsilon = 1.0e-11);
+
+            for epc in [whole, carried] {
+                let (y, mo, d, h, mi, s, ns) = epc.to_datetime();
+                assert_eq!((y, mo, d, h, mi, s), (2020, 2, 3, 4, 5, 6.0), "{:?}", ts);
+                assert_abs_diff_eq!(ns, 0.0, epsilon = 1.0e-3);
+                assert_abs_diff_eq!(
+                    Epoch::from_datetime(y, mo, d, h, mi, s, ns, ts) - epc,
+                    0.0,
+                    epsilon = 1.0e-11
+                );
+            }
+        }
     }
 
     #[test]
@@ -4427,7 +4465,7 @@ mod tests {
 
         // Debug should show internal fields: days, seconds, nanoseconds, nanoseconds_kc, time_system
         assert!(debug_str.contains("2458882")); // days
-        assert!(debug_str.contains("57924")); // seconds
+        assert!(debug_str.contains("57925")); // seconds
         assert!(debug_str.contains("GPS"));
     }
 
@@ -4567,33 +4605,117 @@ mod tests {
     fn test_to_datetime_is_stable_across_repeated_round_trips() {
         setup_global_test_eop();
 
-        // Reading a date and rebuilding it used to add a nanosecond per cycle,
-        // without bound.
-        // UT1, TDB, TCB, and TCG are excluded: their offset from TAI is
-        // recovered iteratively and lands on a slightly different value each
-        // time the epoch is rebuilt, so those systems do not round-trip
-        // exactly either before or after this change. That is a separate
-        // defect in the offset inversion, not in the nanosecond field.
+        // Reading a date and rebuilding it must not move the epoch, in any
+        // time system. UT1, TDB, TCB, and TCG reach TAI through offsets that
+        // are not a whole number of nanoseconds, so their nanosecond field is
+        // reproduced to the precision the representation carries rather than
+        // bit-for-bit; the remaining systems are exact.
         for ts in [
             TimeSystem::UTC,
             TimeSystem::TAI,
             TimeSystem::GPS,
             TimeSystem::TT,
+            TimeSystem::UT1,
+            TimeSystem::TDB,
+            TimeSystem::TCB,
+            TimeSystem::TCG,
         ] {
-            let mut epc = Epoch::from_datetime(1996, 11, 4, 17, 22, 31.0, 0.0, ts);
+            let start = Epoch::from_datetime(1996, 11, 4, 17, 22, 31.0, 0.0, ts);
+            let mut epc = start;
             let first = epc.to_datetime();
             for generation in 0..5 {
                 let (y, mo, d, h, mi, s, ns) = epc.to_datetime();
                 assert_eq!(
-                    (y, mo, d, h, mi, s, ns),
-                    first,
+                    (y, mo, d, h, mi, s),
+                    (first.0, first.1, first.2, first.3, first.4, first.5),
                     "{:?} drifted by generation {}",
                     ts,
                     generation
                 );
+                assert_abs_diff_eq!(ns, first.6, epsilon = 1.0e-3);
+                assert_abs_diff_eq!(epc - start, 0.0, epsilon = 1.0e-11);
                 epc = Epoch::from_datetime(y, mo, d, h, mi, s, ns, ts);
             }
         }
+    }
+
+    #[test]
+    #[parallel]
+    fn test_from_datetime_lands_on_the_requested_second() {
+        setup_global_test_eop();
+
+        // A whole second handed to `from_datetime` must read back as that
+        // second with an empty nanosecond field, in every time system. The
+        // offsets to UT1, TDB, TCB, and TCG are not whole nanoseconds, so
+        // recovering them has to invert the conversion the read performs.
+        for ts in [
+            TimeSystem::UTC,
+            TimeSystem::TAI,
+            TimeSystem::GPS,
+            TimeSystem::TT,
+            TimeSystem::UT1,
+            TimeSystem::TDB,
+            TimeSystem::TCB,
+            TimeSystem::TCG,
+        ] {
+            let epc = Epoch::from_datetime(1996, 11, 4, 17, 22, 31.0, 0.0, ts);
+            let (y, mo, d, h, mi, s, ns) = epc.to_datetime();
+            assert_eq!(
+                (y, mo, d, h, mi, s),
+                (1996, 11, 4, 17, 22, 31.0),
+                "{:?}",
+                ts
+            );
+            assert_abs_diff_eq!(ns, 0.0, epsilon = 1.0e-3);
+        }
+    }
+
+    #[test]
+    #[parallel]
+    fn test_to_datetime_reports_whole_seconds_across_a_leap_second() {
+        setup_global_test_eop();
+
+        // The nanosecond field is carried alongside the calendar fields rather
+        // than recovered from a fractional day, so a whole second stays a whole
+        // second through the 2016 leap second.
+        for (second, expected) in [
+            (59.0, (2016, 12, 31, 23, 59, 59.0)),
+            (60.0, (2016, 12, 31, 23, 59, 60.0)),
+        ] {
+            let epc = Epoch::from_datetime(2016, 12, 31, 23, 59, second, 0.0, TimeSystem::UTC);
+            let (y, mo, d, h, mi, s, ns) = epc.to_datetime();
+            assert_eq!((y, mo, d, h, mi, s), expected);
+            assert_abs_diff_eq!(ns, 0.0, epsilon = 1.0e-3);
+        }
+
+        let epc = Epoch::from_datetime(2016, 12, 31, 23, 59, 60.5, 0.0, TimeSystem::UTC);
+        let (y, mo, d, h, mi, s, ns) = epc.to_datetime();
+        assert_eq!((y, mo, d, h, mi, s), (2016, 12, 31, 23, 59, 60.0));
+        assert_abs_diff_eq!(ns, 5.0e8, epsilon = 1.0e-3);
+    }
+
+    #[test]
+    #[parallel]
+    fn test_to_datetime_as_time_system_reports_the_leap_second_from_tai() {
+        setup_global_test_eop();
+
+        // The leap second must also appear when the epoch is built in TAI and
+        // read as UTC, not only when it is built in UTC.
+        for (tai_second, expected) in [
+            (35.0, (2016, 12, 31, 23, 59, 59.0)),
+            (36.0, (2016, 12, 31, 23, 59, 60.0)),
+            (37.0, (2017, 1, 1, 0, 0, 0.0)),
+        ] {
+            let epc = Epoch::from_datetime(2017, 1, 1, 0, 0, tai_second, 0.0, TimeSystem::TAI);
+            let (y, mo, d, h, mi, s, ns) = epc.to_datetime_as_time_system(TimeSystem::UTC);
+            assert_eq!((y, mo, d, h, mi, s), expected);
+            assert_abs_diff_eq!(ns, 0.0, epsilon = 1.0e-3);
+        }
+
+        let epc = Epoch::from_datetime(2017, 1, 1, 0, 0, 36.5, 0.0, TimeSystem::TAI);
+        let (y, mo, d, h, mi, s, ns) = epc.to_datetime_as_time_system(TimeSystem::UTC);
+        assert_eq!((y, mo, d, h, mi, s), (2016, 12, 31, 23, 59, 60.0));
+        assert_abs_diff_eq!(ns, 5.0e8, epsilon = 1.0e-3);
     }
 
     #[test]

--- a/src/utils/threading.rs
+++ b/src/utils/threading.rs
@@ -176,12 +176,12 @@ mod tests {
     #[test]
     #[parallel]
     fn test_get_max_threads() {
-        // Get current thread count (initializes with default if needed)
+        // The pool holds whatever count was last configured; `set_num_threads`
+        // permits oversubscription, so the CPU count is not an upper bound
+        // here. The bound on the default count is covered by
+        // `test_default_thread_count`.
         let threads = get_max_threads();
-
-        // Should be at least 1 and at most number of CPUs
         assert!(threads >= 1);
-        assert!(threads <= num_cpus::get());
     }
 
     #[test]

--- a/tests/time/test_epoch.py
+++ b/tests/time/test_epoch.py
@@ -1694,12 +1694,84 @@ def test_to_datetime_reports_no_nanoseconds_on_a_whole_second(eop):
 
 def test_to_datetime_is_stable_across_repeated_round_trips(eop):
     """Mirror of test_to_datetime_is_stable_across_repeated_round_trips in Rust."""
-    # UT1 and TDB are excluded: their offset from TAI is recovered iteratively
-    # and does not round-trip exactly, which is a separate defect.
-    for ts in [bh.UTC, bh.TAI, bh.GPS, bh.TT]:
-        epc = bh.Epoch.from_datetime(1996, 11, 4, 17, 22, 31.0, 0.0, ts)
+    # UT1, TDB, TCB, and TCG reach TAI through offsets that are not a whole
+    # number of nanoseconds, so their nanosecond field is reproduced to the
+    # precision the representation carries rather than bit-for-bit.
+    for ts in [bh.UTC, bh.TAI, bh.GPS, bh.TT, bh.UT1, bh.TDB, bh.TCB, bh.TCG]:
+        start = bh.Epoch.from_datetime(1996, 11, 4, 17, 22, 31.0, 0.0, ts)
+        epc = start
         first = epc.to_datetime()
         for _ in range(5):
             fields = epc.to_datetime()
-            assert fields == first, f"{ts} drifted"
+            assert fields[:6] == first[:6], f"{ts} drifted"
+            assert fields[6] == pytest.approx(first[6], abs=1e-3)
+            assert epc - start == pytest.approx(0.0, abs=1e-11)
             epc = bh.Epoch.from_datetime(*fields, ts)
+
+
+def test_from_datetime_lands_on_the_requested_second(eop):
+    """Mirror of test_from_datetime_lands_on_the_requested_second in Rust."""
+    for ts in [bh.UTC, bh.TAI, bh.GPS, bh.TT, bh.UT1, bh.TDB, bh.TCB, bh.TCG]:
+        epc = bh.Epoch.from_datetime(1996, 11, 4, 17, 22, 31.0, 0.0, ts)
+        (year, month, day, hour, minute, second, nanosecond) = epc.to_datetime()
+        assert (year, month, day, hour, minute, second) == (
+            1996,
+            11,
+            4,
+            17,
+            22,
+            31.0,
+        ), ts
+        assert nanosecond == pytest.approx(0.0, abs=1e-3)
+
+
+def test_from_datetime_reaches_the_same_epoch_from_either_spelling_of_a_second(eop):
+    """Mirror of test_from_datetime_reaches_the_same_epoch_from_either_spelling_of_a_second in Rust."""
+    for ts in [bh.GPS, bh.UTC, bh.UT1, bh.TDB]:
+        whole = bh.Epoch.from_datetime(2020, 2, 3, 4, 5, 6.0, 0.0, ts)
+        carried = bh.Epoch.from_datetime(2020, 2, 3, 4, 5, 5.0, 1.0e9, ts)
+
+        assert whole - carried == pytest.approx(0.0, abs=1e-11)
+
+        for epc in [whole, carried]:
+            fields = epc.to_datetime()
+            assert fields[:6] == (2020, 2, 3, 4, 5, 6.0), ts
+            assert fields[6] == pytest.approx(0.0, abs=1e-3)
+            assert bh.Epoch.from_datetime(*fields, ts) - epc == pytest.approx(
+                0.0, abs=1e-11
+            )
+
+
+def test_to_datetime_as_time_system_reports_the_leap_second_from_tai(eop):
+    """Mirror of test_to_datetime_as_time_system_reports_the_leap_second_from_tai in Rust."""
+    for tai_second, expected in [
+        (35.0, (2016, 12, 31, 23, 59, 59.0)),
+        (36.0, (2016, 12, 31, 23, 59, 60.0)),
+        (37.0, (2017, 1, 1, 0, 0, 0.0)),
+    ]:
+        epc = bh.Epoch.from_datetime(2017, 1, 1, 0, 0, tai_second, 0.0, bh.TAI)
+        fields = epc.to_datetime_as_time_system(bh.UTC)
+        assert fields[:6] == expected
+        assert fields[6] == pytest.approx(0.0, abs=1e-3)
+
+    epc = bh.Epoch.from_datetime(2017, 1, 1, 0, 0, 36.5, 0.0, bh.TAI)
+    fields = epc.to_datetime_as_time_system(bh.UTC)
+    assert fields[:6] == (2016, 12, 31, 23, 59, 60.0)
+    assert fields[6] == pytest.approx(5.0e8, abs=1e-3)
+
+
+def test_to_datetime_reports_whole_seconds_across_a_leap_second(eop):
+    """Mirror of test_to_datetime_reports_whole_seconds_across_a_leap_second in Rust."""
+    for second, expected in [
+        (59.0, (2016, 12, 31, 23, 59, 59.0)),
+        (60.0, (2016, 12, 31, 23, 59, 60.0)),
+    ]:
+        epc = bh.Epoch.from_datetime(2016, 12, 31, 23, 59, second, 0.0, bh.UTC)
+        fields = epc.to_datetime()
+        assert fields[:6] == expected
+        assert fields[6] == pytest.approx(0.0, abs=1e-3)
+
+    epc = bh.Epoch.from_datetime(2016, 12, 31, 23, 59, 60.5, 0.0, bh.UTC)
+    fields = epc.to_datetime()
+    assert fields[:6] == (2016, 12, 31, 23, 59, 60.0)
+    assert fields[6] == pytest.approx(5.0e8, abs=1e-3)


### PR DESCRIPTION
# Pull Request

## Description

`Epoch::from_datetime` and `Epoch::to_datetime` were not inverses in UT1, TDB, TCB, and TCG. An epoch built from a whole second in one of those systems read back several hundred nanoseconds away from it, and each rebuild from the reported fields displaced it further.

Two mechanisms were at work, both in how the offset to the internal TAI storage was recovered. `time_system_offset` evaluates its models at whichever instant it is handed. Reading an epoch converts the stored TAI instant into the requested system and so evaluates them there, while `from_datetime` asked for the offset with the source and destination swapped, evaluated at the start of the requested minute. The two therefore disagreed by the drift of the models over the dropped seconds — 692 ns in UT1 at 31 seconds into the minute — and, because the source-side branches evaluate at the source-system Julian date while the destination-side branches use the TT Julian date, by a further 152 ns in TCB. `tai_offset_for_datetime` refines the swapped call until it is the exact negation of what the read computes. TAI, GPS, TT, BDT, and GST sit at a fixed offset that the swapped call already answers exactly; UTC is left unrefined so its leap-second lookup stays anchored on the requested minute, resolving a second of 60 to the leap second rather than to the following midnight.

The sub-second part of an epoch is now carried directly rather than reconstructed through a fractional day. `from_datetime` forms the seconds into the Julian day from the integer hour and minute instead of recovering them from the fraction `iauDtf2d` returns, which cost up to a hundredth of a nanosecond and could store a whole second just below its own boundary. `to_datetime_as_time_system` hands `iauD2dtf` that whole second alone and returns the nanoseconds beside it, so rounding inside SOFA can no longer carry into the next second and displace the reported date. That retires the reconciliation against `ihmsf[3]` and, with it, the case where a value genuinely within half a nanosecond of the next second was clamped onto that boundary. A UTC epoch built on `2016-12-31T23:59:59` now reports second 59 rather than second 58 with 999999999.985 nanoseconds.

Round trip of `1996-11-04T17:22:31.000`, four rebuilds, before and after:

| Time system | First read before | Net displacement before | First read after | Net displacement after |
|---|---|---|---|---|
| UTC, TAI, GPS, TT | `31.0 s + 0.0 ns` | `0` | `31.0 s + 0.0 ns` | `0` |
| UT1 | `30.0 s + 999999307.467 ns` | `-2.770e-6 s` | `31.0 s + 0.0 ns` | `0` |
| TDB | `31.0 s + 5.238 ns` | `+2.095e-8 s` | `31.0 s + 0.0 ns` | `0` |
| TCB | `31.0 s + 333.731 ns` | `+1.335e-6 s` | `31.0 s + 0.0 ns` | `0` |
| TCG | `31.0 s + 21.286 ns` | `+8.514e-8 s` | `31.0 s + 0.0 ns` | `0` |

## Changelog

### Fixed
- Fixed `utils::threading::tests::test_get_max_threads` failing intermittently: it asserted that the configured thread count is at most the CPU count, which `set_num_threads` deliberately permits callers to exceed, against global state other tests in the module leave oversubscribed.
- `Epoch::from_datetime` and `Epoch::to_datetime` now round-trip in UT1, TDB, TCB, and TCG; previously an epoch built from a whole second in one of these systems read back up to 693 ns away from it and drifted further on each rebuild.
- `Epoch::to_datetime` reports the whole second an epoch was built on rather than the preceding second carrying a nanosecond count just short of a full second, and no longer clamps a value lying within half a nanosecond of the next second onto that boundary.

## Related Issue

Closes #491

## Note to Reviewers

`test_get_max_threads` is unrelated to the time-system work and is here only because it blocked this PR's CI once #516 landed. It asserted `get_max_threads() <= num_cpus::get()`, which is not a property of `get_max_threads`: `set_num_threads` accepts any count of one or more, so oversubscription is supported and the pool holds whatever was last configured. `test_get_max_threads_reflects_set_num_threads` finishes on eight threads and `test_reinitialize_changes_thread_count` on five, so the assertion failed whenever this test was scheduled after one of them on a runner with fewer cores — it failed on ubuntu, then on macOS after a re-run, while passing on a ten-core local machine. `#[serial]` would not have helped, since what leaks between the tests is the residual count rather than concurrent access. The bound on the default count is still covered by `test_default_thread_count`.


`test_to_datetime_is_stable_across_repeated_round_trips` now covers all eight time systems; the four whose offset from TAI is not a whole number of nanoseconds are checked to the precision the representation carries rather than bit-for-bit, since the offset is added on construction and subtracted on read. `test_epoch_debug` and `test_debug_shows_internal_representation` pin the internal representation and were updated: `Epoch::from_datetime(2020, 2, 3, 4, 5, 6.0, 0.0, GPS)` stored `57924 s + 999999999.9927241 ns` and now stores exactly `57925 s + 0 ns`. `test_from_datetime_reaches_the_same_epoch_from_either_spelling_of_a_second` covers that both spellings build the same epoch and return to it.

Codex review surfaced a separate defect in UTC before 1972, when UTC ran at a rate offset from TAI rather than a whole number of seconds. It is filed as #512 rather than fixed here: the dominant error is in the read direction — `time_system_offset(TAI -> UTC)` returns `-10.000000000` at `1971-12-31T23:59:59` where the truth is `-9.892241970` — so refining the build direction to invert it would displace the stored instant by 0.108 s to make an incorrect read self-consistent. Correcting the read also requires changing the fractional-day convention `Epoch` hands SOFA, which the leap-second display currently depends on.

