### PR TITLE
Read UTC through SOFA's own quasi-day encoding

### DIFF
--- a/src/time/conversions.rs
+++ b/src/time/conversions.rs
@@ -210,23 +210,22 @@ pub fn mjd_to_datetime(mjd: f64) -> (u32, u8, u8, u8, u8, f64, f64) {
 /// - `jd`: Julian date of epoch in the TAI time system
 /// - `fd`: Fractional day of epoch in the TAI time system
 ///
-/// Returns:
-/// - offset (float): Offset between UTC and TAI in seconds.
+/// # Returns
+/// - `f64`: Offset between UTC and TAI. Units: [s]
 #[allow(dangling_pointers_from_temporaries)]
 fn tai_jdfd_to_utc_offset(jd: f64, fd: f64) -> f64 {
-    // Initial UTC guess
     let mut u1 = jd;
     let mut u2 = fd;
 
-    // Convert TAI into quasi-UTC per SOFA documentation
-    // The quasi-UTC time can then be used with the iauD2dtf function to
-    // get the UTC offset for the current TAI time
+    // `iauTaiutc` runs the TAI to UTC direction and yields the quasi-UTC
+    // encoding that the leap-second table is indexed by, so the lookup below
+    // lands on the entry that applies at this instant: the pre-step value
+    // within `dat` seconds of a leap second, and the right point on the rate
+    // offset that UTC carried from TAI before 1972.
     unsafe {
-        rsofa::iauUtctai(jd, fd, &mut u1, &mut u2);
+        rsofa::iauTaiutc(jd, fd, &mut u1, &mut u2);
     }
 
-    // Return the difference between the input TAI time and the adjusted UTC time
-    // now that we have a good guess for UTC.
     utc_jdfd_to_utc_offset(u1, u2)
 }
 
@@ -237,8 +236,8 @@ fn tai_jdfd_to_utc_offset(jd: f64, fd: f64) -> f64 {
 /// - `jd`: Julian date of epoch in the UTC time system
 /// - `fd`: Fractional day of epoch in the UTC time system
 ///
-/// Returns:
-/// - offset (float): Offset between UTC and TAI in seconds.
+/// # Returns
+/// - `f64`: Offset between UTC and TAI. Units: [s]
 #[allow(dangling_pointers_from_temporaries)]
 fn utc_jdfd_to_utc_offset(jd: f64, fd: f64) -> f64 {
     let mut iy: i32 = 0;
@@ -261,10 +260,15 @@ fn utc_jdfd_to_utc_offset(jd: f64, fd: f64) -> f64 {
             &mut ihmsf as *mut i32,
         );
 
-        // Get utc offset
+        // Get utc offset. A leap second carries the seconds into the day past
+        // 86400, and `iauDat` rejects a day fraction above one and leaves the
+        // offset untouched. The fraction feeds only the drift term that UTC
+        // carried from TAI before 1972, an era with no leap seconds, so
+        // clamping it costs nothing.
         let seconds =
             (ihmsf[0] * 3600 + ihmsf[1] * 60 + ihmsf[2]) as f64 + (ihmsf[3] as f64) / 1.0e9;
-        rsofa::iauDat(iy, im, id, seconds / 86400.0, &mut dutc);
+        let day_fraction = (seconds / SECONDS_PER_DAY).clamp(0.0, 1.0);
+        rsofa::iauDat(iy, im, id, day_fraction, &mut dutc);
     }
 
     dutc
@@ -333,8 +337,8 @@ fn tcb_tdb_offset(jd_tt: f64) -> f64 {
 /// - `time_system_src`: Source time system
 /// - `time_system_dst`: Destination time system
 ///
-/// Returns:
-///     offset (float): Offset between soruce and destination time systems in seconds.
+/// # Returns
+/// - `f64`: Offset between the source and destination time systems. Units: [s]
 ///
 /// # Panics
 /// Panics when converting to or from UT1 if Earth orientation data is
@@ -344,7 +348,7 @@ fn tcb_tdb_offset(jd_tt: f64) -> f64 {
 /// use (see `ensure_global_eop_coverage`). Conversions between all other time
 /// systems do not require Earth orientation data.
 ///
-/// Example:
+/// # Examples
 /// ```
 /// use brahe::constants::MJD_ZERO;
 /// use brahe::eop::*;
@@ -398,8 +402,8 @@ pub fn time_system_offset(
                 )
             });
 
-            // UTC -> TAI offset
-            offset += utc_jdfd_to_utc_offset(jd, fd - dut1);
+            // UTC -> TAI offset. `dut1` is in seconds and `fd` in days.
+            offset += utc_jdfd_to_utc_offset(jd, fd - dut1 / SECONDS_PER_DAY);
             offset -= dut1;
         }
         TimeSystem::TDB => {
@@ -496,19 +500,22 @@ pub fn time_system_offset(
 /// handed. Reading an epoch converts the stored TAI instant into the requested
 /// system and so evaluates them at that TAI instant, while asking for the
 /// offset with the source and destination swapped evaluates them at the
-/// instant expressed in `time_system`. For UT1, TDB, TCB, and TCG those models
-/// vary with time, so the two evaluations disagree and the swapped call is not
-/// the inverse of the read. This function refines the swapped call until it is:
+/// instant expressed in `time_system`. For UT1, TDB, TCB and TCG, and for UTC
+/// before 1972, those models vary with time, so the two evaluations disagree
+/// and the swapped call is not the inverse of the read. After 1972 UTC steps
+/// rather than varies, and the two already agree. This function refines the
+/// swapped call until it inverts the read:
 /// the returned offset `dt` satisfies
 /// `time_system_offset(jd, fd + (seconds + dt) / 86400, TAI, time_system) == -dt`.
 ///
-/// The remaining systems are returned unrefined. TAI, GPS, TT, BDT, and GST
-/// sit at a fixed offset from TAI that does not depend on the instant, so the
-/// swapped call already answers exactly. UTC is held back so that its
-/// leap-second lookup stays anchored on `fd`, resolving a `seconds` of 60 on a
+/// TAI, GPS, TT, BDT, and GST sit at a fixed offset from TAI that does not
+/// depend on the instant, so the swapped call already answers exactly and is
+/// returned unrefined.
+///
+/// `fd` locates the start of the requested minute rather than the epoch so that
+/// the leap-second lookup seeding the refinement resolves a `seconds` of 60 on a
 /// leap-second day to the leap second rather than to midnight of the following
-/// day. Refining UTC would additionally require the TAI to UTC direction to
-/// agree with it, which it does not in the pre-1972 rate-offset regime.
+/// day.
 ///
 /// # Arguments
 /// - `jd`: Julian date of the start of the requested minute, expressed in `time_system`
@@ -537,11 +544,12 @@ pub(crate) fn tai_offset_for_datetime(
     let mut offset = time_system_offset(jd, fd, time_system, TimeSystem::TAI);
 
     match time_system {
-        TimeSystem::UT1 | TimeSystem::TDB | TimeSystem::TCB | TimeSystem::TCG => {
+        TimeSystem::UTC | TimeSystem::UT1 | TimeSystem::TDB | TimeSystem::TCB | TimeSystem::TCG => {
             // Every model involved varies by less than 3e-8 seconds per second,
             // so each pass shrinks the residual by at least that factor and two
             // are enough to reach the resolution of an f64 offset. The third is
-            // there to let the loop exit on an exact fixed point.
+            // there to let the loop exit on an exact fixed point. UTC steps
+            // rather than varies after 1972, and settles on the first pass.
             let fd = fd + seconds / SECONDS_PER_DAY;
             for _ in 0..3 {
                 let refined = -time_system_offset(
@@ -556,12 +564,7 @@ pub(crate) fn tai_offset_for_datetime(
                 offset = refined;
             }
         }
-        TimeSystem::TAI
-        | TimeSystem::UTC
-        | TimeSystem::GPS
-        | TimeSystem::TT
-        | TimeSystem::BDT
-        | TimeSystem::GST => {}
+        TimeSystem::TAI | TimeSystem::GPS | TimeSystem::TT | TimeSystem::BDT | TimeSystem::GST => {}
     }
 
     offset
@@ -921,6 +924,58 @@ mod tests {
             time_system_offset(jd, 0.0, TimeSystem::GST, TimeSystem::GPS),
             0.0
         );
+    }
+
+    #[test]
+    #[parallel]
+    fn test_time_system_offset_tai_utc_before_1972() {
+        setup_global_test_eop();
+
+        // Before 1972 UTC ran at a rate offset from TAI rather than a whole
+        // number of seconds. The IERS entry in force from 1968 February 1 is
+        // TAI - UTC = 4.2131700 + (MJD - 39126) * 0.0025920 seconds, so at
+        // 1971-12-31T23:59:59 UTC (MJD 41316.99998843) it is 9.892242 s.
+        let jd = 2441316.5;
+        let fd = 86399.0 / SECONDS_PER_DAY;
+        let expected = 4.213_170_0 + (41316.0 + fd - 39126.0) * 0.002_592_0;
+        assert_abs_diff_eq!(expected, 9.892_242, epsilon = 1.0e-6);
+
+        // Both directions must report that offset at the same instant, so that
+        // building an epoch from a date and reading it back agree.
+        let utc_to_tai = time_system_offset(jd, fd, TimeSystem::UTC, TimeSystem::TAI);
+        assert_abs_diff_eq!(utc_to_tai, expected, epsilon = 1.0e-6);
+
+        let tai_to_utc = time_system_offset(
+            jd,
+            fd + utc_to_tai / SECONDS_PER_DAY,
+            TimeSystem::TAI,
+            TimeSystem::UTC,
+        );
+        assert_abs_diff_eq!(tai_to_utc, -expected, epsilon = 1.0e-6);
+    }
+
+    #[test]
+    #[parallel]
+    fn test_time_system_offset_tai_utc_within_a_leap_second() {
+        setup_global_test_eop();
+
+        // 2016-12-31T23:59:60 UTC is TAI 2017-01-01T00:00:36, so TAI - UTC is
+        // still 36 s throughout the leap second and steps to 37 s after it.
+        let jd = 2457753.5;
+        for (tai_seconds_into_day, expected) in [
+            (86435.0, -36.0),
+            (86436.0, -36.0),
+            (86436.5, -36.0),
+            (86437.0, -37.0),
+        ] {
+            let offset = time_system_offset(
+                jd,
+                tai_seconds_into_day / SECONDS_PER_DAY,
+                TimeSystem::TAI,
+                TimeSystem::UTC,
+            );
+            assert_eq!(offset, expected, "TAI second {}", tai_seconds_into_day);
+        }
     }
 
     #[test]

--- a/src/time/epoch.rs
+++ b/src/time/epoch.rs
@@ -893,7 +893,35 @@ impl Epoch {
         // date from the stored instant, which is what recovering the
         // nanoseconds through a fractional day would risk: the fractional day
         // resolves the counter only to roughly a hundredth of a nanosecond.
-        let fd = seconds as f64 / SECONDS_PER_DAY;
+        let (jd, fd) = match time_system {
+            TimeSystem::UTC => {
+                // SOFA encodes UTC so that a day carrying a leap second still
+                // spans exactly one day of Julian date, and `iauD2dtf` undoes
+                // that scaling when it reports the time of day. `iauTaiutc`
+                // builds the encoding; a fraction formed by dividing seconds by
+                // 86400 would be scaled a second time, moving the reported time
+                // by up to a second across a leap-second day. Feed it the TAI
+                // instant of the whole UTC second, which is the stored instant
+                // less the nanoseconds into that second.
+                let (d, s, ns) = align_epoch_data(
+                    self.days,
+                    self.seconds as i64,
+                    self.nanoseconds + self.nanoseconds_kc - nanoseconds,
+                );
+                let mut utc1: f64 = 0.0;
+                let mut utc2: f64 = 0.0;
+                unsafe {
+                    rsofa::iauTaiutc(
+                        d as f64,
+                        (s as f64 + ns / NANOSECONDS_PER_SECOND_FLOAT) / SECONDS_PER_DAY,
+                        &mut utc1,
+                        &mut utc2,
+                    );
+                }
+                (utc1, utc2)
+            }
+            _ => (days as f64, seconds as f64 / SECONDS_PER_DAY),
+        };
 
         let mut iy: i32 = 0;
         let mut im: i32 = 0;
@@ -904,7 +932,7 @@ impl Epoch {
             rsofa::iauD2dtf(
                 CString::new(time_system.to_string()).unwrap().as_ptr() as *const c_char,
                 0,
-                days as f64,
+                jd,
                 fd,
                 &mut iy,
                 &mut im,
@@ -4692,6 +4720,65 @@ mod tests {
         let (y, mo, d, h, mi, s, ns) = epc.to_datetime();
         assert_eq!((y, mo, d, h, mi, s), (2016, 12, 31, 23, 59, 60.0));
         assert_abs_diff_eq!(ns, 5.0e8, epsilon = 1.0e-3);
+    }
+
+    #[test]
+    #[parallel]
+    fn test_from_datetime_round_trips_before_1972() {
+        setup_global_test_eop();
+
+        // Before 1972 UTC ran at a rate offset from TAI rather than a whole
+        // number of seconds, so the offset varies across the requested minute
+        // and has a sub-second part that the nanosecond field has to carry.
+        for (year, month, day, hour, minute, second) in [
+            (1961, 1, 1, 0, 0, 30.0),
+            (1965, 7, 1, 12, 34, 56.0),
+            (1968, 3, 15, 6, 0, 0.0),
+            (1970, 1, 1, 0, 0, 0.0),
+            (1971, 12, 31, 23, 59, 59.0),
+        ] {
+            let epc =
+                Epoch::from_datetime(year, month, day, hour, minute, second, 0.0, TimeSystem::UTC);
+            let (y, mo, d, h, mi, s, ns) = epc.to_datetime();
+            assert_eq!(
+                (y, mo, d, h, mi, s),
+                (year, month, day, hour, minute, second)
+            );
+            assert_abs_diff_eq!(ns, 0.0, epsilon = 1.0e-3);
+            assert_abs_diff_eq!(
+                Epoch::from_datetime(y, mo, d, h, mi, s, ns, TimeSystem::UTC) - epc,
+                0.0,
+                epsilon = 1.0e-11
+            );
+        }
+    }
+
+    #[test]
+    #[parallel]
+    fn test_to_datetime_reports_whole_seconds_throughout_a_leap_second_day() {
+        setup_global_test_eop();
+
+        // SOFA encodes UTC so that a day carrying a leap second still spans one
+        // day of Julian date, and undoes that scaling when reporting the time of
+        // day. An epoch anywhere in such a day must still report the second it
+        // was built on rather than one scaled by how far into the day it falls.
+        for (year, month, day) in [(2016, 12, 31), (2015, 6, 30), (2012, 6, 30)] {
+            for hour in [0, 3, 6, 9, 12, 15, 18, 21, 23] {
+                let epc =
+                    Epoch::from_datetime(year, month, day, hour, 30, 15.0, 0.0, TimeSystem::UTC);
+                let (y, mo, d, h, mi, s, ns) = epc.to_datetime();
+                assert_eq!(
+                    (y, mo, d, h, mi, s),
+                    (year, month, day, hour, 30, 15.0),
+                    "{}-{}-{} {}h",
+                    year,
+                    month,
+                    day,
+                    hour
+                );
+                assert_abs_diff_eq!(ns, 0.0, epsilon = 1.0e-3);
+            }
+        }
     }
 
     #[test]

--- a/tests/time/test_conversions.py
+++ b/tests/time/test_conversions.py
@@ -19,6 +19,41 @@ def test_mjd_to_datetime():
     assert brahe.mjd_to_datetime(51544.5) == (2000, 1, 1, 12, 0, 0.0, 0.0)
 
 
+def test_time_system_offset_tai_utc_before_1972(eop):
+    """Mirror of test_time_system_offset_tai_utc_before_1972 in Rust."""
+    # Before 1972 UTC ran at a rate offset from TAI rather than a whole number
+    # of seconds. The IERS entry in force from 1968 February 1 is
+    # TAI - UTC = 4.2131700 + (MJD - 39126) * 0.0025920 seconds, so at
+    # 1971-12-31T23:59:59 UTC (MJD 41316.99998843) it is 9.892242 s.
+    fd = 86399.0 / 86400.0
+    expected = 4.2131700 + (41316.0 + fd - 39126.0) * 0.0025920
+    assert expected == pytest.approx(9.892242, abs=1e-6)
+
+    jd = 2441316.5 + fd
+    utc_to_tai = brahe.time_system_offset_for_jd(jd, brahe.UTC, brahe.TAI)
+    assert utc_to_tai == pytest.approx(expected, abs=1e-6)
+
+    tai_to_utc = brahe.time_system_offset_for_jd(
+        jd + utc_to_tai / 86400.0, brahe.TAI, brahe.UTC
+    )
+    assert tai_to_utc == pytest.approx(-expected, abs=1e-6)
+
+
+def test_time_system_offset_tai_utc_within_a_leap_second(eop):
+    """Mirror of test_time_system_offset_tai_utc_within_a_leap_second in Rust."""
+    # 2016-12-31T23:59:60 UTC is TAI 2017-01-01T00:00:36, so TAI - UTC is still
+    # 36 s throughout the leap second and steps to 37 s after it.
+    for tai_seconds_into_day, expected in [
+        (86435.0, -36.0),
+        (86436.0, -36.0),
+        (86436.5, -36.0),
+        (86437.0, -37.0),
+    ]:
+        jd = 2457753.5 + tai_seconds_into_day / 86400.0
+        offset = brahe.time_system_offset_for_jd(jd, brahe.TAI, brahe.UTC)
+        assert offset == expected, f"TAI second {tai_seconds_into_day}"
+
+
 def test_time_system_offset_for_jd(eop):  # Test date
     jd = brahe.datetime_to_jd(2018, 6, 1, 0, 0, 0.0, 0.0)
 

--- a/tests/time/test_epoch.py
+++ b/tests/time/test_epoch.py
@@ -1742,6 +1742,34 @@ def test_from_datetime_reaches_the_same_epoch_from_either_spelling_of_a_second(e
             )
 
 
+def test_from_datetime_round_trips_before_1972(eop):
+    """Mirror of test_from_datetime_round_trips_before_1972 in Rust."""
+    for args in [
+        (1961, 1, 1, 0, 0, 30.0),
+        (1965, 7, 1, 12, 34, 56.0),
+        (1968, 3, 15, 6, 0, 0.0),
+        (1970, 1, 1, 0, 0, 0.0),
+        (1971, 12, 31, 23, 59, 59.0),
+    ]:
+        epc = bh.Epoch.from_datetime(*args, 0.0, bh.UTC)
+        fields = epc.to_datetime()
+        assert fields[:6] == args
+        assert fields[6] == pytest.approx(0.0, abs=1e-3)
+        assert bh.Epoch.from_datetime(*fields, bh.UTC) - epc == pytest.approx(
+            0.0, abs=1e-11
+        )
+
+
+def test_to_datetime_reports_whole_seconds_throughout_a_leap_second_day(eop):
+    """Mirror of test_to_datetime_reports_whole_seconds_throughout_a_leap_second_day in Rust."""
+    for year, month, day in [(2016, 12, 31), (2015, 6, 30), (2012, 6, 30)]:
+        for hour in [0, 3, 6, 9, 12, 15, 18, 21, 23]:
+            epc = bh.Epoch.from_datetime(year, month, day, hour, 30, 15.0, 0.0, bh.UTC)
+            fields = epc.to_datetime()
+            assert fields[:6] == (year, month, day, hour, 30, 15.0)
+            assert fields[6] == pytest.approx(0.0, abs=1e-3)
+
+
 def test_to_datetime_as_time_system_reports_the_leap_second_from_tai(eop):
     """Mirror of test_to_datetime_as_time_system_reports_the_leap_second_from_tai in Rust."""
     for tai_second, expected in [


### PR DESCRIPTION
# Pull Request

## Description

Stacked on #513.

`Epoch` recovered UTC from its internal TAI storage by calling `iauUtctai`, which runs the UTC to TAI direction. Reading its result as UTC lands `dat` seconds late, which picks the wrong leap-second table entry within `dat` seconds of a leap second and, before 1972 when UTC ran at a rate offset from TAI rather than a whole number of seconds, the wrong point on that rate. At `1971-12-31T23:59:59` the offset in force is `-9.892241970 s`, and `time_system_offset` returned `-10.000000000 s`; an epoch built from that date stored the right instant and read back 0.108 s earlier. `iauTaiutc` runs the direction actually wanted.

Reporting a date compounded it. A Julian date in the UTC scale is a quasi-day in which a day carrying a leap second still spans exactly one day, and `iauD2dtf` undoes that scaling when it reports the time of day. A fraction formed by dividing seconds into the day by 86400 is therefore scaled a second time, displacing the reported time in proportion to how far into the day the epoch falls — every UTC epoch past midday on a leap-second day reported one second late. `iauTaiutc` now builds the two-part Julian date, so SOFA is handed the encoding it reads. That also resolves the P1 Codex raised on #513; the same sweep against `main` reports `2016-12-31T18:00:00 UTC` as second `0` carrying `1000000000.0` ns, so the defect predates that PR, which changed only how the wrong answer was spelled.

With both directions agreeing, UTC joins the systems whose offset is refined against the read, removing the drift of the pre-1972 rate across the requested minute.

Two further defects surfaced along the way. `iauDat` rejects a day fraction above one and leaves the offset it was handed untouched; a leap second carries the seconds into the day past 86400, so the offset came back as a silent zero throughout a leap second, which made the refinement oscillate. The fraction feeds only the pre-1972 drift term, an era with no leap seconds, so it is clamped. And the UT1 branch subtracted a UT1-UTC offset in seconds from a fractional day, moving the leap-second lookup by up to 0.9 days.

Pre-1972 UTC round trip, `from_datetime` then `to_datetime` then `from_datetime`:

| Epoch (UTC) | Reported before | Displacement before | Reported after | Displacement after |
|---|---|---|---|---|
| `1961-01-01T00:00:30` | `29 s + 999999507.315 ns` | `-4.927e-7 s` | `30 s + 0.0 ns` | `0` |
| `1965-07-01T12:34:56` | `55 s + 999999040.738 ns` | `-9.593e-7 s` | `56 s + 0.0 ns` | `0` |
| `1968-03-15T06:00:00` | `59 s + 999999622.133 ns` | `-2.178e-6 s` | `0 s + 0.0 ns` | `0` |
| `1971-12-31T23:59:59` | `58 s + 892240200.000 ns` | `-1.078e-1 s` | `59 s + 0.0 ns` | `0` |

Leap-second days, an epoch at `hh:30:15 UTC`:

| Epoch (UTC) | Reported before | Reported after |
|---|---|---|
| `2016-12-31T00:30:15` | `15 s + 0.0 ns` | `15 s + 0.0 ns` |
| `2016-12-31T12:30:15` | `16 s + 0.0 ns` | `15 s + 0.0 ns` |
| `2016-12-31T18:30:15` | `16 s + 0.0 ns` | `15 s + 0.0 ns` |
| `2015-06-30T12:30:15` | `16 s + 0.0 ns` | `15 s + 0.0 ns` |

## Changelog

### Fixed
- UTC epochs before 1972, when UTC ran at a rate offset from TAI rather than a whole number of seconds, now report the date they were built from; previously `Epoch::to_datetime` returned up to 0.108 s early and rebuilding from the reported fields displaced the epoch by that amount.
- UTC epochs on a day carrying a leap second now report the second they were built on throughout the day; previously every epoch past midday on such a day reported one second late.
- `time_system_offset` returns the UTC offset in force at the instant it is given, rather than the entry `TAI - UTC` seconds later, correcting conversions within a leap second and across the pre-1972 rate offset.
- Converting from UT1 no longer shifts the leap-second lookup by up to 0.9 days by subtracting a UT1-UTC offset expressed in seconds from a fractional day.

## Related Issue

Closes #512

## Note to Reviewers

The UTC leap-second display previously depended on two errors cancelling: the offset was one second too large in the window after a leap second, and the fractional day was scaled a second time by `iauD2dtf`, which added the second back at the end of the day. Both are corrected here, so `2016-12-31T23:59:60` and `23:59:60.5` still report as the leap second while the rest of the day now reports correctly too.

Pre-1972 support needs no Earth orientation data — UTC to TAI comes from the leap-second table, not the EOP tables, which begin at MJD 41684. UT1 before 1972 remains limited by EOP coverage and extrapolation as it always was.
