### PR TITLE
Replace OrbitFrame with ReferenceFrame in trajectories

### DIFF
--- a/brahe/plots/trajectory_3d.py
+++ b/brahe/plots/trajectory_3d.py
@@ -250,7 +250,9 @@ def _body_inertial_frame(naif_id):
         3: CelestialFrame.EMBI,
         0: CelestialFrame.SSBI,
     }
-    return named.get(naif_id) or CelestialFrame.BodyCenteredICRF(naif_id)
+    if naif_id in named:
+        return named[naif_id]
+    return CelestialFrame.BodyCenteredICRF(naif_id)
 
 
 def _coerce_trajectory_frame(trajectory, body):

--- a/brahe/plots/trajectory_3d.py
+++ b/brahe/plots/trajectory_3d.py
@@ -12,7 +12,7 @@ import numpy as np
 import plotly.graph_objects as go
 from loguru import logger
 
-from brahe._brahe import OrbitFrame, OrbitRepresentation, OrbitTrajectory
+from brahe._brahe import CelestialFrame, OrbitRepresentation, OrbitTrajectory
 from brahe.plots.backend import apply_scienceplots_style, validate_backend
 from brahe.plots.bodies import resolve_body
 from brahe.plots.texture_utils import load_body_texture
@@ -40,11 +40,9 @@ def plot_trajectory_3d(
     """Plot 3D trajectories about a central body.
 
     Trajectories are plotted in the central body's centered-inertial frame.
-    For Earth (the default), trajectories in any frame are converted via
-    ``to_eci()``. For other central bodies, trajectories must already be in
-    ``OrbitFrame.BodyCenteredInertial(naif_id)`` for that body's NAIF ID;
-    custom bodies without a NAIF ID are plotted using the trajectory's raw
-    Cartesian position, unconverted.
+    A trajectory declared in any other frame is converted to it via
+    ``to_frame()``. Custom bodies without a NAIF ID are plotted using the
+    trajectory's raw Cartesian position, unconverted.
 
     Args:
         trajectories (list of dict): List of trajectory groups, each with:
@@ -100,8 +98,10 @@ def plot_trajectory_3d(
         object: Generated figure (matplotlib.figure.Figure or plotly.graph_objects.Figure)
 
     Raises:
-        ValueError: If ``central_body`` is not recognized, or a trajectory's
-            frame does not match the expected body-centered-inertial frame.
+        ValueError: If ``central_body`` is not recognized, if a trajectory
+            cannot be converted to the central body's centered-inertial frame,
+            or if a non-Cartesian trajectory is plotted about a custom central
+            body that has no NAIF ID.
         TypeError: If a trajectory is not an OrbitTrajectory object.
 
     Example:
@@ -146,7 +146,7 @@ def plot_trajectory_3d(
         ])
         lunar_traj = bh.OrbitTrajectory.from_orbital_data(
             [epoch + i*60 for i in range(20)], states,
-            bh.OrbitFrame.BodyCenteredInertial(301),
+            bh.CelestialFrame.LCI,
             bh.OrbitRepresentation.CARTESIAN, None, None
         )
 
@@ -241,31 +241,37 @@ def _normalize_trajectory_groups(trajectories):
     return [{**defaults, **group} for group in trajectories]
 
 
+def _body_inertial_frame(naif_id):
+    """Centered inertial frame for a body's NAIF ID."""
+    named = {
+        399: CelestialFrame.GCRF,
+        301: CelestialFrame.LCI,
+        499: CelestialFrame.MCI,
+        3: CelestialFrame.EMBI,
+        0: CelestialFrame.SSBI,
+    }
+    return named.get(naif_id) or CelestialFrame.BodyCenteredICRF(naif_id)
+
+
 def _coerce_trajectory_frame(trajectory, body):
-    """Validate/convert a trajectory into the central body's centered-inertial frame."""
+    """Convert a trajectory into the central body's centered-inertial frame."""
     if not isinstance(trajectory, OrbitTrajectory):
         raise TypeError(
             f"Trajectory must be an OrbitTrajectory object, got {type(trajectory)}"
         )
 
-    if body["naif_id"] == 399:
+    if body["naif_id"] is not None:
+        frame = _body_inertial_frame(body["naif_id"])
         if (
-            trajectory.frame != OrbitFrame.ECI
+            trajectory.frame != frame
             or trajectory.representation != OrbitRepresentation.CARTESIAN
         ):
             logger.debug(
-                f"Converting trajectory from {trajectory.frame}/{trajectory.representation} to ECI/CARTESIAN"
+                f"Converting trajectory from {trajectory.frame}/"
+                f"{trajectory.representation} to {frame}/CARTESIAN"
             )
-            trajectory = trajectory.to_eci()
+            trajectory = trajectory.to_frame(frame)
         return trajectory
-
-    if body["naif_id"] is not None:
-        expected_frame = OrbitFrame.BodyCenteredInertial(body["naif_id"])
-        if trajectory.frame != expected_frame:
-            raise ValueError(
-                f"Trajectory frame {trajectory.frame} does not match the expected "
-                f"frame {expected_frame} for central body '{body['name']}'"
-            )
 
     if trajectory.representation != OrbitRepresentation.CARTESIAN:
         raise ValueError(

--- a/brahe/trajectories.py
+++ b/brahe/trajectories.py
@@ -20,7 +20,6 @@ This module provides containers for storing and interpolating spacecraft traject
   angles, Euler axis, rotation matrix, angular velocity)
 
 **Enumerations:**
-- OrbitFrame: Reference frame specification
 - OrbitRepresentation: State representation format
 - AngleFormat: Angle unit specification
 - InterpolationMethod: Interpolation algorithm selection
@@ -34,7 +33,6 @@ from brahe._brahe import (
     CovarianceInterpolationMethod,
     InterpolationMethod,
     # Configuration enums
-    OrbitFrame,
     OrbitRepresentation,
     OrbitTrajectory,
     # Trajectory classes
@@ -48,7 +46,6 @@ __all__ = [
     "CovarianceInterpolationMethod",
     "InterpolationMethod",
     # Configuration enums
-    "OrbitFrame",
     "OrbitRepresentation",
     "OrbitTrajectory",
     # Trajectory classes

--- a/crates/brahe-py/src/ccsds.rs
+++ b/crates/brahe-py/src/ccsds.rs
@@ -31,16 +31,32 @@ use brahe::ccsds::interop::ccsds_ref_frame_to_reference_frame;
 use brahe::ccsds::oem::{OEM as RustOEM, OEMMetadata, OEMSegment, OEMStateVector};
 use brahe::ccsds::omm::OMM as RustOMM;
 use brahe::ccsds::opm::{OPM as RustOPM, OPMManeuver};
-use brahe::frames::{CelestialFrame, state_frame_to_frame};
+use brahe::frames::{CelestialFrame, ReferenceFrame};
 use brahe::trajectories::DOrbitTrajectory;
+
+/// Celestial frame an OEM segment's declared reference frame resolves to.
+///
+/// Every CCSDS reference frame maps onto a celestial frame; the error arm
+/// guards against a future mapping that does not.
+fn oem_segment_celestial_frame(
+    frame: &ReferenceFrame,
+) -> Result<CelestialFrame, brahe::utils::BraheError> {
+    match frame {
+        ReferenceFrame::Celestial(target) => Ok(*target),
+        other => Err(brahe::utils::BraheError::Error(format!(
+            "OEM segment frame {} is not a celestial frame",
+            other
+        ))),
+    }
+}
 
 /// Push all states from a trajectory into an OEM segment, converting to the
 /// segment's declared reference frame using the trajectory's frame-aware methods.
 fn push_trajectory_states(seg: &mut OEMSegment, traj: &DOrbitTrajectory) -> Result<(), brahe::utils::BraheError> {
     let frame = ccsds_ref_frame_to_reference_frame(&seg.metadata.ref_frame)?;
+    let target = oem_segment_celestial_frame(&frame)?;
     for epoch in traj.epochs.iter() {
-        let x = traj.state_gcrf(*epoch)?;
-        let state = state_frame_to_frame(CelestialFrame::GCRF, frame.clone(), *epoch, x)?;
+        let state = traj.state_in_frame(target, *epoch)?;
         seg.states.push(OEMStateVector {
             epoch: *epoch,
             position: [state[0], state[1], state[2]],
@@ -1039,17 +1055,18 @@ impl PyOEMSegment {
                     ))
                 })?;
 
+                let target = oem_segment_celestial_frame(&frame).map_err(|e| {
+                    pyo3::exceptions::PyValueError::new_err(format!(
+                        "Unsupported ref_frame for trajectory conversion: {}", e
+                    ))
+                })?;
+
                 for epoch in traj.epochs.iter() {
-                    let state = traj
-                        .state_gcrf(*epoch)
-                        .and_then(|x| {
-                            state_frame_to_frame(CelestialFrame::GCRF, frame.clone(), *epoch, x)
-                        })
-                        .map_err(|e| {
-                            pyo3::exceptions::PyRuntimeError::new_err(format!(
-                                "Failed to convert trajectory state at {}: {}", epoch, e
-                            ))
-                        })?;
+                    let state = traj.state_in_frame(target, *epoch).map_err(|e| {
+                        pyo3::exceptions::PyRuntimeError::new_err(format!(
+                            "Failed to convert trajectory state at {}: {}", epoch, e
+                        ))
+                    })?;
 
                     let pos = vec![state[0], state[1], state[2]];
                     let vel = vec![state[3], state[4], state[5]];

--- a/crates/brahe-py/src/ccsds.rs
+++ b/crates/brahe-py/src/ccsds.rs
@@ -27,29 +27,20 @@ use brahe::ccsds::common::{
     CCSDSFormat, CCSDSRefFrame, CCSDSTimeSystem, ODMHeader,
 };
 use brahe::ccsds::frames::ADMReferenceFrame;
-use brahe::ccsds::interop::ccsds_ref_frame_to_orbit_frame;
+use brahe::ccsds::interop::ccsds_ref_frame_to_reference_frame;
 use brahe::ccsds::oem::{OEM as RustOEM, OEMMetadata, OEMSegment, OEMStateVector};
 use brahe::ccsds::omm::OMM as RustOMM;
 use brahe::ccsds::opm::{OPM as RustOPM, OPMManeuver};
+use brahe::frames::{CelestialFrame, state_frame_to_frame};
 use brahe::trajectories::DOrbitTrajectory;
-use brahe::trajectories::traits::OrbitFrame;
 
 /// Push all states from a trajectory into an OEM segment, converting to the
 /// segment's declared reference frame using the trajectory's frame-aware methods.
 fn push_trajectory_states(seg: &mut OEMSegment, traj: &DOrbitTrajectory) -> Result<(), brahe::utils::BraheError> {
-    let orbit_frame = ccsds_ref_frame_to_orbit_frame(&seg.metadata.ref_frame)?;
+    let frame = ccsds_ref_frame_to_reference_frame(&seg.metadata.ref_frame)?;
     for epoch in traj.epochs.iter() {
-        let state = match orbit_frame {
-            OrbitFrame::EME2000 => traj.state_eme2000(*epoch)?,
-            OrbitFrame::GCRF => traj.state_gcrf(*epoch)?,
-            OrbitFrame::ECI => traj.state_eci(*epoch)?,
-            OrbitFrame::ECEF | OrbitFrame::ITRF => traj.state_itrf(*epoch)?,
-            OrbitFrame::BodyCenteredInertial(_) => {
-                return Err(brahe::utils::BraheError::Error(
-                    "body-centered inertial (non-Earth) trajectories cannot be exported to CCSDS Earth reference frames".to_string(),
-                ));
-            }
-        };
+        let x = traj.state_gcrf(*epoch)?;
+        let state = state_frame_to_frame(CelestialFrame::GCRF, frame.clone(), *epoch, x)?;
         seg.states.push(OEMStateVector {
             epoch: *epoch,
             position: [state[0], state[1], state[2]],
@@ -1042,26 +1033,23 @@ impl PyOEMSegment {
                         "Parent is not an OEM object"
                     ))?;
                 let ref_frame = oem_bound.borrow().inner.segments[*seg_idx].metadata.ref_frame.clone();
-                let orbit_frame = ccsds_ref_frame_to_orbit_frame(&ref_frame).map_err(|e| {
+                let frame = ccsds_ref_frame_to_reference_frame(&ref_frame).map_err(|e| {
                     pyo3::exceptions::PyValueError::new_err(format!(
                         "Unsupported ref_frame for trajectory conversion: {}", e
                     ))
                 })?;
 
                 for epoch in traj.epochs.iter() {
-                    let state = match orbit_frame {
-                        OrbitFrame::EME2000 => traj.state_eme2000(*epoch),
-                        OrbitFrame::GCRF => traj.state_gcrf(*epoch),
-                        OrbitFrame::ECI => traj.state_eci(*epoch),
-                        OrbitFrame::ECEF | OrbitFrame::ITRF => traj.state_itrf(*epoch),
-                        OrbitFrame::BodyCenteredInertial(_) => Err(brahe::utils::BraheError::Error(
-                            "body-centered inertial (non-Earth) trajectories cannot be exported to CCSDS Earth reference frames".to_string(),
-                        )),
-                    }.map_err(|e| {
-                        pyo3::exceptions::PyRuntimeError::new_err(format!(
-                            "Failed to convert trajectory state at {}: {}", epoch, e
-                        ))
-                    })?;
+                    let state = traj
+                        .state_gcrf(*epoch)
+                        .and_then(|x| {
+                            state_frame_to_frame(CelestialFrame::GCRF, frame.clone(), *epoch, x)
+                        })
+                        .map_err(|e| {
+                            pyo3::exceptions::PyRuntimeError::new_err(format!(
+                                "Failed to convert trajectory state at {}: {}", epoch, e
+                            ))
+                        })?;
 
                     let pos = vec![state[0], state[1], state[2]];
                     let vel = vec![state[3], state[4], state[5]];

--- a/crates/brahe-py/src/frames.rs
+++ b/crates/brahe-py/src/frames.rs
@@ -4403,7 +4403,7 @@ impl PyCelestialFrame {
 /// Extracts a `frames::ReferenceFrame` from a Python object that is either a
 /// `CelestialFrame` or a `ReferenceFrame` (`Body`/`OrbitRelative`), for the
 /// `*_frame_to_frame` functions that accept either.
-fn extract_frame(obj: &Bound<'_, PyAny>) -> PyResult<frames::ReferenceFrame> {
+pub(crate) fn extract_frame(obj: &Bound<'_, PyAny>) -> PyResult<frames::ReferenceFrame> {
     if let Ok(celestial) = obj.extract::<PyCelestialFrame>() {
         return Ok(frames::ReferenceFrame::Celestial(celestial.frame));
     }
@@ -5121,7 +5121,7 @@ impl PyBodyFrame {
 ///     css = bh.ReferenceFrame.CSS("SC", "1")
 ///     print(rtn.is_bound(), rtn.object())
 ///     ```
-#[pyclass(module = "brahe._brahe", eq, from_py_object)]
+#[pyclass(module = "brahe._brahe", from_py_object)]
 #[pyo3(name = "ReferenceFrame")]
 #[derive(Clone, PartialEq)]
 pub struct PyReferenceFrame {
@@ -5616,6 +5616,15 @@ impl PyReferenceFrame {
 
     fn __repr__(&self) -> String {
         format!("ReferenceFrame(\"{}\")", self.frame)
+    }
+
+    /// Equality with another `ReferenceFrame` or with a `CelestialFrame`
+    /// (which compares equal to the `ReferenceFrame` wrapping it).
+    fn __eq__(&self, py: Python<'_>, other: &Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {
+        match extract_frame(other) {
+            Ok(frame) => Ok((self.frame == frame).into_pyobject(py)?.to_owned().into_any().unbind()),
+            Err(_) => Ok(py.NotImplemented()),
+        }
     }
 }
 

--- a/crates/brahe-py/src/lib.rs
+++ b/crates/brahe-py/src/lib.rs
@@ -1165,7 +1165,6 @@ pub fn _brahe(py: Python<'_>, module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_function(wrap_pyfunction!(py_state_roe_to_eci, module)?)?;
 
     //* Trajectories *//
-    module.add_class::<PyOrbitFrame>()?;
     module.add_class::<PyOrbitRepresentation>()?;
     module.add_class::<PyAngleFormat>()?;
     module.add_class::<PyInterpolationMethod>()?;

--- a/crates/brahe-py/src/propagators.rs
+++ b/crates/brahe-py/src/propagators.rs
@@ -449,7 +449,7 @@ impl PySGPPropagator {
     /// Set output format (frame, representation, and angle format).
     ///
     /// Args:
-    ///     frame (CelestialFrame or ReferenceFrame): Output frame (ECI or ECEF).
+    ///     frame (CelestialFrame or ReferenceFrame): Output frame; any Earth-centered CelestialFrame or ReferenceFrame.
     ///     representation (OrbitRepresentation): Output representation (Cartesian or Keplerian).
     ///     angle_format (AngleFormat or None): Angle format for Keplerian (None for Cartesian).
     #[pyo3(text_signature = "(frame, representation, angle_format)")]
@@ -2171,7 +2171,7 @@ impl PySGPPropagatorBuilder {
     /// frame/representation/angle-format combinations it accepts.
     ///
     /// Args:
-    ///     frame (CelestialFrame or ReferenceFrame): Output frame (ECI or ECEF).
+    ///     frame (CelestialFrame or ReferenceFrame): Output frame; any Earth-centered CelestialFrame or ReferenceFrame.
     ///     representation (OrbitRepresentation): Output representation (Cartesian or Keplerian).
     ///     angle_format (AngleFormat or None): Angle format for Keplerian (None for Cartesian).
     ///
@@ -2279,7 +2279,7 @@ impl PyKeplerianPropagator {
     ///     state (numpy.ndarray): 6-element state vector.
     ///     frame (CelestialFrame or ReferenceFrame): Reference frame.
     ///     representation (OrbitRepresentation): State representation.
-    ///     angle_format (AngleFormat): Angle format (only for Keplerian).
+    ///     angle_format (AngleFormat or None): Angle format for Keplerian elements; None for Cartesian.
     ///     step_size (float): Step size in seconds for propagation.
     ///
     /// Returns:
@@ -2291,7 +2291,7 @@ impl PyKeplerianPropagator {
         state: PyReadonlyArray1<f64>,
         frame: &Bound<'_, PyAny>,
         representation: PyRef<PyOrbitRepresentation>,
-        angle_format: PyRef<PyAngleFormat>,
+        angle_format: Option<PyRef<PyAngleFormat>>,
         step_size: f64,
     ) -> PyResult<Self> {
         let frame = extract_frame(frame)?;
@@ -2313,7 +2313,7 @@ impl PyKeplerianPropagator {
             state_vec,
             frame,
             representation.representation,
-            Some(angle_format.value),
+            angle_format.map(|a| a.value),
             step_size,
         )?;
 
@@ -2668,7 +2668,7 @@ impl PyKeplerianPropagator {
     ///     state (numpy.ndarray): Initial state vector.
     ///     frame (CelestialFrame or ReferenceFrame): Reference frame.
     ///     representation (OrbitRepresentation): State representation.
-    ///     angle_format (AngleFormat): Angle format.
+    ///     angle_format (AngleFormat or None): Angle format for Keplerian elements; None for Cartesian.
     ///
     /// Example:
     ///     ```python
@@ -2687,14 +2687,14 @@ impl PyKeplerianPropagator {
     ///     prop.set_initial_conditions(new_epc, new_state, bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, bh.AngleFormat.RADIANS)
     ///     print(f"New initial epoch: {prop.initial_epoch}")
     ///     ```
-    #[pyo3(text_signature = "(epoch, state, frame, representation, angle_format)")]
+    #[pyo3(signature = (epoch, state, frame, representation, angle_format), text_signature = "(epoch, state, frame, representation, angle_format)")]
     pub fn set_initial_conditions(
         &mut self,
         epoch: PyRef<PyEpoch>,
         state: PyReadonlyArray1<f64>,
         frame: &Bound<'_, PyAny>,
         representation: PyRef<PyOrbitRepresentation>,
-        angle_format: PyRef<PyAngleFormat>,
+        angle_format: Option<PyRef<PyAngleFormat>>,
     ) -> PyResult<()> {
         let frame = extract_frame(frame)?;
         let state_array = state.as_array();
@@ -2715,7 +2715,7 @@ impl PyKeplerianPropagator {
             state_vec,
             frame,
             representation.representation,
-            Some(angle_format.value),
+            angle_format.map(|a| a.value),
         )?;
 
         Ok(())

--- a/crates/brahe-py/src/propagators.rs
+++ b/crates/brahe-py/src/propagators.rs
@@ -449,19 +449,20 @@ impl PySGPPropagator {
     /// Set output format (frame, representation, and angle format).
     ///
     /// Args:
-    ///     frame (OrbitFrame): Output frame (ECI or ECEF).
+    ///     frame (CelestialFrame or ReferenceFrame): Output frame (ECI or ECEF).
     ///     representation (OrbitRepresentation): Output representation (Cartesian or Keplerian).
     ///     angle_format (AngleFormat or None): Angle format for Keplerian (None for Cartesian).
     #[pyo3(text_signature = "(frame, representation, angle_format)")]
     pub fn set_output_format(
         &mut self,
-        frame: PyRef<PyOrbitFrame>,
+        frame: &Bound<'_, PyAny>,
         representation: PyRef<PyOrbitRepresentation>,
         angle_format: Option<PyRef<PyAngleFormat>>,
     ) -> PyResult<()> {
+        let frame = extract_frame(frame)?;
         let angle_fmt = angle_format.map(|af| af.value);
         self.propagator = self.propagator.clone().with_output_format(
-            frame.frame,
+            frame,
             representation.representation,
             angle_fmt,
         )?;
@@ -2170,7 +2171,7 @@ impl PySGPPropagatorBuilder {
     /// frame/representation/angle-format combinations it accepts.
     ///
     /// Args:
-    ///     frame (OrbitFrame): Output frame (ECI or ECEF).
+    ///     frame (CelestialFrame or ReferenceFrame): Output frame (ECI or ECEF).
     ///     representation (OrbitRepresentation): Output representation (Cartesian or Keplerian).
     ///     angle_format (AngleFormat or None): Angle format for Keplerian (None for Cartesian).
     ///
@@ -2178,16 +2179,17 @@ impl PySGPPropagatorBuilder {
     ///     SGPPropagatorBuilder: The builder, for method chaining.
     fn output_format<'a>(
         mut slf: PyRefMut<'a, Self>,
-        frame: PyRef<PyOrbitFrame>,
+        frame: &Bound<'_, PyAny>,
         representation: PyRef<PyOrbitRepresentation>,
         angle_format: Option<PyRef<PyAngleFormat>>,
-    ) -> PyRefMut<'a, Self> {
+    ) -> PyResult<PyRefMut<'a, Self>> {
+        let frame = extract_frame(frame)?;
         let angle_fmt = angle_format.map(|af| af.value);
         slf.inner = slf
             .inner
             .take()
-            .map(|b| b.output_format(frame.frame, representation.representation, angle_fmt));
-        slf
+            .map(|b| b.output_format(frame, representation.representation, angle_fmt));
+        Ok(slf)
     }
 
     /// Construct the propagator from the accumulated configuration.
@@ -2257,7 +2259,7 @@ impl PySGPPropagatorBuilder {
 ///     # Create from Cartesian state
 ///     x_cart = np.array([7000000.0, 0.0, 0.0, 0.0, 7546.0, 0.0])
 ///     prop2 = bh.KeplerianPropagator(
-///         epc0, x_cart, bh.OrbitFrame.ECI,
+///         epc0, x_cart, bh.CelestialFrame.ECI,
 ///         bh.OrbitRepresentation.CARTESIAN,
 ///         bh.AngleFormat.RADIANS, 60.0
 ///     )
@@ -2275,7 +2277,7 @@ impl PyKeplerianPropagator {
     /// Args:
     ///     epoch (Epoch): Initial epoch.
     ///     state (numpy.ndarray): 6-element state vector.
-    ///     frame (OrbitFrame): Reference frame.
+    ///     frame (CelestialFrame or ReferenceFrame): Reference frame.
     ///     representation (OrbitRepresentation): State representation.
     ///     angle_format (AngleFormat): Angle format (only for Keplerian).
     ///     step_size (float): Step size in seconds for propagation.
@@ -2287,11 +2289,12 @@ impl PyKeplerianPropagator {
     pub fn new(
         epoch: PyRef<PyEpoch>,
         state: PyReadonlyArray1<f64>,
-        frame: PyRef<PyOrbitFrame>,
+        frame: &Bound<'_, PyAny>,
         representation: PyRef<PyOrbitRepresentation>,
         angle_format: PyRef<PyAngleFormat>,
         step_size: f64,
     ) -> PyResult<Self> {
+        let frame = extract_frame(frame)?;
         let state_array = state.as_array();
         if state_array.len() != 6 {
             return Err(exceptions::PyValueError::new_err(
@@ -2308,7 +2311,7 @@ impl PyKeplerianPropagator {
         let propagator = propagators::KeplerianPropagator::new(
             epoch.obj,
             state_vec,
-            frame.frame,
+            frame,
             representation.representation,
             Some(angle_format.value),
             step_size,
@@ -2524,7 +2527,7 @@ impl PyKeplerianPropagator {
     ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     oe = np.array([bh.R_EARTH + 500e3, 0.01, 0.9, 1.0, 0.5, 0.0])
     ///     state = bh.state_koe_to_eci(oe, bh.AngleFormat.RADIANS)
-    ///     prop = bh.KeplerianPropagator(epc, state, bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None, 60.0)
+    ///     prop = bh.KeplerianPropagator(epc, state, bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None, 60.0)
     ///     prop.step()  # Advance by default step_size (60 seconds)
     ///     print(f"Advanced to: {prop.current_epoch()}")
     ///     ```
@@ -2549,7 +2552,7 @@ impl PyKeplerianPropagator {
     ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     oe = np.array([bh.R_EARTH + 500e3, 0.01, 0.9, 1.0, 0.5, 0.0])
     ///     state = bh.state_koe_to_eci(oe, bh.AngleFormat.RADIANS)
-    ///     prop = bh.KeplerianPropagator(epc, state, bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None, 60.0)
+    ///     prop = bh.KeplerianPropagator(epc, state, bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None, 60.0)
     ///     prop.step_by(120.0)  # Advance by 120 seconds
     ///     print(f"Advanced to: {prop.current_epoch()}")
     ///     ```
@@ -2574,7 +2577,7 @@ impl PyKeplerianPropagator {
     ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     oe = np.array([bh.R_EARTH + 500e3, 0.01, 0.9, 1.0, 0.5, 0.0])
     ///     state = bh.state_koe_to_eci(oe, bh.AngleFormat.RADIANS)
-    ///     prop = bh.KeplerianPropagator(epc, state, bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None, 60.0)
+    ///     prop = bh.KeplerianPropagator(epc, state, bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None, 60.0)
     ///     target = epc + 300.0  # Target 5 minutes ahead
     ///     prop.step_past(target)
     ///     print(f"Advanced to: {prop.current_epoch()}")
@@ -2600,7 +2603,7 @@ impl PyKeplerianPropagator {
     ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     oe = np.array([bh.R_EARTH + 500e3, 0.01, 0.9, 1.0, 0.5, 0.0])
     ///     state = bh.state_koe_to_eci(oe, bh.AngleFormat.RADIANS)
-    ///     prop = bh.KeplerianPropagator(epc, state, bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None, 60.0)
+    ///     prop = bh.KeplerianPropagator(epc, state, bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None, 60.0)
     ///     prop.propagate_steps(10)  # Take 10 steps (600 seconds total)
     ///     print(f"Advanced to: {prop.current_epoch()}")
     ///     ```
@@ -2625,7 +2628,7 @@ impl PyKeplerianPropagator {
     ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     oe = np.array([bh.R_EARTH + 500e3, 0.01, 0.9, 1.0, 0.5, 0.0])
     ///     state = bh.state_koe_to_eci(oe, bh.AngleFormat.RADIANS)
-    ///     prop = bh.KeplerianPropagator(epc, state, bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None, 60.0)
+    ///     prop = bh.KeplerianPropagator(epc, state, bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None, 60.0)
     ///     target = epc + 3600.0  # Propagate to 1 hour ahead
     ///     prop.propagate_to(target)
     ///     print(f"Propagated to: {prop.current_epoch()}")
@@ -2648,7 +2651,7 @@ impl PyKeplerianPropagator {
     ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     oe = np.array([bh.R_EARTH + 500e3, 0.01, 0.9, 1.0, 0.5, 0.0])
     ///     state = bh.state_koe_to_eci(oe, bh.AngleFormat.RADIANS)
-    ///     prop = bh.KeplerianPropagator(epc, state, bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None, 60.0)
+    ///     prop = bh.KeplerianPropagator(epc, state, bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None, 60.0)
     ///     prop.propagate_steps(10)
     ///     prop.reset()  # Return to initial epoch and state
     ///     print(f"Reset to: {prop.current_epoch()}")
@@ -2663,7 +2666,7 @@ impl PyKeplerianPropagator {
     /// Args:
     ///     epoch (Epoch): Initial epoch.
     ///     state (numpy.ndarray): Initial state vector.
-    ///     frame (OrbitFrame): Reference frame.
+    ///     frame (CelestialFrame or ReferenceFrame): Reference frame.
     ///     representation (OrbitRepresentation): State representation.
     ///     angle_format (AngleFormat): Angle format.
     ///
@@ -2675,13 +2678,13 @@ impl PyKeplerianPropagator {
     ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     oe = np.array([bh.R_EARTH + 500e3, 0.01, 0.9, 1.0, 0.5, 0.0])
     ///     state = bh.state_koe_to_eci(oe, bh.AngleFormat.RADIANS)
-    ///     prop = bh.KeplerianPropagator(epc, state, bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None, 60.0)
+    ///     prop = bh.KeplerianPropagator(epc, state, bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None, 60.0)
     ///
     ///     # Change initial conditions to a different orbit
     ///     new_oe = np.array([bh.R_EARTH + 800e3, 0.02, 1.2, 0.5, 0.3, 0.0])
     ///     new_state = bh.state_koe_to_eci(new_oe, bh.AngleFormat.RADIANS)
     ///     new_epc = bh.Epoch.from_datetime(2024, 1, 2, 0, 0, 0.0, 0.0, bh.TimeSystem.UTC)
-    ///     prop.set_initial_conditions(new_epc, new_state, bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, bh.AngleFormat.RADIANS)
+    ///     prop.set_initial_conditions(new_epc, new_state, bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, bh.AngleFormat.RADIANS)
     ///     print(f"New initial epoch: {prop.initial_epoch}")
     ///     ```
     #[pyo3(text_signature = "(epoch, state, frame, representation, angle_format)")]
@@ -2689,10 +2692,11 @@ impl PyKeplerianPropagator {
         &mut self,
         epoch: PyRef<PyEpoch>,
         state: PyReadonlyArray1<f64>,
-        frame: PyRef<PyOrbitFrame>,
+        frame: &Bound<'_, PyAny>,
         representation: PyRef<PyOrbitRepresentation>,
         angle_format: PyRef<PyAngleFormat>,
     ) -> PyResult<()> {
+        let frame = extract_frame(frame)?;
         let state_array = state.as_array();
         if state_array.len() != 6 {
             return Err(exceptions::PyValueError::new_err(
@@ -2709,7 +2713,7 @@ impl PyKeplerianPropagator {
         self.propagator.set_initial_conditions(
             epoch.obj,
             state_vec,
-            frame.frame,
+            frame,
             representation.representation,
             Some(angle_format.value),
         )?;
@@ -2730,7 +2734,7 @@ impl PyKeplerianPropagator {
     ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     oe = np.array([bh.R_EARTH + 500e3, 0.01, 0.9, 1.0, 0.5, 0.0])
     ///     state = bh.state_koe_to_eci(oe, bh.AngleFormat.RADIANS)
-    ///     prop = bh.KeplerianPropagator(epc, state, bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None, 60.0)
+    ///     prop = bh.KeplerianPropagator(epc, state, bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None, 60.0)
     ///     prop.set_eviction_policy_max_size(100)  # Keep only 100 most recent states
     ///     prop.propagate_steps(200)
     ///     print(f"Trajectory length: {prop.trajectory.len()}")
@@ -2756,7 +2760,7 @@ impl PyKeplerianPropagator {
     ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     oe = np.array([bh.R_EARTH + 500e3, 0.01, 0.9, 1.0, 0.5, 0.0])
     ///     state = bh.state_koe_to_eci(oe, bh.AngleFormat.RADIANS)
-    ///     prop = bh.KeplerianPropagator(epc, state, bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None, 60.0)
+    ///     prop = bh.KeplerianPropagator(epc, state, bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None, 60.0)
     ///     prop.set_eviction_policy_max_age(3600.0)  # Keep only states within 1 hour
     ///     prop.propagate_to(epc + 7200.0)  # Propagate 2 hours
     ///     print(f"Trajectory length: {prop.trajectory.len()}")
@@ -3235,7 +3239,7 @@ impl PyKeplerianPropagator {
     ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     oe = np.array([bh.R_EARTH + 500e3, 0.01, 0.9, 1.0, 0.5, 0.0])
     ///     state = bh.state_koe_to_eci(oe, bh.AngleFormat.RADIANS)
-    ///     prop = bh.KeplerianPropagator(epc, state, bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None, 60.0)
+    ///     prop = bh.KeplerianPropagator(epc, state, bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None, 60.0)
     ///     prop.propagate_steps(10)
     ///     traj = prop.trajectory
     ///     print(f"Trajectory contains {traj.len()} states")
@@ -3261,7 +3265,7 @@ impl PyKeplerianPropagator {
         let mut d_traj = trajectories::DOrbitTrajectory::from_orbital_data(
             traj.epochs.clone(),
             states,
-            traj.frame,
+            traj.frame.clone(),
             traj.representation,
             traj.angle_format,
             covariances,

--- a/crates/brahe-py/src/trajectories.rs
+++ b/crates/brahe-py/src/trajectories.rs
@@ -1453,8 +1453,12 @@ impl PyOrbitalTrajectory {
     ///     ```python
     ///     import brahe as bh
     ///
+    ///     import numpy as np
+    ///
     ///     bh.initialize_eop()
     ///     traj = bh.OrbitTrajectory(6, bh.CelestialFrame.GCRF, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
+    ///     traj.add(epc, np.array([bh.R_EARTH + 500e3, 0.0, 0.0, 0.0, 7600.0, 0.0]))
     ///     traj_tod = traj.to_frame(bh.CelestialFrame.TOD)
     ///     ```
     #[pyo3(text_signature = "(frame)")]

--- a/crates/brahe-py/src/trajectories.rs
+++ b/crates/brahe-py/src/trajectories.rs
@@ -215,126 +215,6 @@ impl PyCovarianceInterpolationMethod {
 }
 
 
-/// Reference frame for orbital trajectory representation.
-///
-/// Specifies the coordinate reference frame for position and velocity states.
-#[pyclass(module = "brahe._brahe", from_py_object)]
-#[pyo3(name = "OrbitFrame")]
-#[derive(Clone)]
-pub struct PyOrbitFrame {
-    pub(crate) frame: trajectories::traits::OrbitFrame,
-}
-
-#[pymethods]
-impl PyOrbitFrame {
-    /// Earth-Centered Inertial (J2000) frame.
-    ///
-    /// Returns:
-    ///     OrbitFrame: ECI frame constant
-    #[classattr]
-    #[pyo3(name = "ECI")]
-    fn eci() -> Self {
-        PyOrbitFrame { frame: trajectories::traits::OrbitFrame::ECI }
-    }
-
-    /// Earth-Centered Earth-Fixed frame.
-    ///
-    /// Returns:
-    ///     OrbitFrame: ECEF frame constant
-    #[classattr]
-    #[pyo3(name = "ECEF")]
-    fn ecef() -> Self {
-        PyOrbitFrame { frame: trajectories::traits::OrbitFrame::ECEF }
-    }
-
-    /// Geocentric Celestial Reference Frame (IAU 2006/2000A).
-    ///
-    /// Returns:
-    ///     OrbitFrame: GCRF frame constant
-    #[classattr]
-    #[pyo3(name = "GCRF")]
-    fn gcrf() -> Self {
-        PyOrbitFrame { frame: trajectories::traits::OrbitFrame::GCRF }
-    }
-
-    /// Earth Mean Equator and Equinox of J2000.0 frame.
-    ///
-    /// Returns:
-    ///     OrbitFrame: EME2000 frame constant
-    #[classattr]
-    #[pyo3(name = "EME2000")]
-    fn eme2000() -> Self {
-        PyOrbitFrame { frame: trajectories::traits::OrbitFrame::EME2000 }
-    }
-
-    /// International Terrestrial Reference Frame.
-    ///
-    /// Returns:
-    ///     OrbitFrame: ITRF frame constant
-    #[classattr]
-    #[pyo3(name = "ITRF")]
-    fn itrf() -> Self {
-        PyOrbitFrame { frame: trajectories::traits::OrbitFrame::ITRF }
-    }
-
-    /// Body-centered inertial frame for a non-Earth central body: ICRF-aligned
-    /// axes centered on the body with the given NAIF ID (e.g. 301 for LCI
-    /// samples from a Moon-centered propagator, 499 for MCI). Produced by
-    /// non-Earth `NumericalOrbitPropagator` trajectories; Earth-frame
-    /// conversions re-center through the loaded SPK kernels.
-    ///
-    /// Args:
-    ///     naif_id (int): NAIF ID of the body the frame is centered on.
-    ///
-    /// Returns:
-    ///     OrbitFrame: Body-centered inertial frame for that body
-    #[staticmethod]
-    #[allow(non_snake_case)]
-    fn BodyCenteredInertial(naif_id: i32) -> Self {
-        PyOrbitFrame {
-            frame: trajectories::traits::OrbitFrame::BodyCenteredInertial(naif_id),
-        }
-    }
-
-    /// Get the full name of the reference frame.
-    ///
-    /// Returns:
-    ///     str: Human-readable frame name
-    fn name(&self) -> &str {
-        match self.frame {
-            trajectories::traits::OrbitFrame::ECI => "Earth-Centered Inertial",
-            trajectories::traits::OrbitFrame::ECEF => "Earth-Centered Earth-Fixed",
-            trajectories::traits::OrbitFrame::GCRF => "Geocentric Celestial Reference Frame",
-            trajectories::traits::OrbitFrame::EME2000 => "Earth Mean Equator and Equinox of J2000.0",
-            trajectories::traits::OrbitFrame::ITRF => "International Terrestrial Reference Frame",
-            trajectories::traits::OrbitFrame::BodyCenteredInertial(_) => "Body-Centered Inertial",
-        }
-    }
-
-    fn __str__(&self) -> String {
-        match self.frame {
-            trajectories::traits::OrbitFrame::ECI => "ECI".to_string(),
-            trajectories::traits::OrbitFrame::ECEF => "ECEF".to_string(),
-            trajectories::traits::OrbitFrame::GCRF => "GCRF".to_string(),
-            trajectories::traits::OrbitFrame::EME2000 => "EME2000".to_string(),
-            trajectories::traits::OrbitFrame::ITRF => "ITRF".to_string(),
-            trajectories::traits::OrbitFrame::BodyCenteredInertial(center) => format!("BCI({})", center),
-        }
-    }
-
-    fn __repr__(&self) -> String {
-        format!("OrbitFrame({})", self.name())
-    }
-
-    fn __richcmp__(&self, other: &Self, op: CompareOp) -> PyResult<bool> {
-        match op {
-            CompareOp::Eq => Ok(self.frame == other.frame),
-            CompareOp::Ne => Ok(self.frame != other.frame),
-            _ => Err(exceptions::PyNotImplementedError::new_err("Comparison not supported")),
-        }
-    }
-}
-
 /// Orbital state representation format.
 ///
 /// Specifies how orbital states are represented in the trajectory.
@@ -402,14 +282,14 @@ impl PyOrbitRepresentation {
 ///
 /// Args:
 ///     dimension (int): State dimension (minimum 6 for position + velocity)
-///     frame (OrbitFrame): Reference frame for the trajectory
+///     frame (CelestialFrame or ReferenceFrame): Reference frame for the trajectory
 ///     representation (OrbitRepresentation): State representation format
 ///     angle_format (AngleFormat or None): Angle format for Keplerian states,
 ///         must be None for Cartesian representation
 ///
 /// Attributes:
 ///     dimension (int): State vector dimension
-///     frame (OrbitFrame): Reference frame
+///     frame (ReferenceFrame): Reference frame
 ///     representation (OrbitRepresentation): State representation format
 ///     angle_format (AngleFormat or None): Angle format for Keplerian representation
 ///     interpolation_method (InterpolationMethod): Current interpolation method
@@ -419,7 +299,7 @@ impl PyOrbitRepresentation {
 ///     import brahe as bh
 ///
 ///     # Create trajectory in ECI Cartesian frame
-///     traj = bh.OrbitTrajectory(6, bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+///     traj = bh.OrbitTrajectory(6, bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
 ///     ```
 #[pyclass(module = "brahe._brahe")]
 #[pyo3(name = "OrbitTrajectory")]
@@ -432,7 +312,7 @@ impl PyOrbitalTrajectory {
     /// Create a new empty orbital trajectory.
     ///
     /// Args:
-    ///     frame (OrbitFrame): Reference frame for the trajectory
+    ///     frame (CelestialFrame or ReferenceFrame): Reference frame for the trajectory
     ///     representation (OrbitRepresentation): State representation format
     ///     angle_format (AngleFormat or None): Angle format for Keplerian states,
     ///         must be None for Cartesian representation
@@ -450,7 +330,7 @@ impl PyOrbitalTrajectory {
     ///     import numpy as np
     ///
     ///     # Create trajectory in ECI Cartesian frame
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///
     ///     # Define Keplerian elements for a 500 km circular orbit
     ///     oe = np.array([bh.R_EARTH + 500e3, 0.01, 0.9, 1.0, 0.5, 0.0])  # a, e, i, raan, argp, M
@@ -463,16 +343,18 @@ impl PyOrbitalTrajectory {
     ///     print(f"Trajectory has {traj.len()} states")
     ///
     ///     # Extended 9D trajectory (6D orbit + 3 additional states)
-    ///     traj_extended = bh.OrbitTrajectory(9, bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj_extended = bh.OrbitTrajectory(9, bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     ```
     #[new]
     #[pyo3(signature = (dimension, frame, representation, angle_format=None), text_signature = "(dimension, frame, representation, angle_format=None)")]
     pub fn new(
         dimension: usize,
-        frame: PyRef<PyOrbitFrame>,
+        frame: &Bound<'_, PyAny>,
         representation: PyRef<PyOrbitRepresentation>,
         angle_format: Option<PyRef<PyAngleFormat>>,
     ) -> PyResult<Self> {
+        let frame = extract_frame(frame)?;
+
         // Validate dimension
         if dimension < 6 {
             return Err(exceptions::PyValueError::new_err(
@@ -499,7 +381,7 @@ impl PyOrbitalTrajectory {
 
         let trajectory = trajectories::DOrbitTrajectory::new(
             dimension,
-            frame.frame,
+            frame,
             representation.representation,
             angle_fmt,
         )?;
@@ -524,7 +406,7 @@ impl PyOrbitalTrajectory {
     ///     epochs (list[Epoch]): List of time epochs for each state
     ///     states (numpy.ndarray): 2D array of 6-element state vectors with shape (N, 6)
     ///         where N is the number of epochs. Each row is one state vector.
-    ///     frame (OrbitFrame): Reference frame for the states
+    ///     frame (CelestialFrame or ReferenceFrame): Reference frame for the states
     ///     representation (OrbitRepresentation): State representation format
     ///     angle_format (AngleFormat or None): Angle format for Keplerian states,
     ///         must be None for Cartesian representation
@@ -550,7 +432,7 @@ impl PyOrbitalTrajectory {
     ///     covs = np.array([np.eye(6) * 100.0])  # 100 m² position variance
     ///
     ///     traj = bh.OrbitTrajectory.from_orbital_data(
-    ///         epochs, states, bh.OrbitFrame.ECI,
+    ///         epochs, states, bh.CelestialFrame.ECI,
     ///         bh.OrbitRepresentation.CARTESIAN, None,
     ///         covariances=covs
     ///     )
@@ -561,11 +443,13 @@ impl PyOrbitalTrajectory {
         _cls: &Bound<'_, PyType>,
         epochs: Vec<PyRef<PyEpoch>>,
         states: PyReadonlyArray2<f64>,
-        frame: PyRef<PyOrbitFrame>,
+        frame: &Bound<'_, PyAny>,
         representation: PyRef<PyOrbitRepresentation>,
         angle_format: Option<PyRef<PyAngleFormat>>,
         covariances: Option<PyReadonlyArray3<f64>>,
     ) -> PyResult<Self> {
+        let frame = extract_frame(frame)?;
+
         // Validate: Cartesian must have None, Keplerian must have Some
         match (representation.representation, &angle_format) {
             (trajectories::traits::OrbitRepresentation::Cartesian, Some(_)) => {
@@ -649,7 +533,7 @@ impl PyOrbitalTrajectory {
         let trajectory = trajectories::DOrbitTrajectory::from_orbital_data(
             epochs_vec,
             states_vec,
-            frame.frame,
+            frame,
             representation.representation,
             angle_fmt,
             covariances_vec,
@@ -669,7 +553,7 @@ impl PyOrbitalTrajectory {
     ///     ```python
     ///     import brahe as bh
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     traj = traj.with_interpolation_method(bh.InterpolationMethod.LINEAR)
     ///     ```
     #[pyo3(text_signature = "(interpolation_method)")]
@@ -690,7 +574,7 @@ impl PyOrbitalTrajectory {
     ///     ```python
     ///     import brahe as bh
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     traj = traj.with_covariance_interpolation_method(bh.CovarianceInterpolationMethod.TWO_WASSERSTEIN)
     ///     ```
     #[pyo3(text_signature = "(method)")]
@@ -711,7 +595,7 @@ impl PyOrbitalTrajectory {
     ///     ```python
     ///     import brahe as bh
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     traj.set_covariance_interpolation_method(bh.CovarianceInterpolationMethod.MATRIX_SQUARE_ROOT)
     ///     ```
     #[pyo3(text_signature = "(method)")]
@@ -731,7 +615,7 @@ impl PyOrbitalTrajectory {
     ///     ```python
     ///     import brahe as bh
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     method = traj.get_covariance_interpolation_method()
     ///     ```
     #[pyo3(text_signature = "()")]
@@ -756,7 +640,7 @@ impl PyOrbitalTrajectory {
     ///     ```python
     ///     import brahe as bh
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     traj = traj.with_eviction_policy_max_size(1000)
     ///     ```
     #[pyo3(text_signature = "(max_size)")]
@@ -780,7 +664,7 @@ impl PyOrbitalTrajectory {
     ///     ```python
     ///     import brahe as bh
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     traj = traj.with_eviction_policy_max_age(3600.0)
     ///     ```
     #[pyo3(text_signature = "(max_age)")]
@@ -798,7 +682,7 @@ impl PyOrbitalTrajectory {
     ///     ```python
     ///     import brahe as bh
     ///
-    ///     traj = bh.OrbitTrajectory(6, bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(6, bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     print(f"Dimension: {traj.dimension()}")
     ///     print(f"Orbital dimension: {traj.orbital_dimension()}")
     ///     print(f"Additional dimension: {traj.additional_dimension()}")
@@ -819,7 +703,7 @@ impl PyOrbitalTrajectory {
     ///     ```python
     ///     import brahe as bh
     ///
-    ///     traj = bh.OrbitTrajectory(9, bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(9, bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     print(f"Orbital dimension: {traj.orbital_dimension()}")  # 6
     ///     ```
     #[pyo3(text_signature = "()")]
@@ -836,7 +720,7 @@ impl PyOrbitalTrajectory {
     ///     ```python
     ///     import brahe as bh
     ///
-    ///     traj = bh.OrbitTrajectory(9, bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(9, bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     print(f"Additional dimension: {traj.additional_dimension()}")  # 3
     ///     ```
     #[pyo3(text_signature = "()")]
@@ -856,13 +740,13 @@ impl PyOrbitalTrajectory {
     ///     import numpy as np
     ///
     ///     # Standard 6D trajectory
-    ///     traj = bh.OrbitTrajectory(6, bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(6, bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     state = np.array([bh.R_EARTH + 500e3, 0.0, 0.0, 0.0, 7600.0, 0.0])
     ///     traj.add(epc, state)
     ///
     ///     # Extended 9D trajectory
-    ///     traj_ext = bh.OrbitTrajectory(9, bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj_ext = bh.OrbitTrajectory(9, bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     state_ext = np.array([bh.R_EARTH + 500e3, 0.0, 0.0, 0.0, 7600.0, 0.0, 1.0, 2.0, 3.0])
     ///     traj_ext.add(epc, state_ext)
     ///     ```
@@ -900,7 +784,7 @@ impl PyOrbitalTrajectory {
     ///     import brahe as bh
     ///     import numpy as np
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc1 = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     state = np.array([bh.R_EARTH + 500e3, 0.0, 0.0, 0.0, 7600.0, 0.0])
     ///     traj.add(epc1, state)
@@ -930,7 +814,7 @@ impl PyOrbitalTrajectory {
     ///     import brahe as bh
     ///     import numpy as np
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc1 = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     state = np.array([bh.R_EARTH + 500e3, 0.0, 0.0, 0.0, 7600.0, 0.0])
     ///     traj.add(epc1, state)
@@ -958,7 +842,7 @@ impl PyOrbitalTrajectory {
     ///     import brahe as bh
     ///     import numpy as np
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc1 = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     state = np.array([bh.R_EARTH + 500e3, 0.0, 0.0, 0.0, 7600.0, 0.0])
     ///     traj.add(epc1, state)
@@ -986,7 +870,7 @@ impl PyOrbitalTrajectory {
     ///     import brahe as bh
     ///     import numpy as np
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc1 = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     state = np.array([bh.R_EARTH + 500e3, 0.0, 0.0, 0.0, 7600.0, 0.0])
     ///     traj.add(epc1, state)
@@ -1016,7 +900,7 @@ impl PyOrbitalTrajectory {
     ///     import brahe as bh
     ///     import numpy as np
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc1 = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     state = np.array([bh.R_EARTH + 500e3, 0.0, 0.0, 0.0, 7600.0, 0.0])
     ///     traj.add(epc1, state)
@@ -1042,7 +926,7 @@ impl PyOrbitalTrajectory {
     ///     ```python
     ///     import brahe as bh
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     traj.set_interpolation_method(bh.InterpolationMethod.LINEAR)
     ///     ```
     #[pyo3(text_signature = "(method)")]
@@ -1059,7 +943,7 @@ impl PyOrbitalTrajectory {
     ///     ```python
     ///     import brahe as bh
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     method = traj.get_interpolation_method()
     ///     ```
     #[pyo3(text_signature = "()")]
@@ -1080,7 +964,7 @@ impl PyOrbitalTrajectory {
     ///     import brahe as bh
     ///     import numpy as np
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc1 = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     state1 = np.array([bh.R_EARTH + 500e3, 0.0, 0.0, 0.0, 7600.0, 0.0])
     ///     traj.add(epc1, state1)
@@ -1111,7 +995,7 @@ impl PyOrbitalTrajectory {
     ///     import brahe as bh
     ///     import numpy as np
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc1 = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     state1 = np.array([bh.R_EARTH + 500e3, 0.0, 0.0, 0.0, 7600.0, 0.0])
     ///     traj.add(epc1, state1)
@@ -1174,18 +1058,18 @@ impl PyOrbitalTrajectory {
     /// Get trajectory reference frame.
     ///
     /// Returns:
-    ///     OrbitFrame: Reference frame of the trajectory
+    ///     ReferenceFrame: Reference frame of the trajectory
     ///
     /// Example:
     ///     ```python
     ///     import brahe as bh
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     print(f"Frame: {traj.frame}")
     ///     ```
     #[getter]
-    pub fn frame(&self) -> PyOrbitFrame {
-        PyOrbitFrame { frame: self.trajectory.frame }
+    pub fn frame(&self) -> PyReferenceFrame {
+        PyReferenceFrame { frame: self.trajectory.frame.clone() }
     }
 
     /// Get trajectory state representation.
@@ -1197,7 +1081,7 @@ impl PyOrbitalTrajectory {
     ///     ```python
     ///     import brahe as bh
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     print(f"Representation: {traj.representation}")
     ///     ```
     #[getter]
@@ -1214,7 +1098,7 @@ impl PyOrbitalTrajectory {
     ///     ```python
     ///     import brahe as bh
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     print(f"Angle format: {traj.angle_format}")
     ///     ```
     #[getter]
@@ -1229,7 +1113,7 @@ impl PyOrbitalTrajectory {
     ///     import brahe as bh
     ///     import numpy as np
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     state = np.array([bh.R_EARTH + 500e3, 0.0, 0.0, 0.0, 7600.0, 0.0])
     ///     traj.add(epc, state)
@@ -1250,7 +1134,7 @@ impl PyOrbitalTrajectory {
     ///     import brahe as bh
     ///     import numpy as np
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     state = np.array([bh.R_EARTH + 500e3, 0.0, 0.0, 0.0, 7600.0, 0.0])
     ///     traj.add(epc, state)
@@ -1271,7 +1155,7 @@ impl PyOrbitalTrajectory {
     ///     import brahe as bh
     ///     import numpy as np
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     state = np.array([bh.R_EARTH + 500e3, 0.0, 0.0, 0.0, 7600.0, 0.0])
     ///     traj.add(epc, state)
@@ -1292,7 +1176,7 @@ impl PyOrbitalTrajectory {
     ///     import brahe as bh
     ///     import numpy as np
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     state = np.array([bh.R_EARTH + 500e3, 0.0, 0.0, 0.0, 7600.0, 0.0])
     ///     traj.add(epc, state)
@@ -1314,7 +1198,7 @@ impl PyOrbitalTrajectory {
     ///     import brahe as bh
     ///     import numpy as np
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     state = np.array([bh.R_EARTH + 500e3, 0.0, 0.0, 0.0, 7600.0, 0.0])
     ///     traj.add(epc, state)
@@ -1337,7 +1221,7 @@ impl PyOrbitalTrajectory {
     ///     import brahe as bh
     ///     import numpy as np
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     state = np.array([bh.R_EARTH + 500e3, 0.0, 0.0, 0.0, 7600.0, 0.0])
     ///     traj.add(epc, state)
@@ -1360,7 +1244,7 @@ impl PyOrbitalTrajectory {
     ///     import brahe as bh
     ///     import numpy as np
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     state = np.array([bh.R_EARTH + 500e3, 0.0, 0.0, 0.0, 7600.0, 0.0])
     ///     traj.add(epc, state)
@@ -1383,7 +1267,7 @@ impl PyOrbitalTrajectory {
     ///     import brahe as bh
     ///     import numpy as np
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     state = np.array([bh.R_EARTH + 500e3, 0.0, 0.0, 0.0, 7600.0, 0.0])
     ///     traj.add(epc, state)
@@ -1419,7 +1303,7 @@ impl PyOrbitalTrajectory {
     ///     ```python
     ///     import brahe as bh
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     print(f"Is empty: {traj.is_empty()}")
     ///     ```
     #[pyo3(text_signature = "()")]
@@ -1440,7 +1324,7 @@ impl PyOrbitalTrajectory {
     ///     import brahe as bh
     ///     import numpy as np
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECEF, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECEF, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     state = np.array([bh.R_EARTH + 500e3, 0.0, 0.0, 0.0, 0.0, 0.0])
     ///     traj.add(epc, state)
@@ -1465,7 +1349,7 @@ impl PyOrbitalTrajectory {
     ///     import brahe as bh
     ///     import numpy as np
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     state = np.array([bh.R_EARTH + 500e3, 0.0, 0.0, 0.0, 7600.0, 0.0])
     ///     traj.add(epc, state)
@@ -1490,7 +1374,7 @@ impl PyOrbitalTrajectory {
     ///     import brahe as bh
     ///     import numpy as np
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.EME2000, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.EME2000, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     state = np.array([bh.R_EARTH + 500e3, 0.0, 0.0, 0.0, 7600.0, 0.0])
     ///     traj.add(epc, state)
@@ -1515,7 +1399,7 @@ impl PyOrbitalTrajectory {
     ///     import brahe as bh
     ///     import numpy as np
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.GCRF, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.GCRF, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     state = np.array([bh.R_EARTH + 500e3, 0.0, 0.0, 0.0, 7600.0, 0.0])
     ///     traj.add(epc, state)
@@ -1540,7 +1424,7 @@ impl PyOrbitalTrajectory {
     ///     import brahe as bh
     ///     import numpy as np
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.GCRF, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.GCRF, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     state = np.array([bh.R_EARTH + 500e3, 0.0, 0.0, 0.0, 7600.0, 0.0])
     ///     traj.add(epc, state)
@@ -1550,6 +1434,33 @@ impl PyOrbitalTrajectory {
     pub fn to_itrf(&self) -> PyResult<Self> {
         let new_trajectory = self.trajectory.to_itrf()?;
         Ok(PyOrbitalTrajectory { trajectory: new_trajectory })
+    }
+
+    /// Convert every sample to Cartesian coordinates in `frame` through the
+    /// reference frame router. Covariances, STMs, sensitivities, and
+    /// accelerations are dropped.
+    ///
+    /// Args:
+    ///     frame (CelestialFrame or ReferenceFrame): Target frame.
+    ///
+    /// Returns:
+    ///     OrbitTrajectory: New Cartesian trajectory in `frame`.
+    ///
+    /// Raises:
+    ///     BraheError: If the frame conversion fails.
+    ///
+    /// Example:
+    ///     ```python
+    ///     import brahe as bh
+    ///
+    ///     bh.initialize_eop()
+    ///     traj = bh.OrbitTrajectory(6, bh.CelestialFrame.GCRF, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj_tod = traj.to_frame(bh.CelestialFrame.TOD)
+    ///     ```
+    #[pyo3(text_signature = "(frame)")]
+    pub fn to_frame(&self, frame: &Bound<'_, PyAny>) -> PyResult<Self> {
+        let frame = extract_frame(frame)?;
+        Ok(PyOrbitalTrajectory { trajectory: self.trajectory.to_frame(frame)? })
     }
 
     /// Convert to Keplerian representation in ECI frame.
@@ -1568,7 +1479,7 @@ impl PyOrbitalTrajectory {
     ///     import brahe as bh
     ///     import numpy as np
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     state = np.array([bh.R_EARTH + 500e3, 0.0, 0.0, 0.0, 7600.0, 0.0])
     ///     traj.add(epc, state)
@@ -1590,7 +1501,7 @@ impl PyOrbitalTrajectory {
     ///     import brahe as bh
     ///     import numpy as np
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     state = np.array([bh.R_EARTH + 500e3, 0.0, 0.0, 0.0, 7600.0, 0.0])
     ///     traj.add(epc, state)
@@ -1629,7 +1540,7 @@ impl PyOrbitalTrajectory {
     ///     import brahe as bh
     ///     import numpy as np
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     state = np.array([bh.R_EARTH + 500e3, 0.0, 0.0, 0.0, 7600.0, 0.0])
     ///     traj.add(epc, state)
@@ -1656,7 +1567,7 @@ impl PyOrbitalTrajectory {
     ///     import brahe as bh
     ///     import numpy as np
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     state = np.array([bh.R_EARTH + 500e3, 0.0, 0.0, 0.0, 7600.0, 0.0])
     ///     traj.add(epc, state)
@@ -1685,7 +1596,7 @@ impl PyOrbitalTrajectory {
     ///     import brahe as bh
     ///     import numpy as np
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     state = np.array([bh.R_EARTH + 500e3, 0.0, 0.0, 0.0, 7600.0, 0.0])
     ///     traj.add(epc, state)
@@ -1710,7 +1621,7 @@ impl PyOrbitalTrajectory {
     fn __repr__(&self) -> String {
         format!(
             "DOrbitTrajectory(frame={}, representation={}, states={})",
-            PyOrbitFrame { frame: self.trajectory.frame }.__repr__(),
+            self.trajectory.frame,
             PyOrbitRepresentation { representation: self.trajectory.representation }.__repr__(),
             self.trajectory.len()
         )
@@ -1720,7 +1631,7 @@ impl PyOrbitalTrajectory {
     fn __str__(&self) -> String {
         format!(
             "DOrbitTrajectory(frame={}, representation={}, states={})",
-            PyOrbitFrame { frame: self.trajectory.frame }.__str__(),
+            self.trajectory.frame,
             PyOrbitRepresentation { representation: self.trajectory.representation }.__str__(),
             self.trajectory.len()
         )
@@ -1735,7 +1646,7 @@ impl PyOrbitalTrajectory {
     ///     ```python
     ///     import brahe as bh
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     traj.set_eviction_policy_max_size(1000)
     ///     ```
     #[pyo3(text_signature = "(max_size)")]
@@ -1755,7 +1666,7 @@ impl PyOrbitalTrajectory {
     ///     ```python
     ///     import brahe as bh
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     traj.set_eviction_policy_max_age(3600.0)
     ///     ```
     #[pyo3(text_signature = "(max_age)")]
@@ -1775,7 +1686,7 @@ impl PyOrbitalTrajectory {
     ///     ```python
     ///     import brahe as bh
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     policy = traj.get_eviction_policy()
     ///     ```
     #[pyo3(text_signature = "()")]
@@ -1819,7 +1730,7 @@ impl PyOrbitalTrajectory {
     ///     import brahe as bh
     ///     import numpy as np
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.UTC)
     ///     state = np.array([7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0])
     ///     traj.add(epc, state)
@@ -1848,7 +1759,7 @@ impl PyOrbitalTrajectory {
     ///     import brahe as bh
     ///     import numpy as np
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.UTC)
     ///     state = np.array([7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0])
     ///     traj.add(epc, state)
@@ -1878,7 +1789,7 @@ impl PyOrbitalTrajectory {
     ///     import numpy as np
     ///
     ///     # Create ECI Cartesian trajectory
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc1 = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.UTC)
     ///     state1 = np.array([7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0])
     ///     traj.add(epc1, state1)
@@ -1906,7 +1817,7 @@ impl PyOrbitalTrajectory {
     ///     import numpy as np
     ///
     ///     # Create trajectory in any frame/representation
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.KEPLERIAN, bh.AngleFormat.DEGREES)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.KEPLERIAN, bh.AngleFormat.DEGREES)
     ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.UTC)
     ///     oe = np.array([bh.R_EARTH + 500e3, 0.001, 98.0, 15.0, 30.0, 45.0])
     ///     traj.add(epc, oe)
@@ -1934,7 +1845,7 @@ impl PyOrbitalTrajectory {
     ///     import numpy as np
     ///
     ///     # Create ECI trajectory
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.UTC)
     ///     state_eci = np.array([7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0])
     ///     traj.add(epc, state_eci)
@@ -1962,7 +1873,7 @@ impl PyOrbitalTrajectory {
     ///     import numpy as np
     ///
     ///     # Create ITRF trajectory
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ITRF, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ITRF, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.UTC)
     ///     state_itrf = np.array([7000e3, 0.0, 0.0, 0.0, 0.0, 7.5e3])
     ///     traj.add(epc, state_itrf)
@@ -2051,7 +1962,7 @@ impl PyOrbitalTrajectory {
     ///     import numpy as np
     ///
     ///     # Create GCRF trajectory
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.GCRF, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.GCRF, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.UTC)
     ///     state_gcrf = np.array([7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0])
     ///     traj.add(epc, state_gcrf)
@@ -2079,7 +1990,7 @@ impl PyOrbitalTrajectory {
     ///     import numpy as np
     ///
     ///     # Create GCRF trajectory
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.GCRF, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.GCRF, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.UTC)
     ///     state_gcrf = np.array([7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0])
     ///     traj.add(epc, state_gcrf)
@@ -2108,7 +2019,7 @@ impl PyOrbitalTrajectory {
     ///     import numpy as np
     ///
     ///     # Create Cartesian trajectory
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.UTC)
     ///     state_cart = np.array([7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0])
     ///     traj.add(epc, state_cart)
@@ -2147,7 +2058,7 @@ impl PyOrbitalTrajectory {
     ///     import numpy as np
     ///
     ///     # Create Cartesian trajectory
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.UTC)
     ///     state_cart = np.array([7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0])
     ///     traj.add(epc, state_cart)
@@ -2234,7 +2145,7 @@ impl PyOrbitalTrajectory {
     ///     ```python
     ///     import brahe as bh
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     traj = traj.with_name("My Trajectory")
     ///     ```
     fn with_name(slf: PyRefMut<'_, Self>, name: &str) -> Py<Self> {
@@ -2256,7 +2167,7 @@ impl PyOrbitalTrajectory {
     ///     ```python
     ///     import brahe as bh
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     traj = traj.with_id(12345)
     ///     ```
     fn with_id(slf: PyRefMut<'_, Self>, id: u64) -> Py<Self> {
@@ -2275,7 +2186,7 @@ impl PyOrbitalTrajectory {
     ///     ```python
     ///     import brahe as bh
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     traj = traj.with_name("My Trajectory")
     ///     print(traj.get_name())  # "My Trajectory"
     ///     ```
@@ -2288,7 +2199,7 @@ impl PyOrbitalTrajectory {
     ///     ```python
     ///     import brahe as bh
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     traj = traj.with_name("My Trajectory")
     ///     print(traj.get_name())  # "My Trajectory"
     ///     ```
@@ -2313,7 +2224,7 @@ impl PyOrbitalTrajectory {
     ///     ```python
     ///     import brahe as bh
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     traj = traj.with_id(12345)
     ///     print(traj.get_id())  # 12345
     ///     ```
@@ -2338,7 +2249,7 @@ impl PyOrbitalTrajectory {
     ///     ```python
     ///     import brahe as bh
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     traj = traj.with_new_uuid()
     ///     print(traj.get_uuid())  # e.g., "550e8400-e29b-41d4-a716-446655440000"
     ///     ```
@@ -2355,7 +2266,7 @@ impl PyOrbitalTrajectory {
     ///     ```python
     ///     import brahe as bh
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     traj = traj.with_new_uuid()
     ///     ```
     fn with_new_uuid(slf: PyRefMut<'_, Self>) -> Py<Self> {
@@ -2385,7 +2296,7 @@ impl PyOrbitalTrajectory {
     ///     cov = np.eye(6) * 1000.0
     ///
     ///     traj = bh.OrbitTrajectory.from_orbital_data(
-    ///         [epoch], [state], bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN,
+    ///         [epoch], [state], bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN,
     ///         covariances=np.array([cov])
     ///     )
     ///
@@ -2448,7 +2359,7 @@ impl PyOrbitalTrajectory {
     ///     cov = np.eye(6) * 1000.0
     ///
     ///     traj = bh.OrbitTrajectory.from_orbital_data(
-    ///         [epoch], [state], bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN,
+    ///         [epoch], [state], bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN,
     ///         covariances=np.array([cov])
     ///     )
     ///
@@ -2487,7 +2398,7 @@ impl PyOrbitalTrajectory {
     ///     cov = np.eye(6) * 1000.0
     ///
     ///     traj = bh.OrbitTrajectory.from_orbital_data(
-    ///         [epoch], [state], bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN,
+    ///         [epoch], [state], bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN,
     ///         covariances=np.array([cov])
     ///     )
     ///
@@ -2526,7 +2437,7 @@ impl PyOrbitalTrajectory {
     ///     cov = np.eye(6) * 1000.0
     ///
     ///     traj = bh.OrbitTrajectory.from_orbital_data(
-    ///         [epoch], [state], bh.OrbitFrame.GCRF, bh.OrbitRepresentation.CARTESIAN,
+    ///         [epoch], [state], bh.CelestialFrame.GCRF, bh.OrbitRepresentation.CARTESIAN,
     ///         covariances=np.array([cov])
     ///     )
     ///
@@ -2570,7 +2481,7 @@ impl PyOrbitalTrajectory {
     ///     cov = np.eye(6) * 1000.0
     ///
     ///     traj = bh.OrbitTrajectory.from_orbital_data(
-    ///         [epoch], [state], bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN,
+    ///         [epoch], [state], bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN,
     ///         covariances=np.array([cov])
     ///     )
     ///
@@ -2615,7 +2526,7 @@ impl PyOrbitalTrajectory {
     ///     import brahe as bh
     ///     import numpy as np
     ///
-    ///     traj = bh.OrbitTrajectory(6, bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(6, bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     traj.enable_acceleration_storage(3)  # Enable 3D acceleration storage
     ///
     ///     epoch = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
@@ -2637,7 +2548,7 @@ impl PyOrbitalTrajectory {
     ///     ```python
     ///     import brahe as bh
     ///
-    ///     traj = bh.OrbitTrajectory(6, bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(6, bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     print(traj.has_accelerations())  # False
     ///
     ///     traj.enable_acceleration_storage(3)
@@ -2664,7 +2575,7 @@ impl PyOrbitalTrajectory {
     ///     import brahe as bh
     ///     import numpy as np
     ///
-    ///     traj = bh.OrbitTrajectory(6, bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(6, bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     traj.enable_acceleration_storage(3)
     ///
     ///     epoch = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
@@ -2704,7 +2615,7 @@ impl PyOrbitalTrajectory {
     ///     import brahe as bh
     ///     import numpy as np
     ///
-    ///     traj = bh.OrbitTrajectory(6, bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(6, bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     traj.enable_acceleration_storage(3)
     ///
     ///     epoch = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
@@ -2748,7 +2659,7 @@ impl PyOrbitalTrajectory {
     ///     import brahe as bh
     ///     import numpy as np
     ///
-    ///     traj = bh.OrbitTrajectory(6, bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(6, bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     traj.enable_acceleration_storage(3)
     ///     traj.set_interpolation_method(bh.InterpolationMethod.HERMITE_QUINTIC)
     ///
@@ -3082,7 +2993,7 @@ impl PyTrajectory {
     ///     import brahe as bh
     ///     import numpy as np
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc1 = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     state = np.array([bh.R_EARTH + 500e3, 0.0, 0.0, 0.0, 7600.0, 0.0])
     ///     traj.add(epc1, state)
@@ -3112,7 +3023,7 @@ impl PyTrajectory {
     ///     import brahe as bh
     ///     import numpy as np
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc1 = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     state = np.array([bh.R_EARTH + 500e3, 0.0, 0.0, 0.0, 7600.0, 0.0])
     ///     traj.add(epc1, state)
@@ -3140,7 +3051,7 @@ impl PyTrajectory {
     ///     import brahe as bh
     ///     import numpy as np
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc1 = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     state = np.array([bh.R_EARTH + 500e3, 0.0, 0.0, 0.0, 7600.0, 0.0])
     ///     traj.add(epc1, state)
@@ -3168,7 +3079,7 @@ impl PyTrajectory {
     ///     import brahe as bh
     ///     import numpy as np
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc1 = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     state = np.array([bh.R_EARTH + 500e3, 0.0, 0.0, 0.0, 7600.0, 0.0])
     ///     traj.add(epc1, state)
@@ -3198,7 +3109,7 @@ impl PyTrajectory {
     ///     import brahe as bh
     ///     import numpy as np
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc1 = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     state = np.array([bh.R_EARTH + 500e3, 0.0, 0.0, 0.0, 7600.0, 0.0])
     ///     traj.add(epc1, state)
@@ -3228,7 +3139,7 @@ impl PyTrajectory {
     ///     import brahe as bh
     ///     import numpy as np
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc1 = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     state1 = np.array([bh.R_EARTH + 500e3, 0.0, 0.0, 0.0, 7600.0, 0.0])
     ///     traj.add(epc1, state1)
@@ -3259,7 +3170,7 @@ impl PyTrajectory {
     ///     import brahe as bh
     ///     import numpy as np
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc1 = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     state1 = np.array([bh.R_EARTH + 500e3, 0.0, 0.0, 0.0, 7600.0, 0.0])
     ///     traj.add(epc1, state1)
@@ -3528,7 +3439,7 @@ impl PyTrajectory {
     ///     ```python
     ///     import brahe as bh
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     policy = traj.get_eviction_policy()
     ///     ```
     #[pyo3(text_signature = "()")]
@@ -3570,7 +3481,7 @@ impl PyTrajectory {
     ///     import brahe as bh
     ///     import numpy as np
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     state = np.array([bh.R_EARTH + 500e3, 0.0, 0.0, 0.0, 7600.0, 0.0])
     ///     traj.add(epc, state)
@@ -3593,7 +3504,7 @@ impl PyTrajectory {
     ///     import brahe as bh
     ///     import numpy as np
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     state = np.array([bh.R_EARTH + 500e3, 0.0, 0.0, 0.0, 7600.0, 0.0])
     ///     traj.add(epc, state)
@@ -3640,7 +3551,7 @@ impl PyTrajectory {
     ///     import brahe as bh
     ///     import numpy as np
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     state = np.array([bh.R_EARTH + 500e3, 0.0, 0.0, 0.0, 7600.0, 0.0])
     ///     traj.add(epc, state)
@@ -3667,7 +3578,7 @@ impl PyTrajectory {
     ///     import brahe as bh
     ///     import numpy as np
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     state = np.array([bh.R_EARTH + 500e3, 0.0, 0.0, 0.0, 7600.0, 0.0])
     ///     traj.add(epc, state)
@@ -3696,7 +3607,7 @@ impl PyTrajectory {
     ///     import brahe as bh
     ///     import numpy as np
     ///
-    ///     traj = bh.OrbitTrajectory(bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+    ///     traj = bh.OrbitTrajectory(bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
     ///     epc = bh.Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     ///     state = np.array([bh.R_EARTH + 500e3, 0.0, 0.0, 0.0, 7600.0, 0.0])
     ///     traj.add(epc, state)

--- a/docs/examples/dawn_ceres_orbit.md
+++ b/docs/examples/dawn_ceres_orbit.md
@@ -182,9 +182,12 @@ propagation shows this divergence accumulating from zero:
 [`plot_trajectory_3d`](../library_api/plots/3d_trajectory.md) accepts `central_body="ceres"`: Ceres is already in the
 plotting library's body-visuals registry (radius and NAIF ID for frame
 validation, plus a default texture), so no custom dict is needed. Non-Earth
-central bodies require the plotted trajectory to already be in
-[`OrbitFrame.BodyCenteredInertial(naif_id)`](../library_api/orbits/enums.md#brahe.OrbitFrame.BodyCenteredInertial) for that body; a Ceres-centered
-[`NumericalOrbitPropagator`](../library_api/propagators/numerical_orbit_propagator.md)'s `.trajectory` is already in that frame:
+central bodies plot the trajectory in that body's centered-inertial frame,
+converting through the [reference frame router](../library_api/frames/router.md)
+with `to_frame()` when the trajectory is declared in another frame; a
+Ceres-centered
+[`NumericalOrbitPropagator`](../library_api/propagators/numerical_orbit_propagator.md)'s `.trajectory` is already in
+`CelestialFrame.BodyCenteredICRF(2000001)`:
 
 ``` python
 --8<-- "./examples/examples/dawn_ceres_orbit.py:plot_3d"

--- a/docs/examples/lro_lunar_orbit.md
+++ b/docs/examples/lro_lunar_orbit.md
@@ -107,12 +107,13 @@ perilune altitude stays above 26 km, remaining bound to the Moon.
 ## 3D Visualization
 
 [`plot_trajectory_3d`](../library_api/plots/3d_trajectory.md) accepts `central_body="moon"` to render an interactive
-3D view of the trajectory around a textured Moon. Non-Earth central bodies
-require the plotted trajectory to already be in
-[`OrbitFrame.BodyCenteredInertial(naif_id)`](../library_api/orbits/enums.md#brahe.OrbitFrame.BodyCenteredInertial) for that body; a Moon-centered
-[`NumericalOrbitPropagator`](../library_api/propagators/numerical_orbit_propagator.md)'s `.trajectory` is already in that frame, so no
-conversion is needed. We plot the final 12 hours of the full-gravity
-trajectory:
+3D view of the trajectory around a textured Moon. Non-Earth central bodies plot
+the trajectory in that body's centered-inertial frame, converting through the
+[reference frame router](../library_api/frames/router.md) with `to_frame()` when
+the trajectory is declared in another frame; a Moon-centered
+[`NumericalOrbitPropagator`](../library_api/propagators/numerical_orbit_propagator.md)'s `.trajectory` is already in
+`CelestialFrame.LCI`, so no conversion is needed. We plot the final 12 hours of
+the full-gravity trajectory:
 
 ``` python
 --8<-- "./examples/examples/lro_lunar_orbit.py:plot_3d"

--- a/docs/examples/mro_mars_orbit.md
+++ b/docs/examples/mro_mars_orbit.md
@@ -125,11 +125,12 @@ above the Mars surface throughout.
 ## 3D Visualization
 
 [`plot_trajectory_3d`](../library_api/plots/3d_trajectory.md) accepts `central_body="mars"` to render an interactive
-3D view of the trajectory around a textured Mars. Non-Earth central bodies
-require the plotted trajectory to already be in
-[`OrbitFrame.BodyCenteredInertial(naif_id)`](../library_api/orbits/enums.md#brahe.OrbitFrame.BodyCenteredInertial) for that body; a Mars-centered
-[`NumericalOrbitPropagator`](../library_api/propagators/numerical_orbit_propagator.md)'s `.trajectory` is already in that frame, so no
-conversion is needed:
+3D view of the trajectory around a textured Mars. Non-Earth central bodies plot
+the trajectory in that body's centered-inertial frame, converting through the
+[reference frame router](../library_api/frames/router.md) with `to_frame()` when
+the trajectory is declared in another frame; a Mars-centered
+[`NumericalOrbitPropagator`](../library_api/propagators/numerical_orbit_propagator.md)'s `.trajectory` is already in
+`CelestialFrame.MCI`, so no conversion is needed:
 
 ``` python
 --8<-- "./examples/examples/mro_mars_orbit.py:plot_3d"

--- a/docs/learn/plots/3d_trajectory.md
+++ b/docs/learn/plots/3d_trajectory.md
@@ -67,7 +67,7 @@ The matplotlib backend produces publication-ready 3D figures with customizable v
 
 ## Plotting Around Other Central Bodies
 
-`plot_trajectory_3d` is not limited to Earth. The `central_body` parameter accepts either a registry key from `brahe.plots.bodies.BODY_VISUALS` (`'earth'`, `'moon'`, `'mars'`, `'sun'`, and the other planets) or a custom dict `{name, radius, texture}` (radius in meters) for bodies outside the registry. Trajectories plotted around a non-Earth central body must already be in `OrbitFrame.BodyCenteredInertial(naif_id)` for that body's NAIF ID; Earth trajectories in any frame are converted via `to_eci()` as before.
+`plot_trajectory_3d` is not limited to Earth. The `central_body` parameter accepts either a registry key from `brahe.plots.bodies.BODY_VISUALS` (`'earth'`, `'moon'`, `'mars'`, `'sun'`, and the other planets) or a custom dict `{name, radius, texture}` (radius in meters) for bodies outside the registry. Trajectories are plotted in the central body's centered-inertial frame (`CelestialFrame.GCRF` for Earth, `CelestialFrame.LCI` for the Moon, `CelestialFrame.MCI` for Mars, and so on); a trajectory declared in any other frame is converted to it with `to_frame()`.
 
 - `show_body` (bool): show the central body sphere at the origin. Default: `True`.
 - `texture`: texture for the central body sphere (plotly only). Accepts `'simple'`, `'blue_marble'` or `'natural_earth_50m'`/`'natural_earth_10m'` (Earth only), any `brahe.plots.texture_utils.PLANET_TEXTURES` key, or a path to an image file. Defaults to the central body's registry texture (or `'simple'` for custom bodies without one).
@@ -88,7 +88,7 @@ states = np.column_stack([
 ])
 lunar_traj = bh.OrbitTrajectory.from_orbital_data(
     [epoch + i * 60 for i in range(20)], states,
-    bh.OrbitFrame.BodyCenteredInertial(301),
+    bh.CelestialFrame.LCI,
     bh.OrbitRepresentation.CARTESIAN, None, None,
 )
 

--- a/docs/learn/trajectories/index.md
+++ b/docs/learn/trajectories/index.md
@@ -106,7 +106,7 @@ Eviction policies are useful for real-time applications where memory must be bou
 
 ### Reference frames
 
-An orbital trajectory's `frame` attribute is a [`ReferenceFrame`](../../library_api/frames/frame.md), the same type used throughout the frame router. Any [`CelestialFrame`](../../library_api/frames/router.md) member is accepted, including `GCRF`, `ITRF`, `EME2000`, `MOD`, `TOD`, and body-centered inertial frames such as `LCI` for the Moon, along with a bound orbit-relative frame (RTN, NTW, VNB, LVLH) or a bound body frame declared through the object registry. `ECI` and `ECEF` remain accepted as aliases of `GCRF` and `ITRF`.
+An orbital trajectory's `frame` attribute is a [`ReferenceFrame`](../../library_api/frames/frame.md), the same type used throughout the frame router. Any [`CelestialFrame`](../../library_api/frames/router.md) member is accepted, including `GCRF`, `ITRF`, `EME2000`, `MOD`, `TOD`, and body-centered inertial frames such as `LCI` for the Moon, along with a bound orbit-relative frame (RTN, NTW, VNC, LVLH) or a bound body frame declared through the object registry. `ECI` and `ECEF` remain accepted as aliases of `GCRF` and `ITRF`.
 
 `to_frame(frame)` converts every stored sample to the target frame by routing through the frame graph, resolving whatever path connects the trajectory's current frame to the requested one. Keplerian representation is restricted to frames that are ICRF-aligned and inertial: `GCRF`, `EME2000`, and the body-centered inertial frames (`LCI`, `MCI`, `EMBI`, `SSBI`, `BodyCenteredICRF`); converting to a Keplerian representation in any other frame returns an error.
 

--- a/docs/learn/trajectories/index.md
+++ b/docs/learn/trajectories/index.md
@@ -69,7 +69,7 @@ Since trajectories often store states at discrete epochs, the `Interpolatable` t
 
 ### `OrbitalTrajectory` Trait
 
-The `OrbitalTrajectory` trait specializes trajectories for orbital mechanics applications. It adds awareness of reference frames (ECI/ECEF) and orbital representations (Cartesian/Keplerian), enabling automatic conversions of the stored states to different frames or representations.
+The `OrbitalTrajectory` trait specializes trajectories for orbital mechanics applications. It adds awareness of reference frames and orbital representations (Cartesian/Keplerian), enabling automatic conversions of the stored states to different frames or representations.
 
 **Creation**:
 
@@ -77,8 +77,10 @@ The `OrbitalTrajectory` trait specializes trajectories for orbital mechanics app
 
 **Frame Conversions**:
 
-- `to_eci()` - Convert all states to Earth-Centered Inertial frame
-- `to_ecef()` - Convert all states to Earth-Centered Earth-Fixed frame
+- `to_frame(frame)` - Convert all states to any reference frame reachable through the frame router
+- `to_eci()` / `to_gcrf()` - Convert all states to the GCRF frame
+- `to_ecef()` / `to_itrf()` - Convert all states to the ITRF frame
+- `to_eme2000()` - Convert all states to the EME2000 frame
 
 **Representation Conversions**:
 
@@ -102,12 +104,11 @@ Controls automatic memory management for long-running applications:
 
 Eviction policies are useful for real-time applications where memory must be bounded, such as satellite ground station passes or long-term simulations.
 
-### OrbitFrame
+### Reference frames
 
-Specifies the reference frame for orbital states:
+An orbital trajectory's `frame` attribute is a [`ReferenceFrame`](../../library_api/frames/frame.md), the same type used throughout the frame router. Any [`CelestialFrame`](../../library_api/frames/router.md) member is accepted, including `GCRF`, `ITRF`, `EME2000`, `MOD`, `TOD`, and body-centered inertial frames such as `LCI` for the Moon, along with a bound orbit-relative frame (RTN, NTW, VNB, LVLH) or a bound body frame declared through the object registry. `ECI` and `ECEF` remain accepted as aliases of `GCRF` and `ITRF`.
 
-- `ECI` - Earth-Centered Inertial frame (GCRF/J2000)
-- `ECEF` - Earth-Centered Earth-Fixed frame
+`to_frame(frame)` converts every stored sample to the target frame by routing through the frame graph, resolving whatever path connects the trajectory's current frame to the requested one. Keplerian representation is restricted to frames that are ICRF-aligned and inertial: `GCRF`, `EME2000`, and the body-centered inertial frames (`LCI`, `MCI`, `EMBI`, `SSBI`, `BodyCenteredICRF`); converting to a Keplerian representation in any other frame returns an error.
 
 ### OrbitRepresentation
 
@@ -155,14 +156,14 @@ The `STrajectory<R>` implementation uses compile-time sized state vectors, provi
 
 ### SOrbitTrajectory - Orbital Mechanics
 
-The `SOrbitTrajectory` implementation is specialized for orbital mechanics applications. It always 6-dimensional state vectors (position + velocity or orbital elements) and tracks the reference frame (ECI/ECEF) and representation (Cartesian/Keplerian). It provides built-in methods for converting between frames and representations. The `SOrbitTrajectory` is ideal for satellite orbit propagation and analysis where you expect to need frame conversions.
+The `SOrbitTrajectory` implementation is specialized for orbital mechanics applications. It always 6-dimensional state vectors (position + velocity or orbital elements) and tracks the reference frame and representation (Cartesian/Keplerian). It provides built-in methods for converting between frames and representations. The `SOrbitTrajectory` is ideal for satellite orbit propagation and analysis where you expect to need frame conversions.
 
 **Features**:
 
 - Always 6-dimensional (position + velocity)
-- Tracks reference frame (ECI/ECEF)
+- Tracks reference frame as a `ReferenceFrame`
 - Tracks representation (Cartesian/Keplerian)
-- Frame conversions: ECI ↔ ECEF
+- Frame conversions through `to_frame(frame)` to any frame reachable via the frame router
 - Representation conversions: Cartesian ↔ Keplerian
 - Implements traits: `Trajectory`, `Interpolatable`, `OrbitalTrajectory`
 

--- a/docs/learn/trajectories/index.md
+++ b/docs/learn/trajectories/index.md
@@ -108,7 +108,7 @@ Eviction policies are useful for real-time applications where memory must be bou
 
 An orbital trajectory's `frame` attribute is a [`ReferenceFrame`](../../library_api/frames/frame.md), the same type used throughout the frame router. Any [`CelestialFrame`](../../library_api/frames/router.md) member is accepted, including `GCRF`, `ITRF`, `EME2000`, `MOD`, `TOD`, and body-centered inertial frames such as `LCI` for the Moon, along with a bound orbit-relative frame (RTN, NTW, VNC, LVLH) or a bound body frame declared through the object registry. `ECI` and `ECEF` remain accepted as aliases of `GCRF` and `ITRF`.
 
-`to_frame(frame)` converts every stored sample to the target frame by routing through the frame graph, resolving whatever path connects the trajectory's current frame to the requested one. Keplerian representation is restricted to frames that are ICRF-aligned and inertial: `GCRF`, `EME2000`, and the body-centered inertial frames (`LCI`, `MCI`, `EMBI`, `SSBI`, `BodyCenteredICRF`); converting to a Keplerian representation in any other frame returns an error.
+`to_frame(frame)` converts every stored sample to the target frame by routing through the frame graph, resolving whatever path connects the trajectory's current frame to the requested one. Keplerian elements are accepted in the ICRF-aligned inertial frames, `GCRF` and the body-centered inertial frames (`LCI`, `MCI`, `EMBI`, `SSBI`, `BodyCenteredICRF`), and in `EME2000`, whose axes carry the frame bias. `to_keplerian(angle_format)` follows the same rule: it converts Cartesian samples about the center of the trajectory's own frame and returns an error for any frame outside that set, such as `ITRF`, `TOD`, or an orbit-relative frame.
 
 ### OrbitRepresentation
 

--- a/docs/library_api/orbits/enums.md
+++ b/docs/library_api/orbits/enums.md
@@ -1,6 +1,6 @@
 # Orbit Enumerations
 
-Enumerations for specifying orbit representation types and reference frames.
+Enumerations for specifying orbit representation types.
 
 ## OrbitRepresentation
 
@@ -11,16 +11,6 @@ Enumerations for specifying orbit representation types and reference frames.
       heading_level: 3
 
 Specifies the type of orbital elements being used.
-
----
-
-## OrbitFrame
-
-::: brahe.OrbitFrame
-    options:
-      show_root_heading: true
-      show_root_full_path: false
-      heading_level: 3
 
 ---
 

--- a/docs/library_api/orbits/index.md
+++ b/docs/library_api/orbits/index.md
@@ -11,6 +11,6 @@ Comprehensive tools for orbital mechanics computations and TLE handling.
 - **[Mean Elements](mean_elements.md)** - Mean-osculating Keplerian element conversions
 - **[Two-Line Elements (TLE)](tle.md)** - TLE parsing, validation, and conversion utilities
 - **[Walker Constellations](walker.md)** - Generator for Walker Delta and Star constellation patterns
-- **[Enumerations](enums.md)** - Orbit-related enumerations (OrbitRepresentation, OrbitFrame, etc.)
+- **[Enumerations](enums.md)** - Orbit-related enumerations (OrbitRepresentation, InterpolationMethod, etc.)
 
 **Note**: Orbit propagators have been moved to the [`brahe.propagators`](../propagators/index.md) module.

--- a/docs/library_api/trajectories/index.md
+++ b/docs/library_api/trajectories/index.md
@@ -20,6 +20,7 @@ Trajectory containers for storing, managing, and interpolating time-series state
 ## See Also
 
 - [InterpolationMethod](../orbits/enums.md#interpolationmethod) - Interpolation options
-- [OrbitFrame](../orbits/enums.md#orbitframe) - Frame specifications
+- [CelestialFrame](../frames/router.md#brahe.CelestialFrame) - Named celestial reference frames
+- [ReferenceFrame](../frames/frame.md#brahe.ReferenceFrame) - Unified frame identity accepted by trajectories
 - [KeplerianPropagator](../propagators/keplerian_propagator.md) - Analytical orbit propagation
 - [SGPPropagator](../propagators/sgp_propagator.md) - SGP4/SDP4 orbit propagation

--- a/docs/library_api/trajectories/orbit_trajectory.md
+++ b/docs/library_api/trajectories/orbit_trajectory.md
@@ -1,6 +1,6 @@
 # OrbitTrajectory
 
-`OrbitTrajectory` is a specialized trajectory container for orbital mechanics that stores states in a specific reference frame (ECI or ECEF) and can automatically transform between frames when querying.
+`OrbitTrajectory` is a specialized trajectory container for orbital mechanics that stores states in a specific `ReferenceFrame` and can automatically transform between frames when querying.
 
 OrbitTrajectory has the same API as [Trajectory](trajectory.md), plus frame awareness.
 
@@ -14,4 +14,5 @@ OrbitTrajectory has the same API as [Trajectory](trajectory.md), plus frame awar
 ## See Also
 
 - [Trajectory](trajectory.md) - Dynamic-dimension trajectory
-- [OrbitFrame](../orbits/enums.md#orbitframe) - Frame specifications
+- [CelestialFrame](../frames/router.md#brahe.CelestialFrame) - Named celestial reference frames
+- [ReferenceFrame](../frames/frame.md#brahe.ReferenceFrame) - Unified frame identity accepted by trajectories

--- a/examples/orbit_propagation/sgp_propagation/output_format.py
+++ b/examples/orbit_propagation/sgp_propagation/output_format.py
@@ -14,12 +14,14 @@ line2 = "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537"
 
 # Create with ECEF Cartesian output
 prop_ecef = bh.SGPPropagator.from_tle(line1, line2, 60.0)
-prop_ecef.set_output_format(bh.OrbitFrame.ECEF, bh.OrbitRepresentation.CARTESIAN, None)
+prop_ecef.set_output_format(
+    bh.CelestialFrame.ECEF, bh.OrbitRepresentation.CARTESIAN, None
+)
 
-# Or with Keplerian output (ECI only)
+# Or with Keplerian output (GCRF only)
 prop_kep = bh.SGPPropagator.from_tle(line1, line2, 60.0)
 prop_kep.set_output_format(
-    bh.OrbitFrame.ECI, bh.OrbitRepresentation.KEPLERIAN, bh.AngleFormat.DEGREES
+    bh.CelestialFrame.ECI, bh.OrbitRepresentation.KEPLERIAN, bh.AngleFormat.DEGREES
 )
 
 # Propagate to 1 hour after epoch

--- a/examples/orbit_propagation/sgp_propagation/output_format.py
+++ b/examples/orbit_propagation/sgp_propagation/output_format.py
@@ -18,7 +18,7 @@ prop_ecef.set_output_format(
     bh.CelestialFrame.ECEF, bh.OrbitRepresentation.CARTESIAN, None
 )
 
-# Or with Keplerian output (GCRF only)
+# Or with Keplerian output (available in GCRF and EME2000)
 prop_kep = bh.SGPPropagator.from_tle(line1, line2, 60.0)
 prop_kep.set_output_format(
     bh.CelestialFrame.ECI, bh.OrbitRepresentation.KEPLERIAN, bh.AngleFormat.DEGREES

--- a/examples/orbit_propagation/sgp_propagation/output_format.rs
+++ b/examples/orbit_propagation/sgp_propagation/output_format.rs
@@ -15,7 +15,7 @@ fn main() {
     let mut prop_ecef = bh::SGPPropagator::from_tle(line1, line2, 60.0).unwrap()
         .with_output_format(CelestialFrame::ECEF, OrbitRepresentation::Cartesian, None).unwrap();
 
-    // Or with Keplerian output (GCRF only)
+    // Or with Keplerian output (available in GCRF and EME2000)
     let mut prop_kep = bh::SGPPropagator::from_tle(line1, line2, 60.0).unwrap()
         .with_output_format(CelestialFrame::ECI, OrbitRepresentation::Keplerian, Some(bh::AngleFormat::Degrees)).unwrap();
 

--- a/examples/orbit_propagation/sgp_propagation/output_format.rs
+++ b/examples/orbit_propagation/sgp_propagation/output_format.rs
@@ -2,7 +2,8 @@
 
 #[allow(unused_imports)]
 use brahe as bh;
-use brahe::traits::{OrbitFrame, SStatePropagator, OrbitRepresentation};
+use brahe::frames::CelestialFrame;
+use brahe::traits::{SStatePropagator, OrbitRepresentation};
 
 fn main() {
     bh::initialize_eop().unwrap();
@@ -12,11 +13,11 @@ fn main() {
 
     // Create with ECEF Cartesian output
     let mut prop_ecef = bh::SGPPropagator::from_tle(line1, line2, 60.0).unwrap()
-        .with_output_format(OrbitFrame::ECEF, OrbitRepresentation::Cartesian, None).unwrap();
+        .with_output_format(CelestialFrame::ECEF, OrbitRepresentation::Cartesian, None).unwrap();
 
-    // Or with Keplerian output (ECI only)
+    // Or with Keplerian output (GCRF only)
     let mut prop_kep = bh::SGPPropagator::from_tle(line1, line2, 60.0).unwrap()
-        .with_output_format(OrbitFrame::ECI, OrbitRepresentation::Keplerian, Some(bh::AngleFormat::Degrees)).unwrap();
+        .with_output_format(CelestialFrame::ECI, OrbitRepresentation::Keplerian, Some(bh::AngleFormat::Degrees)).unwrap();
 
     // Propagate to 1 hour after epoch
     let dt = 3600.0;

--- a/examples/trajectories/orbit_trajectory/orbit_trajectory_angle_formats.py
+++ b/examples/trajectories/orbit_trajectory/orbit_trajectory_angle_formats.py
@@ -13,7 +13,7 @@ bh.initialize_eop()
 
 # Create trajectory in ECI Cartesian
 traj_cart = bh.OrbitTrajectory(
-    6, bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None
+    6, bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None
 )
 
 # Add a state

--- a/examples/trajectories/orbit_trajectory/orbit_trajectory_angle_formats.rs
+++ b/examples/trajectories/orbit_trajectory/orbit_trajectory_angle_formats.rs
@@ -4,7 +4,8 @@
 use brahe as bh;
 use bh::time::Epoch;
 use bh::trajectories::SOrbitTrajectory;
-use bh::trajectories::traits::{OrbitFrame, OrbitRepresentation, OrbitalTrajectory};
+use bh::frames::CelestialFrame;
+use bh::trajectories::traits::{OrbitRepresentation, OrbitalTrajectory};
 use bh::traits::Trajectory;
 use bh::{state_koe_to_eci, R_EARTH, AngleFormat};
 use nalgebra as na;
@@ -14,7 +15,7 @@ fn main() {
 
     // Create trajectory in ECI Cartesian
     let mut traj_cart = SOrbitTrajectory::new(
-        OrbitFrame::ECI,
+        CelestialFrame::ECI,
         OrbitRepresentation::Cartesian,
         None
     ).unwrap();

--- a/examples/trajectories/orbit_trajectory/orbit_trajectory_cart_to_kep.py
+++ b/examples/trajectories/orbit_trajectory/orbit_trajectory_cart_to_kep.py
@@ -13,7 +13,7 @@ bh.initialize_eop()
 
 # Create trajectory in ECI Cartesian
 traj_cart = bh.OrbitTrajectory(
-    6, bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None
+    6, bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None
 )
 
 # Add Cartesian states

--- a/examples/trajectories/orbit_trajectory/orbit_trajectory_cart_to_kep.rs
+++ b/examples/trajectories/orbit_trajectory/orbit_trajectory_cart_to_kep.rs
@@ -4,7 +4,8 @@
 use brahe as bh;
 use bh::time::Epoch;
 use bh::trajectories::SOrbitTrajectory;
-use bh::trajectories::traits::{OrbitFrame, OrbitRepresentation, OrbitalTrajectory};
+use bh::frames::CelestialFrame;
+use bh::trajectories::traits::{OrbitRepresentation, OrbitalTrajectory};
 use bh::traits::Trajectory;
 use bh::{state_koe_to_eci, R_EARTH, AngleFormat};
 use nalgebra as na;
@@ -14,7 +15,7 @@ fn main() {
 
     // Create trajectory in ECI Cartesian
     let mut traj_cart = SOrbitTrajectory::new(
-        OrbitFrame::ECI,
+        CelestialFrame::ECI,
         OrbitRepresentation::Cartesian,
         None
     ).unwrap();

--- a/examples/trajectories/orbit_trajectory/orbit_trajectory_combined.py
+++ b/examples/trajectories/orbit_trajectory/orbit_trajectory_combined.py
@@ -13,7 +13,7 @@ bh.initialize_eop()
 
 # Start with ECI Cartesian trajectory
 traj_eci_cart = bh.OrbitTrajectory(
-    6, bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None
+    6, bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None
 )
 
 # Add states

--- a/examples/trajectories/orbit_trajectory/orbit_trajectory_combined.rs
+++ b/examples/trajectories/orbit_trajectory/orbit_trajectory_combined.rs
@@ -4,7 +4,8 @@
 use brahe as bh;
 use bh::time::Epoch;
 use bh::trajectories::SOrbitTrajectory;
-use bh::trajectories::traits::{OrbitFrame, OrbitRepresentation, OrbitalTrajectory};
+use bh::frames::CelestialFrame;
+use bh::trajectories::traits::{OrbitRepresentation, OrbitalTrajectory};
 use bh::traits::Trajectory;
 use bh::{state_koe_to_eci, R_EARTH, AngleFormat};
 use nalgebra as na;
@@ -14,7 +15,7 @@ fn main() {
 
     // Start with ECI Cartesian trajectory
     let mut traj_eci_cart = SOrbitTrajectory::new(
-        OrbitFrame::ECI,
+        CelestialFrame::ECI,
         OrbitRepresentation::Cartesian,
         None
     ).unwrap();

--- a/examples/trajectories/orbit_trajectory/orbit_trajectory_ecef_to_eci.py
+++ b/examples/trajectories/orbit_trajectory/orbit_trajectory_ecef_to_eci.py
@@ -13,7 +13,7 @@ bh.initialize_eop()
 
 # Create trajectory in ECEF frame
 traj_ecef = bh.OrbitTrajectory(
-    6, bh.OrbitFrame.ECEF, bh.OrbitRepresentation.CARTESIAN, None
+    6, bh.CelestialFrame.ECEF, bh.OrbitRepresentation.CARTESIAN, None
 )
 
 # Add dummy states in ECEF
@@ -24,12 +24,12 @@ for i in range(3):
     state_ecef = np.array([bh.R_EARTH + 500e3, 0.0, 0.0, 0.0, 0.0, 7600.0])
     traj_ecef.add(epoch, state_ecef)
 
-print(f"Original frame: {traj_ecef.frame}")  # Output: OrbitFrame.ECEF
+print(f"Original frame: {traj_ecef.frame}")  # Output: ITRF
 
 # Convert to ECI
 traj_eci = traj_ecef.to_eci()
 
-print(f"Converted frame: {traj_eci.frame}")  # Output: OrbitFrame.ECI
+print(f"Converted frame: {traj_eci.frame}")  # Output: GCRF
 print(f"Trajectory length: {len(traj_eci)}")  # Output: 3
 
 # Iterate over converted states

--- a/examples/trajectories/orbit_trajectory/orbit_trajectory_ecef_to_eci.rs
+++ b/examples/trajectories/orbit_trajectory/orbit_trajectory_ecef_to_eci.rs
@@ -4,7 +4,8 @@
 use brahe as bh;
 use bh::time::Epoch;
 use bh::trajectories::SOrbitTrajectory;
-use bh::trajectories::traits::{OrbitFrame, OrbitRepresentation, OrbitalTrajectory};
+use bh::frames::CelestialFrame;
+use bh::trajectories::traits::{OrbitRepresentation, OrbitalTrajectory};
 use bh::traits::Trajectory;
 use bh::constants::R_EARTH;
 use nalgebra as na;
@@ -14,7 +15,7 @@ fn main() {
 
     // Create trajectory in ECEF frame
     let mut traj_ecef = SOrbitTrajectory::new(
-        OrbitFrame::ECEF,
+        CelestialFrame::ECEF,
         OrbitRepresentation::Cartesian,
         None
     ).unwrap();

--- a/examples/trajectories/orbit_trajectory/orbit_trajectory_eci_to_ecef.py
+++ b/examples/trajectories/orbit_trajectory/orbit_trajectory_eci_to_ecef.py
@@ -13,7 +13,7 @@ bh.initialize_eop()
 
 # Create trajectory in ECI frame
 traj_eci = bh.OrbitTrajectory(
-    6, bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None
+    6, bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None
 )
 
 # Add states in ECI

--- a/examples/trajectories/orbit_trajectory/orbit_trajectory_eci_to_ecef.rs
+++ b/examples/trajectories/orbit_trajectory/orbit_trajectory_eci_to_ecef.rs
@@ -4,7 +4,8 @@
 use brahe as bh;
 use bh::time::Epoch;
 use bh::trajectories::SOrbitTrajectory;
-use bh::trajectories::traits::{OrbitFrame, OrbitRepresentation, OrbitalTrajectory};
+use bh::frames::CelestialFrame;
+use bh::trajectories::traits::{OrbitRepresentation, OrbitalTrajectory};
 use bh::traits::Trajectory;
 use bh::constants::R_EARTH;
 use nalgebra as na;
@@ -14,7 +15,7 @@ fn main() {
 
     // Create trajectory in ECI frame
     let mut traj_eci = SOrbitTrajectory::new(
-        OrbitFrame::ECI,
+        CelestialFrame::ECI,
         OrbitRepresentation::Cartesian,
         None
     ).unwrap();

--- a/examples/trajectories/orbit_trajectory/orbit_trajectory_empty_cartesian.py
+++ b/examples/trajectories/orbit_trajectory/orbit_trajectory_empty_cartesian.py
@@ -12,14 +12,12 @@ bh.initialize_eop()
 # Create trajectory in ECI frame, Cartesian representation
 traj_eci = bh.OrbitTrajectory(
     6,  # State dimension (position + velocity)
-    bh.OrbitFrame.ECI,
+    bh.CelestialFrame.ECI,
     bh.OrbitRepresentation.CARTESIAN,
     None,  # No angle format for Cartesian
 )
-print(f"Frame (str): {traj_eci.frame}")  # Output: ECI
-print(
-    f"Frame (repr): {traj_eci.frame!r}"
-)  # Output: OrbitFrame(Earth-Centered Inertial)
+print(f"Frame (str): {traj_eci.frame}")  # Output: GCRF
+print(f"Frame (repr): {traj_eci.frame!r}")  # Output: ReferenceFrame("GCRF")
 print(f"Representation (str): {traj_eci.representation}")  # Output: Cartesian
 print(
     f"Representation (repr): {traj_eci.representation!r}"
@@ -27,9 +25,7 @@ print(
 
 # Create trajectory in ECEF frame, Cartesian representation
 traj_ecef = bh.OrbitTrajectory(
-    6, bh.OrbitFrame.ECEF, bh.OrbitRepresentation.CARTESIAN, None
+    6, bh.CelestialFrame.ECEF, bh.OrbitRepresentation.CARTESIAN, None
 )
-print(f"Frame (str): {traj_ecef.frame}")  # Output: ECEF
-print(
-    f"Frame (repr): {traj_ecef.frame!r}"
-)  # Output: OrbitFrame(Earth-Centered Earth-Fixed)
+print(f"Frame (str): {traj_ecef.frame}")  # Output: ITRF
+print(f"Frame (repr): {traj_ecef.frame!r}")  # Output: ReferenceFrame("ITRF")

--- a/examples/trajectories/orbit_trajectory/orbit_trajectory_empty_cartesian.rs
+++ b/examples/trajectories/orbit_trajectory/orbit_trajectory_empty_cartesian.rs
@@ -3,14 +3,15 @@
 #[allow(unused_imports)]
 use brahe as bh;
 use bh::trajectories::SOrbitTrajectory;
-use bh::trajectories::traits::{OrbitFrame, OrbitRepresentation};
+use bh::frames::CelestialFrame;
+use bh::trajectories::traits::OrbitRepresentation;
 
 fn main() {
     bh::initialize_eop().unwrap();
 
     // Create trajectory in ECI frame, Cartesian representation
     let traj_eci = SOrbitTrajectory::new(
-        OrbitFrame::ECI,
+        CelestialFrame::ECI,
         OrbitRepresentation::Cartesian,
         None
     ).unwrap();
@@ -21,7 +22,7 @@ fn main() {
 
     // Create trajectory in ECEF frame, Cartesian representation
     let traj_ecef = SOrbitTrajectory::new(
-        OrbitFrame::ECEF,
+        CelestialFrame::ECEF,
         OrbitRepresentation::Cartesian,
         None
     ).unwrap();

--- a/examples/trajectories/orbit_trajectory/orbit_trajectory_empty_keplerian.py
+++ b/examples/trajectories/orbit_trajectory/orbit_trajectory_empty_keplerian.py
@@ -12,12 +12,12 @@ bh.initialize_eop()
 # Create trajectory in ECI frame, Keplerian representation with radians
 traj_kep_rad = bh.OrbitTrajectory(
     6,  # State dimension (6 orbital elements)
-    bh.OrbitFrame.ECI,
+    bh.CelestialFrame.ECI,
     bh.OrbitRepresentation.KEPLERIAN,
     bh.AngleFormat.RADIANS,  # Required for Keplerian
 )
 
 # Create trajectory in ECI frame, Keplerian representation with degrees
 traj_kep_deg = bh.OrbitTrajectory(
-    6, bh.OrbitFrame.ECI, bh.OrbitRepresentation.KEPLERIAN, bh.AngleFormat.DEGREES
+    6, bh.CelestialFrame.ECI, bh.OrbitRepresentation.KEPLERIAN, bh.AngleFormat.DEGREES
 )

--- a/examples/trajectories/orbit_trajectory/orbit_trajectory_empty_keplerian.rs
+++ b/examples/trajectories/orbit_trajectory/orbit_trajectory_empty_keplerian.rs
@@ -3,7 +3,8 @@
 #[allow(unused_imports)]
 use brahe as bh;
 use bh::trajectories::SOrbitTrajectory;
-use bh::trajectories::traits::{OrbitFrame, OrbitRepresentation};
+use bh::frames::CelestialFrame;
+use bh::trajectories::traits::OrbitRepresentation;
 use bh::AngleFormat;
 
 fn main() {
@@ -11,14 +12,14 @@ fn main() {
 
     // Create trajectory in ECI frame, Keplerian representation with radians
     let _traj_kep_rad = SOrbitTrajectory::new(
-        OrbitFrame::ECI,
+        CelestialFrame::ECI,
         OrbitRepresentation::Keplerian,
         Some(AngleFormat::Radians)
     ).unwrap();
 
     // Create trajectory in ECI frame, Keplerian representation with degrees
     let _traj_kep_deg = SOrbitTrajectory::new(
-        OrbitFrame::ECI,
+        CelestialFrame::ECI,
         OrbitRepresentation::Keplerian,
         Some(AngleFormat::Degrees)
     ).unwrap();

--- a/examples/trajectories/orbit_trajectory/orbit_trajectory_from_data.py
+++ b/examples/trajectories/orbit_trajectory/orbit_trajectory_from_data.py
@@ -25,7 +25,7 @@ state2 = np.array([bh.R_EARTH + 500e3, 0.0, 0.0, 0.0, -7600.0, 0.0])
 epochs = [epoch0, epoch1, epoch2]
 states = np.array([state0, state1, state2])  # Flattened array
 traj = bh.OrbitTrajectory.from_orbital_data(
-    epochs, states, bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None
+    epochs, states, bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None
 )
 
 print(f"Trajectory length: {len(traj)}")

--- a/examples/trajectories/orbit_trajectory/orbit_trajectory_from_data.rs
+++ b/examples/trajectories/orbit_trajectory/orbit_trajectory_from_data.rs
@@ -4,7 +4,8 @@
 use brahe as bh;
 use bh::time::Epoch;
 use bh::trajectories::SOrbitTrajectory;
-use bh::trajectories::traits::{OrbitFrame, OrbitRepresentation, OrbitalTrajectory};
+use bh::frames::CelestialFrame;
+use bh::trajectories::traits::{OrbitRepresentation, OrbitalTrajectory};
 use bh::traits::Trajectory;
 use bh::constants::R_EARTH;
 use nalgebra as na;
@@ -35,7 +36,7 @@ fn main() {
     let traj = SOrbitTrajectory::from_orbital_data(
         epochs,
         states,
-        OrbitFrame::ECI,
+        CelestialFrame::ECI.into(),
         OrbitRepresentation::Cartesian,
         None, // Angle Format
         None  // No covariances

--- a/examples/trajectories/orbit_trajectory/orbit_trajectory_from_data.rs
+++ b/examples/trajectories/orbit_trajectory/orbit_trajectory_from_data.rs
@@ -36,7 +36,7 @@ fn main() {
     let traj = SOrbitTrajectory::from_orbital_data(
         epochs,
         states,
-        CelestialFrame::ECI.into(),
+        CelestialFrame::ECI,
         OrbitRepresentation::Cartesian,
         None, // Angle Format
         None  // No covariances

--- a/examples/trajectories/orbit_trajectory/orbit_trajectory_from_propagator.py
+++ b/examples/trajectories/orbit_trajectory/orbit_trajectory_from_propagator.py
@@ -32,5 +32,5 @@ propagator.propagate_steps(10)
 # Access the trajectory
 traj = propagator.trajectory
 print(f"Trajectory length: {len(traj)}")  # Output: 11 (initial + 10 steps)
-print(f"Frame: {traj.frame}")  # Output: OrbitFrame.ECI
+print(f"Frame: {traj.frame}")  # Output: GCRF
 print(f"Representation: {traj.representation}")  # Output: Keplerian

--- a/examples/trajectories/orbit_trajectory/orbit_trajectory_from_propagator.rs
+++ b/examples/trajectories/orbit_trajectory/orbit_trajectory_from_propagator.rs
@@ -29,7 +29,7 @@ fn main() {
     // Access the trajectory
     let traj = &propagator.trajectory;
     println!("Trajectory length: {}", traj.len());  // Output: 11
-    println!("Frame: {}", traj.frame);  // Output: ECI
+    println!("Frame: {}", traj.frame);  // Output: GCRF
     println!("Representation: {}", traj.representation);  // Output: Keplerian
 }
 

--- a/examples/trajectories/orbit_trajectory/orbit_trajectory_operations.py
+++ b/examples/trajectories/orbit_trajectory/orbit_trajectory_operations.py
@@ -12,7 +12,9 @@ import brahe as bh
 bh.initialize_eop()
 
 # Create trajectory
-traj = bh.OrbitTrajectory(6, bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None)
+traj = bh.OrbitTrajectory(
+    6, bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None
+)
 
 # Add states
 epoch0 = bh.Epoch.from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, bh.TimeSystem.UTC)

--- a/examples/trajectories/orbit_trajectory/orbit_trajectory_operations.rs
+++ b/examples/trajectories/orbit_trajectory/orbit_trajectory_operations.rs
@@ -4,7 +4,8 @@
 use brahe as bh;
 use bh::time::Epoch;
 use bh::trajectories::SOrbitTrajectory;
-use bh::trajectories::traits::{OrbitFrame, OrbitRepresentation};
+use bh::frames::CelestialFrame;
+use bh::trajectories::traits::OrbitRepresentation;
 use bh::traits::{Trajectory, InterpolatableTrajectory};
 use bh::{state_koe_to_eci, R_EARTH, AngleFormat};
 use nalgebra as na;
@@ -14,7 +15,7 @@ fn main() {
 
     // Create trajectory
     let mut traj = SOrbitTrajectory::new(
-        OrbitFrame::ECI,
+        CelestialFrame::ECI,
         OrbitRepresentation::Cartesian,
         None
     ).unwrap();

--- a/examples/trajectories/orbit_trajectory/orbit_trajectory_roundtrip.py
+++ b/examples/trajectories/orbit_trajectory/orbit_trajectory_roundtrip.py
@@ -13,7 +13,7 @@ bh.initialize_eop()
 
 # Create trajectory in ECI
 traj_eci_original = bh.OrbitTrajectory(
-    6, bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None
+    6, bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None
 )
 
 # Add a state

--- a/examples/trajectories/orbit_trajectory/orbit_trajectory_roundtrip.rs
+++ b/examples/trajectories/orbit_trajectory/orbit_trajectory_roundtrip.rs
@@ -4,7 +4,8 @@
 use brahe as bh;
 use bh::time::Epoch;
 use bh::trajectories::SOrbitTrajectory;
-use bh::trajectories::traits::{OrbitFrame, OrbitRepresentation, OrbitalTrajectory};
+use bh::frames::CelestialFrame;
+use bh::trajectories::traits::{OrbitRepresentation, OrbitalTrajectory};
 use bh::traits::Trajectory;
 use bh::constants::R_EARTH;
 use nalgebra as na;
@@ -14,7 +15,7 @@ fn main() {
 
     // Create trajectory in ECI
     let mut traj_eci_original = SOrbitTrajectory::new(
-        OrbitFrame::ECI,
+        CelestialFrame::ECI,
         OrbitRepresentation::Cartesian,
         None
     ).unwrap();

--- a/src/access/compute.rs
+++ b/src/access/compute.rs
@@ -300,7 +300,7 @@ mod tests {
         KeplerianPropagator::new(
             epoch,
             oe,
-            crate::trajectories::traits::OrbitFrame::ECI,
+            crate::frames::CelestialFrame::ECI,
             crate::trajectories::traits::OrbitRepresentation::Keplerian,
             Some(AngleFormat::Radians),
             60.0,
@@ -379,7 +379,7 @@ mod tests {
                 KeplerianPropagator::new(
                     epoch,
                     oe,
-                    crate::trajectories::traits::OrbitFrame::ECI,
+                    crate::frames::CelestialFrame::ECI,
                     crate::trajectories::traits::OrbitRepresentation::Keplerian,
                     Some(AngleFormat::Radians),
                     60.0,
@@ -398,7 +398,7 @@ mod tests {
                 KeplerianPropagator::new(
                     epoch,
                     oe,
-                    crate::trajectories::traits::OrbitFrame::ECI,
+                    crate::frames::CelestialFrame::ECI,
                     crate::trajectories::traits::OrbitRepresentation::Keplerian,
                     Some(AngleFormat::Radians),
                     60.0,
@@ -522,7 +522,7 @@ mod tests {
             KeplerianPropagator::new(
                 epoch,
                 oe,
-                crate::trajectories::traits::OrbitFrame::ECI,
+                crate::frames::CelestialFrame::ECI,
                 crate::trajectories::traits::OrbitRepresentation::Keplerian,
                 Some(AngleFormat::Radians),
                 60.0,
@@ -785,7 +785,7 @@ mod tests {
             KeplerianPropagator::new(
                 epoch,
                 oe,
-                crate::trajectories::traits::OrbitFrame::ECI,
+                crate::frames::CelestialFrame::ECI,
                 crate::trajectories::traits::OrbitRepresentation::Keplerian,
                 Some(AngleFormat::Radians),
                 60.0,

--- a/src/access/properties.rs
+++ b/src/access/properties.rs
@@ -1379,7 +1379,8 @@ mod tests {
     #[test]
     #[parallel]
     fn test_state_provider_propagator() {
-        use crate::trajectories::traits::{OrbitFrame, OrbitRepresentation};
+        use crate::frames::CelestialFrame;
+        use crate::trajectories::traits::OrbitRepresentation;
 
         // Initialize EOP for frame conversions
         setup_global_test_eop();
@@ -1397,7 +1398,7 @@ mod tests {
         let prop = KeplerianPropagator::new(
             epoch,
             elements,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Radians),
             60.0,
@@ -1415,8 +1416,9 @@ mod tests {
     #[test]
     #[parallel]
     fn test_state_provider_orbit_trajectory() {
+        use crate::frames::CelestialFrame;
         use crate::trajectories::sorbit_trajectory::SOrbitTrajectory;
-        use crate::trajectories::traits::{OrbitFrame, OrbitRepresentation, Trajectory};
+        use crate::trajectories::traits::{OrbitRepresentation, Trajectory};
 
         // Initialize EOP for frame conversions
         setup_global_test_eop();
@@ -1429,7 +1431,8 @@ mod tests {
         let state2 = Vector6::new(7000e3, 100e3, 10e3, 10.0, 7500.0, 100.0);
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.add(epoch1, state1).unwrap();
         traj.add(epoch2, state2).unwrap();
 
@@ -1737,7 +1740,8 @@ mod tests {
     #[parallel]
     fn test_property_computer() {
         use crate::access::{AccessibleLocation, PointLocation};
-        use crate::trajectories::traits::{OrbitFrame, OrbitRepresentation};
+        use crate::frames::CelestialFrame;
+        use crate::trajectories::traits::OrbitRepresentation;
 
         // Initialize EOP for frame conversions
         setup_global_test_eop();
@@ -1782,7 +1786,7 @@ mod tests {
         let prop = KeplerianPropagator::new(
             epoch1,
             elements,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Radians),
             60.0,

--- a/src/access/windows.rs
+++ b/src/access/windows.rs
@@ -1059,7 +1059,7 @@ mod tests {
         let propagator = KeplerianPropagator::new(
             epoch,
             oe,
-            crate::trajectories::traits::OrbitFrame::ECI,
+            crate::frames::CelestialFrame::ECI,
             crate::trajectories::traits::OrbitRepresentation::Keplerian,
             Some(AngleFormat::Radians),
             60.0,
@@ -1110,7 +1110,7 @@ mod tests {
         let propagator = KeplerianPropagator::new(
             epoch,
             oe,
-            crate::trajectories::traits::OrbitFrame::ECI,
+            crate::frames::CelestialFrame::ECI,
             crate::trajectories::traits::OrbitRepresentation::Keplerian,
             Some(AngleFormat::Radians),
             60.0,
@@ -1161,7 +1161,7 @@ mod tests {
         let propagator = KeplerianPropagator::new(
             epoch,
             oe,
-            crate::trajectories::traits::OrbitFrame::ECI,
+            crate::frames::CelestialFrame::ECI,
             crate::trajectories::traits::OrbitRepresentation::Keplerian,
             Some(AngleFormat::Radians),
             60.0,
@@ -1197,7 +1197,7 @@ mod tests {
         let propagator = KeplerianPropagator::new(
             epoch,
             oe,
-            crate::trajectories::traits::OrbitFrame::ECI,
+            crate::frames::CelestialFrame::ECI,
             crate::trajectories::traits::OrbitRepresentation::Keplerian,
             Some(AngleFormat::Radians),
             60.0,
@@ -1253,7 +1253,7 @@ mod tests {
         let propagator = KeplerianPropagator::new(
             epoch,
             oe,
-            crate::trajectories::traits::OrbitFrame::ECI,
+            crate::frames::CelestialFrame::ECI,
             crate::trajectories::traits::OrbitRepresentation::Keplerian,
             Some(AngleFormat::Radians),
             60.0,
@@ -1304,7 +1304,7 @@ mod tests {
         let mut propagator = KeplerianPropagator::new(
             epoch,
             oe,
-            crate::trajectories::traits::OrbitFrame::ECI,
+            crate::frames::CelestialFrame::ECI,
             crate::trajectories::traits::OrbitRepresentation::Keplerian,
             Some(AngleFormat::Radians),
             60.0,
@@ -1344,7 +1344,7 @@ mod tests {
         let propagator = KeplerianPropagator::new(
             epoch,
             oe,
-            crate::trajectories::traits::OrbitFrame::ECI,
+            crate::frames::CelestialFrame::ECI,
             crate::trajectories::traits::OrbitRepresentation::Keplerian,
             Some(AngleFormat::Radians),
             60.0,
@@ -1382,7 +1382,7 @@ mod tests {
         let propagator = KeplerianPropagator::new(
             epoch,
             oe,
-            crate::trajectories::traits::OrbitFrame::ECI,
+            crate::frames::CelestialFrame::ECI,
             crate::trajectories::traits::OrbitRepresentation::Keplerian,
             Some(AngleFormat::Radians),
             60.0,
@@ -1457,7 +1457,7 @@ mod tests {
         let propagator = KeplerianPropagator::new(
             epoch,
             oe,
-            crate::trajectories::traits::OrbitFrame::ECI,
+            crate::frames::CelestialFrame::ECI,
             crate::trajectories::traits::OrbitRepresentation::Keplerian,
             Some(AngleFormat::Radians),
             60.0,
@@ -1538,7 +1538,7 @@ mod tests {
         let propagator = KeplerianPropagator::new(
             epoch,
             oe,
-            crate::trajectories::traits::OrbitFrame::ECI,
+            crate::frames::CelestialFrame::ECI,
             crate::trajectories::traits::OrbitRepresentation::Keplerian,
             Some(AngleFormat::Radians),
             60.0,
@@ -1581,7 +1581,7 @@ mod tests {
         let propagator = KeplerianPropagator::new(
             epoch,
             oe,
-            crate::trajectories::traits::OrbitFrame::ECI,
+            crate::frames::CelestialFrame::ECI,
             crate::trajectories::traits::OrbitRepresentation::Keplerian,
             Some(AngleFormat::Radians),
             60.0,
@@ -1632,7 +1632,7 @@ mod tests {
         let propagator = KeplerianPropagator::new(
             epoch,
             oe,
-            crate::trajectories::traits::OrbitFrame::ECI,
+            crate::frames::CelestialFrame::ECI,
             crate::trajectories::traits::OrbitRepresentation::Keplerian,
             Some(AngleFormat::Radians),
             60.0,
@@ -1685,7 +1685,7 @@ mod tests {
         let propagator = KeplerianPropagator::new(
             epoch,
             oe,
-            crate::trajectories::traits::OrbitFrame::ECI,
+            crate::frames::CelestialFrame::ECI,
             crate::trajectories::traits::OrbitRepresentation::Keplerian,
             Some(AngleFormat::Radians),
             60.0,
@@ -1737,7 +1737,7 @@ mod tests {
         let propagator = KeplerianPropagator::new(
             epoch,
             oe,
-            crate::trajectories::traits::OrbitFrame::ECI,
+            crate::frames::CelestialFrame::ECI,
             crate::trajectories::traits::OrbitRepresentation::Keplerian,
             Some(AngleFormat::Radians),
             60.0,
@@ -1785,7 +1785,7 @@ mod tests {
         let propagator = KeplerianPropagator::new(
             epoch,
             oe,
-            crate::trajectories::traits::OrbitFrame::ECI,
+            crate::frames::CelestialFrame::ECI,
             crate::trajectories::traits::OrbitRepresentation::Keplerian,
             Some(AngleFormat::Radians),
             60.0,
@@ -1896,7 +1896,7 @@ mod tests {
         let propagator = KeplerianPropagator::new(
             epoch,
             oe,
-            crate::trajectories::traits::OrbitFrame::ECI,
+            crate::frames::CelestialFrame::ECI,
             crate::trajectories::traits::OrbitRepresentation::Keplerian,
             Some(AngleFormat::Radians),
             60.0,
@@ -2004,7 +2004,7 @@ mod tests {
         let propagator = KeplerianPropagator::new(
             epoch,
             oe,
-            crate::trajectories::traits::OrbitFrame::ECI,
+            crate::frames::CelestialFrame::ECI,
             crate::trajectories::traits::OrbitRepresentation::Keplerian,
             Some(AngleFormat::Radians),
             60.0,
@@ -2121,7 +2121,7 @@ mod tests {
         let propagator = KeplerianPropagator::new(
             epoch,
             oe,
-            crate::trajectories::traits::OrbitFrame::ECI,
+            crate::frames::CelestialFrame::ECI,
             crate::trajectories::traits::OrbitRepresentation::Keplerian,
             Some(AngleFormat::Radians),
             60.0,
@@ -2216,7 +2216,7 @@ mod tests {
         let propagator = KeplerianPropagator::new(
             epoch,
             oe,
-            crate::trajectories::traits::OrbitFrame::ECI,
+            crate::frames::CelestialFrame::ECI,
             crate::trajectories::traits::OrbitRepresentation::Keplerian,
             Some(AngleFormat::Radians),
             60.0,
@@ -2287,7 +2287,7 @@ mod tests {
         let propagator = KeplerianPropagator::new(
             epoch,
             oe,
-            crate::trajectories::traits::OrbitFrame::ECI,
+            crate::frames::CelestialFrame::ECI,
             crate::trajectories::traits::OrbitRepresentation::Keplerian,
             Some(AngleFormat::Radians),
             60.0,
@@ -2346,7 +2346,7 @@ mod tests {
         let propagator = KeplerianPropagator::new(
             epoch,
             oe,
-            crate::trajectories::traits::OrbitFrame::ECI,
+            crate::frames::CelestialFrame::ECI,
             crate::trajectories::traits::OrbitRepresentation::Keplerian,
             Some(AngleFormat::Radians),
             60.0,
@@ -2438,7 +2438,7 @@ mod tests {
         let propagator = KeplerianPropagator::new(
             epoch,
             oe,
-            crate::trajectories::traits::OrbitFrame::ECI,
+            crate::frames::CelestialFrame::ECI,
             crate::trajectories::traits::OrbitRepresentation::Keplerian,
             Some(AngleFormat::Radians),
             60.0,

--- a/src/ccsds/interop.rs
+++ b/src/ccsds/interop.rs
@@ -36,7 +36,7 @@ use crate::trajectories::{AttitudeInterpolationMethod, AttitudeState, AttitudeTr
 use crate::types::GPRecord;
 use crate::utils::errors::BraheError;
 
-/// Map a CCSDS reference frame to a brahe `ReferenceFrame`.
+/// Map a CCSDS reference frame to a brahe `CelestialFrame`.
 ///
 /// Only inertial and terrestrial frames supported by brahe are mapped.
 /// Orbit-relative frames (RTN, TNW, RSW) and exotic frames return an error.
@@ -45,21 +45,33 @@ use crate::utils::errors::BraheError;
 /// * `frame` - CCSDS ODM reference frame token
 ///
 /// # Returns
-/// * `Ok(ReferenceFrame)`: The equivalent native frame
+/// * `Ok(CelestialFrame)`: The equivalent native celestial frame
 /// * `Err(BraheError)`: If the token has no native equivalent
-pub fn ccsds_ref_frame_to_reference_frame(
+///
+/// # Examples
+/// ```rust
+/// use brahe::ccsds::common::CCSDSRefFrame;
+/// use brahe::ccsds::interop::ccsds_ref_frame_to_celestial_frame;
+/// use brahe::frames::CelestialFrame;
+///
+/// let frame = ccsds_ref_frame_to_celestial_frame(&CCSDSRefFrame::J2000).unwrap();
+/// assert_eq!(frame, CelestialFrame::EME2000);
+///
+/// assert!(ccsds_ref_frame_to_celestial_frame(&CCSDSRefFrame::TEME).is_err());
+/// ```
+pub fn ccsds_ref_frame_to_celestial_frame(
     frame: &CCSDSRefFrame,
-) -> Result<ReferenceFrame, BraheError> {
+) -> Result<CelestialFrame, BraheError> {
     match frame {
-        CCSDSRefFrame::EME2000 => Ok(CelestialFrame::EME2000.into()),
-        CCSDSRefFrame::J2000 => Ok(CelestialFrame::EME2000.into()),
-        CCSDSRefFrame::GCRF => Ok(CelestialFrame::GCRF.into()),
+        CCSDSRefFrame::EME2000 => Ok(CelestialFrame::EME2000),
+        CCSDSRefFrame::J2000 => Ok(CelestialFrame::EME2000),
+        CCSDSRefFrame::GCRF => Ok(CelestialFrame::GCRF),
         CCSDSRefFrame::ITRF2000
         | CCSDSRefFrame::ITRF93
         | CCSDSRefFrame::ITRF97
         | CCSDSRefFrame::ITRF2005
         | CCSDSRefFrame::ITRF2008
-        | CCSDSRefFrame::ITRF2014 => Ok(CelestialFrame::ITRF.into()),
+        | CCSDSRefFrame::ITRF2014 => Ok(CelestialFrame::ITRF),
         CCSDSRefFrame::TEME => Err(BraheError::Error(
             "Cannot map CCSDS frame 'TEME' to brahe ReferenceFrame. TEME is not equivalent to GCRF or EME2000. \
              Use frame conversion before creating a trajectory.".to_string(),
@@ -73,6 +85,33 @@ pub fn ccsds_ref_frame_to_reference_frame(
             frame
         ))),
     }
+}
+
+/// Map a CCSDS reference frame to a brahe `ReferenceFrame`.
+///
+/// Only inertial and terrestrial frames supported by brahe are mapped.
+/// Orbit-relative frames (RTN, TNW, RSW) and exotic frames return an error.
+///
+/// # Arguments
+/// * `frame` - CCSDS ODM reference frame token
+///
+/// # Returns
+/// * `Ok(ReferenceFrame)`: The equivalent native frame
+/// * `Err(BraheError)`: If the token has no native equivalent
+///
+/// # Examples
+/// ```rust
+/// use brahe::ccsds::common::CCSDSRefFrame;
+/// use brahe::ccsds::interop::ccsds_ref_frame_to_reference_frame;
+/// use brahe::frames::CelestialFrame;
+///
+/// let frame = ccsds_ref_frame_to_reference_frame(&CCSDSRefFrame::GCRF).unwrap();
+/// assert_eq!(frame, CelestialFrame::GCRF);
+/// ```
+pub fn ccsds_ref_frame_to_reference_frame(
+    frame: &CCSDSRefFrame,
+) -> Result<ReferenceFrame, BraheError> {
+    ccsds_ref_frame_to_celestial_frame(frame).map(ReferenceFrame::Celestial)
 }
 
 impl OEM {
@@ -211,7 +250,7 @@ impl OEM {
     /// Converts the OEM to a `DOrbitTrajectory` via `TryFrom<&OEM>`
     /// (erroring for a zero- or multi-segment OEM exactly as that
     /// conversion does) and registers it under `name` with the celestial
-    /// frame carried by the converted trajectory. The registered object can then be queried through
+    /// frame its segment's `REF_FRAME` maps to. The registered object can then be queried through
     /// `object_state`, or used as the anchor for an orbit-relative frame
     /// such as `ReferenceFrame::RTN(name)`.
     ///
@@ -240,16 +279,10 @@ impl OEM {
     /// clear_object_registry();
     /// ```
     pub fn register_for(&self, name: impl Into<ObjectId>) -> Result<(), BraheError> {
+        // TryFrom requires exactly one segment, so segment 0 is the
+        // trajectory's segment and carries the frame it was built in.
         let traj = DOrbitTrajectory::try_from(self)?;
-        let frame = match traj.frame {
-            ReferenceFrame::Celestial(c) => c,
-            ref other => {
-                return Err(BraheError::Error(format!(
-                    "OEM::register_for cannot map frame '{}' to a CelestialFrame",
-                    other
-                )));
-            }
-        };
+        let frame = ccsds_ref_frame_to_celestial_frame(&self.segments[0].metadata.ref_frame)?;
         let adapter = DStateAdapter::new(traj)?;
         register_object(name, adapter, frame)
     }
@@ -1503,6 +1536,32 @@ mod tests {
         // TEME and TOD should fail (not equivalent to GCRF/EME2000)
         assert!(ccsds_ref_frame_to_reference_frame(&CCSDSRefFrame::TEME).is_err());
         assert!(ccsds_ref_frame_to_reference_frame(&CCSDSRefFrame::TOD).is_err());
+    }
+
+    #[test]
+    #[parallel]
+    fn test_ccsds_ref_frame_to_celestial_frame() {
+        assert_eq!(
+            ccsds_ref_frame_to_celestial_frame(&CCSDSRefFrame::EME2000).unwrap(),
+            CelestialFrame::EME2000
+        );
+        assert_eq!(
+            ccsds_ref_frame_to_celestial_frame(&CCSDSRefFrame::GCRF).unwrap(),
+            CelestialFrame::GCRF
+        );
+        assert_eq!(
+            ccsds_ref_frame_to_celestial_frame(&CCSDSRefFrame::ITRF2000).unwrap(),
+            CelestialFrame::ITRF
+        );
+        assert_eq!(
+            ccsds_ref_frame_to_celestial_frame(&CCSDSRefFrame::J2000).unwrap(),
+            CelestialFrame::EME2000
+        );
+        // Orbit-relative frames should fail
+        assert!(ccsds_ref_frame_to_celestial_frame(&CCSDSRefFrame::RTN).is_err());
+        // TEME and TOD should fail (not equivalent to GCRF/EME2000)
+        assert!(ccsds_ref_frame_to_celestial_frame(&CCSDSRefFrame::TEME).is_err());
+        assert!(ccsds_ref_frame_to_celestial_frame(&CCSDSRefFrame::TOD).is_err());
     }
 
     fn sample_gp_record_json() -> &'static str {

--- a/src/ccsds/interop.rs
+++ b/src/ccsds/interop.rs
@@ -36,31 +36,40 @@ use crate::trajectories::{AttitudeInterpolationMethod, AttitudeState, AttitudeTr
 use crate::types::GPRecord;
 use crate::utils::errors::BraheError;
 
-/// Map a CCSDS reference frame to a brahe `CelestialFrame`.
+/// Map a CCSDS reference frame to a brahe `ReferenceFrame`.
 ///
 /// Only inertial and terrestrial frames supported by brahe are mapped.
 /// Orbit-relative frames (RTN, TNW, RSW) and exotic frames return an error.
-pub fn ccsds_ref_frame_to_orbit_frame(frame: &CCSDSRefFrame) -> Result<CelestialFrame, BraheError> {
+///
+/// # Arguments
+/// * `frame` - CCSDS ODM reference frame token
+///
+/// # Returns
+/// * `Ok(ReferenceFrame)`: The equivalent native frame
+/// * `Err(BraheError)`: If the token has no native equivalent
+pub fn ccsds_ref_frame_to_reference_frame(
+    frame: &CCSDSRefFrame,
+) -> Result<ReferenceFrame, BraheError> {
     match frame {
-        CCSDSRefFrame::EME2000 => Ok(CelestialFrame::EME2000),
-        CCSDSRefFrame::J2000 => Ok(CelestialFrame::EME2000),
-        CCSDSRefFrame::GCRF => Ok(CelestialFrame::GCRF),
+        CCSDSRefFrame::EME2000 => Ok(CelestialFrame::EME2000.into()),
+        CCSDSRefFrame::J2000 => Ok(CelestialFrame::EME2000.into()),
+        CCSDSRefFrame::GCRF => Ok(CelestialFrame::GCRF.into()),
         CCSDSRefFrame::ITRF2000
         | CCSDSRefFrame::ITRF93
         | CCSDSRefFrame::ITRF97
         | CCSDSRefFrame::ITRF2005
         | CCSDSRefFrame::ITRF2008
-        | CCSDSRefFrame::ITRF2014 => Ok(CelestialFrame::ITRF),
+        | CCSDSRefFrame::ITRF2014 => Ok(CelestialFrame::ITRF.into()),
         CCSDSRefFrame::TEME => Err(BraheError::Error(
-            "Cannot map CCSDS frame 'TEME' to brahe CelestialFrame. TEME is not equivalent to GCRF or EME2000. \
+            "Cannot map CCSDS frame 'TEME' to brahe ReferenceFrame. TEME is not equivalent to GCRF or EME2000. \
              Use frame conversion before creating a trajectory.".to_string(),
         )),
         CCSDSRefFrame::TOD => Err(BraheError::Error(
-            "Cannot map CCSDS frame 'TOD' to brahe CelestialFrame. TOD is not equivalent to GCRF or EME2000. \
+            "Cannot map CCSDS frame 'TOD' to brahe ReferenceFrame. TOD is not equivalent to GCRF or EME2000. \
              Use frame conversion before creating a trajectory.".to_string(),
         )),
         _ => Err(BraheError::Error(format!(
-            "Cannot map CCSDS frame '{}' to brahe CelestialFrame",
+            "Cannot map CCSDS frame '{}' to brahe ReferenceFrame",
             frame
         ))),
     }
@@ -92,9 +101,9 @@ impl OEM {
             ))
         })?;
 
-        let orbit_frame = ccsds_ref_frame_to_orbit_frame(&segment.metadata.ref_frame)?;
+        let frame = ccsds_ref_frame_to_reference_frame(&segment.metadata.ref_frame)?;
 
-        let mut traj = DOrbitTrajectory::new(6, orbit_frame, OrbitRepresentation::Cartesian, None)?;
+        let mut traj = DOrbitTrajectory::new(6, frame, OrbitRepresentation::Cartesian, None)?;
 
         traj.name = Some(segment.metadata.object_name.clone());
 
@@ -139,9 +148,9 @@ impl OEM {
             ))
         })?;
 
-        let orbit_frame = ccsds_ref_frame_to_orbit_frame(&segment.metadata.ref_frame)?;
+        let frame = ccsds_ref_frame_to_reference_frame(&segment.metadata.ref_frame)?;
 
-        let mut traj = SOrbitTrajectory::new(orbit_frame, OrbitRepresentation::Cartesian, None)?;
+        let mut traj = SOrbitTrajectory::new(frame, OrbitRepresentation::Cartesian, None)?;
 
         traj.name = Some(segment.metadata.object_name.clone());
 
@@ -233,9 +242,7 @@ impl OEM {
     pub fn register_for(&self, name: impl Into<ObjectId>) -> Result<(), BraheError> {
         let traj = DOrbitTrajectory::try_from(self)?;
         let frame = match traj.frame {
-            ReferenceFrame::Celestial(
-                c @ (CelestialFrame::GCRF | CelestialFrame::ITRF | CelestialFrame::EME2000),
-            ) => c,
+            ReferenceFrame::Celestial(c) => c,
             ref other => {
                 return Err(BraheError::Error(format!(
                     "OEM::register_for cannot map frame '{}' to a CelestialFrame",
@@ -1474,28 +1481,28 @@ mod tests {
 
     #[test]
     #[parallel]
-    fn test_ccsds_ref_frame_mapping() {
+    fn test_ccsds_ref_frame_to_reference_frame() {
         assert_eq!(
-            ccsds_ref_frame_to_orbit_frame(&CCSDSRefFrame::EME2000).unwrap(),
+            ccsds_ref_frame_to_reference_frame(&CCSDSRefFrame::EME2000).unwrap(),
             CelestialFrame::EME2000
         );
         assert_eq!(
-            ccsds_ref_frame_to_orbit_frame(&CCSDSRefFrame::GCRF).unwrap(),
+            ccsds_ref_frame_to_reference_frame(&CCSDSRefFrame::GCRF).unwrap(),
             CelestialFrame::GCRF
         );
         assert_eq!(
-            ccsds_ref_frame_to_orbit_frame(&CCSDSRefFrame::ITRF2000).unwrap(),
+            ccsds_ref_frame_to_reference_frame(&CCSDSRefFrame::ITRF2000).unwrap(),
             CelestialFrame::ITRF
         );
         assert_eq!(
-            ccsds_ref_frame_to_orbit_frame(&CCSDSRefFrame::J2000).unwrap(),
+            ccsds_ref_frame_to_reference_frame(&CCSDSRefFrame::J2000).unwrap(),
             CelestialFrame::EME2000
         );
         // Orbit-relative frames should fail
-        assert!(ccsds_ref_frame_to_orbit_frame(&CCSDSRefFrame::RTN).is_err());
+        assert!(ccsds_ref_frame_to_reference_frame(&CCSDSRefFrame::RTN).is_err());
         // TEME and TOD should fail (not equivalent to GCRF/EME2000)
-        assert!(ccsds_ref_frame_to_orbit_frame(&CCSDSRefFrame::TEME).is_err());
-        assert!(ccsds_ref_frame_to_orbit_frame(&CCSDSRefFrame::TOD).is_err());
+        assert!(ccsds_ref_frame_to_reference_frame(&CCSDSRefFrame::TEME).is_err());
+        assert!(ccsds_ref_frame_to_reference_frame(&CCSDSRefFrame::TOD).is_err());
     }
 
     fn sample_gp_record_json() -> &'static str {

--- a/src/ccsds/interop.rs
+++ b/src/ccsds/interop.rs
@@ -1410,6 +1410,16 @@ mod tests {
 
     #[test]
     #[parallel]
+    fn test_oem_segment_to_sorbit_trajectory_rejects_unmapped_frame() {
+        let oem = OEM::from_file("test_assets/ccsds/oem/test.oem").unwrap();
+        assert_eq!(oem.segments[0].metadata.ref_frame, CCSDSRefFrame::TOD);
+
+        let err = oem.segment_to_sorbit_trajectory(0).unwrap_err();
+        assert!(err.to_string().contains("TOD"));
+    }
+
+    #[test]
+    #[parallel]
     fn test_oem_to_trajectory_example5() {
         let content = std::fs::read_to_string("test_assets/ccsds/oem/OEMExample5.txt").unwrap();
         let oem = OEM::from_str(&content).unwrap();

--- a/src/ccsds/interop.rs
+++ b/src/ccsds/interop.rs
@@ -31,36 +31,36 @@ use crate::frames::{
 use crate::time::Epoch;
 use crate::trajectories::dorbit_trajectory::DOrbitTrajectory;
 use crate::trajectories::sorbit_trajectory::SOrbitTrajectory;
-use crate::trajectories::traits::{OrbitFrame, OrbitRepresentation, Trajectory};
+use crate::trajectories::traits::{OrbitRepresentation, Trajectory};
 use crate::trajectories::{AttitudeInterpolationMethod, AttitudeState, AttitudeTrajectory};
 use crate::types::GPRecord;
 use crate::utils::errors::BraheError;
 
-/// Map a CCSDS reference frame to a brahe `OrbitFrame`.
+/// Map a CCSDS reference frame to a brahe `CelestialFrame`.
 ///
 /// Only inertial and terrestrial frames supported by brahe are mapped.
 /// Orbit-relative frames (RTN, TNW, RSW) and exotic frames return an error.
-pub fn ccsds_ref_frame_to_orbit_frame(frame: &CCSDSRefFrame) -> Result<OrbitFrame, BraheError> {
+pub fn ccsds_ref_frame_to_orbit_frame(frame: &CCSDSRefFrame) -> Result<CelestialFrame, BraheError> {
     match frame {
-        CCSDSRefFrame::EME2000 => Ok(OrbitFrame::EME2000),
-        CCSDSRefFrame::J2000 => Ok(OrbitFrame::EME2000),
-        CCSDSRefFrame::GCRF => Ok(OrbitFrame::GCRF),
+        CCSDSRefFrame::EME2000 => Ok(CelestialFrame::EME2000),
+        CCSDSRefFrame::J2000 => Ok(CelestialFrame::EME2000),
+        CCSDSRefFrame::GCRF => Ok(CelestialFrame::GCRF),
         CCSDSRefFrame::ITRF2000
         | CCSDSRefFrame::ITRF93
         | CCSDSRefFrame::ITRF97
         | CCSDSRefFrame::ITRF2005
         | CCSDSRefFrame::ITRF2008
-        | CCSDSRefFrame::ITRF2014 => Ok(OrbitFrame::ITRF),
+        | CCSDSRefFrame::ITRF2014 => Ok(CelestialFrame::ITRF),
         CCSDSRefFrame::TEME => Err(BraheError::Error(
-            "Cannot map CCSDS frame 'TEME' to brahe OrbitFrame. TEME is not equivalent to GCRF or EME2000. \
+            "Cannot map CCSDS frame 'TEME' to brahe CelestialFrame. TEME is not equivalent to GCRF or EME2000. \
              Use frame conversion before creating a trajectory.".to_string(),
         )),
         CCSDSRefFrame::TOD => Err(BraheError::Error(
-            "Cannot map CCSDS frame 'TOD' to brahe OrbitFrame. TOD is not equivalent to GCRF or EME2000. \
+            "Cannot map CCSDS frame 'TOD' to brahe CelestialFrame. TOD is not equivalent to GCRF or EME2000. \
              Use frame conversion before creating a trajectory.".to_string(),
         )),
         _ => Err(BraheError::Error(format!(
-            "Cannot map CCSDS frame '{}' to brahe OrbitFrame",
+            "Cannot map CCSDS frame '{}' to brahe CelestialFrame",
             frame
         ))),
     }
@@ -233,12 +233,12 @@ impl OEM {
     pub fn register_for(&self, name: impl Into<ObjectId>) -> Result<(), BraheError> {
         let traj = DOrbitTrajectory::try_from(self)?;
         let frame = match traj.frame {
-            OrbitFrame::GCRF => CelestialFrame::GCRF,
-            OrbitFrame::ITRF => CelestialFrame::ITRF,
-            OrbitFrame::EME2000 => CelestialFrame::EME2000,
-            other => {
+            ReferenceFrame::Celestial(
+                c @ (CelestialFrame::GCRF | CelestialFrame::ITRF | CelestialFrame::EME2000),
+            ) => c,
+            ref other => {
                 return Err(BraheError::Error(format!(
-                    "OEM::register_for cannot map OrbitFrame '{}' to a CelestialFrame",
+                    "OEM::register_for cannot map frame '{}' to a CelestialFrame",
                     other
                 )));
             }
@@ -1360,7 +1360,7 @@ mod tests {
         let traj = oem.segment_to_trajectory(0).unwrap();
         assert_eq!(traj.len(), 3);
         assert_eq!(traj.name.as_deref(), Some("MARS GLOBAL SURVEYOR"));
-        assert_eq!(traj.frame, OrbitFrame::EME2000);
+        assert_eq!(traj.frame, CelestialFrame::EME2000);
 
         // Verify first state
         let (_epoch, state) = traj.first().unwrap();
@@ -1376,7 +1376,7 @@ mod tests {
 
         let traj = oem.segment_to_trajectory(0).unwrap();
         assert_eq!(traj.len(), 49);
-        assert_eq!(traj.frame, OrbitFrame::GCRF);
+        assert_eq!(traj.frame, CelestialFrame::GCRF);
     }
 
     #[test]
@@ -1437,7 +1437,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_oem_register_for_itrf() {
-        // Covers the ITRF arm of register_for's OrbitFrame -> CelestialFrame
+        // Covers the ITRF arm of register_for's frame mapping
         // mapping (test_oem_register_for above only exercises GCRF). The
         // asset is a short single-segment ITRF2014 OEM, which is all
         // register_for needs.
@@ -1450,7 +1450,7 @@ mod tests {
         oem.register_for("ISS_ITRF").unwrap();
 
         let traj = DOrbitTrajectory::try_from(&oem).unwrap();
-        assert_eq!(traj.frame, OrbitFrame::ITRF);
+        assert_eq!(traj.frame, CelestialFrame::ITRF);
         let epoch = traj.first().unwrap().0 + 300.0;
 
         let (frame, state) = object_state(&"ISS_ITRF".into(), epoch).unwrap();
@@ -1477,19 +1477,19 @@ mod tests {
     fn test_ccsds_ref_frame_mapping() {
         assert_eq!(
             ccsds_ref_frame_to_orbit_frame(&CCSDSRefFrame::EME2000).unwrap(),
-            OrbitFrame::EME2000
+            CelestialFrame::EME2000
         );
         assert_eq!(
             ccsds_ref_frame_to_orbit_frame(&CCSDSRefFrame::GCRF).unwrap(),
-            OrbitFrame::GCRF
+            CelestialFrame::GCRF
         );
         assert_eq!(
             ccsds_ref_frame_to_orbit_frame(&CCSDSRefFrame::ITRF2000).unwrap(),
-            OrbitFrame::ITRF
+            CelestialFrame::ITRF
         );
         assert_eq!(
             ccsds_ref_frame_to_orbit_frame(&CCSDSRefFrame::J2000).unwrap(),
-            OrbitFrame::EME2000
+            CelestialFrame::EME2000
         );
         // Orbit-relative frames should fail
         assert!(ccsds_ref_frame_to_orbit_frame(&CCSDSRefFrame::RTN).is_err());

--- a/src/frames/frame/mod.rs
+++ b/src/frames/frame/mod.rs
@@ -835,6 +835,20 @@ impl From<CelestialFrame> for ReferenceFrame {
     }
 }
 
+impl PartialEq<CelestialFrame> for ReferenceFrame {
+    /// A `ReferenceFrame` equals a `CelestialFrame` when it is that celestial
+    /// frame; orbit-relative and body frames never equal a celestial frame.
+    fn eq(&self, other: &CelestialFrame) -> bool {
+        matches!(self, ReferenceFrame::Celestial(c) if c == other)
+    }
+}
+
+impl PartialEq<ReferenceFrame> for CelestialFrame {
+    fn eq(&self, other: &ReferenceFrame) -> bool {
+        other == self
+    }
+}
+
 impl From<OrbitRelativeFrame> for ReferenceFrame {
     fn from(frame: OrbitRelativeFrame) -> Self {
         ReferenceFrame::OrbitRelative {
@@ -919,6 +933,16 @@ mod tests {
             )
             .is_ok()
         );
+    }
+
+    #[test]
+    #[parallel]
+    fn test_reference_frame_equals_celestial_frame() {
+        let gcrf: ReferenceFrame = CelestialFrame::GCRF.into();
+        assert!(gcrf == CelestialFrame::GCRF);
+        assert!(CelestialFrame::GCRF == gcrf);
+        assert!(gcrf != CelestialFrame::ITRF);
+        assert!(ReferenceFrame::RTN("SC") != CelestialFrame::GCRF);
     }
 
     #[test]

--- a/src/frames/graph.rs
+++ b/src/frames/graph.rs
@@ -526,7 +526,6 @@ pub(crate) fn icrf_aligned_inertial(frame: CelestialFrame) -> CelestialFrame {
 /// - `Ok(CelestialFrame)`: The root
 /// - `Err(BraheError)`: If `frame` is unbound, its object is not
 ///   registered, or a link in its chain is missing
-#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn celestial_root(frame: &ReferenceFrame) -> Result<CelestialFrame, BraheError> {
     match frame {
         ReferenceFrame::Celestial(celestial) => Ok(*celestial),

--- a/src/frames/graph.rs
+++ b/src/frames/graph.rs
@@ -919,7 +919,6 @@ mod tests {
         );
 
         // Orbit-relative: root is the bound object's declared frame.
-        let epc = Epoch::from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
         let oe = SVector6::new(R_EARTH + 500e3, 0.001, 97.8, 15.0, 30.0, 45.0);
         let x = state_koe_to_eci(oe, AngleFormat::Degrees);
         register_object("SC", FnProvider(move |_e| Ok(x)), CelestialFrame::EME2000).unwrap();
@@ -960,7 +959,6 @@ mod tests {
         );
         assert!(celestial_root(&ReferenceFrame::RTN("GHOST")).is_err());
         assert!(celestial_root(&ReferenceFrame::SC_BODY("GHOST")).is_err());
-        let _ = epc;
         clear_frame_registry();
         clear_object_registry();
     }

--- a/src/frames/graph.rs
+++ b/src/frames/graph.rs
@@ -27,8 +27,8 @@
 use nalgebra::Vector3;
 
 use crate::frames::kinematics::{state_inertial_to_rotating, state_rotating_to_inertial};
-use crate::frames::object_registry::object_state;
-use crate::frames::registry::{FrameKey, frame_entry};
+use crate::frames::object_registry::{object_frame, object_state};
+use crate::frames::registry::{FrameKey, frame_entry, frame_key};
 use crate::frames::{
     BodyFrame, CelestialFrame, ObjectId, OrbitRelativeFrameKind, OrbitRelativeFrameVariant,
     ReferenceFrame,
@@ -484,7 +484,7 @@ fn resolve_orbit_relative(
 ///
 /// # Returns
 /// - `CelestialFrame`: The ICRF-aligned frame centered on `frame`'s center
-fn icrf_aligned_inertial(frame: CelestialFrame) -> CelestialFrame {
+pub(crate) fn icrf_aligned_inertial(frame: CelestialFrame) -> CelestialFrame {
     match frame {
         CelestialFrame::GCRF
         | CelestialFrame::LCI
@@ -509,6 +509,47 @@ fn icrf_aligned_inertial(frame: CelestialFrame) -> CelestialFrame {
                 CelestialFrame::BodyCenteredICRF(center)
             }
         }
+    }
+}
+
+/// The celestial frame terminating `frame`'s chain, found without
+/// evaluating any rotation.
+///
+/// A celestial frame is its own root. A bound orbit-relative frame's root is
+/// its object's declared frame. A bound body frame's root is found by walking
+/// the frame registry's parent links until a celestial frame.
+///
+/// # Arguments
+/// - `frame`: The frame to resolve
+///
+/// # Returns
+/// - `Ok(CelestialFrame)`: The root
+/// - `Err(BraheError)`: If `frame` is unbound, its object is not
+///   registered, or a link in its chain is missing
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) fn celestial_root(frame: &ReferenceFrame) -> Result<CelestialFrame, BraheError> {
+    match frame {
+        ReferenceFrame::Celestial(celestial) => Ok(*celestial),
+        ReferenceFrame::OrbitRelative {
+            object: Some(object),
+            ..
+        } => object_frame(object),
+        ReferenceFrame::Body {
+            object: Some(_), ..
+        } => {
+            let mut current = frame.clone();
+            loop {
+                let key = frame_key(&current).ok_or_else(|| missing_link_error(frame, &current))?;
+                let entry = frame_entry(&key).ok_or_else(|| missing_link_error(frame, &current))?;
+                match entry.parent {
+                    Some(ReferenceFrame::Celestial(celestial)) => return Ok(celestial),
+                    Some(parent) => current = parent,
+                    None => return Err(missing_link_error(frame, &current)),
+                }
+            }
+        }
+        ReferenceFrame::Body { object: None, .. }
+        | ReferenceFrame::OrbitRelative { object: None, .. } => Err(unbound_frame_error(frame)),
     }
 }
 
@@ -863,6 +904,65 @@ mod tests {
         let r =
             rotation_frame_to_frame(CelestialFrame::GCRF, ReferenceFrame::RTN("A"), epc).unwrap();
         assert_abs_diff_eq!(r, rotation_eci_to_rtn(x), epsilon = 1e-14);
+        clear_object_registry();
+    }
+
+    #[test]
+    #[serial]
+    fn test_celestial_root_resolves_every_frame_kind() {
+        clear_frame_registry();
+        clear_object_registry();
+        setup_global_test_eop();
+
+        assert_eq!(
+            celestial_root(&CelestialFrame::TOD.into()).unwrap(),
+            CelestialFrame::TOD
+        );
+
+        // Orbit-relative: root is the bound object's declared frame.
+        let epc = Epoch::from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+        let oe = SVector6::new(R_EARTH + 500e3, 0.001, 97.8, 15.0, 30.0, 45.0);
+        let x = state_koe_to_eci(oe, AngleFormat::Degrees);
+        register_object("SC", FnProvider(move |_e| Ok(x)), CelestialFrame::EME2000).unwrap();
+        assert_eq!(
+            celestial_root(&ReferenceFrame::RTN("SC")).unwrap(),
+            CelestialFrame::EME2000
+        );
+
+        // Body chain: SC_BODY -> GCRF, CSS_1 -> SC_BODY.
+        register_frame(
+            ReferenceFrame::SC_BODY("SC"),
+            CelestialFrame::GCRF.into(),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+        )
+        .unwrap();
+        register_frame(
+            ReferenceFrame::CSS("SC", "1"),
+            ReferenceFrame::SC_BODY("SC"),
+            Quaternion::new(1.0, 0.0, 0.0, 0.0),
+        )
+        .unwrap();
+        assert_eq!(
+            celestial_root(&ReferenceFrame::CSS("SC", "1")).unwrap(),
+            CelestialFrame::GCRF
+        );
+
+        // Unbound and unregistered frames error.
+        assert!(
+            celestial_root(
+                &ReferenceFrame::orbit_relative(
+                    OrbitRelativeFrameKind::RTN,
+                    OrbitRelativeFrameVariant::Rotating,
+                    None
+                )
+                .unwrap()
+            )
+            .is_err()
+        );
+        assert!(celestial_root(&ReferenceFrame::RTN("GHOST")).is_err());
+        assert!(celestial_root(&ReferenceFrame::SC_BODY("GHOST")).is_err());
+        let _ = epc;
+        clear_frame_registry();
         clear_object_registry();
     }
 

--- a/src/frames/graph.rs
+++ b/src/frames/graph.rs
@@ -538,12 +538,13 @@ pub(crate) fn celestial_root(frame: &ReferenceFrame) -> Result<CelestialFrame, B
         } => {
             let mut current = frame.clone();
             loop {
-                let key = frame_key(&current).ok_or_else(|| missing_link_error(frame, &current))?;
-                let entry = frame_entry(&key).ok_or_else(|| missing_link_error(frame, &current))?;
-                match entry.parent {
-                    Some(ReferenceFrame::Celestial(celestial)) => return Ok(celestial),
-                    Some(parent) => current = parent,
-                    None => return Err(missing_link_error(frame, &current)),
+                let parent = frame_key(&current)
+                    .and_then(|key| frame_entry(&key))
+                    .and_then(|entry| entry.parent)
+                    .ok_or_else(|| missing_link_error(frame, &current))?;
+                match parent {
+                    ReferenceFrame::Celestial(celestial) => return Ok(celestial),
+                    parent => current = parent,
                 }
             }
         }

--- a/src/frames/mod.rs
+++ b/src/frames/mod.rs
@@ -35,6 +35,8 @@ mod registry;
 pub mod synodic;
 pub mod transform;
 
+pub(crate) use graph::{celestial_root, icrf_aligned_inertial};
+
 pub use custom::*;
 pub use eci_ecef::*;
 pub use emb::*;

--- a/src/frames/object_registry.rs
+++ b/src/frames/object_registry.rs
@@ -195,6 +195,24 @@ pub(crate) fn object_state(
     Ok((entry.frame, state))
 }
 
+/// The celestial frame a registered object's states are declared in.
+///
+/// # Arguments
+/// * `name` - The registered object
+///
+/// # Returns
+/// * `Ok(CelestialFrame)`: The declared frame
+/// * `Err(BraheError)`: If no object is registered under `name`
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) fn object_frame(name: &ObjectId) -> Result<CelestialFrame, BraheError> {
+    OBJECT_REGISTRY
+        .read()
+        .unwrap()
+        .get(name)
+        .map(|entry| entry.frame)
+        .ok_or_else(|| unknown_object_error(name))
+}
+
 /// Adapts a dynamic-sized [`DStateProvider`] into [`SStateProvider`], so a
 /// provider whose native state is a `DVector` (e.g. `DOrbitTrajectory`, or a
 /// propagator carrying a state transition matrix alongside the state) can

--- a/src/frames/object_registry.rs
+++ b/src/frames/object_registry.rs
@@ -203,7 +203,6 @@ pub(crate) fn object_state(
 /// # Returns
 /// * `Ok(CelestialFrame)`: The declared frame
 /// * `Err(BraheError)`: If no object is registered under `name`
-#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn object_frame(name: &ObjectId) -> Result<CelestialFrame, BraheError> {
     OBJECT_REGISTRY
         .read()

--- a/src/frames/registry.rs
+++ b/src/frames/registry.rs
@@ -56,7 +56,7 @@ pub(crate) static FRAME_REGISTRY: Lazy<RwLock<HashMap<FrameKey, FrameEntry>>> =
 /// Converts a bound `Body` frame into its registry key. Returns `None` for
 /// every other frame (celestial, orbit-relative, or an unbound body frame),
 /// none of which can be registered under [`register_frame`].
-fn frame_key(frame: &ReferenceFrame) -> Option<FrameKey> {
+pub(crate) fn frame_key(frame: &ReferenceFrame) -> Option<FrameKey> {
     match frame {
         ReferenceFrame::Body {
             frame,

--- a/src/propagators/dnumerical_orbit_propagator.rs
+++ b/src/propagators/dnumerical_orbit_propagator.rs
@@ -45,8 +45,9 @@ use crate::propagators::{
 use crate::relative_motion::rotation_eci_to_rtn;
 use crate::spice::{SPICEKernel, moon_position_spice, spk_position, spk_state, sun_position_spice};
 use crate::time::Epoch;
-use crate::traits::{OrbitFrame, OrbitRepresentation};
+use crate::traits::OrbitRepresentation;
 use crate::trajectories::DOrbitTrajectory;
+use crate::trajectories::traits::bci_reference_frame;
 use crate::trajectories::traits::{
     InterpolatableTrajectory, STMStorage, SensitivityStorage, Trajectory,
 };
@@ -1077,8 +1078,8 @@ impl DNumericalOrbitPropagator {
         // stored states and Earth-frame trajectory conversions are rejected
         // for non-Earth propagators.
         let trajectory_frame = match force_config.central_body {
-            CentralBody::Earth => OrbitFrame::ECI,
-            ref cb => OrbitFrame::BodyCenteredInertial(cb.naif_id()),
+            CentralBody::Earth => CelestialFrame::GCRF,
+            ref cb => bci_reference_frame(cb.naif_id()),
         };
         let trajectory = DOrbitTrajectory::new(
             state_dim,
@@ -3324,8 +3325,8 @@ impl super::traits::DStatePropagator for DNumericalOrbitPropagator {
         // Clear trajectory, keeping the frame metadata consistent with the
         // central body (ECI for Earth, body-centered inertial otherwise).
         let trajectory_frame = match self.central_body.as_ref() {
-            CentralBody::Earth => OrbitFrame::ECI,
-            cb => OrbitFrame::BodyCenteredInertial(cb.naif_id()),
+            CentralBody::Earth => CelestialFrame::GCRF,
+            cb => bci_reference_frame(cb.naif_id()),
         };
         self.trajectory = DOrbitTrajectory::new(
             self.state_dim,
@@ -7557,7 +7558,7 @@ mod tests {
         let mut kep_prop = KeplerianPropagator::new(
             epoch,
             state,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             60.0,
@@ -14107,10 +14108,7 @@ mod tests {
         setup_global_test_eop();
 
         let (mut prop, epoch0, _x0) = lunar_point_mass_propagator_at_epoch0();
-        assert_eq!(
-            prop.trajectory().frame,
-            OrbitFrame::BodyCenteredInertial(301)
-        );
+        assert_eq!(prop.trajectory().frame, CelestialFrame::LCI);
 
         // Earth-frame conversions on the body-centered trajectory re-center
         // through SPK instead of mislabeling LCI samples as geocentric: the
@@ -14147,10 +14145,7 @@ mod tests {
 
         // reset preserves the body-centered frame metadata.
         prop.reset();
-        assert_eq!(
-            prop.trajectory().frame,
-            OrbitFrame::BodyCenteredInertial(301)
-        );
+        assert_eq!(prop.trajectory().frame, CelestialFrame::LCI);
 
         // Earth-centered propagators keep the ECI label and conversions.
         let epoch = Epoch::from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
@@ -14166,7 +14161,7 @@ mod tests {
             None,
         )
         .unwrap();
-        assert_eq!(earth_prop.trajectory().frame, OrbitFrame::ECI);
+        assert_eq!(earth_prop.trajectory().frame, CelestialFrame::ECI);
         earth_prop.propagate_to(epoch + 60.0).unwrap();
         assert!(earth_prop.trajectory().state_eci(epoch).is_ok());
     }

--- a/src/propagators/dnumerical_orbit_propagator.rs
+++ b/src/propagators/dnumerical_orbit_propagator.rs
@@ -1077,10 +1077,7 @@ impl DNumericalOrbitPropagator {
         // (LCI/MCI/EMBI/...) otherwise, so the frame metadata matches the
         // stored states and Earth-frame trajectory conversions are rejected
         // for non-Earth propagators.
-        let trajectory_frame = match force_config.central_body {
-            CentralBody::Earth => CelestialFrame::GCRF,
-            ref cb => bci_reference_frame(cb.naif_id()),
-        };
+        let trajectory_frame = bci_reference_frame(force_config.central_body.naif_id());
         let trajectory = DOrbitTrajectory::new(
             state_dim,
             trajectory_frame,
@@ -3324,10 +3321,7 @@ impl super::traits::DStatePropagator for DNumericalOrbitPropagator {
 
         // Clear trajectory, keeping the frame metadata consistent with the
         // central body (ECI for Earth, body-centered inertial otherwise).
-        let trajectory_frame = match self.central_body.as_ref() {
-            CentralBody::Earth => CelestialFrame::GCRF,
-            cb => bci_reference_frame(cb.naif_id()),
-        };
+        let trajectory_frame = bci_reference_frame(self.central_body.naif_id());
         self.trajectory = DOrbitTrajectory::new(
             self.state_dim,
             trajectory_frame,

--- a/src/propagators/dnumerical_orbit_propagator.rs
+++ b/src/propagators/dnumerical_orbit_propagator.rs
@@ -14092,10 +14092,10 @@ mod tests {
         (prop, epoch0, x0)
     }
 
-    /// A non-Earth propagator's stored trajectory is labeled
-    /// `BodyCenteredInertial`, so Earth-frame trajectory conversions are
-    /// rejected instead of silently treating body-centered samples as
-    /// geocentric ECI; an Earth propagator's trajectory stays `ECI`.
+    /// A non-Earth propagator's stored trajectory is labeled with that body's
+    /// centered inertial frame, so Earth-frame trajectory conversions re-center
+    /// the samples instead of silently treating them as geocentric ECI; an
+    /// Earth propagator's trajectory stays `ECI`.
     #[test]
     #[serial]
     fn test_trajectory_frame_matches_central_body() {

--- a/src/propagators/keplerian_propagator.rs
+++ b/src/propagators/keplerian_propagator.rs
@@ -9,16 +9,16 @@ use std::f64::consts::PI;
 use crate::constants::AngleFormat;
 use crate::constants::{DEG2RAD, RAD2DEG, RADIANS};
 use crate::coordinates::{state_eci_to_koe, state_koe_to_eci};
-use crate::frames::CelestialFrame;
 use crate::frames::{
-    state_eci_to_ecef, state_eme2000_to_gcrf, state_gcrf_to_eme2000, state_gcrf_to_itrf,
-    state_itrf_to_gcrf,
+    CelestialFrame, ReferenceFrame, celestial_root, state_eci_to_ecef, state_frame_to_frame,
+    state_gcrf_to_eme2000, state_gcrf_to_itrf,
 };
 use crate::orbits::keplerian::mean_motion;
 use crate::propagators::traits::{SOrbitPropagator, SStatePropagator};
+use crate::spice::NAIFId;
 use crate::time::Epoch;
 use crate::trajectories::DOrbitTrajectory;
-use crate::trajectories::traits::{OrbitRepresentation, Trajectory};
+use crate::trajectories::traits::{OrbitRepresentation, Trajectory, keplerian_center};
 use crate::utils::state_providers::{DOrbitStateProvider, DStateProvider};
 use crate::utils::{BraheError, Identifiable};
 
@@ -38,7 +38,7 @@ pub struct KeplerianPropagator {
     pub initial_state: Vector6<f64>,
 
     /// Frame of the input/output states
-    pub frame: CelestialFrame,
+    pub frame: ReferenceFrame,
 
     /// Representation of the input/output states
     pub representation: OrbitRepresentation,
@@ -77,11 +77,16 @@ pub struct KeplerianPropagator {
 impl KeplerianPropagator {
     /// Validate a frame / representation / angle-format combination.
     ///
+    /// # Arguments
+    /// * `frame` - Frame the states are expressed in
+    /// * `representation` - Type of state representation
+    /// * `angle_format` - Format for angular elements (`None` for Cartesian)
+    ///
     /// # Returns
     /// `Ok(())` when the combination is supported, or an error describing the
     /// incompatibility.
     fn validate_format(
-        frame: CelestialFrame,
+        frame: &ReferenceFrame,
         representation: OrbitRepresentation,
         angle_format: Option<AngleFormat>,
     ) -> Result<(), BraheError> {
@@ -91,25 +96,20 @@ impl KeplerianPropagator {
             ));
         }
 
-        if representation == OrbitRepresentation::Keplerian && frame != CelestialFrame::ECI {
-            return Err(BraheError::PropagatorError(
-                "Keplerian elements must be in ECI frame".to_string(),
-            ));
-        }
-
         if representation == OrbitRepresentation::Cartesian && angle_format.is_some() {
             return Err(BraheError::PropagatorError(
                 "Angle format should be None for Cartesian representation".to_string(),
             ));
         }
 
-        if !matches!(
-            frame,
-            CelestialFrame::GCRF | CelestialFrame::EME2000 | CelestialFrame::ITRF
-        ) {
+        if representation == OrbitRepresentation::Keplerian {
+            keplerian_center(frame)?;
+        }
+
+        let center = celestial_root(frame)?.center_naif_id();
+        if center != NAIFId::Earth.id() {
             return Err(BraheError::PropagatorError(format!(
-                "frame {frame} is not supported by KeplerianPropagator (Earth-only: \
-                 GCRF/ECI, EME2000, and ITRF/ECEF)"
+                "KeplerianPropagator is Earth-only; frame {frame} is centered on {center}"
             )));
         }
 
@@ -123,16 +123,18 @@ impl KeplerianPropagator {
     ///
     /// If the output format needs to be changed, use the `with_output_format` method after initialization.
     ///
-    /// The input representation and angle format must be compatible:
-    /// * Keplerian representation requires ECI frame and a specified angle format (Degrees or Radians)
-    /// * Cartesian representation can be in ECI or ECEF frame, but angle format must be None
+    /// The propagator models two-body motion about the Earth, so every frame it
+    /// accepts must resolve to an Earth-centered frame. Cartesian states may be
+    /// expressed in any such frame, including non-celestial ones such as an
+    /// orbit-relative `RTN` frame anchored on a registered object. Keplerian
+    /// elements additionally require an inertial frame and an angle format.
     ///
     /// The step size must be positive.
     ///
     /// # Arguments
     /// * `epoch` - Initial epoch
     /// * `state` - State vector (Keplerian elements or Cartesian position/velocity)
-    /// * `frame` - Reference frame
+    /// * `frame` - Reference frame of the input and output states
     /// * `representation` - Type of state representation
     /// * `angle_format` - Format for angular elements (only for Keplerian)
     /// * `step_size` - Step size in seconds for propagation
@@ -140,19 +142,47 @@ impl KeplerianPropagator {
     /// # Returns
     /// New KeplerianPropagator instance, or an error if:
     /// - Angle format is None for Keplerian representation
-    /// - Keplerian elements are not in ECI frame
+    /// - Keplerian elements are not in an inertial frame
     /// - Angle format is not None for Cartesian representation
-    /// - The frame is body-centered inertial (Earth-only propagator)
+    /// - The frame is not Earth-centered (Earth-only propagator), or cannot be
+    ///   resolved because it is unbound or unregistered
     /// - Step size is not positive
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use brahe::propagators::KeplerianPropagator;
+    /// use brahe::traits::OrbitRepresentation;
+    /// use brahe::frames::CelestialFrame;
+    /// use brahe::constants::AngleFormat;
+    /// use brahe::eop::{StaticEOPProvider, set_global_eop_provider};
+    /// use brahe::time::{Epoch, TimeSystem};
+    /// use nalgebra::Vector6;
+    ///
+    /// set_global_eop_provider(StaticEOPProvider::from_zero());
+    ///
+    /// let epc = Epoch::from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+    /// let oe = Vector6::new(6878e3, 0.001, 97.8, 15.0, 30.0, 45.0);
+    ///
+    /// let prop = KeplerianPropagator::new(
+    ///     epc,
+    ///     oe,
+    ///     CelestialFrame::GCRF,
+    ///     OrbitRepresentation::Keplerian,
+    ///     Some(AngleFormat::Degrees),
+    ///     60.0,
+    /// ).unwrap();
+    /// ```
     pub fn new(
         epoch: Epoch,
         state: Vector6<f64>,
-        frame: CelestialFrame,
+        frame: impl Into<ReferenceFrame>,
         representation: OrbitRepresentation,
         angle_format: Option<AngleFormat>,
         step_size: f64,
     ) -> Result<Self, BraheError> {
-        Self::validate_format(frame, representation, angle_format)?;
+        let frame = frame.into();
+        Self::validate_format(&frame, representation, angle_format)?;
 
         if step_size <= 0.0 {
             return Err(BraheError::PropagatorError(
@@ -163,17 +193,17 @@ impl KeplerianPropagator {
         // Unwrap angle_format for internal conversion (use RADIANS for Cartesian)
         let angle_format_unwrapped = angle_format.unwrap_or(RADIANS);
 
-        // Convert input state to internal osculating elements in ECI frame with radians
+        // Convert input state to internal osculating elements in GCRF with radians
         let internal_elements = Self::convert_to_internal_osculating(
             epoch,
             state,
-            frame,
+            &frame,
             representation,
             angle_format_unwrapped,
-        );
+        )?;
 
         // Create initial trajectory (Keplerian propagator always uses 6D states)
-        let mut trajectory = DOrbitTrajectory::new(6, frame, representation, angle_format)?;
+        let mut trajectory = DOrbitTrajectory::new(6, frame.clone(), representation, angle_format)?;
         trajectory.add(epoch, svec6_to_dvec(state))?;
 
         let n = mean_motion(internal_elements[0], AngleFormat::Radians);
@@ -279,8 +309,8 @@ impl KeplerianPropagator {
     /// used with initialization or after a reset to avoid inconsistencies.
     ///
     /// The frame, representation, and angle format must be compatible:
-    /// * Keplerian representation requires ECI frame and a specified angle format (Degrees or Radians)
-    /// * Cartesian representation can be in ECI or ECEF frame, but angle format must be None
+    /// * Keplerian representation requires an inertial frame and a specified angle format (Degrees or Radians)
+    /// * Cartesian representation accepts any Earth-centered frame, but angle format must be None
     ///
     /// # Arguments
     /// * `frame` - Desired output frame
@@ -293,13 +323,14 @@ impl KeplerianPropagator {
     #[allow(dead_code)]
     fn with_output_format(
         mut self,
-        frame: CelestialFrame,
+        frame: impl Into<ReferenceFrame>,
         representation: OrbitRepresentation,
         angle_format: Option<AngleFormat>,
     ) -> Result<Self, BraheError> {
-        Self::validate_format(frame, representation, angle_format)?;
+        let frame = frame.into();
+        Self::validate_format(&frame, representation, angle_format)?;
 
-        self.frame = frame;
+        self.frame = frame.clone();
         self.representation = representation;
         self.angle_format = angle_format;
 
@@ -315,7 +346,7 @@ impl KeplerianPropagator {
         let converted_state = self.convert_from_internal_osculating(
             self.initial_epoch,
             self.internal_osculating_elements,
-        );
+        )?;
         self.trajectory
             .add(self.initial_epoch, svec6_to_dvec(converted_state))?;
 
@@ -325,7 +356,7 @@ impl KeplerianPropagator {
         Ok(self)
     }
 
-    /// Convert any state to internal osculating elements (ECI, radians)
+    /// Convert any state to internal osculating elements (GCRF, radians)
     ///
     /// # Arguments
     /// * `epoch` - Epoch of the input state
@@ -335,7 +366,8 @@ impl KeplerianPropagator {
     /// * `angle_format` - Angle format of the input state (only for Keplerian)
     ///
     /// # Returns
-    /// * Internal osculating elements in ECI frame with radians
+    /// * `Ok(Vector6<f64>)`: Internal osculating elements in GCRF with radians
+    /// * `Err(BraheError)`: If the frame conversion from `frame` to GCRF fails
     ///
     /// # Note
     /// Assumes that the input state is valid and consistent with the specified frame, representation, and angle format.
@@ -343,76 +375,85 @@ impl KeplerianPropagator {
     fn convert_to_internal_osculating(
         epoch: Epoch,
         state: Vector6<f64>,
-        frame: CelestialFrame,
+        frame: &ReferenceFrame,
         representation: OrbitRepresentation,
         angle_format: AngleFormat,
-    ) -> Vector6<f64> {
+    ) -> Result<Vector6<f64>, BraheError> {
         match representation {
             OrbitRepresentation::Cartesian => {
-                // First convert to ECI frame if needed
-                let eci_state = match frame {
-                    CelestialFrame::GCRF => state,
-                    CelestialFrame::EME2000 => state_eme2000_to_gcrf(state),
-                    CelestialFrame::ITRF => state_itrf_to_gcrf(epoch, state),
-                    other => {
-                        unreachable!("frame {other} is rejected by validate_format at construction")
-                    }
-                };
-
-                // Convert Cartesian to osculating elements
-                state_eci_to_koe(eci_state, AngleFormat::Radians)
+                let x_gcrf =
+                    state_frame_to_frame(frame.clone(), CelestialFrame::GCRF, epoch, state)?;
+                Ok(state_eci_to_koe(x_gcrf, AngleFormat::Radians))
             }
             OrbitRepresentation::Keplerian => {
-                // Convert angles to radians if needed
-                if angle_format == AngleFormat::Radians {
-                    state
-                } else {
-                    let mut elements = state;
+                let mut elements = state;
+                if angle_format == AngleFormat::Degrees {
                     // Convert angles from degrees to radians (i, RAAN, argp, mean_anomaly)
                     for i in 2..6 {
                         elements[i] *= DEG2RAD;
                     }
-                    elements
                 }
+
+                if *frame == CelestialFrame::GCRF {
+                    return Ok(elements);
+                }
+
+                // Elements about the Earth in another inertial frame's axes:
+                // realize them as a Cartesian state and rotate into GCRF.
+                let x_frame = state_koe_to_eci(elements, AngleFormat::Radians);
+                let x_gcrf =
+                    state_frame_to_frame(frame.clone(), CelestialFrame::GCRF, epoch, x_frame)?;
+                Ok(state_eci_to_koe(x_gcrf, AngleFormat::Radians))
             }
         }
     }
 
-    /// Convert internal osculating elements back to original state format
+    /// Convert internal osculating elements back to the output state format
+    ///
+    /// # Arguments
+    /// * `epoch` - Epoch of the internal elements
+    /// * `internal_elements` - Internal osculating elements (GCRF, radians)
+    ///
+    /// # Returns
+    /// * `Ok(Vector6<f64>)`: State in the propagator's output frame, representation and angle format
+    /// * `Err(BraheError)`: If the frame conversion from GCRF to the output frame fails
     fn convert_from_internal_osculating(
         &self,
         epoch: Epoch,
         internal_elements: Vector6<f64>,
-    ) -> Vector6<f64> {
+    ) -> Result<Vector6<f64>, BraheError> {
         match self.representation {
             OrbitRepresentation::Cartesian => {
-                // Convert osculating elements to Cartesian in ECI
-                let eci_cartesian = state_koe_to_eci(internal_elements, AngleFormat::Radians);
-
-                // Convert to original frame if needed
-                match self.frame {
-                    CelestialFrame::GCRF => eci_cartesian,
-                    CelestialFrame::EME2000 => state_gcrf_to_eme2000(eci_cartesian),
-                    CelestialFrame::ITRF => state_gcrf_to_itrf(epoch, eci_cartesian),
-                    other => {
-                        unreachable!("frame {other} is rejected by validate_format at construction")
-                    }
-                }
+                let x_gcrf = state_koe_to_eci(internal_elements, AngleFormat::Radians);
+                state_frame_to_frame(CelestialFrame::GCRF, self.frame.clone(), epoch, x_gcrf)
             }
             OrbitRepresentation::Keplerian => {
-                // Convert to original angle format
                 // For Keplerian, angle_format is guaranteed to be Some() by validation
-                match self.angle_format.unwrap() {
-                    AngleFormat::Radians => internal_elements,
-                    AngleFormat::Degrees => {
-                        let mut elements = internal_elements;
-                        // Convert angles from radians to degrees (i, RAAN, argp, mean_anomaly)
-                        for i in 2..6 {
-                            elements[i] *= RAD2DEG;
-                        }
-                        elements
+                let format = self.angle_format.unwrap();
+
+                let mut elements = if self.frame == CelestialFrame::GCRF {
+                    internal_elements
+                } else {
+                    // Elements about the Earth in another inertial frame's
+                    // axes: realize them in GCRF and rotate before converting.
+                    let x_gcrf = state_koe_to_eci(internal_elements, AngleFormat::Radians);
+                    let x_frame = state_frame_to_frame(
+                        CelestialFrame::GCRF,
+                        self.frame.clone(),
+                        epoch,
+                        x_gcrf,
+                    )?;
+                    state_eci_to_koe(x_frame, AngleFormat::Radians)
+                };
+
+                if format == AngleFormat::Degrees {
+                    // Convert angles from radians to degrees (i, RAAN, argp, mean_anomaly)
+                    for i in 2..6 {
+                        elements[i] *= RAD2DEG;
                     }
                 }
+
+                Ok(elements)
             }
         }
     }
@@ -450,7 +491,7 @@ impl SStatePropagator for KeplerianPropagator {
         let new_state = self.propagate_internal(target_epoch);
 
         // Convert back to original state format
-        let state = self.convert_from_internal_osculating(target_epoch, new_state);
+        let state = self.convert_from_internal_osculating(target_epoch, new_state)?;
 
         self.trajectory.add(target_epoch, svec6_to_dvec(state))?;
         self.epoch_current = target_epoch;
@@ -489,22 +530,32 @@ impl SStatePropagator for KeplerianPropagator {
         self.step_size = step_size;
     }
 
+    /// # Panics
+    ///
+    /// Panics if the initial state cannot be converted into the propagator's
+    /// output frame. The trait method is infallible, and the only way the
+    /// conversion can fail is an output frame that has become unresolvable
+    /// since the propagator was constructed, for example an orbit-relative
+    /// frame whose anchor object was removed from the object registry.
     fn reset(&mut self) {
         // Reset trajectory to initial state only, preserving identity
         let name = self.trajectory.get_name().map(|s| s.to_string());
         let uuid = self.trajectory.get_uuid();
         let id = self.trajectory.get_id();
 
-        self.trajectory =
-            DOrbitTrajectory::new(6, self.frame, self.representation, self.angle_format)
-                .expect("trajectory format validated at construction")
-                .with_identity(name.as_deref(), uuid, id);
+        self.trajectory = DOrbitTrajectory::new(
+            6,
+            self.frame.clone(),
+            self.representation,
+            self.angle_format,
+        )
+        .expect("trajectory format validated at construction")
+        .with_identity(name.as_deref(), uuid, id);
 
         // Convert initial state to new format and add to trajectory
-        let converted_state = self.convert_from_internal_osculating(
-            self.initial_epoch,
-            self.internal_osculating_elements,
-        );
+        let converted_state = self
+            .convert_from_internal_osculating(self.initial_epoch, self.internal_osculating_elements)
+            .unwrap_or_else(|e| panic!("frame conversion to {} failed: {}", self.frame, e));
         self.trajectory
             .add(self.initial_epoch, svec6_to_dvec(converted_state))
             .expect("trajectory state validated at construction");
@@ -527,31 +578,31 @@ impl SOrbitPropagator for KeplerianPropagator {
         &mut self,
         epoch: Epoch,
         state: Vector6<f64>,
-        frame: CelestialFrame,
+        frame: ReferenceFrame,
         representation: OrbitRepresentation,
         angle_format: Option<AngleFormat>,
     ) -> Result<(), BraheError> {
-        Self::validate_format(frame, representation, angle_format)?;
+        Self::validate_format(&frame, representation, angle_format)?;
 
         // Unwrap angle_format for internal conversion (use RADIANS for Cartesian)
         let angle_format_unwrapped = angle_format.unwrap_or(RADIANS);
-
-        // Update all state
-        self.initial_epoch = epoch;
-        self.initial_state = state;
-        self.frame = frame;
-        self.representation = representation;
-        self.angle_format = angle_format;
 
         // Recompute internal elements
         self.internal_osculating_elements = Self::convert_to_internal_osculating(
             epoch,
             state,
-            frame,
+            &frame,
             representation,
             angle_format_unwrapped,
-        );
+        )?;
         self.n = mean_motion(self.internal_osculating_elements[0], AngleFormat::Radians);
+
+        // Update all state
+        self.initial_epoch = epoch;
+        self.initial_state = state;
+        self.frame = frame.clone();
+        self.representation = representation;
+        self.angle_format = angle_format;
 
         // Reset trajectory to new initial conditions, preserving identity
         let name = self.trajectory.get_name().map(|s| s.to_string());
@@ -646,7 +697,7 @@ impl DStateProvider for KeplerianPropagator {
     fn state(&self, epoch: Epoch) -> Result<DVector<f64>, BraheError> {
         // Reuse existing internal propagation logic
         let internal_state = self.propagate_internal(epoch);
-        let sv = self.convert_from_internal_osculating(epoch, internal_state);
+        let sv = self.convert_from_internal_osculating(epoch, internal_state)?;
         Ok(svec6_to_dvec(sv))
     }
 
@@ -693,19 +744,13 @@ impl DOrbitStateProvider for KeplerianPropagator {
         Ok(state_eci_to_ecef(epoch, state_eci))
     }
 
+    /// The internal osculating elements are held in GCRF, so this is the
+    /// propagator's native output and does not depend on the configured output
+    /// frame.
     fn state_gcrf(&self, epoch: Epoch) -> Result<Vector6<f64>, BraheError> {
         let internal_state = self.propagate_internal(epoch);
         // Always convert to Cartesian for DOrbitStateProvider methods
-        let state_eci = state_koe_to_eci(internal_state, AngleFormat::Radians);
-
-        match self.frame {
-            CelestialFrame::GCRF | CelestialFrame::ITRF => Ok(state_eci),
-            CelestialFrame::EME2000 => Ok(state_eme2000_to_gcrf(state_eci)),
-            other => Err(BraheError::Error(format!(
-                "frame {other} is not supported by KeplerianPropagator (Earth-only: \
-                 GCRF/ECI, EME2000, and ITRF/ECEF)"
-            ))),
-        }
+        Ok(state_koe_to_eci(internal_state, AngleFormat::Radians))
     }
 
     fn state_itrf(&self, epoch: Epoch) -> Result<Vector6<f64>, BraheError> {
@@ -745,12 +790,15 @@ mod tests {
     use super::*;
     use crate::DEGREES;
     use crate::coordinates::state_eci_to_koe;
-    use crate::frames::{CelestialFrame, state_ecef_to_eci};
+    use crate::frames::{
+        CelestialFrame, DStateAdapter, ReferenceFrame, clear_object_registry, register_object,
+        state_ecef_to_eci, state_eme2000_to_gcrf, state_gcrf_to_tod, state_itrf_to_gcrf,
+    };
     use crate::orbits::keplerian::orbital_period;
     use crate::time::{Epoch, TimeSystem};
     use crate::utils::testing::setup_global_test_eop;
     use approx::assert_abs_diff_eq;
-    use serial_test::parallel;
+    use serial_test::{parallel, serial};
 
     // Test data constants
     const TEST_EPOCH_JD: f64 = 2451545.0;
@@ -801,7 +849,7 @@ mod tests {
     #[test]
     #[parallel]
     fn test_keplerianpropagator_new_rejects_bci_frame() {
-        // KeplerianPropagator is Earth-only; body-centered inertial frames are rejected
+        // KeplerianPropagator is Earth-only; frames centered on another body are rejected
         let epoch = Epoch::from_jd(TEST_EPOCH_JD, TimeSystem::UTC);
         let state = create_cartesian_state();
 
@@ -819,7 +867,7 @@ mod tests {
             result
                 .unwrap_err()
                 .to_string()
-                .contains("is not supported by KeplerianPropagator")
+                .contains("KeplerianPropagator is Earth-only")
         );
     }
 
@@ -900,13 +948,13 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Keplerian elements must be in ECI frame")]
+    #[should_panic(expected = "Keplerian element trajectories should be in an inertial frame")]
     #[parallel]
     fn test_keplerianpropagator_new_invalid_frame() {
         let epoch = Epoch::from_jd(TEST_EPOCH_JD, TimeSystem::UTC);
         let elements = create_test_elements();
 
-        // This should panic because Keplerian elements are not in ECI frame
+        // This should panic because Keplerian elements are not in an inertial frame
         let _propagator = KeplerianPropagator::new(
             epoch,
             elements,
@@ -1290,7 +1338,7 @@ mod tests {
             .set_initial_conditions(
                 new_epoch,
                 new_elements,
-                CelestialFrame::ECI,
+                CelestialFrame::ECI.into(),
                 OrbitRepresentation::Keplerian,
                 Some(AngleFormat::Radians),
             )
@@ -1888,5 +1936,150 @@ mod tests {
         assert_eq!(prop.get_name(), Some("Chained Orbit"));
         assert_eq!(prop.get_id(), Some(999));
         assert_eq!(prop.get_uuid(), Some(test_uuid));
+    }
+
+    #[test]
+    #[serial]
+    fn test_keplerian_propagator_output_in_tod_and_rtn() {
+        setup_global_test_eop();
+        clear_object_registry();
+
+        let epc = Epoch::from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+        let x_gcrf = create_cartesian_state();
+
+        let prop = KeplerianPropagator::new(
+            epc,
+            x_gcrf,
+            CelestialFrame::GCRF,
+            OrbitRepresentation::Cartesian,
+            None,
+            60.0,
+        )
+        .unwrap();
+
+        // A true-of-date output format matches the direct GCRF -> TOD rotation.
+        let tod = prop
+            .clone()
+            .with_output_format(CelestialFrame::TOD, OrbitRepresentation::Cartesian, None)
+            .unwrap();
+        let x_tod = tod.state(epc).unwrap();
+        let expected = state_gcrf_to_tod(epc, x_gcrf);
+        for k in 0..6 {
+            assert_abs_diff_eq!(x_tod[k], expected[k], epsilon = 1e-6);
+        }
+
+        // The inertial accessors are independent of the output format.
+        let x_back = tod.state_gcrf(epc).unwrap();
+        for k in 0..6 {
+            assert_abs_diff_eq!(x_back[k], x_gcrf[k], epsilon = 1e-6);
+        }
+
+        // An orbit-relative output frame anchored on the propagated orbit puts
+        // the propagated state at the frame origin.
+        let mut anchor = DOrbitTrajectory::new(
+            6,
+            CelestialFrame::GCRF,
+            OrbitRepresentation::Cartesian,
+            None,
+        )
+        .unwrap();
+        for k in 0..5 {
+            let epc_k = epc + 60.0 * k as f64;
+            anchor
+                .add(epc_k, svec6_to_dvec(prop.state_gcrf(epc_k).unwrap()))
+                .unwrap();
+        }
+        register_object(
+            "KEPLERIAN_RTN_ANCHOR",
+            DStateAdapter::new(anchor).unwrap(),
+            CelestialFrame::GCRF,
+        )
+        .unwrap();
+
+        let rtn = prop
+            .clone()
+            .with_output_format(
+                ReferenceFrame::RTN("KEPLERIAN_RTN_ANCHOR"),
+                OrbitRepresentation::Cartesian,
+                None,
+            )
+            .unwrap();
+        let x_rtn = rtn.state(epc + 120.0).unwrap();
+        for k in 0..3 {
+            assert_abs_diff_eq!(x_rtn[k], 0.0, epsilon = 1e-6);
+        }
+
+        // Non-Earth frames are rejected: Earth-only propagator.
+        assert!(
+            prop.clone()
+                .with_output_format(CelestialFrame::LCI, OrbitRepresentation::Cartesian, None)
+                .is_err()
+        );
+
+        // Keplerian output requires an inertial frame.
+        assert!(
+            prop.clone()
+                .with_output_format(
+                    CelestialFrame::ITRF,
+                    OrbitRepresentation::Keplerian,
+                    Some(AngleFormat::Degrees),
+                )
+                .is_err()
+        );
+
+        clear_object_registry();
+    }
+
+    #[test]
+    #[serial]
+    fn test_keplerian_propagator_keplerian_elements_in_eme2000() {
+        setup_global_test_eop();
+
+        // Keplerian output is allowed in any inertial Earth-centered frame, and
+        // the elements are about the Earth in that frame's own axes.
+        let epc = Epoch::from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+        let x_gcrf = create_cartesian_state();
+
+        let prop = KeplerianPropagator::new(
+            epc,
+            x_gcrf,
+            CelestialFrame::GCRF,
+            OrbitRepresentation::Cartesian,
+            None,
+            60.0,
+        )
+        .unwrap();
+
+        let eme = prop
+            .clone()
+            .with_output_format(
+                CelestialFrame::EME2000,
+                OrbitRepresentation::Keplerian,
+                Some(DEGREES),
+            )
+            .unwrap();
+
+        let oe_eme = eme.state(epc).unwrap();
+        let expected = state_eci_to_koe(state_gcrf_to_eme2000(x_gcrf), DEGREES);
+        for k in 0..6 {
+            assert_abs_diff_eq!(oe_eme[k], expected[k], epsilon = 1e-8);
+        }
+
+        // Feeding those elements back in as EME2000 elements recovers the
+        // original GCRF state, rather than treating them as GCRF elements.
+        let round_trip = KeplerianPropagator::new(
+            epc,
+            Vector6::from_iterator(oe_eme.iter().copied()),
+            CelestialFrame::EME2000,
+            OrbitRepresentation::Keplerian,
+            Some(DEGREES),
+            60.0,
+        )
+        .unwrap();
+
+        let x_back = round_trip.state_gcrf(epc).unwrap();
+        for k in 0..6 {
+            assert_abs_diff_eq!(x_back[k], x_gcrf[k], epsilon = 1e-6);
+        }
     }
 }

--- a/src/propagators/keplerian_propagator.rs
+++ b/src/propagators/keplerian_propagator.rs
@@ -9,15 +9,16 @@ use std::f64::consts::PI;
 use crate::constants::AngleFormat;
 use crate::constants::{DEG2RAD, RAD2DEG, RADIANS};
 use crate::coordinates::{state_eci_to_koe, state_koe_to_eci};
+use crate::frames::CelestialFrame;
 use crate::frames::{
-    state_ecef_to_eci, state_eci_to_ecef, state_eme2000_to_gcrf, state_gcrf_to_eme2000,
-    state_gcrf_to_itrf, state_itrf_to_gcrf,
+    state_eci_to_ecef, state_eme2000_to_gcrf, state_gcrf_to_eme2000, state_gcrf_to_itrf,
+    state_itrf_to_gcrf,
 };
 use crate::orbits::keplerian::mean_motion;
 use crate::propagators::traits::{SOrbitPropagator, SStatePropagator};
 use crate::time::Epoch;
 use crate::trajectories::DOrbitTrajectory;
-use crate::trajectories::traits::{OrbitFrame, OrbitRepresentation, Trajectory};
+use crate::trajectories::traits::{OrbitRepresentation, Trajectory};
 use crate::utils::state_providers::{DOrbitStateProvider, DStateProvider};
 use crate::utils::{BraheError, Identifiable};
 
@@ -37,7 +38,7 @@ pub struct KeplerianPropagator {
     pub initial_state: Vector6<f64>,
 
     /// Frame of the input/output states
-    pub frame: OrbitFrame,
+    pub frame: CelestialFrame,
 
     /// Representation of the input/output states
     pub representation: OrbitRepresentation,
@@ -80,7 +81,7 @@ impl KeplerianPropagator {
     /// `Ok(())` when the combination is supported, or an error describing the
     /// incompatibility.
     fn validate_format(
-        frame: OrbitFrame,
+        frame: CelestialFrame,
         representation: OrbitRepresentation,
         angle_format: Option<AngleFormat>,
     ) -> Result<(), BraheError> {
@@ -90,7 +91,7 @@ impl KeplerianPropagator {
             ));
         }
 
-        if representation == OrbitRepresentation::Keplerian && frame != OrbitFrame::ECI {
+        if representation == OrbitRepresentation::Keplerian && frame != CelestialFrame::ECI {
             return Err(BraheError::PropagatorError(
                 "Keplerian elements must be in ECI frame".to_string(),
             ));
@@ -102,12 +103,14 @@ impl KeplerianPropagator {
             ));
         }
 
-        if matches!(frame, OrbitFrame::BodyCenteredInertial(_)) {
-            return Err(BraheError::PropagatorError(
-                "OrbitFrame::BodyCenteredInertial is not supported by KeplerianPropagator \
-                 (Earth-only)"
-                    .to_string(),
-            ));
+        if !matches!(
+            frame,
+            CelestialFrame::GCRF | CelestialFrame::EME2000 | CelestialFrame::ITRF
+        ) {
+            return Err(BraheError::PropagatorError(format!(
+                "frame {frame} is not supported by KeplerianPropagator (Earth-only: \
+                 GCRF/ECI, EME2000, and ITRF/ECEF)"
+            )));
         }
 
         Ok(())
@@ -144,7 +147,7 @@ impl KeplerianPropagator {
     pub fn new(
         epoch: Epoch,
         state: Vector6<f64>,
-        frame: OrbitFrame,
+        frame: CelestialFrame,
         representation: OrbitRepresentation,
         angle_format: Option<AngleFormat>,
         step_size: f64,
@@ -219,7 +222,7 @@ impl KeplerianPropagator {
         Self::new(
             epoch,
             elements,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Keplerian,
             Some(angle_format),
             step_size,
@@ -240,7 +243,7 @@ impl KeplerianPropagator {
         Self::new(
             epoch,
             state,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             step_size,
@@ -264,7 +267,7 @@ impl KeplerianPropagator {
         Self::new(
             epoch,
             state,
-            OrbitFrame::ECEF,
+            CelestialFrame::ECEF,
             OrbitRepresentation::Cartesian,
             None,
             step_size,
@@ -290,7 +293,7 @@ impl KeplerianPropagator {
     #[allow(dead_code)]
     fn with_output_format(
         mut self,
-        frame: OrbitFrame,
+        frame: CelestialFrame,
         representation: OrbitRepresentation,
         angle_format: Option<AngleFormat>,
     ) -> Result<Self, BraheError> {
@@ -340,7 +343,7 @@ impl KeplerianPropagator {
     fn convert_to_internal_osculating(
         epoch: Epoch,
         state: Vector6<f64>,
-        frame: OrbitFrame,
+        frame: CelestialFrame,
         representation: OrbitRepresentation,
         angle_format: AngleFormat,
     ) -> Vector6<f64> {
@@ -348,17 +351,12 @@ impl KeplerianPropagator {
             OrbitRepresentation::Cartesian => {
                 // First convert to ECI frame if needed
                 let eci_state = match frame {
-                    OrbitFrame::BodyCenteredInertial(_) => {
-                        unreachable!(
-                            "BodyCenteredInertial frames are rejected by validate_format at \
-                             construction"
-                        )
+                    CelestialFrame::GCRF => state,
+                    CelestialFrame::EME2000 => state_eme2000_to_gcrf(state),
+                    CelestialFrame::ITRF => state_itrf_to_gcrf(epoch, state),
+                    other => {
+                        unreachable!("frame {other} is rejected by validate_format at construction")
                     }
-                    OrbitFrame::ECI => state,
-                    OrbitFrame::GCRF => state,
-                    OrbitFrame::EME2000 => state_eme2000_to_gcrf(state),
-                    OrbitFrame::ECEF => state_ecef_to_eci(epoch, state),
-                    OrbitFrame::ITRF => state_itrf_to_gcrf(epoch, state),
                 };
 
                 // Convert Cartesian to osculating elements
@@ -393,17 +391,12 @@ impl KeplerianPropagator {
 
                 // Convert to original frame if needed
                 match self.frame {
-                    OrbitFrame::BodyCenteredInertial(_) => {
-                        unreachable!(
-                            "BodyCenteredInertial frames are rejected by validate_format at \
-                             construction"
-                        )
+                    CelestialFrame::GCRF => eci_cartesian,
+                    CelestialFrame::EME2000 => state_gcrf_to_eme2000(eci_cartesian),
+                    CelestialFrame::ITRF => state_gcrf_to_itrf(epoch, eci_cartesian),
+                    other => {
+                        unreachable!("frame {other} is rejected by validate_format at construction")
                     }
-                    OrbitFrame::ECI => eci_cartesian,
-                    OrbitFrame::GCRF => eci_cartesian,
-                    OrbitFrame::EME2000 => state_gcrf_to_eme2000(eci_cartesian),
-                    OrbitFrame::ECEF => state_eci_to_ecef(epoch, eci_cartesian),
-                    OrbitFrame::ITRF => state_gcrf_to_itrf(epoch, eci_cartesian),
                 }
             }
             OrbitRepresentation::Keplerian => {
@@ -534,7 +527,7 @@ impl SOrbitPropagator for KeplerianPropagator {
         &mut self,
         epoch: Epoch,
         state: Vector6<f64>,
-        frame: OrbitFrame,
+        frame: CelestialFrame,
         representation: OrbitRepresentation,
         angle_format: Option<AngleFormat>,
     ) -> Result<(), BraheError> {
@@ -706,17 +699,12 @@ impl DOrbitStateProvider for KeplerianPropagator {
         let state_eci = state_koe_to_eci(internal_state, AngleFormat::Radians);
 
         match self.frame {
-            OrbitFrame::BodyCenteredInertial(_) => {
-                Err(BraheError::Error("OrbitFrame::BodyCenteredInertial is not supported by KeplerianPropagator (Earth-only)".to_string()))
-            }
-            OrbitFrame::ECI | OrbitFrame::GCRF => Ok(state_eci),
-            OrbitFrame::ECEF => Ok(state_ecef_to_eci(epoch, state_eci)),
-            OrbitFrame::ITRF => {
-                // This should not be possible due to validation, but handle just in case
-                // Since GCRF is requested but frame is ITRF we just return GCRF
-                Ok(state_eci)
-            }
-            OrbitFrame::EME2000 => Ok(state_eme2000_to_gcrf(state_eci)),
+            CelestialFrame::GCRF | CelestialFrame::ITRF => Ok(state_eci),
+            CelestialFrame::EME2000 => Ok(state_eme2000_to_gcrf(state_eci)),
+            other => Err(BraheError::Error(format!(
+                "frame {other} is not supported by KeplerianPropagator (Earth-only: \
+                 GCRF/ECI, EME2000, and ITRF/ECEF)"
+            ))),
         }
     }
 
@@ -757,7 +745,7 @@ mod tests {
     use super::*;
     use crate::DEGREES;
     use crate::coordinates::state_eci_to_koe;
-    use crate::frames::CelestialFrame;
+    use crate::frames::{CelestialFrame, state_ecef_to_eci};
     use crate::orbits::keplerian::orbital_period;
     use crate::time::{Epoch, TimeSystem};
     use crate::utils::testing::setup_global_test_eop;
@@ -797,7 +785,7 @@ mod tests {
         let propagator = KeplerianPropagator::new(
             epoch,
             elements,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Keplerian,
             Some(RADIANS),
             60.0,
@@ -820,7 +808,7 @@ mod tests {
         let result = KeplerianPropagator::new(
             epoch,
             state,
-            OrbitFrame::BodyCenteredInertial(301),
+            CelestialFrame::LCI,
             OrbitRepresentation::Cartesian,
             None,
             60.0,
@@ -831,7 +819,7 @@ mod tests {
             result
                 .unwrap_err()
                 .to_string()
-                .contains("BodyCenteredInertial is not supported")
+                .contains("is not supported by KeplerianPropagator")
         );
     }
 
@@ -846,7 +834,7 @@ mod tests {
         let prop = KeplerianPropagator::new(
             epoch,
             elements,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Keplerian,
             Some(DEGREES),
             60.0,
@@ -855,7 +843,7 @@ mod tests {
 
         let prop = prop
             .with_output_format(
-                OrbitFrame::ECI,
+                CelestialFrame::ECI,
                 OrbitRepresentation::Keplerian,
                 Some(RADIANS),
             )
@@ -880,14 +868,15 @@ mod tests {
         let prop = KeplerianPropagator::new(
             epoch,
             elements,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Keplerian,
             Some(DEGREES),
             60.0,
         )
         .unwrap();
 
-        let result = prop.with_output_format(OrbitFrame::ECI, OrbitRepresentation::Keplerian, None);
+        let result =
+            prop.with_output_format(CelestialFrame::ECI, OrbitRepresentation::Keplerian, None);
         assert!(result.is_err());
     }
 
@@ -902,7 +891,7 @@ mod tests {
         let _propagator = KeplerianPropagator::new(
             epoch,
             elements,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Keplerian,
             None,
             60.0,
@@ -921,7 +910,7 @@ mod tests {
         let _propagator = KeplerianPropagator::new(
             epoch,
             elements,
-            OrbitFrame::ECEF,
+            CelestialFrame::ECEF,
             OrbitRepresentation::Keplerian,
             Some(RADIANS),
             60.0,
@@ -940,7 +929,7 @@ mod tests {
         let _propagator = KeplerianPropagator::new(
             epoch,
             state,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             Some(RADIANS),
             60.0,
@@ -959,7 +948,7 @@ mod tests {
         let _propagator = KeplerianPropagator::new(
             epoch,
             elements,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Keplerian,
             Some(RADIANS),
             -10.0,
@@ -978,7 +967,7 @@ mod tests {
         let _propagator = KeplerianPropagator::new(
             epoch,
             elements,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Keplerian,
             Some(RADIANS),
             0.0,
@@ -1023,7 +1012,7 @@ mod tests {
 
         assert_eq!(propagator.initial_epoch(), epoch);
         assert_eq!(propagator.step_size(), 60.0);
-        assert_eq!(propagator.frame, OrbitFrame::ECEF);
+        assert_eq!(propagator.frame, CelestialFrame::ECEF);
     }
 
     // OrbitPropagator Trait Tests
@@ -1301,7 +1290,7 @@ mod tests {
             .set_initial_conditions(
                 new_epoch,
                 new_elements,
-                OrbitFrame::ECI,
+                CelestialFrame::ECI,
                 OrbitRepresentation::Keplerian,
                 Some(AngleFormat::Radians),
             )

--- a/src/propagators/keplerian_propagator.rs
+++ b/src/propagators/keplerian_propagator.rs
@@ -2164,4 +2164,51 @@ mod tests {
             assert_abs_diff_eq!(x_back[k], x_gcrf[k], epsilon = 1e-6);
         }
     }
+
+    #[test]
+    #[serial]
+    fn test_keplerianpropagator_propagate_keplerian_elements_in_eme2000() {
+        setup_global_test_eop();
+
+        let epc = Epoch::from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+        let x_gcrf = create_cartesian_state();
+        let oe_eme = state_eci_to_koe(state_gcrf_to_eme2000(x_gcrf), DEGREES);
+
+        let mut prop = KeplerianPropagator::new(
+            epc,
+            oe_eme,
+            CelestialFrame::EME2000,
+            OrbitRepresentation::Keplerian,
+            Some(DEGREES),
+            60.0,
+        )
+        .unwrap();
+
+        // Independent oracle: the same orbit propagated as a GCRF Cartesian
+        // state, then rotated into EME2000 and converted to elements.
+        let mut oracle = KeplerianPropagator::new(
+            epc,
+            x_gcrf,
+            CelestialFrame::GCRF,
+            OrbitRepresentation::Cartesian,
+            None,
+            60.0,
+        )
+        .unwrap();
+
+        let target = epc + 3600.0;
+        prop.propagate_to(target).unwrap();
+        oracle.propagate_to(target).unwrap();
+
+        assert_eq!(prop.current_epoch(), target);
+
+        let expected = state_eci_to_koe(state_gcrf_to_eme2000(oracle.current_state()), DEGREES);
+        let elements = prop.current_state();
+        // Semi-major axis is in meters, the remaining elements are
+        // dimensionless or in degrees.
+        assert_abs_diff_eq!(elements[0], expected[0], epsilon = 1e-6);
+        for k in 1..6 {
+            assert_abs_diff_eq!(elements[k], expected[k], epsilon = 1e-8);
+        }
+    }
 }

--- a/src/propagators/keplerian_propagator.rs
+++ b/src/propagators/keplerian_propagator.rs
@@ -929,6 +929,92 @@ mod tests {
     }
 
     #[test]
+    #[serial]
+    fn test_keplerianpropagator_new_errors_when_orbit_relative_provider_fails() {
+        use crate::frames::object_registry::FnProvider;
+
+        setup_global_test_eop();
+        clear_object_registry();
+        register_object(
+            "CHIEF_FAIL",
+            FnProvider(|_epoch| Err(BraheError::Error("provider unavailable".to_string()))),
+            CelestialFrame::GCRF,
+        )
+        .unwrap();
+
+        let epoch = Epoch::from_jd(TEST_EPOCH_JD, TimeSystem::UTC);
+        let state = create_cartesian_state();
+        let result = KeplerianPropagator::new(
+            epoch,
+            state,
+            ReferenceFrame::RTN("CHIEF_FAIL"),
+            OrbitRepresentation::Cartesian,
+            None,
+            60.0,
+        );
+
+        assert!(result.is_err());
+        clear_object_registry();
+    }
+
+    #[test]
+    #[serial]
+    fn test_keplerianpropagator_with_output_format_errors_when_orbit_relative_provider_fails() {
+        use crate::frames::object_registry::FnProvider;
+
+        setup_global_test_eop();
+        clear_object_registry();
+        register_object(
+            "CHIEF_FAIL",
+            FnProvider(|_epoch| Err(BraheError::Error("provider unavailable".to_string()))),
+            CelestialFrame::GCRF,
+        )
+        .unwrap();
+
+        let epoch = Epoch::from_jd(TEST_EPOCH_JD, TimeSystem::UTC);
+        let prop = KeplerianPropagator::from_eci(epoch, create_cartesian_state(), 60.0).unwrap();
+
+        let result = prop.with_output_format(
+            ReferenceFrame::RTN("CHIEF_FAIL"),
+            OrbitRepresentation::Cartesian,
+            None,
+        );
+
+        assert!(result.is_err());
+        clear_object_registry();
+    }
+
+    #[test]
+    #[serial]
+    fn test_keplerianpropagator_set_initial_conditions_errors_when_orbit_relative_provider_fails() {
+        use crate::frames::object_registry::FnProvider;
+
+        setup_global_test_eop();
+        clear_object_registry();
+        register_object(
+            "CHIEF_FAIL",
+            FnProvider(|_epoch| Err(BraheError::Error("provider unavailable".to_string()))),
+            CelestialFrame::GCRF,
+        )
+        .unwrap();
+
+        let epoch = Epoch::from_jd(TEST_EPOCH_JD, TimeSystem::UTC);
+        let mut prop =
+            KeplerianPropagator::from_eci(epoch, create_cartesian_state(), 60.0).unwrap();
+
+        let result = prop.set_initial_conditions(
+            epoch,
+            create_cartesian_state(),
+            ReferenceFrame::RTN("CHIEF_FAIL"),
+            OrbitRepresentation::Cartesian,
+            None,
+        );
+
+        assert!(result.is_err());
+        clear_object_registry();
+    }
+
+    #[test]
     #[should_panic(expected = "Angle format must be specified for Keplerian elements")]
     #[parallel]
     fn test_keplerianpropagator_new_invalid_angle_format() {

--- a/src/propagators/keplerian_propagator.rs
+++ b/src/propagators/keplerian_propagator.rs
@@ -534,9 +534,10 @@ impl SStatePropagator for KeplerianPropagator {
     ///
     /// Panics if the initial state cannot be converted into the propagator's
     /// output frame. The trait method is infallible, and the only way the
-    /// conversion can fail is an output frame that has become unresolvable
-    /// since the propagator was constructed, for example an orbit-relative
-    /// frame whose anchor object was removed from the object registry.
+    /// conversion can fail is if the output frame can no longer be resolved by
+    /// the reference frame router, for example an orbit-relative frame whose
+    /// anchor object was unregistered, or a body-fixed frame whose kernels are
+    /// no longer loaded.
     fn reset(&mut self) {
         // Reset trajectory to initial state only, preserving identity
         let name = self.trajectory.get_name().map(|s| s.to_string());
@@ -790,6 +791,7 @@ mod tests {
     use super::*;
     use crate::DEGREES;
     use crate::coordinates::state_eci_to_koe;
+    use crate::frames::object_registry::FnProvider;
     use crate::frames::{
         CelestialFrame, DStateAdapter, ReferenceFrame, clear_object_registry, register_object,
         state_ecef_to_eci, state_eme2000_to_gcrf, state_gcrf_to_tod, state_itrf_to_gcrf,
@@ -931,8 +933,6 @@ mod tests {
     #[test]
     #[serial]
     fn test_keplerianpropagator_new_errors_when_orbit_relative_provider_fails() {
-        use crate::frames::object_registry::FnProvider;
-
         setup_global_test_eop();
         clear_object_registry();
         register_object(
@@ -960,8 +960,6 @@ mod tests {
     #[test]
     #[serial]
     fn test_keplerianpropagator_with_output_format_errors_when_orbit_relative_provider_fails() {
-        use crate::frames::object_registry::FnProvider;
-
         setup_global_test_eop();
         clear_object_registry();
         register_object(
@@ -987,8 +985,6 @@ mod tests {
     #[test]
     #[serial]
     fn test_keplerianpropagator_set_initial_conditions_errors_when_orbit_relative_provider_fails() {
-        use crate::frames::object_registry::FnProvider;
-
         setup_global_test_eop();
         clear_object_registry();
         register_object(
@@ -2026,7 +2022,7 @@ mod tests {
 
     #[test]
     #[serial]
-    fn test_keplerian_propagator_output_in_tod_and_rtn() {
+    fn test_keplerianpropagator_output_in_tod_and_rtn() {
         setup_global_test_eop();
         clear_object_registry();
 
@@ -2118,7 +2114,7 @@ mod tests {
 
     #[test]
     #[serial]
-    fn test_keplerian_propagator_keplerian_elements_in_eme2000() {
+    fn test_keplerianpropagator_keplerian_elements_in_eme2000() {
         setup_global_test_eop();
 
         // Keplerian output is allowed in any inertial Earth-centered frame, and

--- a/src/propagators/sgp_propagator.rs
+++ b/src/propagators/sgp_propagator.rs
@@ -32,6 +32,7 @@
 use crate::attitude::RotationMatrix;
 use crate::constants::{AngleFormat, DEG2RAD, OMEGA_EARTH, RAD2DEG};
 use crate::coordinates::state_eci_to_koe;
+use crate::frames::CelestialFrame;
 use crate::frames::{polar_motion, state_ecef_to_eci, state_gcrf_to_eme2000, state_itrf_to_gcrf};
 use crate::orbits::tle::{
     TleFormat, calculate_tle_line_checksum, create_tle_lines, epoch_from_tle,
@@ -41,7 +42,7 @@ use crate::propagators::TrajectoryMode;
 use crate::propagators::traits::{SOrbitStateProvider, SStatePropagator, SStateProvider};
 use crate::time::{Epoch, TimeSystem};
 use crate::trajectories::DOrbitTrajectory;
-use crate::trajectories::traits::{OrbitFrame, OrbitRepresentation, Trajectory};
+use crate::trajectories::traits::{OrbitRepresentation, Trajectory};
 use crate::utils::{BraheError, Identifiable};
 use nalgebra::{DVector, Vector3, Vector6};
 use sgp4::chrono::{Datelike, NaiveDate, NaiveDateTime, Timelike};
@@ -83,7 +84,7 @@ fn tle_gmst82(epoch: Epoch, angle_format: AngleFormat) -> f64 {
 fn convert_state_from_spg4_frame(
     epoch: Epoch,
     tle_state: Vector6<f64>,
-    frame: OrbitFrame,
+    frame: CelestialFrame,
     representation: OrbitRepresentation,
     angle_format: Option<AngleFormat>,
 ) -> Vector6<f64> {
@@ -112,22 +113,16 @@ fn convert_state_from_spg4_frame(
 
     match representation {
         OrbitRepresentation::Cartesian => match frame {
-            OrbitFrame::BodyCenteredInertial(_) => {
-                unreachable!(
-                    "BodyCenteredInertial frames are rejected when the output format is set"
-                )
-            }
-            OrbitFrame::ECI => state_ecef_to_eci(epoch, ecef_state),
-            OrbitFrame::GCRF => state_ecef_to_eci(epoch, ecef_state),
-            OrbitFrame::EME2000 => {
+            CelestialFrame::GCRF => state_ecef_to_eci(epoch, ecef_state),
+            CelestialFrame::EME2000 => {
                 let gcrf_state = state_ecef_to_eci(epoch, ecef_state);
                 state_gcrf_to_eme2000(gcrf_state)
             }
-            OrbitFrame::ECEF => ecef_state,
-            OrbitFrame::ITRF => ecef_state,
+            CelestialFrame::ITRF => ecef_state,
+            other => unreachable!("frame {other} is rejected when the output format is set"),
         },
         OrbitRepresentation::Keplerian => {
-            if frame != OrbitFrame::ECI && frame != OrbitFrame::GCRF {
+            if frame != CelestialFrame::ECI && frame != CelestialFrame::GCRF {
                 unreachable!(
                     "Keplerian output outside ECI/GCRF is rejected when the output format is set"
                 );
@@ -161,9 +156,9 @@ fn svec6_to_dvec(sv: &Vector6<f64>) -> DVector<f64> {
 /// - Keplerian representation is requested without `angle_format`
 /// - Keplerian representation is requested in a non-ECI frame
 /// - Cartesian representation is given with `angle_format`
-/// - The frame is body-centered inertial (Earth-only propagator)
+/// - The frame is not one of GCRF, EME2000, or ITRF (Earth-only propagator)
 fn validate_output_format(
-    frame: OrbitFrame,
+    frame: CelestialFrame,
     representation: OrbitRepresentation,
     angle_format: Option<AngleFormat>,
 ) -> Result<(), BraheError> {
@@ -173,7 +168,7 @@ fn validate_output_format(
         ));
     }
 
-    if representation == OrbitRepresentation::Keplerian && frame != OrbitFrame::ECI {
+    if representation == OrbitRepresentation::Keplerian && frame != CelestialFrame::ECI {
         return Err(BraheError::PropagatorError(
             "Keplerian elements must be in ECI frame".to_string(),
         ));
@@ -185,11 +180,14 @@ fn validate_output_format(
         ));
     }
 
-    if matches!(frame, OrbitFrame::BodyCenteredInertial(_)) {
-        return Err(BraheError::PropagatorError(
-            "OrbitFrame::BodyCenteredInertial is not supported by SGPPropagator (Earth-only)"
-                .to_string(),
-        ));
+    if !matches!(
+        frame,
+        CelestialFrame::GCRF | CelestialFrame::EME2000 | CelestialFrame::ITRF
+    ) {
+        return Err(BraheError::PropagatorError(format!(
+            "frame {frame} is not supported by SGPPropagator (Earth-only: GCRF/ECI, \
+             EME2000, and ITRF/ECEF)"
+        )));
     }
 
     Ok(())
@@ -241,7 +239,7 @@ pub struct SGPPropagator {
     pub step_size: f64,
 
     /// Output frame (default: ECI)
-    pub frame: OrbitFrame,
+    pub frame: CelestialFrame,
 
     /// Output representation (default: Cartesian)
     pub representation: OrbitRepresentation,
@@ -396,7 +394,7 @@ pub struct SGPPropagatorBuilder {
     ephemeris_type: Option<u8>,
     element_set_no: Option<u64>,
     rev_at_epoch: Option<u64>,
-    output_format: Option<(OrbitFrame, OrbitRepresentation, Option<AngleFormat>)>,
+    output_format: Option<(CelestialFrame, OrbitRepresentation, Option<AngleFormat>)>,
 }
 
 impl SGPPropagatorBuilder {
@@ -762,7 +760,8 @@ impl SGPPropagatorBuilder {
     ///
     /// ```rust
     /// use brahe::propagators::SGPPropagator;
-    /// use brahe::traits::{OrbitFrame, OrbitRepresentation};
+    /// use brahe::traits::OrbitRepresentation;
+    /// use brahe::frames::CelestialFrame;
     /// use brahe::constants::AngleFormat;
     /// use brahe::eop::{StaticEOPProvider, set_global_eop_provider};
     /// use brahe::time::{Epoch, TimeSystem};
@@ -775,13 +774,13 @@ impl SGPPropagatorBuilder {
     ///     15.49193835, 0.0003723, 51.6312,
     ///     206.3646, 184.1118, 175.9840, 25544,
     /// )
-    /// .output_format(OrbitFrame::ECI, OrbitRepresentation::Keplerian, Some(AngleFormat::Degrees))
+    /// .output_format(CelestialFrame::ECI, OrbitRepresentation::Keplerian, Some(AngleFormat::Degrees))
     /// .build()
     /// .unwrap();
     /// ```
     pub fn output_format(
         mut self,
-        frame: OrbitFrame,
+        frame: CelestialFrame,
         representation: OrbitRepresentation,
         angle_format: Option<AngleFormat>,
     ) -> Self {
@@ -977,14 +976,14 @@ impl SGPPropagator {
         let initial_state = convert_state_from_spg4_frame(
             epoch,
             tle_state,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None, // angle_format is not meaningful for Cartesian
         );
 
         // Create trajectory with initial state
         let mut trajectory =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)?;
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)?;
 
         // Set trajectory identity from propagator identity
         if let Some(n) = name {
@@ -1010,7 +1009,7 @@ impl SGPPropagator {
             trajectory,
             trajectory_mode: TrajectoryMode::OutputStepsOnly,
             step_size,
-            frame: OrbitFrame::ECI,
+            frame: CelestialFrame::ECI,
             representation: OrbitRepresentation::Cartesian,
             angle_format: None, // angle_format is not meaningful for Cartesian
             name: name.map(|s| s.to_string()),
@@ -1248,14 +1247,14 @@ impl SGPPropagator {
         let initial_state = convert_state_from_spg4_frame(
             brahe_epoch,
             tle_state,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
         );
 
         // Create trajectory with initial state
         let mut trajectory =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)?;
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)?;
 
         // Set trajectory identity from propagator identity
         if let Some(n) = object_name {
@@ -1280,7 +1279,7 @@ impl SGPPropagator {
             trajectory,
             trajectory_mode: TrajectoryMode::OutputStepsOnly,
             step_size,
-            frame: OrbitFrame::ECI,
+            frame: CelestialFrame::ECI,
             representation: OrbitRepresentation::Cartesian,
             angle_format: None,
             name: object_name.map(|s| s.to_string()),
@@ -1514,7 +1513,7 @@ impl SGPPropagator {
     /// - SGP4 propagation of the TLE epoch state fails
     pub fn with_output_format(
         mut self,
-        frame: OrbitFrame,
+        frame: CelestialFrame,
         representation: OrbitRepresentation,
         angle_format: Option<AngleFormat>,
     ) -> Result<Self, BraheError> {
@@ -1883,7 +1882,7 @@ impl SGPPropagator {
         Ok(convert_state_from_spg4_frame(
             epoch,
             tle_state,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
         ))
@@ -2955,14 +2954,14 @@ mod tests {
             25544,
         )
         .output_format(
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Degrees),
         )
         .build()
         .unwrap();
 
-        assert_eq!(prop.frame, OrbitFrame::ECI);
+        assert_eq!(prop.frame, CelestialFrame::ECI);
         assert_eq!(prop.representation, OrbitRepresentation::Keplerian);
         assert_eq!(prop.angle_format, Some(AngleFormat::Degrees));
     }
@@ -2982,7 +2981,7 @@ mod tests {
             175.9840,
             25544,
         )
-        .output_format(OrbitFrame::ECI, OrbitRepresentation::Keplerian, None)
+        .output_format(CelestialFrame::ECI, OrbitRepresentation::Keplerian, None)
         .build();
 
         assert!(result.is_err());
@@ -3010,7 +3009,7 @@ mod tests {
             25544,
         )
         .output_format(
-            OrbitFrame::ECEF,
+            CelestialFrame::ECEF,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Degrees),
         )
@@ -3041,7 +3040,7 @@ mod tests {
             25544,
         )
         .output_format(
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             Some(AngleFormat::Degrees),
         )
@@ -3862,10 +3861,10 @@ mod tests {
         setup_global_test_eop();
         let prop = SGPPropagator::from_tle(ISS_LINE1, ISS_LINE2, 60.0)
             .unwrap()
-            .with_output_format(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            .with_output_format(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
             .unwrap();
 
-        assert_eq!(prop.frame, OrbitFrame::ECI);
+        assert_eq!(prop.frame, CelestialFrame::ECI);
         assert_eq!(prop.representation, OrbitRepresentation::Cartesian);
         assert_eq!(prop.angle_format, None);
         assert_eq!(prop.trajectory.len(), 1); // Only initial state
@@ -3877,10 +3876,10 @@ mod tests {
         setup_global_test_eop();
         let prop = SGPPropagator::from_tle(ISS_LINE1, ISS_LINE2, 60.0)
             .unwrap()
-            .with_output_format(OrbitFrame::ECEF, OrbitRepresentation::Cartesian, None)
+            .with_output_format(CelestialFrame::ECEF, OrbitRepresentation::Cartesian, None)
             .unwrap();
 
-        assert_eq!(prop.frame, OrbitFrame::ECEF);
+        assert_eq!(prop.frame, CelestialFrame::ECEF);
         assert_eq!(prop.representation, OrbitRepresentation::Cartesian);
         assert_eq!(prop.angle_format, None);
 
@@ -3895,10 +3894,10 @@ mod tests {
         setup_global_test_eop();
         let prop = SGPPropagator::from_tle(ISS_LINE1, ISS_LINE2, 60.0)
             .unwrap()
-            .with_output_format(OrbitFrame::GCRF, OrbitRepresentation::Cartesian, None)
+            .with_output_format(CelestialFrame::GCRF, OrbitRepresentation::Cartesian, None)
             .unwrap();
 
-        assert_eq!(prop.frame, OrbitFrame::GCRF);
+        assert_eq!(prop.frame, CelestialFrame::GCRF);
         assert_eq!(prop.representation, OrbitRepresentation::Cartesian);
         assert_eq!(prop.angle_format, None);
 
@@ -3913,10 +3912,14 @@ mod tests {
         setup_global_test_eop();
         let prop = SGPPropagator::from_tle(ISS_LINE1, ISS_LINE2, 60.0)
             .unwrap()
-            .with_output_format(OrbitFrame::EME2000, OrbitRepresentation::Cartesian, None)
+            .with_output_format(
+                CelestialFrame::EME2000,
+                OrbitRepresentation::Cartesian,
+                None,
+            )
             .unwrap();
 
-        assert_eq!(prop.frame, OrbitFrame::EME2000);
+        assert_eq!(prop.frame, CelestialFrame::EME2000);
         assert_eq!(prop.representation, OrbitRepresentation::Cartesian);
         assert_eq!(prop.angle_format, None);
 
@@ -3931,10 +3934,10 @@ mod tests {
         setup_global_test_eop();
         let prop = SGPPropagator::from_tle(ISS_LINE1, ISS_LINE2, 60.0)
             .unwrap()
-            .with_output_format(OrbitFrame::ITRF, OrbitRepresentation::Cartesian, None)
+            .with_output_format(CelestialFrame::ITRF, OrbitRepresentation::Cartesian, None)
             .unwrap();
 
-        assert_eq!(prop.frame, OrbitFrame::ITRF);
+        assert_eq!(prop.frame, CelestialFrame::ITRF);
         assert_eq!(prop.representation, OrbitRepresentation::Cartesian);
         assert_eq!(prop.angle_format, None);
 
@@ -3950,13 +3953,13 @@ mod tests {
         let prop = SGPPropagator::from_tle(ISS_LINE1, ISS_LINE2, 60.0)
             .unwrap()
             .with_output_format(
-                OrbitFrame::ECI,
+                CelestialFrame::ECI,
                 OrbitRepresentation::Keplerian,
                 Some(AngleFormat::Degrees),
             )
             .unwrap();
 
-        assert_eq!(prop.frame, OrbitFrame::ECI);
+        assert_eq!(prop.frame, CelestialFrame::ECI);
         assert_eq!(prop.representation, OrbitRepresentation::Keplerian);
         assert_eq!(prop.angle_format, Some(AngleFormat::Degrees));
 
@@ -3973,13 +3976,13 @@ mod tests {
         let prop = SGPPropagator::from_tle(ISS_LINE1, ISS_LINE2, 60.0)
             .unwrap()
             .with_output_format(
-                OrbitFrame::ECI,
+                CelestialFrame::ECI,
                 OrbitRepresentation::Keplerian,
                 Some(AngleFormat::Radians),
             )
             .unwrap();
 
-        assert_eq!(prop.frame, OrbitFrame::ECI);
+        assert_eq!(prop.frame, CelestialFrame::ECI);
         assert_eq!(prop.representation, OrbitRepresentation::Keplerian);
         assert_eq!(prop.angle_format, Some(AngleFormat::Radians));
 
@@ -4003,7 +4006,7 @@ mod tests {
 
         // Change output format - should reset trajectory
         let prop = prop
-            .with_output_format(OrbitFrame::ECEF, OrbitRepresentation::Cartesian, None)
+            .with_output_format(CelestialFrame::ECEF, OrbitRepresentation::Cartesian, None)
             .unwrap();
         assert_eq!(prop.trajectory.len(), 1); // Only initial state in new format
     }
@@ -4014,7 +4017,7 @@ mod tests {
         setup_global_test_eop();
         let mut prop = SGPPropagator::from_tle(ISS_LINE1, ISS_LINE2, 60.0)
             .unwrap()
-            .with_output_format(OrbitFrame::ECEF, OrbitRepresentation::Cartesian, None)
+            .with_output_format(CelestialFrame::ECEF, OrbitRepresentation::Cartesian, None)
             .unwrap();
 
         // Propagate in new format
@@ -4033,7 +4036,7 @@ mod tests {
         setup_global_test_eop();
         let _prop = SGPPropagator::from_tle(ISS_LINE1, ISS_LINE2, 60.0)
             .unwrap()
-            .with_output_format(OrbitFrame::ECI, OrbitRepresentation::Keplerian, None)
+            .with_output_format(CelestialFrame::ECI, OrbitRepresentation::Keplerian, None)
             .unwrap();
     }
 
@@ -4045,7 +4048,7 @@ mod tests {
         let _prop = SGPPropagator::from_tle(ISS_LINE1, ISS_LINE2, 60.0)
             .unwrap()
             .with_output_format(
-                OrbitFrame::ECEF,
+                CelestialFrame::ECEF,
                 OrbitRepresentation::Keplerian,
                 Some(AngleFormat::Degrees),
             )
@@ -4060,7 +4063,7 @@ mod tests {
         let _prop = SGPPropagator::from_tle(ISS_LINE1, ISS_LINE2, 60.0)
             .unwrap()
             .with_output_format(
-                OrbitFrame::ECI,
+                CelestialFrame::ECI,
                 OrbitRepresentation::Cartesian,
                 Some(AngleFormat::Degrees),
             )
@@ -5088,20 +5091,17 @@ mod tests {
     fn test_sgppropagator_with_output_format_rejects_bci() {
         setup_global_test_eop();
 
-        // SGPPropagator is Earth-only; body-centered inertial output is rejected
+        // SGPPropagator is Earth-only; other central bodies are rejected
         let prop = SGPPropagator::from_tle(ISS_LINE1, ISS_LINE2, 60.0).unwrap();
-        let result = prop.with_output_format(
-            OrbitFrame::BodyCenteredInertial(399),
-            OrbitRepresentation::Cartesian,
-            None,
-        );
+        let result =
+            prop.with_output_format(CelestialFrame::LCI, OrbitRepresentation::Cartesian, None);
 
         assert!(result.is_err());
         assert!(
             result
                 .unwrap_err()
                 .to_string()
-                .contains("BodyCenteredInertial is not supported")
+                .contains("is not supported by SGPPropagator")
         );
     }
 

--- a/src/propagators/sgp_propagator.rs
+++ b/src/propagators/sgp_propagator.rs
@@ -4090,6 +4090,106 @@ mod tests {
             .unwrap();
     }
 
+    #[test]
+    #[serial]
+    fn test_sgppropagator_with_output_format_errors_when_orbit_relative_provider_fails() {
+        use crate::frames::object_registry::FnProvider;
+        use crate::frames::{clear_object_registry, register_object};
+
+        setup_global_test_eop();
+        clear_object_registry();
+        register_object(
+            "CHIEF_FAIL",
+            FnProvider(|_epoch| Err(BraheError::Error("provider unavailable".to_string()))),
+            CelestialFrame::GCRF,
+        )
+        .unwrap();
+
+        let result = SGPPropagator::from_tle(ISS_LINE1, ISS_LINE2, 60.0)
+            .unwrap()
+            .with_output_format(
+                ReferenceFrame::RTN("CHIEF_FAIL"),
+                OrbitRepresentation::Cartesian,
+                None,
+            );
+
+        assert!(result.is_err());
+        clear_object_registry();
+    }
+
+    #[test]
+    #[serial]
+    fn test_sgppropagator_step_by_errors_when_orbit_relative_object_becomes_unavailable() {
+        use crate::frames::object_registry::FnProvider;
+        use crate::frames::{clear_object_registry, register_object, unregister_object};
+
+        setup_global_test_eop();
+        clear_object_registry();
+        let chief_state = Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0);
+        register_object(
+            "CHIEF_OK",
+            FnProvider(move |_epoch| Ok(chief_state)),
+            CelestialFrame::GCRF,
+        )
+        .unwrap();
+
+        let mut prop = SGPPropagator::from_tle(ISS_LINE1, ISS_LINE2, 60.0)
+            .unwrap()
+            .with_output_format(
+                ReferenceFrame::RTN("CHIEF_OK"),
+                OrbitRepresentation::Cartesian,
+                None,
+            )
+            .unwrap();
+
+        // Remove the chief object so the next step can no longer resolve the
+        // RTN frame's rotation.
+        unregister_object(&"CHIEF_OK".into());
+
+        let result = prop.step_by(60.0);
+        assert!(result.is_err());
+
+        clear_object_registry();
+    }
+
+    #[test]
+    #[serial]
+    fn test_sgppropagator_step_by_errors_converting_event_state_when_orbit_relative_object_becomes_unavailable()
+     {
+        use crate::frames::object_registry::FnProvider;
+        use crate::frames::{clear_object_registry, register_object, unregister_object};
+
+        setup_global_test_eop();
+        clear_object_registry();
+        let chief_state = Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0);
+        register_object(
+            "CHIEF_OK",
+            FnProvider(move |_epoch| Ok(chief_state)),
+            CelestialFrame::GCRF,
+        )
+        .unwrap();
+
+        let mut prop = SGPPropagator::from_tle(ISS_LINE1, ISS_LINE2, 60.0)
+            .unwrap()
+            .with_output_format(
+                ReferenceFrame::RTN("CHIEF_OK"),
+                OrbitRepresentation::Cartesian,
+                None,
+            )
+            .unwrap();
+        let epoch = prop.initial_epoch();
+        prop.add_event_detector(Box::new(DTimeEvent::new(epoch + 30.0, "mid-step")));
+
+        // Remove the chief object so converting the event's state can no
+        // longer resolve the RTN frame's rotation.
+        unregister_object(&"CHIEF_OK".into());
+
+        let result = prop.step_by(60.0);
+        assert!(result.is_err());
+
+        clear_object_registry();
+    }
+
     // state_gcrf and state_eme2000 Tests (non-ignored basic tests)
 
     #[test]

--- a/src/propagators/sgp_propagator.rs
+++ b/src/propagators/sgp_propagator.rs
@@ -32,17 +32,20 @@
 use crate::attitude::RotationMatrix;
 use crate::constants::{AngleFormat, DEG2RAD, OMEGA_EARTH, RAD2DEG};
 use crate::coordinates::state_eci_to_koe;
-use crate::frames::CelestialFrame;
-use crate::frames::{polar_motion, state_ecef_to_eci, state_gcrf_to_eme2000, state_itrf_to_gcrf};
+use crate::frames::{
+    CelestialFrame, ReferenceFrame, celestial_root, polar_motion, state_ecef_to_eci,
+    state_frame_to_frame, state_gcrf_to_eme2000, state_itrf_to_gcrf,
+};
 use crate::orbits::tle::{
     TleFormat, calculate_tle_line_checksum, create_tle_lines, epoch_from_tle,
     norad_id_numeric_to_alpha5, parse_norad_id, validate_tle_lines,
 };
 use crate::propagators::TrajectoryMode;
 use crate::propagators::traits::{SOrbitStateProvider, SStatePropagator, SStateProvider};
+use crate::spice::NAIFId;
 use crate::time::{Epoch, TimeSystem};
 use crate::trajectories::DOrbitTrajectory;
-use crate::trajectories::traits::{OrbitRepresentation, Trajectory};
+use crate::trajectories::traits::{OrbitRepresentation, Trajectory, keplerian_center};
 use crate::utils::{BraheError, Identifiable};
 use nalgebra::{DVector, Vector3, Vector6};
 use sgp4::chrono::{Datelike, NaiveDate, NaiveDateTime, Timelike};
@@ -81,13 +84,25 @@ fn tle_gmst82(epoch: Epoch, angle_format: AngleFormat) -> f64 {
     }
 }
 
+/// Convert an SGP4 TEME state into the requested output frame and representation.
+///
+/// # Arguments
+/// * `epoch` - Epoch of the state
+/// * `tle_state` - SGP4 output state in TEME. Units: (*m*; *m/s*)
+/// * `frame` - Output frame
+/// * `representation` - Output representation
+/// * `angle_format` - Angle format for Keplerian output
+///
+/// # Returns
+/// * `Ok(Vector6<f64>)`: State in `frame` and `representation`
+/// * `Err(BraheError)`: If the conversion from ITRF into `frame` fails
 fn convert_state_from_spg4_frame(
     epoch: Epoch,
     tle_state: Vector6<f64>,
-    frame: CelestialFrame,
+    frame: &ReferenceFrame,
     representation: OrbitRepresentation,
     angle_format: Option<AngleFormat>,
-) -> Vector6<f64> {
+) -> Result<Vector6<f64>, BraheError> {
     // SGP4 outputs state in TEME
     // Conversion chain is TEME -> PEF -> ECEF -> ECI
 
@@ -112,30 +127,22 @@ fn convert_state_from_spg4_frame(
     );
 
     match representation {
-        OrbitRepresentation::Cartesian => match frame {
-            CelestialFrame::GCRF => state_ecef_to_eci(epoch, ecef_state),
-            CelestialFrame::EME2000 => {
-                let gcrf_state = state_ecef_to_eci(epoch, ecef_state);
-                state_gcrf_to_eme2000(gcrf_state)
-            }
-            CelestialFrame::ITRF => ecef_state,
-            other => unreachable!("frame {other} is rejected when the output format is set"),
-        },
+        OrbitRepresentation::Cartesian => {
+            state_frame_to_frame(CelestialFrame::ITRF, frame.clone(), epoch, ecef_state)
+        }
         OrbitRepresentation::Keplerian => {
-            if frame != CelestialFrame::ECI && frame != CelestialFrame::GCRF {
-                unreachable!(
-                    "Keplerian output outside ECI/GCRF is rejected when the output format is set"
-                );
-            }
-
-            if let Some(format) = angle_format {
-                state_eci_to_koe(state_ecef_to_eci(epoch, ecef_state), format)
-            } else {
+            let Some(format) = angle_format else {
                 unreachable!(
                     "Keplerian output without an angle format is rejected when the output \
                      format is set"
                 );
-            }
+            };
+
+            // `frame` is inertial and Earth-centered here, so the rotated state
+            // yields elements about the Earth in that frame's axes.
+            let x_inertial =
+                state_frame_to_frame(CelestialFrame::ITRF, frame.clone(), epoch, ecef_state)?;
+            Ok(state_eci_to_koe(x_inertial, format))
         }
     }
 }
@@ -151,14 +158,24 @@ fn svec6_to_dvec(sv: &Vector6<f64>) -> DVector<f64> {
 /// Shared by [`SGPPropagator::with_output_format`] and
 /// [`SGPPropagatorBuilder::build`].
 ///
+/// # Arguments
+/// * `frame` - Output frame
+/// * `representation` - Output representation
+/// * `angle_format` - Angle format for Keplerian output
+///
+/// # Returns
+/// `Ok(())` when the combination is supported, or an error describing the
+/// incompatibility.
+///
 /// # Errors
 /// Returns `BraheError` if:
 /// - Keplerian representation is requested without `angle_format`
-/// - Keplerian representation is requested in a non-ECI frame
+/// - Keplerian representation is requested in a non-inertial frame
 /// - Cartesian representation is given with `angle_format`
-/// - The frame is not one of GCRF, EME2000, or ITRF (Earth-only propagator)
+/// - The frame is not Earth-centered (Earth-only propagator), or cannot be
+///   resolved because it is unbound or unregistered
 fn validate_output_format(
-    frame: CelestialFrame,
+    frame: &ReferenceFrame,
     representation: OrbitRepresentation,
     angle_format: Option<AngleFormat>,
 ) -> Result<(), BraheError> {
@@ -168,25 +185,20 @@ fn validate_output_format(
         ));
     }
 
-    if representation == OrbitRepresentation::Keplerian && frame != CelestialFrame::ECI {
-        return Err(BraheError::PropagatorError(
-            "Keplerian elements must be in ECI frame".to_string(),
-        ));
-    }
-
     if representation == OrbitRepresentation::Cartesian && angle_format.is_some() {
         return Err(BraheError::PropagatorError(
             "Angle format should be None for Cartesian representation".to_string(),
         ));
     }
 
-    if !matches!(
-        frame,
-        CelestialFrame::GCRF | CelestialFrame::EME2000 | CelestialFrame::ITRF
-    ) {
+    if representation == OrbitRepresentation::Keplerian {
+        keplerian_center(frame)?;
+    }
+
+    let center = celestial_root(frame)?.center_naif_id();
+    if center != NAIFId::Earth.id() {
         return Err(BraheError::PropagatorError(format!(
-            "frame {frame} is not supported by SGPPropagator (Earth-only: GCRF/ECI, \
-             EME2000, and ITRF/ECEF)"
+            "SGPPropagator is Earth-only; frame {frame} is centered on {center}"
         )));
     }
 
@@ -239,7 +251,7 @@ pub struct SGPPropagator {
     pub step_size: f64,
 
     /// Output frame (default: ECI)
-    pub frame: CelestialFrame,
+    pub frame: ReferenceFrame,
 
     /// Output representation (default: Cartesian)
     pub representation: OrbitRepresentation,
@@ -292,7 +304,7 @@ impl Clone for SGPPropagator {
             trajectory: self.trajectory.clone(),
             trajectory_mode: self.trajectory_mode,
             step_size: self.step_size,
-            frame: self.frame,
+            frame: self.frame.clone(),
             representation: self.representation,
             angle_format: self.angle_format,
             name: self.name.clone(),
@@ -394,7 +406,7 @@ pub struct SGPPropagatorBuilder {
     ephemeris_type: Option<u8>,
     element_set_no: Option<u64>,
     rev_at_epoch: Option<u64>,
-    output_format: Option<(CelestialFrame, OrbitRepresentation, Option<AngleFormat>)>,
+    output_format: Option<(ReferenceFrame, OrbitRepresentation, Option<AngleFormat>)>,
 }
 
 impl SGPPropagatorBuilder {
@@ -741,7 +753,7 @@ impl SGPPropagatorBuilder {
     /// for the frame/representation/angle-format combinations it accepts.
     ///
     /// # Arguments
-    /// * `frame` - Target reference frame (ECI or ECEF)
+    /// * `frame` - Target reference frame, which must be Earth-centered
     /// * `representation` - State representation (Cartesian or Keplerian)
     /// * `angle_format` - Angle units (required for Keplerian, `None` for Cartesian)
     ///
@@ -750,7 +762,7 @@ impl SGPPropagatorBuilder {
     /// [`SGPPropagatorBuilder::build`] returns `Err` if the stored
     /// combination is invalid:
     /// - Keplerian representation requested without `angle_format`
-    /// - Keplerian representation requested in a non-ECI frame
+    /// - Keplerian representation requested in a non-inertial frame
     /// - Cartesian representation given with `angle_format`
     ///
     /// # Returns
@@ -780,11 +792,11 @@ impl SGPPropagatorBuilder {
     /// ```
     pub fn output_format(
         mut self,
-        frame: CelestialFrame,
+        frame: impl Into<ReferenceFrame>,
         representation: OrbitRepresentation,
         angle_format: Option<AngleFormat>,
     ) -> Self {
-        self.output_format = Some((frame, representation, angle_format));
+        self.output_format = Some((frame.into(), representation, angle_format));
         self
     }
 
@@ -803,9 +815,9 @@ impl SGPPropagatorBuilder {
     /// - [`SGPPropagatorBuilder::output_format`] was called with an invalid
     ///   combination:
     ///   - Keplerian representation requested without `angle_format`
-    ///   - Keplerian representation requested in a non-ECI frame
+    ///   - Keplerian representation requested in a non-inertial frame
     ///   - Cartesian representation given with `angle_format`
-    ///   - A body-centered inertial frame (Earth-only propagator)
+    ///   - A frame that is not Earth-centered (Earth-only propagator)
     ///
     /// # Examples
     ///
@@ -826,8 +838,8 @@ impl SGPPropagatorBuilder {
     /// .unwrap();
     /// ```
     pub fn build(self) -> Result<SGPPropagator, BraheError> {
-        if let Some((frame, representation, angle_format)) = self.output_format {
-            validate_output_format(frame, representation, angle_format)?;
+        if let Some((frame, representation, angle_format)) = &self.output_format {
+            validate_output_format(frame, *representation, *angle_format)?;
         }
 
         let prop = SGPPropagator::from_omm_elements(
@@ -976,10 +988,10 @@ impl SGPPropagator {
         let initial_state = convert_state_from_spg4_frame(
             epoch,
             tle_state,
-            CelestialFrame::ECI,
+            &CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None, // angle_format is not meaningful for Cartesian
-        );
+        )?;
 
         // Create trajectory with initial state
         let mut trajectory =
@@ -1009,7 +1021,7 @@ impl SGPPropagator {
             trajectory,
             trajectory_mode: TrajectoryMode::OutputStepsOnly,
             step_size,
-            frame: CelestialFrame::ECI,
+            frame: CelestialFrame::ECI.into(),
             representation: OrbitRepresentation::Cartesian,
             angle_format: None, // angle_format is not meaningful for Cartesian
             name: name.map(|s| s.to_string()),
@@ -1247,10 +1259,10 @@ impl SGPPropagator {
         let initial_state = convert_state_from_spg4_frame(
             brahe_epoch,
             tle_state,
-            CelestialFrame::ECI,
+            &CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
-        );
+        )?;
 
         // Create trajectory with initial state
         let mut trajectory =
@@ -1279,7 +1291,7 @@ impl SGPPropagator {
             trajectory,
             trajectory_mode: TrajectoryMode::OutputStepsOnly,
             step_size,
-            frame: CelestialFrame::ECI,
+            frame: CelestialFrame::ECI.into(),
             representation: OrbitRepresentation::Cartesian,
             angle_format: None,
             name: object_name.map(|s| s.to_string()),
@@ -1499,27 +1511,34 @@ impl SGPPropagator {
     ///
     /// Sets the reference frame, representation type, and angle units for propagation output.
     ///
+    /// Cartesian output may be requested in any Earth-centered frame, including
+    /// non-celestial ones such as an orbit-relative `RTN` frame anchored on a
+    /// registered object. Keplerian output additionally requires an inertial
+    /// frame and an angle format.
+    ///
     /// # Arguments
-    /// - `frame`: Target reference frame (ECI or ECEF)
+    /// - `frame`: Target reference frame, which must be Earth-centered
     /// - `representation`: State representation (Cartesian or Keplerian)
     /// - `angle_format`: Angle units (Degrees/Radians) - required for Keplerian, None for Cartesian
     ///
     /// # Returns
     /// Self for method chaining, or an error if:
     /// - Keplerian representation is requested without angle_format
-    /// - Keplerian representation is requested outside the ECI frame
+    /// - Keplerian representation is requested in a non-inertial frame
     /// - Cartesian representation is given with angle_format
-    /// - The frame is body-centered inertial (Earth-only propagator)
+    /// - The frame is not Earth-centered (Earth-only propagator), or cannot be
+    ///   resolved because it is unbound or unregistered
     /// - SGP4 propagation of the TLE epoch state fails
     pub fn with_output_format(
         mut self,
-        frame: CelestialFrame,
+        frame: impl Into<ReferenceFrame>,
         representation: OrbitRepresentation,
         angle_format: Option<AngleFormat>,
     ) -> Result<Self, BraheError> {
-        validate_output_format(frame, representation, angle_format)?;
+        let frame = frame.into();
+        validate_output_format(&frame, representation, angle_format)?;
 
-        self.frame = frame;
+        self.frame = frame.clone();
         self.representation = representation;
         self.angle_format = angle_format;
 
@@ -1550,10 +1569,10 @@ impl SGPPropagator {
         let initial_state = convert_state_from_spg4_frame(
             self.epoch,
             tle_state,
-            frame,
+            &self.frame,
             representation,
             angle_format,
-        );
+        )?;
         self.initial_state = initial_state;
         self.epoch_current = self.epoch;
         self.state_current = initial_state;
@@ -1879,13 +1898,13 @@ impl SGPPropagator {
     /// since all event detectors expect ECI Cartesian state.
     fn state_eci_cartesian(&self, epoch: Epoch) -> Result<Vector6<f64>, BraheError> {
         let tle_state = self.propagate_internal(epoch)?;
-        Ok(convert_state_from_spg4_frame(
+        convert_state_from_spg4_frame(
             epoch,
             tle_state,
-            CelestialFrame::ECI,
+            &CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
-        ))
+        )
     }
 
     /// Scan all event detectors for events in the interval [epoch_prev, epoch_curr]
@@ -2271,10 +2290,10 @@ impl SStatePropagator for SGPPropagator {
                 let event_state_output = convert_state_from_spg4_frame(
                     event.window_open,
                     event_tle_state,
-                    self.frame,
+                    &self.frame,
                     self.representation,
                     self.angle_format,
-                );
+                )?;
 
                 // Always update independent state tracking
                 self.epoch_current = event.window_open;
@@ -2306,10 +2325,10 @@ impl SStatePropagator for SGPPropagator {
         let new_state = convert_state_from_spg4_frame(
             target_epoch,
             tle_state,
-            self.frame,
+            &self.frame,
             self.representation,
             self.angle_format,
-        );
+        )?;
 
         // Always update independent state tracking
         self.epoch_current = target_epoch;
@@ -2657,6 +2676,7 @@ impl Identifiable for SGPPropagator {
 mod tests {
     use super::*;
     use crate::RADIANS;
+    use crate::frames::state_itrf_to_tod;
     use crate::utils::testing::{setup_global_test_eop, setup_global_test_eop_original_brahe};
     use approx::assert_abs_diff_eq;
     use serial_test::{parallel, serial};
@@ -3020,7 +3040,7 @@ mod tests {
             result
                 .unwrap_err()
                 .to_string()
-                .contains("Keplerian elements must be in ECI frame")
+                .contains("Keplerian element trajectories should be in an inertial frame")
         );
     }
 
@@ -4042,7 +4062,7 @@ mod tests {
 
     #[test]
     #[parallel]
-    #[should_panic(expected = "Keplerian elements must be in ECI frame")]
+    #[should_panic(expected = "Keplerian element trajectories should be in an inertial frame")]
     fn test_sgppropagator_with_output_format_keplerian_non_eci_frame() {
         setup_global_test_eop();
         let _prop = SGPPropagator::from_tle(ISS_LINE1, ISS_LINE2, 60.0)
@@ -5091,7 +5111,7 @@ mod tests {
     fn test_sgppropagator_with_output_format_rejects_bci() {
         setup_global_test_eop();
 
-        // SGPPropagator is Earth-only; other central bodies are rejected
+        // SGPPropagator is Earth-only; frames centered on another body are rejected
         let prop = SGPPropagator::from_tle(ISS_LINE1, ISS_LINE2, 60.0).unwrap();
         let result =
             prop.with_output_format(CelestialFrame::LCI, OrbitRepresentation::Cartesian, None);
@@ -5101,7 +5121,7 @@ mod tests {
             result
                 .unwrap_err()
                 .to_string()
-                .contains("is not supported by SGPPropagator")
+                .contains("SGPPropagator is Earth-only")
         );
     }
 
@@ -5148,5 +5168,43 @@ mod tests {
         assert!(prop.current_epoch() < start);
         let time_diff: f64 = prop.current_epoch() - (start - 180.0);
         assert!(time_diff.abs() < 1e-6);
+    }
+
+    #[test]
+    #[serial]
+    fn test_sgppropagator_output_format_tod() {
+        setup_global_test_eop();
+
+        let prop = SGPPropagator::from_tle(ISS_LINE1, ISS_LINE2, 60.0).unwrap();
+        let epc = prop.epoch;
+        let expected = state_itrf_to_tod(epc, prop.state_ecef(epc).unwrap());
+
+        let tod = prop
+            .clone()
+            .with_output_format(CelestialFrame::TOD, OrbitRepresentation::Cartesian, None)
+            .unwrap();
+
+        assert_eq!(tod.frame, CelestialFrame::TOD);
+        let x_tod = tod.current_state();
+        for k in 0..6 {
+            assert_abs_diff_eq!(x_tod[k], expected[k], epsilon = 1e-4);
+        }
+
+        // Non-Earth frames are rejected: Earth-only propagator.
+        assert!(
+            prop.clone()
+                .with_output_format(CelestialFrame::LCI, OrbitRepresentation::Cartesian, None)
+                .is_err()
+        );
+
+        // Keplerian output requires an inertial frame.
+        assert!(
+            prop.with_output_format(
+                CelestialFrame::ITRF,
+                OrbitRepresentation::Keplerian,
+                Some(AngleFormat::Degrees),
+            )
+            .is_err()
+        );
     }
 }

--- a/src/propagators/sgp_propagator.rs
+++ b/src/propagators/sgp_propagator.rs
@@ -2676,7 +2676,10 @@ impl Identifiable for SGPPropagator {
 mod tests {
     use super::*;
     use crate::RADIANS;
-    use crate::frames::state_itrf_to_tod;
+    use crate::frames::object_registry::FnProvider;
+    use crate::frames::{
+        clear_object_registry, register_object, state_itrf_to_tod, unregister_object,
+    };
     use crate::utils::testing::{setup_global_test_eop, setup_global_test_eop_original_brahe};
     use approx::assert_abs_diff_eq;
     use serial_test::{parallel, serial};
@@ -4093,9 +4096,6 @@ mod tests {
     #[test]
     #[serial]
     fn test_sgppropagator_with_output_format_errors_when_orbit_relative_provider_fails() {
-        use crate::frames::object_registry::FnProvider;
-        use crate::frames::{clear_object_registry, register_object};
-
         setup_global_test_eop();
         clear_object_registry();
         register_object(
@@ -4120,9 +4120,6 @@ mod tests {
     #[test]
     #[serial]
     fn test_sgppropagator_step_by_errors_when_orbit_relative_object_becomes_unavailable() {
-        use crate::frames::object_registry::FnProvider;
-        use crate::frames::{clear_object_registry, register_object, unregister_object};
-
         setup_global_test_eop();
         clear_object_registry();
         let chief_state = Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0);
@@ -4156,9 +4153,6 @@ mod tests {
     #[serial]
     fn test_sgppropagator_step_by_errors_converting_event_state_when_orbit_relative_object_becomes_unavailable()
      {
-        use crate::frames::object_registry::FnProvider;
-        use crate::frames::{clear_object_registry, register_object, unregister_object};
-
         setup_global_test_eop();
         clear_object_registry();
         let chief_state = Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0);

--- a/src/propagators/traits.rs
+++ b/src/propagators/traits.rs
@@ -5,8 +5,9 @@
 use nalgebra::{DVector, Vector6};
 
 use crate::constants::AngleFormat;
+use crate::frames::CelestialFrame;
 use crate::time::Epoch;
-use crate::trajectories::traits::{OrbitFrame, OrbitRepresentation};
+use crate::trajectories::traits::OrbitRepresentation;
 use crate::utils::BraheError;
 
 // Re-export state provider traits for convenience
@@ -411,7 +412,7 @@ pub trait SOrbitPropagator: SStatePropagator {
         &mut self,
         epoch: Epoch,
         state: Vector6<f64>,
-        frame: OrbitFrame,
+        frame: CelestialFrame,
         representation: OrbitRepresentation,
         angle_format: Option<AngleFormat>,
     ) -> Result<(), BraheError>;
@@ -444,7 +445,7 @@ pub trait DOrbitPropagator: DStatePropagator {
         &mut self,
         epoch: Epoch,
         state: DVector<f64>,
-        frame: OrbitFrame,
+        frame: CelestialFrame,
         representation: OrbitRepresentation,
         angle_format: Option<AngleFormat>,
     ) -> Result<(), BraheError>;
@@ -478,7 +479,7 @@ mod tests {
         KeplerianPropagator::new(
             epoch,
             state,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Radians),
             60.0,
@@ -829,7 +830,7 @@ mod tests {
         let prop = KeplerianPropagator::new(
             epoch,
             elements,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Degrees),
             60.0,
@@ -880,7 +881,7 @@ mod tests {
         let prop = KeplerianPropagator::new(
             epoch,
             elements,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Degrees),
             60.0,
@@ -917,7 +918,7 @@ mod tests {
         let prop = KeplerianPropagator::new(
             epoch,
             elements,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Degrees),
             60.0,
@@ -947,7 +948,7 @@ mod tests {
         let prop = KeplerianPropagator::new(
             epoch,
             elements,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Degrees),
             60.0,
@@ -977,7 +978,7 @@ mod tests {
         let prop = KeplerianPropagator::new(
             epoch,
             elements,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Degrees),
             60.0,

--- a/src/propagators/traits.rs
+++ b/src/propagators/traits.rs
@@ -5,7 +5,7 @@
 use nalgebra::{DVector, Vector6};
 
 use crate::constants::AngleFormat;
-use crate::frames::CelestialFrame;
+use crate::frames::ReferenceFrame;
 use crate::time::Epoch;
 use crate::trajectories::traits::OrbitRepresentation;
 use crate::utils::BraheError;
@@ -412,7 +412,7 @@ pub trait SOrbitPropagator: SStatePropagator {
         &mut self,
         epoch: Epoch,
         state: Vector6<f64>,
-        frame: CelestialFrame,
+        frame: ReferenceFrame,
         representation: OrbitRepresentation,
         angle_format: Option<AngleFormat>,
     ) -> Result<(), BraheError>;
@@ -445,7 +445,7 @@ pub trait DOrbitPropagator: DStatePropagator {
         &mut self,
         epoch: Epoch,
         state: DVector<f64>,
-        frame: CelestialFrame,
+        frame: ReferenceFrame,
         representation: OrbitRepresentation,
         angle_format: Option<AngleFormat>,
     ) -> Result<(), BraheError>;
@@ -455,6 +455,7 @@ pub trait DOrbitPropagator: DStatePropagator {
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
+    use crate::frames::CelestialFrame;
     use crate::orbits;
     use crate::propagators::KeplerianPropagator;
     use crate::time::{Epoch, TimeSystem};

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -75,7 +75,7 @@ pub use crate::math::interpolation::{
 
 // Trajectory traits and types
 pub use crate::trajectories::traits::{
-    InterpolatableTrajectory, OrbitFrame, OrbitRepresentation, OrbitalTrajectory, Trajectory,
+    InterpolatableTrajectory, OrbitRepresentation, OrbitalTrajectory, Trajectory,
     TrajectoryEvictionPolicy,
 };
 

--- a/src/trajectories/dorbit_trajectory.rs
+++ b/src/trajectories/dorbit_trajectory.rs
@@ -6289,6 +6289,54 @@ mod tests {
         }
     }
 
+    #[test]
+    #[parallel]
+    fn test_dorbittrajectory_state_koe_osc_from_eci_keplerian_degrees_to_radians() {
+        setup_global_test_eop();
+
+        let mut traj = DOrbitTrajectory::new(
+            6,
+            CelestialFrame::ECI,
+            OrbitRepresentation::Keplerian,
+            Some(AngleFormat::Degrees),
+        )
+        .unwrap();
+        let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
+        let state = DVector::from_vec(vec![7000e3, 0.01, 45.0, 15.0, 30.0, 60.0]);
+        traj.add(epoch, state.clone()).unwrap();
+
+        let koe = traj.state_koe_osc(epoch, AngleFormat::Radians).unwrap();
+        assert_abs_diff_eq!(koe[0], state[0], epsilon = 1e-6);
+        assert_abs_diff_eq!(koe[1], state[1], epsilon = 1e-9);
+        for i in 2..6 {
+            assert_abs_diff_eq!(koe[i], state[i] * DEG2RAD, epsilon = 1e-9);
+        }
+    }
+
+    #[test]
+    #[parallel]
+    fn test_dorbittrajectory_state_koe_osc_from_eci_keplerian_radians_to_degrees() {
+        setup_global_test_eop();
+
+        let mut traj = DOrbitTrajectory::new(
+            6,
+            CelestialFrame::ECI,
+            OrbitRepresentation::Keplerian,
+            Some(AngleFormat::Radians),
+        )
+        .unwrap();
+        let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
+        let state = DVector::from_vec(vec![7000e3, 0.01, 0.5, 0.2, 0.4, 0.9]);
+        traj.add(epoch, state.clone()).unwrap();
+
+        let koe = traj.state_koe_osc(epoch, AngleFormat::Degrees).unwrap();
+        assert_abs_diff_eq!(koe[0], state[0], epsilon = 1e-6);
+        assert_abs_diff_eq!(koe[1], state[1], epsilon = 1e-9);
+        for i in 2..6 {
+            assert_abs_diff_eq!(koe[i], state[i] * RAD2DEG, epsilon = 1e-9);
+        }
+    }
+
     // ========== DOrbitCovarianceProvider Trait Tests ==========
 
     #[test]
@@ -6356,6 +6404,38 @@ mod tests {
         // ECEF covariances cannot be transformed to ECI
         let result = traj.covariance_eci(epoch);
         assert!(result.is_err());
+    }
+
+    #[test]
+    #[parallel]
+    fn test_dorbittrajectory_covariance_eci_from_eme2000() {
+        setup_global_test_eop();
+
+        let mut traj = DOrbitTrajectory::new(
+            6,
+            CelestialFrame::EME2000,
+            OrbitRepresentation::Cartesian,
+            None,
+        )
+        .unwrap();
+        traj.covariances = Some(Vec::new());
+
+        let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
+        let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
+        let cov = DMatrix::identity(6, 6) * 100.0;
+        traj.add_state_and_covariance(epoch, state, cov).unwrap();
+
+        let retrieved = traj.covariance_eci(epoch).unwrap();
+        // The EME2000-GCRF frame bias rotation is a small angle, so the
+        // diagonal is preserved to within numerical precision.
+        for i in 0..6 {
+            assert_abs_diff_eq!(retrieved[(i, i)], 100.0, epsilon = 1e-3);
+        }
+        for i in 0..6 {
+            for j in 0..6 {
+                assert_abs_diff_eq!(retrieved[(i, j)], retrieved[(j, i)], epsilon = 1e-9);
+            }
+        }
     }
 
     #[test]

--- a/src/trajectories/dorbit_trajectory.rs
+++ b/src/trajectories/dorbit_trajectory.rs
@@ -90,7 +90,7 @@ use uuid::Uuid;
 
 use crate::constants::AngleFormat;
 use crate::constants::{DEG2RAD, RAD2DEG};
-use crate::coordinates::{state_eci_to_koe, state_inertial_to_koe_gm, state_koe_to_inertial_gm};
+use crate::coordinates::{state_inertial_to_koe_gm, state_koe_to_inertial_gm};
 use crate::frames::{
     CelestialFrame, ReferenceFrame, celestial_root, icrf_aligned_inertial,
     rotation_eme2000_to_gcrf, state_frame_to_frame,
@@ -102,7 +102,6 @@ use crate::math::{
 };
 use crate::propagators::CentralBody;
 use crate::relative_motion::rotation_eci_to_rtn;
-use crate::spice::NAIFId;
 use crate::time::Epoch;
 use crate::utils::state_providers::{
     DCovarianceProvider, DOrbitCovarianceProvider, DOrbitStateProvider, DStateProvider,
@@ -2126,9 +2125,10 @@ impl DOrbitTrajectory {
 
     /// Convert trajectory to Keplerian orbital elements representation.
     ///
-    /// Converts all states to Keplerian elements [a, e, i, raan, argp, anomaly]
-    /// in the current frame. For Cartesian inputs, uses two-body conversion.
-    /// For Keplerian inputs with different angle format, converts angles.
+    /// Cartesian samples are converted to elements [a, e, i, raan, argp, anomaly]
+    /// with a two-body conversion about the center of this trajectory's frame,
+    /// using that body's gravitational parameter. Keplerian samples only have
+    /// their angular elements rescaled to `angle_format`.
     ///
     /// For extended states (dimension > 6), only the first 6 elements (orbital state)
     /// are converted. Additional elements (6+) are preserved unchanged.
@@ -2137,10 +2137,12 @@ impl DOrbitTrajectory {
     /// * `angle_format` - Desired angle format (Radians or Degrees) for output elements
     ///
     /// # Returns
-    /// * `Ok(Self)` - New trajectory with Keplerian representation in specified
-    ///   angle format, preserving dimension.
-    /// * `Err(BraheError)` - If the trajectory is not Earth-centered (its
-    ///   Keplerian result would be undefined) or conversion otherwise fails.
+    /// * `Ok(Self)` - New trajectory of Keplerian elements referenced to this
+    ///   trajectory's own frame, in the requested angle format, preserving dimension.
+    /// * `Err(BraheError)` - If the frame does not admit Keplerian elements
+    ///   (Earth-fixed, of-date, or orbit-relative frames), if the frame's center
+    ///   is an unknown body or a massless barycenter, or if a Keplerian
+    ///   trajectory is missing its angle format.
     pub fn to_keplerian(&self, angle_format: AngleFormat) -> Result<Self, BraheError> {
         let states_converted: Vec<DVector<f64>> = match self.representation {
             OrbitRepresentation::Keplerian => {
@@ -2184,33 +2186,24 @@ impl DOrbitTrajectory {
                 }
             }
             OrbitRepresentation::Cartesian => {
-                if celestial_root(&self.frame)?.center_naif_id() != NAIFId::Earth.id() {
-                    return Err(BraheError::Error(
-                        "to_keplerian labels its result ECI, which is undefined for a \
-                         trajectory centered on another body; use state_koe_osc for \
-                         per-epoch elements about the trajectory's own center"
-                            .to_string(),
-                    ));
+                let center = keplerian_center(&self.frame)?;
+                let cb = CentralBody::from_naif_id(center)?;
+                if cb.is_barycenter() {
+                    return Err(BraheError::Error(format!(
+                        "Keplerian elements are undefined about massless barycenter {}",
+                        center
+                    )));
                 }
-                // Route to GCRF, then take two-body elements about the Earth.
-                let gcrf = self.to_frame(CelestialFrame::GCRF)?;
-                let mut states_converted = Vec::with_capacity(gcrf.states.len());
-                for (_e, s) in (&gcrf).into_iter() {
-                    let converted = gcrf.convert_orbital_preserving_additional(&s, |orbital| {
-                        state_eci_to_koe(orbital, angle_format)
+                let gm = cb.gm();
+                let mut states_converted = Vec::with_capacity(self.states.len());
+                for (_e, s) in self.into_iter() {
+                    let converted = self.convert_orbital_preserving_additional(&s, |orbital| {
+                        state_inertial_to_koe_gm(orbital, gm, angle_format)
                     });
                     states_converted.push(converted);
                 }
                 states_converted
             }
-        };
-
-        // Cartesian samples are relabeled GCRF; element samples keep the
-        // frame their elements are already referenced to.
-        let frame = if self.representation == OrbitRepresentation::Cartesian {
-            CelestialFrame::GCRF.into()
-        } else {
-            self.frame.clone()
         };
 
         Ok(Self {
@@ -2226,7 +2219,7 @@ impl DOrbitTrajectory {
             eviction_policy: self.eviction_policy,
             max_size: self.max_size,
             max_age: self.max_age,
-            frame,
+            frame: self.frame.clone(),
             representation: OrbitRepresentation::Keplerian,
             angle_format: Some(angle_format),
             name: self.name.clone(),
@@ -2623,7 +2616,8 @@ impl DOrbitCovarianceProvider for DOrbitTrajectory {
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
-    use crate::coordinates::state_koe_to_eci;
+    use crate::constants::{GM_MOON, R_EARTH, R_MOON};
+    use crate::coordinates::{state_eci_to_koe, state_koe_to_eci};
     use crate::frames::state_gcrf_to_itrf;
     use crate::time::{Epoch, TimeSystem};
     use crate::utils::testing::setup_global_test_eop;
@@ -5452,6 +5446,65 @@ mod tests {
 
     #[test]
     #[parallel]
+    fn test_dorbittrajectory_to_keplerian_uses_the_frame_center() {
+        setup_global_test_eop();
+
+        let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
+
+        // A circular lunar orbit declared in LCI: elements are taken about the
+        // Moon and keep the trajectory's own frame.
+        let r_moon = R_MOON + 100e3;
+        let v_moon = (GM_MOON / r_moon).sqrt();
+        let mut lci =
+            DOrbitTrajectory::new(6, CelestialFrame::LCI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
+        lci.add(
+            epoch,
+            DVector::from_vec(vec![r_moon, 0.0, 0.0, 0.0, v_moon, 0.0]),
+        )
+        .unwrap();
+
+        let lci_kep = lci.to_keplerian(AngleFormat::Degrees).unwrap();
+        assert_eq!(lci_kep.frame, CelestialFrame::LCI);
+        assert_eq!(lci_kep.representation, OrbitRepresentation::Keplerian);
+        assert_abs_diff_eq!(lci_kep.states[0][0], r_moon, epsilon = 1e-6);
+        assert_abs_diff_eq!(lci_kep.states[0][1], 0.0, epsilon = 1e-9);
+
+        // Earth-centered Cartesian input matches the pairwise Earth conversion
+        // exactly and keeps its GCRF label.
+        let x_gcrf = Vector6::new(R_EARTH + 500e3, 0.0, 0.0, 0.0, 7.6e3, 10.0);
+        let mut gcrf = DOrbitTrajectory::new(
+            6,
+            CelestialFrame::GCRF,
+            OrbitRepresentation::Cartesian,
+            None,
+        )
+        .unwrap();
+        gcrf.add(epoch, svec6_to_dvec(x_gcrf)).unwrap();
+
+        let gcrf_kep = gcrf.to_keplerian(AngleFormat::Degrees).unwrap();
+        assert_eq!(gcrf_kep.frame, CelestialFrame::GCRF);
+        let expected = state_eci_to_koe(x_gcrf, AngleFormat::Degrees);
+        for i in 0..6 {
+            assert_eq!(gcrf_kep.states[0][i], expected[i]);
+        }
+
+        // Earth-fixed and of-date frames admit no Keplerian elements.
+        for frame in [CelestialFrame::ITRF, CelestialFrame::TOD] {
+            let mut traj =
+                DOrbitTrajectory::new(6, frame, OrbitRepresentation::Cartesian, None).unwrap();
+            traj.add(epoch, svec6_to_dvec(x_gcrf)).unwrap();
+            assert!(
+                traj.to_keplerian(AngleFormat::Degrees)
+                    .unwrap_err()
+                    .to_string()
+                    .contains("inertial frame")
+            );
+        }
+    }
+
+    #[test]
+    #[parallel]
     fn test_dorbittrajectory_to_keplerian_already_keplerian_same_format() {
         setup_global_test_eop();
 
@@ -5848,7 +5901,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_dorbittrajectory_bci_all_frame_conversions() {
-        // Remaining BCI(301) arms: state_gcrf/ecef/itrf/eme2000/koe_osc and
+        // Remaining LCI arms: state_gcrf/ecef/itrf/eme2000/koe_osc and
         // the batch to_gcrf/to_ecef/to_itrf/to_eme2000, each checked against
         // the equivalent Earth pairwise conversion of state_eci; covariance
         // passes through unchanged (ICRF-aligned axes).
@@ -6025,8 +6078,14 @@ mod tests {
                 .contains("barycenter")
         );
 
-        // to_keplerian labels its result ECI and rejects BCI.
-        assert!(traj_emb.to_keplerian(AngleFormat::Degrees).is_err());
+        // to_keplerian is undefined about a massless barycenter.
+        assert!(
+            traj_emb
+                .to_keplerian(AngleFormat::Degrees)
+                .unwrap_err()
+                .to_string()
+                .contains("barycenter")
+        );
     }
 
     #[test]
@@ -6982,20 +7041,23 @@ mod tests {
         let rtn = traj.to_frame(ReferenceFrame::RTN("CHIEF")).unwrap();
         assert_eq!(rtn.frame, ReferenceFrame::RTN("CHIEF"));
 
-        // The trajectory is its own chief, so its RTN position is zero.
+        // The trajectory is its own chief, so both its RTN position and its
+        // RTN velocity, which includes the angular-velocity transport term,
+        // are zero.
         for i in 0..traj.len() {
-            for k in 0..3 {
+            for k in 0..6 {
                 assert_abs_diff_eq!(rtn.states[i][k], 0.0, epsilon = 1e-6);
             }
         }
 
         // state_bci on an orbit-relative trajectory resolves GCRF through the
-        // chief's declared frame.
+        // chief's declared frame, recovering the full Cartesian state.
         let e = traj.epochs[3];
         let bci = rtn.state_bci(e).unwrap();
         let expected = traj.state_gcrf(e).unwrap();
-        for k in 0..3 {
-            assert_abs_diff_eq!(bci[k], expected[k], epsilon = 1e-3);
+        for k in 0..6 {
+            let tol = if k < 3 { 1e-3 } else { 1e-6 };
+            assert_abs_diff_eq!(bci[k], expected[k], epsilon = tol);
         }
 
         crate::frames::clear_object_registry();

--- a/src/trajectories/dorbit_trajectory.rs
+++ b/src/trajectories/dorbit_trajectory.rs
@@ -23,7 +23,8 @@
  * ## Standard 6D orbital trajectory
  * ```rust
  * use brahe::trajectories::DOrbitTrajectory;
- * use brahe::traits::{Trajectory, OrbitFrame, OrbitRepresentation};
+ * use brahe::traits::{Trajectory, OrbitRepresentation};
+ * use brahe::frames::CelestialFrame;
  * use brahe::AngleFormat;
  * use brahe::time::{Epoch, TimeSystem};
  * use nalgebra::DVector;
@@ -31,7 +32,7 @@
  * // Create 6D orbital trajectory in ECI Cartesian coordinates
  * let mut traj = DOrbitTrajectory::new(
  *     6,  // dimension
- *     OrbitFrame::ECI,
+ *     CelestialFrame::ECI,
  *     OrbitRepresentation::Cartesian,
  *     None,
  * ).unwrap();
@@ -48,7 +49,8 @@
  * ## Extended state trajectory (6D + additional states)
  * ```rust
  * use brahe::trajectories::DOrbitTrajectory;
- * use brahe::traits::{Trajectory, OrbitFrame, OrbitRepresentation};
+ * use brahe::traits::{Trajectory, OrbitRepresentation};
+ * use brahe::frames::CelestialFrame;
  * use brahe::time::{Epoch, TimeSystem};
  * use nalgebra::DVector;
  *
@@ -60,7 +62,7 @@
  * // Create 9D trajectory (6D orbit + 3 additional states)
  * let mut traj = DOrbitTrajectory::new(
  *     9,  // dimension
- *     OrbitFrame::ECI,
+ *     CelestialFrame::ECI,
  *     OrbitRepresentation::Cartesian,
  *     None,
  * ).unwrap();
@@ -88,17 +90,19 @@ use uuid::Uuid;
 
 use crate::constants::AngleFormat;
 use crate::constants::{DEG2RAD, RAD2DEG};
-use crate::coordinates::{state_eci_to_koe, state_koe_to_eci};
+use crate::coordinates::{state_eci_to_koe, state_inertial_to_koe_gm, state_koe_to_inertial_gm};
 use crate::frames::{
-    rotation_eme2000_to_gcrf, state_ecef_to_eci, state_eci_to_ecef, state_eme2000_to_gcrf,
-    state_gcrf_to_eme2000, state_gcrf_to_itrf, state_itrf_to_gcrf,
+    CelestialFrame, ReferenceFrame, celestial_root, icrf_aligned_inertial,
+    rotation_eme2000_to_gcrf, state_frame_to_frame,
 };
 use crate::math::{
     CovarianceInterpolationConfig, interpolate_covariance_sqrt_dmatrix,
     interpolate_covariance_two_wasserstein_dmatrix, interpolate_hermite_cubic_dvector6,
     interpolate_hermite_quintic_dvector6, interpolate_lagrange_dvector,
 };
+use crate::propagators::CentralBody;
 use crate::relative_motion::rotation_eci_to_rtn;
+use crate::spice::NAIFId;
 use crate::time::Epoch;
 use crate::utils::state_providers::{
     DCovarianceProvider, DOrbitCovarianceProvider, DOrbitStateProvider, DStateProvider,
@@ -138,8 +142,8 @@ fn smat66_to_dmat(sm: SMatrix<f64, 6, 6>) -> DMatrix<f64> {
 
 use super::traits::{
     CovarianceInterpolationMethod, InterpolatableTrajectory, InterpolationConfig,
-    InterpolationMethod, OrbitFrame, OrbitRepresentation, STMStorage, SensitivityStorage,
-    Trajectory, TrajectoryEvictionPolicy,
+    InterpolationMethod, OrbitRepresentation, STMStorage, SensitivityStorage, Trajectory,
+    TrajectoryEvictionPolicy, bci_fixed_frame, covariance_frame_allowed, keplerian_center,
 };
 
 /// Dynamic (runtime-sized) orbital trajectory container.
@@ -208,11 +212,11 @@ pub struct DOrbitTrajectory {
     max_age: Option<f64>,
 
     /// Reference frame of the orbital states.
-    pub frame: OrbitFrame,
+    pub frame: ReferenceFrame,
 
     /// State representation (Cartesian or Keplerian).
-    /// Keplerian elements are always in ECI frame.
-    /// Cartesian can be in ECI or ECEF.
+    /// Keplerian elements require an inertial frame.
+    /// Cartesian states may be declared in any frame.
     pub representation: OrbitRepresentation,
 
     /// Angle format for angular elements
@@ -263,7 +267,7 @@ impl DOrbitTrajectory {
     /// # Arguments
     /// * `dimension` - State vector dimension (must be >= 6). First 6 elements are orbital state,
     ///   elements 6+ are additional states passed through conversions unchanged.
-    /// * `frame` - Reference frame (ECI or ECEF)
+    /// * `frame` - Reference frame the states are declared in
     /// * `representation` - State representation (Cartesian or Keplerian)
     /// * `angle_format` - Angle format (None for Cartesian, Radians/Degrees for Keplerian)
     ///
@@ -275,18 +279,19 @@ impl DOrbitTrajectory {
     /// * If `dimension < 6`
     /// * If Keplerian representation without angle_format
     /// * If Cartesian representation with angle_format
-    /// * If ECEF frame with Keplerian representation
+    /// * If Keplerian representation outside an inertial frame
     ///
     /// # Examples
     /// ```rust
     /// use brahe::trajectories::DOrbitTrajectory;
-    /// use brahe::traits::{OrbitFrame, OrbitRepresentation};
+    /// use brahe::traits::OrbitRepresentation;
+    /// use brahe::frames::CelestialFrame;
     /// use brahe::AngleFormat;
     ///
     /// // Standard 6D orbital trajectory
     /// let traj = DOrbitTrajectory::new(
     ///     6,
-    ///     OrbitFrame::ECI,
+    ///     CelestialFrame::ECI,
     ///     OrbitRepresentation::Cartesian,
     ///     None,
     /// ).unwrap();
@@ -294,17 +299,19 @@ impl DOrbitTrajectory {
     /// // Extended 9D trajectory (6D orbit + 3 additional states)
     /// let traj_extended = DOrbitTrajectory::new(
     ///     9,
-    ///     OrbitFrame::ECI,
+    ///     CelestialFrame::ECI,
     ///     OrbitRepresentation::Cartesian,
     ///     None,
     /// ).unwrap();
     /// ```
     pub fn new(
         dimension: usize,
-        frame: OrbitFrame,
+        frame: impl Into<ReferenceFrame>,
         representation: OrbitRepresentation,
         angle_format: Option<AngleFormat>,
     ) -> Result<Self, BraheError> {
+        let frame = frame.into();
+
         // Validate dimension
         if dimension < 6 {
             return Err(BraheError::Error(format!(
@@ -326,10 +333,8 @@ impl DOrbitTrajectory {
         }
 
         // Validate frame for representation
-        if frame == OrbitFrame::ECEF && representation == OrbitRepresentation::Keplerian {
-            return Err(BraheError::Error(
-                "Keplerian elements should be in ECI frame".to_string(),
-            ));
+        if representation == OrbitRepresentation::Keplerian {
+            keplerian_center(&frame)?;
         }
 
         Ok(Self {
@@ -371,8 +376,9 @@ impl DOrbitTrajectory {
     /// # Examples
     /// ```rust
     /// use brahe::trajectories::DOrbitTrajectory;
-    /// use brahe::traits::{OrbitFrame, OrbitRepresentation, InterpolationMethod};
-    /// let traj = DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+    /// use brahe::traits::{OrbitRepresentation, InterpolationMethod};
+    /// use brahe::frames::CelestialFrame;
+    /// let traj = DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
     ///     .unwrap()
     ///     .with_interpolation_method(InterpolationMethod::Linear);
     /// ```
@@ -399,8 +405,9 @@ impl DOrbitTrajectory {
     /// # Examples
     /// ```rust
     /// use brahe::trajectories::DOrbitTrajectory;
-    /// use brahe::traits::{OrbitFrame, OrbitRepresentation};
-    /// let traj = DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+    /// use brahe::traits::OrbitRepresentation;
+    /// use brahe::frames::CelestialFrame;
+    /// let traj = DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
     ///     .unwrap()
     ///     .with_eviction_policy_max_size(100)
     ///     .unwrap();
@@ -428,8 +435,9 @@ impl DOrbitTrajectory {
     /// # Examples
     /// ```rust
     /// use brahe::trajectories::DOrbitTrajectory;
-    /// use brahe::traits::{OrbitFrame, OrbitRepresentation};
-    /// let traj = DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+    /// use brahe::traits::OrbitRepresentation;
+    /// use brahe::frames::CelestialFrame;
+    /// let traj = DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
     ///     .unwrap()
     ///     .with_eviction_policy_max_age(3600.0)
     ///     .unwrap();
@@ -566,13 +574,14 @@ impl DOrbitTrajectory {
     /// # Examples
     /// ```
     /// use brahe::trajectories::DOrbitTrajectory;
-    /// use brahe::traits::{OrbitFrame, OrbitRepresentation};
+    /// use brahe::traits::OrbitRepresentation;
+    /// use brahe::frames::CelestialFrame;
     /// use brahe::time::{Epoch, TimeSystem};
     /// use nalgebra::{DMatrix, DVector};
     ///
     /// let mut traj = DOrbitTrajectory::new(
     ///     6,
-    ///     OrbitFrame::ECI,
+    ///     CelestialFrame::ECI,
     ///     OrbitRepresentation::Cartesian,
     ///     None,
     /// ).unwrap();
@@ -1083,7 +1092,7 @@ impl Default for DOrbitTrajectory {
     fn default() -> Self {
         Self::new(
             6, // dimension: standard 6D orbital states
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None, // angle_format is None for Cartesian
         )
@@ -1206,7 +1215,7 @@ impl Trajectory for DOrbitTrajectory {
             eviction_policy: TrajectoryEvictionPolicy::None,
             max_size: None,
             max_age: None,
-            frame: OrbitFrame::ECI, // Default to ECI Cartesian
+            frame: CelestialFrame::ECI.into(), // Default to ECI Cartesian
             representation: OrbitRepresentation::Cartesian,
             angle_format: None, // angle_format is not meaningful for Cartesian
             name: None,
@@ -1875,16 +1884,18 @@ impl DOrbitTrajectory {
     /// * `Err(BraheError)` - If parameters are invalid or data validation fails
     ///
     /// # Errors
-    /// * If covariances are provided but frame is not ECI or GCRF
+    /// * If covariances are provided but the frame is neither GCRF nor EME2000
     /// * If covariances length does not match states length
     pub fn from_orbital_data(
         epochs: Vec<Epoch>,
         states: Vec<DVector<f64>>,
-        frame: OrbitFrame,
+        frame: impl Into<ReferenceFrame>,
         representation: OrbitRepresentation,
         angle_format: Option<AngleFormat>,
         covariances: Option<Vec<DMatrix<f64>>>,
     ) -> Result<Self, BraheError> {
+        let frame = frame.into();
+
         // Validate inputs
         if states.is_empty() {
             return Err(BraheError::Error(
@@ -1913,10 +1924,8 @@ impl DOrbitTrajectory {
             }
         }
 
-        if frame == OrbitFrame::ECEF && representation == OrbitRepresentation::Keplerian {
-            return Err(BraheError::Error(
-                "Keplerian elements should be in ECI frame".to_string(),
-            ));
+        if representation == OrbitRepresentation::Keplerian {
+            keplerian_center(&frame)?;
         }
 
         // Validate covariances if provided
@@ -1931,8 +1940,7 @@ impl DOrbitTrajectory {
             }
 
             // Check that frame is ECI, GCRF, or EME2000
-            if frame != OrbitFrame::ECI && frame != OrbitFrame::GCRF && frame != OrbitFrame::EME2000
-            {
+            if !covariance_frame_allowed(&frame) {
                 return Err(BraheError::Error(format!(
                     "Covariances are only supported for ECI, GCRF, and EME2000 frames. Got: {}",
                     frame
@@ -1968,605 +1976,152 @@ impl DOrbitTrajectory {
         })
     }
 
-    /// Cartesian twin of a Keplerian `BodyCenteredInertial` trajectory:
-    /// converts each element set to Cartesian about the center body using
-    /// that body's gravitational parameter. Errors for unknown centers and
-    /// barycenters.
-    fn bci_keplerian_to_cartesian(&self, center: i32) -> Result<Self, BraheError> {
-        let cb = crate::propagators::CentralBody::from_naif_id(center)?;
-        if cb.is_barycenter() {
-            return Err(BraheError::Error(format!(
-                "Keplerian elements are undefined about massless barycenter {}",
-                center
-            )));
+    /// Converts every sample to Cartesian coordinates in `frame`.
+    ///
+    /// Keplerian samples are first converted to Cartesian coordinates about
+    /// their own frame's center, using that body's gravitational parameter.
+    /// The result is then routed to `frame` by the reference frame router,
+    /// which resolves any center offset through the loaded SPK kernels.
+    /// Covariances, state transition matrices, sensitivities, and
+    /// accelerations are dropped.
+    ///
+    /// For extended states (dimension > 6), only the first 6 elements
+    /// (orbital state) are converted. Additional elements (6+) are preserved
+    /// unchanged.
+    ///
+    /// # Arguments
+    /// * `frame` - Target reference frame
+    ///
+    /// # Returns
+    /// * `Ok(DOrbitTrajectory)` - New Cartesian trajectory in `frame`, preserving dimension
+    /// * `Err(BraheError)` - If a sample cannot be converted (unbound or
+    ///   unregistered frame, missing ephemeris, or Keplerian elements about
+    ///   a massless barycenter)
+    ///
+    /// # Examples
+    /// ```rust
+    /// use brahe::trajectories::DOrbitTrajectory;
+    /// use brahe::traits::{Trajectory, OrbitRepresentation};
+    /// use brahe::frames::CelestialFrame;
+    /// use brahe::time::{Epoch, TimeSystem};
+    /// use nalgebra::DVector;
+    ///
+    /// brahe::eop::set_global_eop_provider(
+    ///     brahe::eop::StaticEOPProvider::from_values((0.0, 0.0, 0.0, 0.0, 0.0, 0.0))
+    /// );
+    ///
+    /// let mut traj = DOrbitTrajectory::new(
+    ///     6,
+    ///     CelestialFrame::GCRF,
+    ///     OrbitRepresentation::Cartesian,
+    ///     None,
+    /// ).unwrap();
+    /// let epoch = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
+    /// traj.add(epoch, DVector::from_vec(vec![6.678e6, 0.0, 0.0, 0.0, 7.726e3, 0.0])).unwrap();
+    ///
+    /// let itrf = traj.to_frame(CelestialFrame::ITRF).unwrap();
+    /// assert!(itrf.frame == CelestialFrame::ITRF);
+    /// ```
+    pub fn to_frame(&self, frame: impl Into<ReferenceFrame>) -> Result<Self, BraheError> {
+        let frame = frame.into();
+
+        let mut states_converted = Vec::with_capacity(self.states.len());
+        for (e, s) in self.into_iter() {
+            let converted = self.try_convert_orbital_preserving_additional(&s, |orbital| {
+                let x = self.native_cartesian(orbital)?;
+                if self.frame == frame {
+                    Ok(x)
+                } else {
+                    state_frame_to_frame(self.frame.clone(), frame.clone(), e, x)
+                }
+            })?;
+            states_converted.push(converted);
         }
-        let angle_fmt = self
-            .angle_format
-            .expect("Keplerian representation must have angle_format");
-        let mut out = self.clone();
-        out.states = self
-            .states
-            .iter()
-            .map(|s| {
-                self.convert_orbital_preserving_additional(s, |orbital| {
-                    crate::coordinates::state_koe_to_inertial_gm(orbital, cb.gm(), angle_fmt)
-                })
-            })
-            .collect();
-        out.representation = OrbitRepresentation::Cartesian;
-        out.angle_format = None;
-        Ok(out)
+
+        Ok(Self {
+            epochs: self.epochs.clone(),
+            states: states_converted,
+            covariances: None,   // Covariances are dropped during frame conversions
+            stms: None,          // STMs are dropped during frame conversions
+            sensitivities: None, // Sensitivities are dropped during frame conversions
+            sensitivity_dimension: None,
+            dimension: self.dimension, // Preserve dimension
+            interpolation_method: self.interpolation_method,
+            covariance_interpolation_method: self.covariance_interpolation_method,
+            eviction_policy: self.eviction_policy,
+            max_size: self.max_size,
+            max_age: self.max_age,
+            frame,
+            representation: OrbitRepresentation::Cartesian,
+            angle_format: None,
+            name: self.name.clone(),
+            id: self.id,
+            uuid: self.uuid,
+            metadata: self.metadata.clone(),
+            accelerations: None, // Accelerations are dropped during frame conversions
+            acceleration_dimension: None,
+        })
     }
 
     /// Convert trajectory to ECI (Earth-Centered Inertial) frame with Cartesian representation.
     ///
-    /// Converts all states to ECI frame and Cartesian representation.
-    /// For Keplerian inputs, converts to Cartesian first.
-    /// For ECEF/ITRF frames, uses epoch-dependent transformation.
-    ///
-    /// For extended states (dimension > 6), only the first 6 elements (orbital state)
-    /// are converted. Additional elements (6+) are preserved unchanged.
+    /// ECI is realized as GCRF. See [`Self::to_frame`] for the conversion
+    /// rules and the treatment of extended states.
     ///
     /// # Returns
-    /// New trajectory in ECI frame with Cartesian states, preserving dimension.
+    /// * `Ok(DOrbitTrajectory)` - New trajectory in GCRF with Cartesian states
+    /// * `Err(BraheError)` - If conversion fails
     pub fn to_eci(&self) -> Result<Self, BraheError> {
-        // Keplerian samples about a non-Earth center would otherwise be
-        // converted with Earth's GM and no re-centering: convert to native
-        // Cartesian about the center first, then take the Cartesian path.
-        if let OrbitFrame::BodyCenteredInertial(center) = self.frame
-            && self.representation == OrbitRepresentation::Keplerian
-        {
-            return self.bci_keplerian_to_cartesian(center)?.to_eci();
-        }
-        let states_converted: Vec<DVector<f64>> = match self.representation {
-            OrbitRepresentation::Keplerian => {
-                let mut states_converted = Vec::with_capacity(self.states.len());
-                let angle_fmt = self
-                    .angle_format
-                    .expect("Keplerian representation must have angle_format");
-                // Convert Keplerian to Cartesian (first 6 elements only)
-                for (_e, s) in self.into_iter() {
-                    let converted = self.convert_orbital_preserving_additional(&s, |orbital| {
-                        state_koe_to_eci(orbital, angle_fmt)
-                    });
-                    states_converted.push(converted);
-                }
-                states_converted
-            }
-            OrbitRepresentation::Cartesian => {
-                match self.frame {
-                    OrbitFrame::BodyCenteredInertial(center) => {
-                        // Re-center through the frame router (SPK-resolved
-                        // center offset).
-                        let native = crate::trajectories::traits::bci_reference_frame(center);
-                        let mut states_converted = Vec::with_capacity(self.states.len());
-                        for (e, s) in self.into_iter() {
-                            let converted =
-                                self.try_convert_orbital_preserving_additional(&s, |orbital| {
-                                    crate::frames::state_frame_to_frame(
-                                        native,
-                                        crate::frames::CelestialFrame::GCRF,
-                                        e,
-                                        orbital,
-                                    )
-                                })?;
-                            states_converted.push(converted);
-                        }
-                        states_converted
-                    }
-                    OrbitFrame::EME2000 => {
-                        let mut states_converted = Vec::with_capacity(self.states.len());
-                        // EME2000 Cartesian to GCRF Cartesian (no epoch needed)
-                        for (_e, s) in self.into_iter() {
-                            let converted = self
-                                .convert_orbital_preserving_additional(&s, |orbital| {
-                                    state_eme2000_to_gcrf(orbital)
-                                });
-                            states_converted.push(converted);
-                        }
-                        states_converted
-                    }
-                    OrbitFrame::ITRF | OrbitFrame::ECEF => {
-                        let mut states_converted = Vec::with_capacity(self.states.len());
-                        // ITRF/ECEF Cartesian to GCRF Cartesian (requires epoch)
-                        for (e, s) in self.into_iter() {
-                            let converted = self
-                                .convert_orbital_preserving_additional(&s, |orbital| {
-                                    state_itrf_to_gcrf(e, orbital)
-                                });
-                            states_converted.push(converted);
-                        }
-                        states_converted
-                    }
-                    OrbitFrame::ECI | OrbitFrame::GCRF => {
-                        // No conversion needed
-                        self.states.clone()
-                    }
-                }
-            }
-        };
-
-        Ok(Self {
-            epochs: self.epochs.clone(),
-            states: states_converted,
-            covariances: None,   // Covariances are dropped during frame conversions
-            stms: None,          // STMs are dropped during frame conversions
-            sensitivities: None, // Sensitivities are dropped during frame conversions
-            sensitivity_dimension: None,
-            dimension: self.dimension, // Preserve dimension
-            interpolation_method: self.interpolation_method,
-            covariance_interpolation_method: self.covariance_interpolation_method,
-            eviction_policy: self.eviction_policy,
-            max_size: self.max_size,
-            max_age: self.max_age,
-            frame: OrbitFrame::ECI,
-            representation: OrbitRepresentation::Cartesian,
-            angle_format: None,
-            name: self.name.clone(),
-            id: self.id,
-            uuid: self.uuid,
-            metadata: self.metadata.clone(),
-            accelerations: None, // Accelerations are dropped during frame conversions
-            acceleration_dimension: None,
-        })
+        self.to_frame(CelestialFrame::GCRF)
     }
 
     /// Convert trajectory to GCRF (Geocentric Celestial Reference Frame) with Cartesian representation.
     ///
-    /// Converts all states to GCRF frame and Cartesian representation.
-    /// For Keplerian inputs, converts to Cartesian first.
-    /// For ECEF/ITRF frames, uses epoch-dependent transformation.
-    ///
-    /// For extended states (dimension > 6), only the first 6 elements (orbital state)
-    /// are converted. Additional elements (6+) are preserved unchanged.
+    /// See [`Self::to_frame`] for the conversion rules and the treatment of
+    /// extended states.
     ///
     /// # Returns
-    /// New trajectory in GCRF frame with Cartesian states, preserving dimension.
+    /// * `Ok(DOrbitTrajectory)` - New trajectory in GCRF with Cartesian states
+    /// * `Err(BraheError)` - If conversion fails
     pub fn to_gcrf(&self) -> Result<Self, BraheError> {
-        // Keplerian samples about a non-Earth center would otherwise be
-        // converted with Earth's GM and no re-centering: convert to native
-        // Cartesian about the center first, then take the Cartesian path.
-        if let OrbitFrame::BodyCenteredInertial(center) = self.frame
-            && self.representation == OrbitRepresentation::Keplerian
-        {
-            return self.bci_keplerian_to_cartesian(center)?.to_gcrf();
-        }
-        let states_converted: Vec<DVector<f64>> = match self.representation {
-            OrbitRepresentation::Keplerian => {
-                let mut states_converted = Vec::with_capacity(self.states.len());
-                let angle_fmt = self
-                    .angle_format
-                    .expect("Keplerian representation must have angle_format");
-                // Convert Keplerian to Cartesian (first 6 elements only)
-                for (_e, s) in self.into_iter() {
-                    let converted = self.convert_orbital_preserving_additional(&s, |orbital| {
-                        state_koe_to_eci(orbital, angle_fmt)
-                    });
-                    states_converted.push(converted);
-                }
-                states_converted
-            }
-            OrbitRepresentation::Cartesian => {
-                match self.frame {
-                    OrbitFrame::BodyCenteredInertial(center) => {
-                        // Re-center through the frame router (SPK-resolved
-                        // center offset).
-                        let native = crate::trajectories::traits::bci_reference_frame(center);
-                        let mut states_converted = Vec::with_capacity(self.states.len());
-                        for (e, s) in self.into_iter() {
-                            let converted =
-                                self.try_convert_orbital_preserving_additional(&s, |orbital| {
-                                    crate::frames::state_frame_to_frame(
-                                        native,
-                                        crate::frames::CelestialFrame::GCRF,
-                                        e,
-                                        orbital,
-                                    )
-                                })?;
-                            states_converted.push(converted);
-                        }
-                        states_converted
-                    }
-                    OrbitFrame::EME2000 => {
-                        let mut states_converted = Vec::with_capacity(self.states.len());
-                        // EME2000 Cartesian to GCRF Cartesian (no epoch needed)
-                        for (_e, s) in self.into_iter() {
-                            let converted = self
-                                .convert_orbital_preserving_additional(&s, |orbital| {
-                                    state_eme2000_to_gcrf(orbital)
-                                });
-                            states_converted.push(converted);
-                        }
-                        states_converted
-                    }
-                    OrbitFrame::ITRF | OrbitFrame::ECEF => {
-                        let mut states_converted = Vec::with_capacity(self.states.len());
-                        // ITRF/ECEF Cartesian to GCRF Cartesian (requires epoch)
-                        for (e, s) in self.into_iter() {
-                            let converted = self
-                                .convert_orbital_preserving_additional(&s, |orbital| {
-                                    state_itrf_to_gcrf(e, orbital)
-                                });
-                            states_converted.push(converted);
-                        }
-                        states_converted
-                    }
-                    OrbitFrame::ECI | OrbitFrame::GCRF => {
-                        // No conversion needed
-                        self.states.clone()
-                    }
-                }
-            }
-        };
-
-        Ok(Self {
-            epochs: self.epochs.clone(),
-            states: states_converted,
-            covariances: None,   // Covariances are dropped during frame conversions
-            stms: None,          // STMs are dropped during frame conversions
-            sensitivities: None, // Sensitivities are dropped during frame conversions
-            sensitivity_dimension: None,
-            dimension: self.dimension, // Preserve dimension
-            interpolation_method: self.interpolation_method,
-            covariance_interpolation_method: self.covariance_interpolation_method,
-            eviction_policy: self.eviction_policy,
-            max_size: self.max_size,
-            max_age: self.max_age,
-            frame: OrbitFrame::GCRF,
-            representation: OrbitRepresentation::Cartesian,
-            angle_format: None,
-            name: self.name.clone(),
-            id: self.id,
-            uuid: self.uuid,
-            metadata: self.metadata.clone(),
-            accelerations: None, // Accelerations are dropped during frame conversions
-            acceleration_dimension: None,
-        })
+        self.to_frame(CelestialFrame::GCRF)
     }
 
     /// Convert trajectory to ECEF (Earth-Centered Earth-Fixed) frame with Cartesian representation.
     ///
-    /// Converts all states to ECEF frame and Cartesian representation.
-    /// For Keplerian inputs, converts to Cartesian first.
-    /// For ECI/GCRF/EME2000 frames, uses epoch-dependent transformation.
-    ///
-    /// For extended states (dimension > 6), only the first 6 elements (orbital state)
-    /// are converted. Additional elements (6+) are preserved unchanged.
+    /// ECEF is realized as ITRF. See [`Self::to_frame`] for the conversion
+    /// rules and the treatment of extended states.
     ///
     /// # Returns
-    /// New trajectory in ECEF frame with Cartesian states, preserving dimension.
+    /// * `Ok(DOrbitTrajectory)` - New trajectory in ITRF with Cartesian states
+    /// * `Err(BraheError)` - If conversion fails
     pub fn to_ecef(&self) -> Result<Self, BraheError> {
-        // Keplerian samples about a non-Earth center would otherwise be
-        // converted with Earth's GM and no re-centering: convert to native
-        // Cartesian about the center first, then take the Cartesian path.
-        if let OrbitFrame::BodyCenteredInertial(center) = self.frame
-            && self.representation == OrbitRepresentation::Keplerian
-        {
-            return self.bci_keplerian_to_cartesian(center)?.to_ecef();
-        }
-        let states_converted: Vec<DVector<f64>> = match self.representation {
-            OrbitRepresentation::Keplerian => {
-                let mut states_converted = Vec::with_capacity(self.states.len());
-                let angle_fmt = self
-                    .angle_format
-                    .expect("Keplerian representation must have angle_format");
-                // Convert Keplerian to Cartesian ECI, then to ECEF
-                for (e, s) in self.into_iter() {
-                    let converted = self.convert_orbital_preserving_additional(&s, |orbital| {
-                        let state_eci = state_koe_to_eci(orbital, angle_fmt);
-                        state_eci_to_ecef(e, state_eci)
-                    });
-                    states_converted.push(converted);
-                }
-                states_converted
-            }
-            OrbitRepresentation::Cartesian => {
-                match self.frame {
-                    OrbitFrame::BodyCenteredInertial(center) => {
-                        // Re-center through the frame router (SPK-resolved
-                        // center offset).
-                        let native = crate::trajectories::traits::bci_reference_frame(center);
-                        let mut states_converted = Vec::with_capacity(self.states.len());
-                        for (e, s) in self.into_iter() {
-                            let converted =
-                                self.try_convert_orbital_preserving_additional(&s, |orbital| {
-                                    crate::frames::state_frame_to_frame(
-                                        native,
-                                        crate::frames::CelestialFrame::ITRF,
-                                        e,
-                                        orbital,
-                                    )
-                                })?;
-                            states_converted.push(converted);
-                        }
-                        states_converted
-                    }
-                    OrbitFrame::EME2000 => {
-                        let mut states_converted = Vec::with_capacity(self.states.len());
-                        // EME2000 -> GCRF -> ITRF
-                        for (e, s) in self.into_iter() {
-                            let converted =
-                                self.convert_orbital_preserving_additional(&s, |orbital| {
-                                    let state_gcrf = state_eme2000_to_gcrf(orbital);
-                                    state_gcrf_to_itrf(e, state_gcrf)
-                                });
-                            states_converted.push(converted);
-                        }
-                        states_converted
-                    }
-                    OrbitFrame::ITRF | OrbitFrame::ECEF => {
-                        // Already in ITRF frame
-                        self.states.clone()
-                    }
-                    OrbitFrame::ECI | OrbitFrame::GCRF => {
-                        let mut states_converted = Vec::with_capacity(self.states.len());
-                        // GCRF/ECI to ITRF
-                        for (e, s) in self.into_iter() {
-                            let converted = self
-                                .convert_orbital_preserving_additional(&s, |orbital| {
-                                    state_gcrf_to_itrf(e, orbital)
-                                });
-                            states_converted.push(converted);
-                        }
-                        states_converted
-                    }
-                }
-            }
-        };
-
-        Ok(Self {
-            epochs: self.epochs.clone(),
-            states: states_converted,
-            covariances: None,   // Covariances are dropped during frame conversions
-            stms: None,          // STMs are dropped during frame conversions
-            sensitivities: None, // Sensitivities are dropped during frame conversions
-            sensitivity_dimension: None,
-            dimension: self.dimension, // Preserve dimension
-            interpolation_method: self.interpolation_method,
-            covariance_interpolation_method: self.covariance_interpolation_method,
-            eviction_policy: self.eviction_policy,
-            max_size: self.max_size,
-            max_age: self.max_age,
-            frame: OrbitFrame::ECEF,
-            representation: OrbitRepresentation::Cartesian,
-            angle_format: None,
-            name: self.name.clone(),
-            id: self.id,
-            uuid: self.uuid,
-            metadata: self.metadata.clone(),
-            accelerations: None, // Accelerations are dropped during frame conversions
-            acceleration_dimension: None,
-        })
+        self.to_frame(CelestialFrame::ITRF)
     }
 
     /// Convert trajectory to ITRF (International Terrestrial Reference Frame) with Cartesian representation.
     ///
-    /// Converts all states to ITRF frame and Cartesian representation.
-    /// For Keplerian inputs, converts to Cartesian first.
-    /// For ECI/GCRF/EME2000 frames, uses epoch-dependent transformation.
-    ///
-    /// For extended states (dimension > 6), only the first 6 elements (orbital state)
-    /// are converted. Additional elements (6+) are preserved unchanged.
+    /// See [`Self::to_frame`] for the conversion rules and the treatment of
+    /// extended states.
     ///
     /// # Returns
-    /// New trajectory in ITRF frame with Cartesian states, preserving dimension.
+    /// * `Ok(DOrbitTrajectory)` - New trajectory in ITRF with Cartesian states
+    /// * `Err(BraheError)` - If conversion fails
     pub fn to_itrf(&self) -> Result<Self, BraheError> {
-        // Keplerian samples about a non-Earth center would otherwise be
-        // converted with Earth's GM and no re-centering: convert to native
-        // Cartesian about the center first, then take the Cartesian path.
-        if let OrbitFrame::BodyCenteredInertial(center) = self.frame
-            && self.representation == OrbitRepresentation::Keplerian
-        {
-            return self.bci_keplerian_to_cartesian(center)?.to_itrf();
-        }
-        let states_converted: Vec<DVector<f64>> = match self.representation {
-            OrbitRepresentation::Keplerian => {
-                let mut states_converted = Vec::with_capacity(self.states.len());
-                let angle_fmt = self
-                    .angle_format
-                    .expect("Keplerian representation must have angle_format");
-                // Keplerian to Cartesian (in GCRF/ECI), then GCRF to ITRF
-                for (e, s) in self.into_iter() {
-                    let converted = self.convert_orbital_preserving_additional(&s, |orbital| {
-                        let state_cartesian = state_koe_to_eci(orbital, angle_fmt);
-                        state_gcrf_to_itrf(e, state_cartesian)
-                    });
-                    states_converted.push(converted);
-                }
-                states_converted
-            }
-            OrbitRepresentation::Cartesian => {
-                match self.frame {
-                    OrbitFrame::BodyCenteredInertial(center) => {
-                        // Re-center through the frame router (SPK-resolved
-                        // center offset).
-                        let native = crate::trajectories::traits::bci_reference_frame(center);
-                        let mut states_converted = Vec::with_capacity(self.states.len());
-                        for (e, s) in self.into_iter() {
-                            let converted =
-                                self.try_convert_orbital_preserving_additional(&s, |orbital| {
-                                    crate::frames::state_frame_to_frame(
-                                        native,
-                                        crate::frames::CelestialFrame::ITRF,
-                                        e,
-                                        orbital,
-                                    )
-                                })?;
-                            states_converted.push(converted);
-                        }
-                        states_converted
-                    }
-                    OrbitFrame::EME2000 => {
-                        let mut states_converted = Vec::with_capacity(self.states.len());
-                        // EME2000 -> GCRF -> ITRF
-                        for (e, s) in self.into_iter() {
-                            let converted =
-                                self.convert_orbital_preserving_additional(&s, |orbital| {
-                                    let state_gcrf = state_eme2000_to_gcrf(orbital);
-                                    state_gcrf_to_itrf(e, state_gcrf)
-                                });
-                            states_converted.push(converted);
-                        }
-                        states_converted
-                    }
-                    OrbitFrame::ITRF | OrbitFrame::ECEF => {
-                        // Already in ITRF frame
-                        self.states.clone()
-                    }
-                    OrbitFrame::ECI | OrbitFrame::GCRF => {
-                        let mut states_converted = Vec::with_capacity(self.states.len());
-                        // GCRF/ECI to ITRF
-                        for (e, s) in self.into_iter() {
-                            let converted = self
-                                .convert_orbital_preserving_additional(&s, |orbital| {
-                                    state_gcrf_to_itrf(e, orbital)
-                                });
-                            states_converted.push(converted);
-                        }
-                        states_converted
-                    }
-                }
-            }
-        };
-
-        Ok(Self {
-            epochs: self.epochs.clone(),
-            states: states_converted,
-            covariances: None,   // Covariances are dropped during frame conversions
-            stms: None,          // STMs are dropped during frame conversions
-            sensitivities: None, // Sensitivities are dropped during frame conversions
-            sensitivity_dimension: None,
-            dimension: self.dimension, // Preserve dimension
-            interpolation_method: self.interpolation_method,
-            covariance_interpolation_method: self.covariance_interpolation_method,
-            eviction_policy: self.eviction_policy,
-            max_size: self.max_size,
-            max_age: self.max_age,
-            frame: OrbitFrame::ITRF,
-            representation: OrbitRepresentation::Cartesian,
-            angle_format: None,
-            name: self.name.clone(),
-            id: self.id,
-            uuid: self.uuid,
-            metadata: self.metadata.clone(),
-            accelerations: None, // Accelerations are dropped during frame conversions
-            acceleration_dimension: None,
-        })
+        self.to_frame(CelestialFrame::ITRF)
     }
 
-    /// Convert trajectory to EME2000 (Earth Mean Equator and Equinox of J2000) frame with Cartesian representation.
+    /// Convert trajectory to EME2000 (Earth Mean Equator and Equinox of J2000.0) frame
+    /// with Cartesian representation.
     ///
-    /// Converts all states to EME2000 frame and Cartesian representation.
-    /// For Keplerian inputs, converts to Cartesian first.
-    /// For ECEF/ITRF frames, uses epoch-dependent transformation to GCRF first.
-    ///
-    /// For extended states (dimension > 6), only the first 6 elements (orbital state)
-    /// are converted. Additional elements (6+) are preserved unchanged.
+    /// See [`Self::to_frame`] for the conversion rules and the treatment of
+    /// extended states.
     ///
     /// # Returns
-    /// New trajectory in EME2000 frame with Cartesian states, preserving dimension.
+    /// * `Ok(DOrbitTrajectory)` - New trajectory in EME2000 with Cartesian states
+    /// * `Err(BraheError)` - If conversion fails
     pub fn to_eme2000(&self) -> Result<Self, BraheError> {
-        // Keplerian samples about a non-Earth center would otherwise be
-        // converted with Earth's GM and no re-centering: convert to native
-        // Cartesian about the center first, then take the Cartesian path.
-        if let OrbitFrame::BodyCenteredInertial(center) = self.frame
-            && self.representation == OrbitRepresentation::Keplerian
-        {
-            return self.bci_keplerian_to_cartesian(center)?.to_eme2000();
-        }
-        let states_converted: Vec<DVector<f64>> = match self.representation {
-            OrbitRepresentation::Keplerian => {
-                let mut states_converted = Vec::with_capacity(self.states.len());
-                let angle_fmt = self
-                    .angle_format
-                    .expect("Keplerian representation must have angle_format");
-                // Keplerian to Cartesian GCRF, then to EME2000
-                for (_e, s) in self.into_iter() {
-                    let converted = self.convert_orbital_preserving_additional(&s, |orbital| {
-                        let state_cartesian = state_koe_to_eci(orbital, angle_fmt);
-                        state_gcrf_to_eme2000(state_cartesian)
-                    });
-                    states_converted.push(converted);
-                }
-                states_converted
-            }
-            OrbitRepresentation::Cartesian => {
-                match self.frame {
-                    OrbitFrame::BodyCenteredInertial(center) => {
-                        // Re-center through the frame router (SPK-resolved
-                        // center offset).
-                        let native = crate::trajectories::traits::bci_reference_frame(center);
-                        let mut states_converted = Vec::with_capacity(self.states.len());
-                        for (e, s) in self.into_iter() {
-                            let converted =
-                                self.try_convert_orbital_preserving_additional(&s, |orbital| {
-                                    crate::frames::state_frame_to_frame(
-                                        native,
-                                        crate::frames::CelestialFrame::EME2000,
-                                        e,
-                                        orbital,
-                                    )
-                                })?;
-                            states_converted.push(converted);
-                        }
-                        states_converted
-                    }
-                    OrbitFrame::EME2000 => {
-                        // Already in EME2000 frame
-                        self.states.clone()
-                    }
-                    OrbitFrame::ITRF | OrbitFrame::ECEF => {
-                        let mut states_converted = Vec::with_capacity(self.states.len());
-                        // ITRF/ECEF -> GCRF -> EME2000
-                        for (e, s) in self.into_iter() {
-                            let converted =
-                                self.convert_orbital_preserving_additional(&s, |orbital| {
-                                    let state_gcrf = state_itrf_to_gcrf(e, orbital);
-                                    state_gcrf_to_eme2000(state_gcrf)
-                                });
-                            states_converted.push(converted);
-                        }
-                        states_converted
-                    }
-                    OrbitFrame::ECI | OrbitFrame::GCRF => {
-                        let mut states_converted = Vec::with_capacity(self.states.len());
-                        // ECI/GCRF to EME2000
-                        for (_e, s) in self.into_iter() {
-                            let converted = self
-                                .convert_orbital_preserving_additional(&s, |orbital| {
-                                    state_gcrf_to_eme2000(orbital)
-                                });
-                            states_converted.push(converted);
-                        }
-                        states_converted
-                    }
-                }
-            }
-        };
-
-        Ok(Self {
-            epochs: self.epochs.clone(),
-            states: states_converted,
-            covariances: None,   // Covariances are dropped during frame conversions
-            stms: None,          // STMs are dropped during frame conversions
-            sensitivities: None, // Sensitivities are dropped during frame conversions
-            sensitivity_dimension: None,
-            dimension: self.dimension, // Preserve dimension
-            interpolation_method: self.interpolation_method,
-            covariance_interpolation_method: self.covariance_interpolation_method,
-            eviction_policy: self.eviction_policy,
-            max_size: self.max_size,
-            max_age: self.max_age,
-            frame: OrbitFrame::EME2000,
-            representation: OrbitRepresentation::Cartesian,
-            angle_format: None,
-            name: self.name.clone(),
-            id: self.id,
-            uuid: self.uuid,
-            metadata: self.metadata.clone(),
-            accelerations: None, // Accelerations are dropped during frame conversions
-            acceleration_dimension: None,
-        })
+        self.to_frame(CelestialFrame::EME2000)
     }
 
     /// Convert trajectory to Keplerian orbital elements representation.
@@ -2584,7 +2139,7 @@ impl DOrbitTrajectory {
     /// # Returns
     /// * `Ok(Self)` - New trajectory with Keplerian representation in specified
     ///   angle format, preserving dimension.
-    /// * `Err(BraheError)` - If the trajectory is body-centered inertial (its
+    /// * `Err(BraheError)` - If the trajectory is not Earth-centered (its
     ///   Keplerian result would be undefined) or conversion otherwise fails.
     pub fn to_keplerian(&self, angle_format: AngleFormat) -> Result<Self, BraheError> {
         let states_converted: Vec<DVector<f64>> = match self.representation {
@@ -2629,55 +2184,33 @@ impl DOrbitTrajectory {
                 }
             }
             OrbitRepresentation::Cartesian => {
-                match self.frame {
-                    OrbitFrame::BodyCenteredInertial(_) => {
-                        return Err(BraheError::Error(
-                            "to_keplerian labels its result ECI, which is undefined for a \
-                             body-centered inertial trajectory; use state_koe_osc for \
-                             per-epoch elements about the trajectory's own center"
-                                .to_string(),
-                        ));
-                    }
-                    OrbitFrame::EME2000 => {
-                        let mut states_converted = Vec::with_capacity(self.states.len());
-                        // EME2000 -> GCRF -> Keplerian
-                        for (_e, s) in self.into_iter() {
-                            let converted =
-                                self.convert_orbital_preserving_additional(&s, |orbital| {
-                                    let state_gcrf = state_eme2000_to_gcrf(orbital);
-                                    state_eci_to_koe(state_gcrf, angle_format)
-                                });
-                            states_converted.push(converted);
-                        }
-                        states_converted
-                    }
-                    OrbitFrame::ITRF | OrbitFrame::ECEF => {
-                        let mut states_converted = Vec::with_capacity(self.states.len());
-                        // ITRF/ECEF -> ECI -> Keplerian
-                        for (e, s) in self.into_iter() {
-                            let converted =
-                                self.convert_orbital_preserving_additional(&s, |orbital| {
-                                    let state_eci = state_ecef_to_eci(e, orbital);
-                                    state_eci_to_koe(state_eci, angle_format)
-                                });
-                            states_converted.push(converted);
-                        }
-                        states_converted
-                    }
-                    OrbitFrame::ECI | OrbitFrame::GCRF => {
-                        let mut states_converted = Vec::with_capacity(self.states.len());
-                        // ECI/GCRF Cartesian -> Keplerian
-                        for (_e, s) in self.into_iter() {
-                            let converted = self
-                                .convert_orbital_preserving_additional(&s, |orbital| {
-                                    state_eci_to_koe(orbital, angle_format)
-                                });
-                            states_converted.push(converted);
-                        }
-                        states_converted
-                    }
+                if celestial_root(&self.frame)?.center_naif_id() != NAIFId::Earth.id() {
+                    return Err(BraheError::Error(
+                        "to_keplerian labels its result ECI, which is undefined for a \
+                         trajectory centered on another body; use state_koe_osc for \
+                         per-epoch elements about the trajectory's own center"
+                            .to_string(),
+                    ));
                 }
+                // Route to GCRF, then take two-body elements about the Earth.
+                let gcrf = self.to_frame(CelestialFrame::GCRF)?;
+                let mut states_converted = Vec::with_capacity(gcrf.states.len());
+                for (_e, s) in (&gcrf).into_iter() {
+                    let converted = gcrf.convert_orbital_preserving_additional(&s, |orbital| {
+                        state_eci_to_koe(orbital, angle_format)
+                    });
+                    states_converted.push(converted);
+                }
+                states_converted
             }
+        };
+
+        // Cartesian samples are relabeled GCRF; element samples keep the
+        // frame their elements are already referenced to.
+        let frame = if self.representation == OrbitRepresentation::Cartesian {
+            CelestialFrame::GCRF.into()
+        } else {
+            self.frame.clone()
         };
 
         Ok(Self {
@@ -2693,7 +2226,7 @@ impl DOrbitTrajectory {
             eviction_policy: self.eviction_policy,
             max_size: self.max_size,
             max_age: self.max_age,
-            frame: OrbitFrame::ECI,
+            frame,
             representation: OrbitRepresentation::Keplerian,
             angle_format: Some(angle_format),
             name: self.name.clone(),
@@ -2840,26 +2373,31 @@ impl DCovarianceProvider for DOrbitTrajectory {
 // =============================================================================
 
 impl DOrbitTrajectory {
-    /// Native Cartesian orbital state about this BodyCenteredInertial
-    /// trajectory's own center: identity for Cartesian representation,
-    /// elements-to-Cartesian about the center body (using its GM) for
-    /// Keplerian representation.
-    fn bci_native_cartesian(
-        &self,
-        center: i32,
-        state: Vector6<f64>,
-    ) -> Result<Vector6<f64>, BraheError> {
+    /// The first six elements of `state` as a Cartesian state in this
+    /// trajectory's own frame: unchanged for Cartesian samples, converted
+    /// from Keplerian elements with the gravitational parameter of the
+    /// frame's center otherwise.
+    ///
+    /// # Arguments
+    /// * `state` - Orbital state in this trajectory's native representation
+    ///
+    /// # Returns
+    /// * `Ok(Vector6<f64>)`: Cartesian state in this trajectory's frame. Units: (*m*; *m/s*)
+    /// * `Err(BraheError)`: If the frame does not admit Keplerian elements,
+    ///   or its center is an unknown body or a massless barycenter
+    fn native_cartesian(&self, state: Vector6<f64>) -> Result<Vector6<f64>, BraheError> {
         match self.representation {
             OrbitRepresentation::Cartesian => Ok(state),
             OrbitRepresentation::Keplerian => {
-                let cb = crate::propagators::CentralBody::from_naif_id(center)?;
+                let center = keplerian_center(&self.frame)?;
+                let cb = CentralBody::from_naif_id(center)?;
                 if cb.is_barycenter() {
                     return Err(BraheError::Error(format!(
                         "Keplerian elements are undefined about massless barycenter {}",
                         center
                     )));
                 }
-                Ok(crate::coordinates::state_koe_to_inertial_gm(
+                Ok(state_koe_to_inertial_gm(
                     state,
                     cb.gm(),
                     self.angle_format
@@ -2871,355 +2409,61 @@ impl DOrbitTrajectory {
 }
 
 impl DOrbitStateProvider for DOrbitTrajectory {
-    /// Returns the state in this trajectory's own body-centered inertial
-    /// frame: the raw interpolated state for a `BodyCenteredInertial`
-    /// trajectory (converted from elements if Keplerian), `GCRF` for
-    /// Earth-frame trajectories.
+    /// Returns the state in the ICRF-aligned inertial frame centered on this
+    /// trajectory's own central body, found from the trajectory's frame via
+    /// its celestial root.
     fn state_bci(&self, epoch: Epoch) -> Result<Vector6<f64>, BraheError> {
-        match self.frame {
-            OrbitFrame::BodyCenteredInertial(center) => {
-                let state_dvec = self.interpolate(&epoch)?;
-                let state = Vector6::from_iterator(state_dvec.iter().take(6).copied());
-                self.bci_native_cartesian(center, state)
-            }
-            _ => self.state_gcrf(epoch),
-        }
+        let root = celestial_root(&self.frame)?;
+        self.state_in_frame(icrf_aligned_inertial(root), epoch)
     }
 
-    /// Returns the state in this trajectory's central body's body-fixed
-    /// frame (`ITRF` for Earth-frame trajectories, `LFPA`/`MCMF`/IAU frame
-    /// for a `BodyCenteredInertial` trajectory); errors for centers without
-    /// a body-fixed frame (barycenters, uncatalogued bodies).
+    /// Returns the state in the body-fixed frame of this trajectory's central
+    /// body (`ITRF` for Earth-centered trajectories, `LFPA`/`MCMF`/the IAU
+    /// frame otherwise); errors for centers without a body-fixed frame
+    /// (barycenters, uncatalogued bodies).
     fn state_bcbf(&self, epoch: Epoch) -> Result<Vector6<f64>, BraheError> {
-        match self.frame {
-            OrbitFrame::BodyCenteredInertial(center) => {
-                let fixed =
-                    crate::trajectories::traits::bci_fixed_frame(center).ok_or_else(|| {
-                        BraheError::Error(format!(
-                            "central body {} has no body-fixed frame",
-                            center
-                        ))
-                    })?;
-                let x = self.state_bci(epoch)?;
-                crate::frames::state_frame_to_frame(
-                    crate::trajectories::traits::bci_reference_frame(center),
-                    fixed,
-                    epoch,
-                    x,
-                )
-            }
-            _ => self.state_itrf(epoch),
-        }
+        let root = celestial_root(&self.frame)?;
+        let center = root.center_naif_id();
+        let fixed = bci_fixed_frame(center).ok_or_else(|| {
+            BraheError::Error(format!("central body {} has no body-fixed frame", center))
+        })?;
+        self.state_in_frame(fixed, epoch)
     }
 
-    /// Returns the state expressed in an arbitrary reference frame,
-    /// converting directly from this trajectory's own native frame (no
-    /// Earth round trip for `BodyCenteredInertial` trajectories).
+    /// Returns the state expressed in an arbitrary celestial frame,
+    /// converting directly from this trajectory's own declared frame.
     fn state_in_frame(
         &self,
-        frame: crate::frames::CelestialFrame,
+        frame: CelestialFrame,
         epoch: Epoch,
     ) -> Result<Vector6<f64>, BraheError> {
-        let x = self.state_bci(epoch)?;
-        let native = match self.frame {
-            OrbitFrame::BodyCenteredInertial(center) => {
-                crate::trajectories::traits::bci_reference_frame(center)
-            }
-            _ => crate::frames::CelestialFrame::GCRF,
-        };
-        crate::frames::state_frame_to_frame(native, frame, epoch, x)
+        let state_dvec = self.interpolate(&epoch)?;
+        let state = Vector6::from_iterator(state_dvec.iter().take(6).copied());
+        let x = self.native_cartesian(state)?;
+        if self.frame == frame {
+            return Ok(x);
+        }
+        state_frame_to_frame(self.frame.clone(), frame, epoch, x)
     }
 
     fn state_eci(&self, epoch: Epoch) -> Result<Vector6<f64>, BraheError> {
-        // Get state in native format (full dimensions)
-        let state_dvec = self.interpolate(&epoch)?;
-
-        // Extract first 6 elements (orbital state only - ignore extended dimensions)
-        let state = Vector6::from_iterator(state_dvec.iter().take(6).copied());
-
-        Ok(match (self.frame, self.representation) {
-            (OrbitFrame::BodyCenteredInertial(center), _) => {
-                let x = self.bci_native_cartesian(center, state)?;
-                return crate::frames::state_frame_to_frame(
-                    crate::trajectories::traits::bci_reference_frame(center),
-                    crate::frames::CelestialFrame::GCRF,
-                    epoch,
-                    x,
-                );
-            }
-            (OrbitFrame::ECI, OrbitRepresentation::Cartesian) => state,
-            (OrbitFrame::GCRF, OrbitRepresentation::Cartesian) => state, // GCRF treated as ECI
-            (OrbitFrame::ECI, OrbitRepresentation::Keplerian) => state_koe_to_eci(
-                state,
-                self.angle_format
-                    .expect("Keplerian representation must have angle_format"),
-            ),
-            (OrbitFrame::GCRF, OrbitRepresentation::Keplerian) => state_koe_to_eci(
-                state,
-                self.angle_format
-                    .expect("Keplerian representation must have angle_format"),
-            ),
-            (OrbitFrame::EME2000, OrbitRepresentation::Keplerian) => {
-                state_eme2000_to_gcrf(state_koe_to_eci(
-                    state,
-                    self.angle_format
-                        .expect("Keplerian representation must have angle_format"),
-                ))
-            }
-            (OrbitFrame::ECEF, OrbitRepresentation::Cartesian) => state_ecef_to_eci(epoch, state),
-            (OrbitFrame::ITRF, OrbitRepresentation::Cartesian) => state_itrf_to_gcrf(epoch, state),
-            (OrbitFrame::EME2000, OrbitRepresentation::Cartesian) => state_eme2000_to_gcrf(state),
-            (OrbitFrame::ECEF, OrbitRepresentation::Keplerian) => {
-                return Err(BraheError::Error(
-                    "Keplerian element trajectories should be in an inertial frame".to_string(),
-                ));
-            }
-            (OrbitFrame::ITRF, OrbitRepresentation::Keplerian) => {
-                return Err(BraheError::Error(
-                    "Keplerian element trajectories should be in an inertial frame".to_string(),
-                ));
-            }
-        })
+        self.state_in_frame(CelestialFrame::GCRF, epoch)
     }
 
     fn state_gcrf(&self, epoch: Epoch) -> Result<Vector6<f64>, BraheError> {
-        // Get state in native format (full dimensions)
-        let state_dvec = self.interpolate(&epoch)?;
-
-        // Extract first 6 elements (orbital state only - ignore extended dimensions)
-        let state = Vector6::from_iterator(state_dvec.iter().take(6).copied());
-
-        Ok(match (self.frame, self.representation) {
-            (OrbitFrame::BodyCenteredInertial(center), _) => {
-                let x = self.bci_native_cartesian(center, state)?;
-                return crate::frames::state_frame_to_frame(
-                    crate::trajectories::traits::bci_reference_frame(center),
-                    crate::frames::CelestialFrame::GCRF,
-                    epoch,
-                    x,
-                );
-            }
-            (OrbitFrame::GCRF, OrbitRepresentation::Cartesian) => state,
-            (OrbitFrame::ECI, OrbitRepresentation::Cartesian) => state, // ECI treated as GCRF
-            (OrbitFrame::GCRF, OrbitRepresentation::Keplerian) => state_koe_to_eci(
-                state,
-                self.angle_format
-                    .expect("Keplerian representation must have angle_format"),
-            ),
-            (OrbitFrame::ECI, OrbitRepresentation::Keplerian) => state_koe_to_eci(
-                state,
-                self.angle_format
-                    .expect("Keplerian representation must have angle_format"),
-            ),
-            (OrbitFrame::EME2000, OrbitRepresentation::Keplerian) => {
-                state_eme2000_to_gcrf(state_koe_to_eci(
-                    state,
-                    self.angle_format
-                        .expect("Keplerian representation must have angle_format"),
-                ))
-            }
-            (OrbitFrame::EME2000, OrbitRepresentation::Cartesian) => state_eme2000_to_gcrf(state),
-            (OrbitFrame::ITRF, OrbitRepresentation::Cartesian) => state_itrf_to_gcrf(epoch, state),
-            (OrbitFrame::ECEF, OrbitRepresentation::Cartesian) => state_itrf_to_gcrf(epoch, state),
-            (OrbitFrame::ECEF, OrbitRepresentation::Keplerian) => {
-                return Err(BraheError::Error(
-                    "Keplerian element trajectories should be in an inertial frame".to_string(),
-                ));
-            }
-            (OrbitFrame::ITRF, OrbitRepresentation::Keplerian) => {
-                return Err(BraheError::Error(
-                    "Keplerian element trajectories should be in an inertial frame".to_string(),
-                ));
-            }
-        })
+        self.state_in_frame(CelestialFrame::GCRF, epoch)
     }
 
     fn state_ecef(&self, epoch: Epoch) -> Result<Vector6<f64>, BraheError> {
-        // Get state in native format (full dimensions)
-        let state_dvec = self.interpolate(&epoch)?;
-
-        // Extract first 6 elements (orbital state only - ignore extended dimensions)
-        let state = Vector6::from_iterator(state_dvec.iter().take(6).copied());
-
-        Ok(match (self.frame, self.representation) {
-            (OrbitFrame::BodyCenteredInertial(center), _) => {
-                let x = self.bci_native_cartesian(center, state)?;
-                return crate::frames::state_frame_to_frame(
-                    crate::trajectories::traits::bci_reference_frame(center),
-                    crate::frames::CelestialFrame::ITRF,
-                    epoch,
-                    x,
-                );
-            }
-            (OrbitFrame::ECEF, OrbitRepresentation::Cartesian) => state,
-            (OrbitFrame::ITRF, OrbitRepresentation::Cartesian) => state,
-            (OrbitFrame::ECI, OrbitRepresentation::Cartesian) => state_eci_to_ecef(epoch, state),
-            (OrbitFrame::GCRF, OrbitRepresentation::Cartesian) => state_gcrf_to_itrf(epoch, state),
-            (OrbitFrame::EME2000, OrbitRepresentation::Cartesian) => {
-                let state_gcrf = state_eme2000_to_gcrf(state);
-                state_gcrf_to_itrf(epoch, state_gcrf)
-            }
-            (OrbitFrame::ECI, OrbitRepresentation::Keplerian) => {
-                let state_eci_cart = state_koe_to_eci(
-                    state,
-                    self.angle_format
-                        .expect("Keplerian representation must have angle_format"),
-                );
-                state_eci_to_ecef(epoch, state_eci_cart)
-            }
-            (OrbitFrame::EME2000, OrbitRepresentation::Keplerian) => {
-                let state_eme2000_cart = state_koe_to_eci(
-                    state,
-                    self.angle_format
-                        .expect("Keplerian representation must have angle_format"),
-                );
-                let state_gcrf = state_eme2000_to_gcrf(state_eme2000_cart);
-                state_gcrf_to_itrf(epoch, state_gcrf)
-            }
-            (OrbitFrame::GCRF, OrbitRepresentation::Keplerian) => {
-                let state_gcrf_cart = state_koe_to_eci(
-                    state,
-                    self.angle_format
-                        .expect("Keplerian representation must have angle_format"),
-                );
-                state_gcrf_to_itrf(epoch, state_gcrf_cart)
-            }
-            (OrbitFrame::ECEF, OrbitRepresentation::Keplerian) => {
-                return Err(BraheError::Error(
-                    "Keplerian element trajectories should be in an inertial frame".to_string(),
-                ));
-            }
-            (OrbitFrame::ITRF, OrbitRepresentation::Keplerian) => {
-                return Err(BraheError::Error(
-                    "Keplerian element trajectories should be in an inertial frame".to_string(),
-                ));
-            }
-        })
+        self.state_in_frame(CelestialFrame::ITRF, epoch)
     }
 
     fn state_itrf(&self, epoch: Epoch) -> Result<Vector6<f64>, BraheError> {
-        // Get state in native format (full dimensions)
-        let state_dvec = self.interpolate(&epoch)?;
-
-        // Extract first 6 elements (orbital state only - ignore extended dimensions)
-        let state = Vector6::from_iterator(state_dvec.iter().take(6).copied());
-
-        Ok(match (self.frame, self.representation) {
-            (OrbitFrame::BodyCenteredInertial(center), _) => {
-                let x = self.bci_native_cartesian(center, state)?;
-                return crate::frames::state_frame_to_frame(
-                    crate::trajectories::traits::bci_reference_frame(center),
-                    crate::frames::CelestialFrame::ITRF,
-                    epoch,
-                    x,
-                );
-            }
-            (OrbitFrame::ECEF, OrbitRepresentation::Cartesian) => state,
-            (OrbitFrame::ITRF, OrbitRepresentation::Cartesian) => state,
-            (OrbitFrame::ECI, OrbitRepresentation::Cartesian) => state_eci_to_ecef(epoch, state),
-            (OrbitFrame::GCRF, OrbitRepresentation::Cartesian) => state_gcrf_to_itrf(epoch, state),
-            (OrbitFrame::EME2000, OrbitRepresentation::Cartesian) => {
-                let state_gcrf = state_eme2000_to_gcrf(state);
-                state_gcrf_to_itrf(epoch, state_gcrf)
-            }
-            (OrbitFrame::ECI, OrbitRepresentation::Keplerian) => {
-                let state_eci_cart = state_koe_to_eci(
-                    state,
-                    self.angle_format
-                        .expect("Keplerian representation must have angle_format"),
-                );
-                state_eci_to_ecef(epoch, state_eci_cart)
-            }
-            (OrbitFrame::GCRF, OrbitRepresentation::Keplerian) => {
-                let state_gcrf_cart = state_koe_to_eci(
-                    state,
-                    self.angle_format
-                        .expect("Keplerian representation must have angle_format"),
-                );
-                state_gcrf_to_itrf(epoch, state_gcrf_cart)
-            }
-            (OrbitFrame::EME2000, OrbitRepresentation::Keplerian) => {
-                let state_eme2000_cart = state_koe_to_eci(
-                    state,
-                    self.angle_format
-                        .expect("Keplerian representation must have angle_format"),
-                );
-                let state_gcrf = state_eme2000_to_gcrf(state_eme2000_cart);
-                state_gcrf_to_itrf(epoch, state_gcrf)
-            }
-            (OrbitFrame::ECEF, OrbitRepresentation::Keplerian) => {
-                return Err(BraheError::Error(
-                    "Keplerian element trajectories should be in an inertial frame".to_string(),
-                ));
-            }
-            (OrbitFrame::ITRF, OrbitRepresentation::Keplerian) => {
-                return Err(BraheError::Error(
-                    "Keplerian element trajectories should be in an inertial frame".to_string(),
-                ));
-            }
-        })
+        self.state_in_frame(CelestialFrame::ITRF, epoch)
     }
 
     fn state_eme2000(&self, epoch: Epoch) -> Result<Vector6<f64>, BraheError> {
-        // Get state in native format (full dimensions)
-        let state_dvec = self.interpolate(&epoch)?;
-
-        // Extract first 6 elements (orbital state only - ignore extended dimensions)
-        let state = Vector6::from_iterator(state_dvec.iter().take(6).copied());
-
-        Ok(match (self.frame, self.representation) {
-            (OrbitFrame::BodyCenteredInertial(center), _) => {
-                let x = self.bci_native_cartesian(center, state)?;
-                return crate::frames::state_frame_to_frame(
-                    crate::trajectories::traits::bci_reference_frame(center),
-                    crate::frames::CelestialFrame::EME2000,
-                    epoch,
-                    x,
-                );
-            }
-            (OrbitFrame::EME2000, OrbitRepresentation::Cartesian) => state,
-            (OrbitFrame::GCRF, OrbitRepresentation::Cartesian) => state_gcrf_to_eme2000(state),
-            (OrbitFrame::ECI, OrbitRepresentation::Cartesian) => state_gcrf_to_eme2000(state), // ECI treated as GCRF
-            (OrbitFrame::GCRF, OrbitRepresentation::Keplerian) => {
-                let state_gcrf_cart = state_koe_to_eci(
-                    state,
-                    self.angle_format
-                        .expect("Keplerian representation must have angle_format"),
-                );
-                state_gcrf_to_eme2000(state_gcrf_cart)
-            }
-            (OrbitFrame::ECI, OrbitRepresentation::Keplerian) => {
-                let state_eci_cart = state_koe_to_eci(
-                    state,
-                    self.angle_format
-                        .expect("Keplerian representation must have angle_format"),
-                );
-                state_gcrf_to_eme2000(state_eci_cart)
-            }
-            (OrbitFrame::EME2000, OrbitRepresentation::Keplerian) => state_koe_to_eci(
-                state,
-                self.angle_format
-                    .expect("Keplerian representation must have angle_format"),
-            ),
-            (OrbitFrame::ITRF, OrbitRepresentation::Cartesian) => {
-                let state_gcrf = state_itrf_to_gcrf(epoch, state);
-                state_gcrf_to_eme2000(state_gcrf)
-            }
-            (OrbitFrame::ECEF, OrbitRepresentation::Cartesian) => {
-                let state_gcrf = state_itrf_to_gcrf(epoch, state);
-                state_gcrf_to_eme2000(state_gcrf)
-            }
-            (OrbitFrame::ECEF, OrbitRepresentation::Keplerian) => {
-                return Err(BraheError::Error(
-                    "Keplerian element trajectories should be in an inertial frame".to_string(),
-                ));
-            }
-            (OrbitFrame::ITRF, OrbitRepresentation::Keplerian) => {
-                return Err(BraheError::Error(
-                    "Keplerian element trajectories should be in an inertial frame".to_string(),
-                ));
-            }
-        })
+        self.state_in_frame(CelestialFrame::EME2000, epoch)
     }
 
     fn state_koe_osc(
@@ -3227,109 +2471,40 @@ impl DOrbitStateProvider for DOrbitTrajectory {
         epoch: Epoch,
         angle_format: AngleFormat,
     ) -> Result<Vector6<f64>, BraheError> {
-        // Get state in native format (full dimensions)
-        let state_dvec = self.interpolate(&epoch)?;
+        let root = celestial_root(&self.frame)?;
+        let center = root.center_naif_id();
+        let cb = CentralBody::from_naif_id(center)?;
+        if cb.is_barycenter() {
+            return Err(BraheError::Error(format!(
+                "osculating elements are undefined about massless barycenter {}",
+                center
+            )));
+        }
 
-        // Extract first 6 elements (orbital state only - ignore extended dimensions)
-        let state = Vector6::from_iterator(state_dvec.iter().take(6).copied());
+        let inertial = icrf_aligned_inertial(root);
+        if self.representation == OrbitRepresentation::Keplerian && self.frame == inertial {
+            // Elements already reference this center's inertial axes: only
+            // the angle format may differ.
+            let state_dvec = self.interpolate(&epoch)?;
+            let mut state: Vector6<f64> =
+                Vector6::from_iterator(state_dvec.iter().take(6).copied());
+            let native_format = self.angle_format.unwrap_or(AngleFormat::Radians);
+            if native_format != angle_format {
+                let factor = if angle_format == AngleFormat::Degrees {
+                    RAD2DEG
+                } else {
+                    DEG2RAD
+                };
+                state[2] *= factor; // inclination
+                state[3] *= factor; // RAAN
+                state[4] *= factor; // argument of periapsis
+                state[5] *= factor; // mean anomaly
+            }
+            return Ok(state);
+        }
 
-        Ok(match (self.frame, self.representation) {
-            (OrbitFrame::BodyCenteredInertial(center), _) => {
-                // Osculating elements about the trajectory's own center,
-                // using that body's gravitational parameter.
-                let cb = crate::propagators::CentralBody::from_naif_id(center)?;
-                if cb.is_barycenter() {
-                    return Err(BraheError::Error(format!(
-                        "osculating elements are undefined about massless barycenter {}",
-                        center
-                    )));
-                }
-                let x = self.bci_native_cartesian(center, state)?;
-                return Ok(crate::coordinates::state_inertial_to_koe_gm(
-                    x,
-                    cb.gm(),
-                    angle_format,
-                ));
-            }
-            (OrbitFrame::ECI, OrbitRepresentation::Keplerian) => {
-                // Already in Keplerian, just convert angle format if needed
-                let native_format = self.angle_format.unwrap_or(AngleFormat::Radians);
-                if native_format == angle_format {
-                    state
-                } else {
-                    // Convert angles
-                    let mut converted = state;
-                    let factor = if angle_format == AngleFormat::Degrees {
-                        RAD2DEG
-                    } else {
-                        DEG2RAD
-                    };
-                    converted[2] *= factor; // inclination
-                    converted[3] *= factor; // RAAN
-                    converted[4] *= factor; // arg periapsis
-                    converted[5] *= factor; // mean anomaly
-                    converted
-                }
-            }
-            (OrbitFrame::GCRF, OrbitRepresentation::Keplerian) => {
-                // Already in Keplerian, just convert angle format if needed
-                let native_format = self.angle_format.unwrap_or(AngleFormat::Radians);
-                if native_format == angle_format {
-                    state
-                } else {
-                    // Convert angles
-                    let mut converted = state;
-                    let factor = if angle_format == AngleFormat::Degrees {
-                        RAD2DEG
-                    } else {
-                        DEG2RAD
-                    };
-                    converted[2] *= factor; // inclination
-                    converted[3] *= factor; // RAAN
-                    converted[4] *= factor; // arg periapsis
-                    converted[5] *= factor; // mean anomaly
-                    converted
-                }
-            }
-            (OrbitFrame::EME2000, OrbitRepresentation::Keplerian) => {
-                // Convert back to Cartesian, to GCRF, then to osculating elements
-                let state_eme2000_cart = state_koe_to_eci(
-                    state,
-                    self.angle_format
-                        .expect("Keplerian representation must have angle_format"),
-                );
-                let state_gcrf = state_eme2000_to_gcrf(state_eme2000_cart);
-                state_eci_to_koe(state_gcrf, angle_format)
-            }
-            (OrbitFrame::ECI, OrbitRepresentation::Cartesian) => {
-                state_eci_to_koe(state, angle_format)
-            }
-            (OrbitFrame::GCRF, OrbitRepresentation::Cartesian) => {
-                state_eci_to_koe(state, angle_format)
-            }
-            (OrbitFrame::EME2000, OrbitRepresentation::Cartesian) => {
-                let state_gcrf = state_eme2000_to_gcrf(state);
-                state_eci_to_koe(state_gcrf, angle_format)
-            }
-            (OrbitFrame::ECEF, OrbitRepresentation::Cartesian) => {
-                let state_eci = state_ecef_to_eci(epoch, state);
-                state_eci_to_koe(state_eci, angle_format)
-            }
-            (OrbitFrame::ITRF, OrbitRepresentation::Cartesian) => {
-                let state_gcrf = state_itrf_to_gcrf(epoch, state);
-                state_eci_to_koe(state_gcrf, angle_format)
-            }
-            (OrbitFrame::ECEF, OrbitRepresentation::Keplerian) => {
-                return Err(BraheError::Error(
-                    "Keplerian element trajectories should be in an inertial frame".to_string(),
-                ));
-            }
-            (OrbitFrame::ITRF, OrbitRepresentation::Keplerian) => {
-                return Err(BraheError::Error(
-                    "Keplerian element trajectories should be in an inertial frame".to_string(),
-                ));
-            }
-        })
+        let x = self.state_in_frame(inertial, epoch)?;
+        Ok(state_inertial_to_koe_gm(x, cb.gm(), angle_format))
     }
 }
 
@@ -3342,39 +2517,40 @@ impl DOrbitCovarianceProvider for DOrbitTrajectory {
         let cov_native = self.covariance(epoch)?;
         let dim = cov_native.nrows();
 
-        match self.frame {
-            // Body-centered inertial axes are ICRF-aligned, so the covariance
-            // is identical under the identity rotation (the center offset is a
-            // translation, which does not affect covariance).
-            OrbitFrame::BodyCenteredInertial(_) => Ok(cov_native),
-            OrbitFrame::ECI | OrbitFrame::GCRF => Ok(cov_native),
-            OrbitFrame::EME2000 => {
-                // Apply frame bias rotation to first 6x6 block only
-                let rot = rotation_eme2000_to_gcrf();
+        let root = celestial_root(&self.frame)?;
 
-                // Build full-dimensional Jacobian
-                let mut jacobian = DMatrix::<f64>::zeros(dim, dim);
+        if self.frame == CelestialFrame::EME2000 {
+            // Apply frame bias rotation to first 6x6 block only
+            let rot = rotation_eme2000_to_gcrf();
 
-                // Position and velocity blocks (top-left 3x3, and indices 3-5)
-                for i in 0..3 {
-                    for j in 0..3 {
-                        jacobian[(i, j)] = rot[(i, j)];
-                        jacobian[(3 + i, 3 + j)] = rot[(i, j)];
-                    }
+            // Build full-dimensional Jacobian
+            let mut jacobian = DMatrix::<f64>::zeros(dim, dim);
+
+            // Position and velocity blocks (top-left 3x3, and indices 3-5)
+            for i in 0..3 {
+                for j in 0..3 {
+                    jacobian[(i, j)] = rot[(i, j)];
+                    jacobian[(3 + i, 3 + j)] = rot[(i, j)];
                 }
-
-                // Extended dimensions use identity (pass through unchanged)
-                for i in 6..dim {
-                    jacobian[(i, i)] = 1.0;
-                }
-
-                // Transform: C_ECI = J * C_EME2000 * J^T
-                Ok(&jacobian * &cov_native * jacobian.transpose())
             }
-            OrbitFrame::ECEF | OrbitFrame::ITRF => Err(BraheError::Error(
-                "ECEF/ITRF covariance transformation not supported (requires time-dependent rotation derivatives)"
-                    .to_string(),
-            )),
+
+            // Extended dimensions use identity (pass through unchanged)
+            for i in 6..dim {
+                jacobian[(i, i)] = 1.0;
+            }
+
+            // Transform: C_ECI = J * C_EME2000 * J^T
+            Ok(&jacobian * &cov_native * jacobian.transpose())
+        } else if self.frame == icrf_aligned_inertial(root) {
+            // ICRF-aligned axes leave the covariance unchanged under the
+            // identity rotation (a center offset is a translation, which does
+            // not affect covariance).
+            Ok(cov_native)
+        } else {
+            Err(BraheError::Error(format!(
+                "covariance transformation from {} is not supported (requires time-dependent rotation derivatives)",
+                self.frame
+            )))
         }
     }
 
@@ -3447,6 +2623,8 @@ impl DOrbitCovarianceProvider for DOrbitTrajectory {
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
+    use crate::coordinates::state_koe_to_eci;
+    use crate::frames::state_gcrf_to_itrf;
     use crate::time::{Epoch, TimeSystem};
     use crate::utils::testing::setup_global_test_eop;
     use approx::assert_abs_diff_eq;
@@ -3456,9 +2634,10 @@ mod tests {
     #[test]
     #[parallel]
     fn test_dorbittrajectory_new() {
-        let traj = DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
-            .unwrap();
-        assert_eq!(traj.frame, OrbitFrame::ECI);
+        let traj =
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
+        assert_eq!(traj.frame, CelestialFrame::ECI);
         assert_eq!(traj.representation, OrbitRepresentation::Cartesian);
         assert_eq!(traj.dimension(), 6);
         assert_eq!(traj.orbital_dimension(), 6);
@@ -3470,7 +2649,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_default() {
         let traj = DOrbitTrajectory::default();
-        assert_eq!(traj.frame, OrbitFrame::ECI);
+        assert_eq!(traj.frame, CelestialFrame::ECI);
         assert_eq!(traj.representation, OrbitRepresentation::Cartesian);
         assert_eq!(traj.dimension(), 6);
         assert!(traj.is_empty());
@@ -3480,7 +2659,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_add_state() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -3502,7 +2681,7 @@ mod tests {
         // trajectory, add() must insert placeholders sized to the trajectory
         // dimension, not a hard-coded 6.
         let mut traj =
-            DOrbitTrajectory::new(7, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(7, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         traj.covariances = Some(Vec::new());
         STMStorage::enable_stm_storage(&mut traj);
@@ -3530,11 +2709,12 @@ mod tests {
     #[test]
     #[parallel]
     fn test_dorbittrajectory_display() {
-        let traj = DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
-            .unwrap();
+        let traj =
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         let display = format!("{}", traj);
         assert!(display.contains("DOrbitTrajectory"));
-        assert!(display.contains("ECI"));
+        assert!(display.contains("GCRF"));
         assert!(display.contains("Cartesian"));
     }
 
@@ -3544,7 +2724,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_extended_state_7d() {
         let mut traj =
-            DOrbitTrajectory::new(7, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(7, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         assert_eq!(traj.dimension(), 7);
         assert_eq!(traj.orbital_dimension(), 6);
@@ -3568,7 +2748,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_extended_state_9d() {
         let mut traj =
-            DOrbitTrajectory::new(9, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(9, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         assert_eq!(traj.dimension(), 9);
         assert_eq!(traj.additional_dimension(), 3);
@@ -3594,7 +2774,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_invalid_dimension() {
         let result =
-            DOrbitTrajectory::new(5, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None);
+            DOrbitTrajectory::new(5, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None);
         assert!(result.is_err());
     }
 
@@ -3602,7 +2782,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_dimension_mismatch() {
         let mut traj =
-            DOrbitTrajectory::new(7, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(7, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]); // 6D state for 7D trajectory
@@ -3658,7 +2838,7 @@ mod tests {
         setup_global_test_eop();
 
         let mut traj =
-            DOrbitTrajectory::new(9, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(9, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![
@@ -3672,7 +2852,7 @@ mod tests {
         // Convert ECI -> ECEF
         let traj_ecef = traj.to_ecef().unwrap();
         assert_eq!(traj_ecef.dimension(), 9);
-        assert_eq!(traj_ecef.frame, OrbitFrame::ECEF);
+        assert_eq!(traj_ecef.frame, CelestialFrame::ECEF);
 
         let (_, state_ecef) = traj_ecef.get(0).unwrap();
         // Orbital part should be different (transformed)
@@ -3687,7 +2867,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_to_gcrf_preserves_additional() {
         let mut traj =
-            DOrbitTrajectory::new(9, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(9, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0, 100.0, 200.0, 300.0]);
@@ -3710,7 +2890,7 @@ mod tests {
         setup_global_test_eop();
 
         let mut traj =
-            DOrbitTrajectory::new(8, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(8, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0, 50.0, 60.0]);
@@ -3729,7 +2909,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_to_eme2000_preserves_additional() {
         let mut traj =
-            DOrbitTrajectory::new(7, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(7, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0, 999.0]);
@@ -3749,7 +2929,7 @@ mod tests {
         use crate::constants::{GM_EARTH, R_EARTH};
 
         let mut traj =
-            DOrbitTrajectory::new(9, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(9, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
@@ -3786,7 +2966,7 @@ mod tests {
         let traj = DOrbitTrajectory::from_orbital_data(
             vec![epoch],
             vec![state],
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![cov.clone()]),
@@ -3860,7 +3040,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_new_err_keplerian_no_angle_format() {
         let result =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Keplerian, None);
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Keplerian, None);
         assert!(result.is_err());
     }
 
@@ -3869,7 +3049,7 @@ mod tests {
     fn test_dorbittrajectory_new_err_cartesian_with_angle_format() {
         let result = DOrbitTrajectory::new(
             6,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             Some(AngleFormat::Degrees),
         );
@@ -3881,7 +3061,7 @@ mod tests {
     fn test_dorbittrajectory_new_err_ecef_keplerian() {
         let result = DOrbitTrajectory::new(
             6,
-            OrbitFrame::ECEF,
+            CelestialFrame::ECEF,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Degrees),
         );
@@ -3893,18 +3073,20 @@ mod tests {
     #[test]
     #[parallel]
     fn test_dorbittrajectory_with_interpolation_method_linear() {
-        let traj = DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
-            .unwrap()
-            .with_interpolation_method(InterpolationMethod::Linear);
+        let traj =
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap()
+                .with_interpolation_method(InterpolationMethod::Linear);
         assert_eq!(traj.interpolation_method, InterpolationMethod::Linear);
     }
 
     #[test]
     #[parallel]
     fn test_dorbittrajectory_with_interpolation_method_lagrange() {
-        let traj = DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
-            .unwrap()
-            .with_interpolation_method(InterpolationMethod::Lagrange { degree: 5 });
+        let traj =
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap()
+                .with_interpolation_method(InterpolationMethod::Lagrange { degree: 5 });
         assert!(matches!(
             traj.interpolation_method,
             InterpolationMethod::Lagrange { degree: 5 }
@@ -3914,19 +3096,21 @@ mod tests {
     #[test]
     #[parallel]
     fn test_dorbittrajectory_with_interpolation_method_hermite() {
-        let traj = DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
-            .unwrap()
-            .with_interpolation_method(InterpolationMethod::HermiteCubic);
+        let traj =
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap()
+                .with_interpolation_method(InterpolationMethod::HermiteCubic);
         assert_eq!(traj.interpolation_method, InterpolationMethod::HermiteCubic);
     }
 
     #[test]
     #[parallel]
     fn test_dorbittrajectory_with_eviction_policy_max_size() {
-        let traj = DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
-            .unwrap()
-            .with_eviction_policy_max_size(100)
-            .unwrap();
+        let traj =
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap()
+                .with_eviction_policy_max_size(100)
+                .unwrap();
         assert_eq!(traj.eviction_policy, TrajectoryEvictionPolicy::KeepCount);
         assert_eq!(traj.max_size, Some(100));
         assert_eq!(traj.max_age, None);
@@ -3936,7 +3120,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_with_eviction_policy_max_size_err_zero() {
         let result =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap()
                 .with_eviction_policy_max_size(0);
         assert!(result.is_err());
@@ -3945,10 +3129,11 @@ mod tests {
     #[test]
     #[parallel]
     fn test_dorbittrajectory_with_eviction_policy_max_age() {
-        let traj = DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
-            .unwrap()
-            .with_eviction_policy_max_age(3600.0)
-            .unwrap();
+        let traj =
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap()
+                .with_eviction_policy_max_age(3600.0)
+                .unwrap();
         assert_eq!(
             traj.eviction_policy,
             TrajectoryEvictionPolicy::KeepWithinDuration
@@ -3961,7 +3146,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_with_eviction_policy_max_age_err_zero() {
         let result =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap()
                 .with_eviction_policy_max_age(0.0);
         assert!(result.is_err());
@@ -3971,7 +3156,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_with_eviction_policy_max_age_err_negative() {
         let result =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap()
                 .with_eviction_policy_max_age(-1.0);
         assert!(result.is_err());
@@ -3983,7 +3168,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_add_state_and_covariance_basic() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         traj.covariances = Some(Vec::new());
 
@@ -4003,7 +3188,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_add_state_and_covariance_ordering() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         traj.covariances = Some(Vec::new());
 
@@ -4031,7 +3216,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_add_state_and_covariance_err_no_init() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -4046,7 +3231,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_to_matrix_basic() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 1000.0, 2000.0, 100.0, 7.5e3, 50.0]);
@@ -4064,7 +3249,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_to_matrix_multiple_states() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch1 = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let epoch2 = Epoch::from_datetime(2024, 1, 1, 12, 1, 0.0, 0.0, TimeSystem::UTC);
@@ -4085,8 +3270,9 @@ mod tests {
     #[test]
     #[parallel]
     fn test_dorbittrajectory_to_matrix_error_empty() {
-        let traj = DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
-            .unwrap();
+        let traj =
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         let result = traj.to_matrix();
         assert!(result.is_err());
         assert!(
@@ -4109,7 +3295,7 @@ mod tests {
         let traj = DOrbitTrajectory::from_orbital_data(
             vec![epoch],
             vec![state],
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![cov.clone()]),
@@ -4132,7 +3318,7 @@ mod tests {
         let traj = DOrbitTrajectory::from_orbital_data(
             vec![epoch1, epoch2],
             vec![state.clone(), state],
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![cov1, cov2]),
@@ -4150,7 +3336,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_covariance_at_none_disabled() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -4164,7 +3350,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_covariance_at_none_empty() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         traj.covariances = Some(Vec::new());
 
@@ -4183,7 +3369,7 @@ mod tests {
         let traj = DOrbitTrajectory::from_orbital_data(
             vec![epoch],
             vec![state],
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![cov]),
@@ -4202,7 +3388,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_add_full_all_optional_provided() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -4232,7 +3418,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_add_full_only_state() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -4250,7 +3436,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_add_full_with_covariance() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -4271,7 +3457,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_add_full_with_stm() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -4288,7 +3474,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_add_full_with_sensitivity() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -4311,7 +3497,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_add_full_with_acceleration() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -4333,7 +3519,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_add_full_err_state_dimension() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3]); // 5D instead of 6D
@@ -4345,7 +3531,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_add_full_err_cov_dimension() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -4361,7 +3547,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_add_full_err_stm_dimension() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -4377,7 +3563,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_add_full_err_sens_rows() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -4393,7 +3579,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_add_full_err_sens_cols() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch1 = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let epoch2 = Epoch::from_datetime(2024, 1, 1, 12, 1, 0.0, 0.0, TimeSystem::UTC);
@@ -4413,7 +3599,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_add_full_err_accel_dimension() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch1 = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let epoch2 = Epoch::from_datetime(2024, 1, 1, 12, 1, 0.0, 0.0, TimeSystem::UTC);
@@ -4436,7 +3622,7 @@ mod tests {
         // covariance combined with an invalid STM must not auto-enable
         // covariance storage or insert any data.
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -4589,7 +3775,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_epoch_at_idx_valid() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -4602,8 +3788,9 @@ mod tests {
     #[test]
     #[parallel]
     fn test_dorbittrajectory_epoch_at_idx_error_out_of_bounds() {
-        let traj = DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
-            .unwrap();
+        let traj =
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         let result = traj.epoch_at_idx(0);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("out of bounds"));
@@ -4613,7 +3800,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_state_at_idx_valid() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 100.0, 200.0, 10.0, 7.5e3, 5.0]);
@@ -4628,8 +3815,9 @@ mod tests {
     #[test]
     #[parallel]
     fn test_dorbittrajectory_state_at_idx_error_out_of_bounds() {
-        let traj = DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
-            .unwrap();
+        let traj =
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         let result = traj.state_at_idx(0);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("out of bounds"));
@@ -4639,7 +3827,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_nearest_state_exact() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -4656,7 +3844,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_nearest_state_closest() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch1 = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let epoch2 = Epoch::from_datetime(2024, 1, 1, 12, 10, 0.0, 0.0, TimeSystem::UTC);
@@ -4679,8 +3867,9 @@ mod tests {
     #[test]
     #[parallel]
     fn test_dorbittrajectory_nearest_state_error_empty() {
-        let traj = DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
-            .unwrap();
+        let traj =
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let result = traj.nearest_state(&epoch);
         assert!(result.is_err());
@@ -4691,7 +3880,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_len_and_is_empty() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         assert!(traj.is_empty());
         assert_eq!(traj.len(), 0);
@@ -4708,7 +3897,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_start_end_epoch() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch1 = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let epoch2 = Epoch::from_datetime(2024, 1, 1, 12, 10, 0.0, 0.0, TimeSystem::UTC);
@@ -4723,8 +3912,9 @@ mod tests {
     #[test]
     #[parallel]
     fn test_dorbittrajectory_start_end_epoch_empty() {
-        let traj = DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
-            .unwrap();
+        let traj =
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         assert_eq!(traj.start_epoch(), None);
         assert_eq!(traj.end_epoch(), None);
     }
@@ -4733,7 +3923,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_timespan_multiple() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch1 = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let epoch2 = Epoch::from_datetime(2024, 1, 1, 12, 10, 0.0, 0.0, TimeSystem::UTC);
@@ -4749,7 +3939,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_timespan_single_none() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -4761,8 +3951,9 @@ mod tests {
     #[test]
     #[parallel]
     fn test_dorbittrajectory_timespan_empty_none() {
-        let traj = DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
-            .unwrap();
+        let traj =
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         assert!(traj.timespan().is_none());
     }
 
@@ -4770,7 +3961,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_first_last() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch1 = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let epoch2 = Epoch::from_datetime(2024, 1, 1, 12, 10, 0.0, 0.0, TimeSystem::UTC);
@@ -4791,8 +3982,9 @@ mod tests {
     #[test]
     #[parallel]
     fn test_dorbittrajectory_first_last_empty() {
-        let traj = DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
-            .unwrap();
+        let traj =
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         assert!(traj.first().is_none());
         assert!(traj.last().is_none());
     }
@@ -4801,7 +3993,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_clear_all_storage_types() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -4841,7 +4033,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_remove_epoch_found() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch1 = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let epoch2 = Epoch::from_datetime(2024, 1, 1, 12, 10, 0.0, 0.0, TimeSystem::UTC);
@@ -4860,7 +4052,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_remove_epoch_not_found() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch1 = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let epoch2 = Epoch::from_datetime(2024, 1, 1, 12, 10, 0.0, 0.0, TimeSystem::UTC);
@@ -4876,7 +4068,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_remove_by_index() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch1 = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let epoch2 = Epoch::from_datetime(2024, 1, 1, 12, 10, 0.0, 0.0, TimeSystem::UTC);
@@ -4893,7 +4085,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_remove_by_index_error_out_of_bounds() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let result = traj.remove(0);
         assert!(result.is_err());
@@ -4904,7 +4096,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_get_valid() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -4920,8 +4112,9 @@ mod tests {
     #[test]
     #[parallel]
     fn test_dorbittrajectory_get_error_out_of_bounds() {
-        let traj = DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
-            .unwrap();
+        let traj =
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         let result = traj.get(0);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("out of bounds"));
@@ -4931,7 +4124,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_index_before_epoch_valid() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch1 = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let epoch2 = Epoch::from_datetime(2024, 1, 1, 12, 10, 0.0, 0.0, TimeSystem::UTC);
@@ -4949,7 +4142,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_index_before_epoch_exact_match() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -4962,8 +4155,9 @@ mod tests {
     #[test]
     #[parallel]
     fn test_dorbittrajectory_index_before_epoch_error_empty() {
-        let traj = DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
-            .unwrap();
+        let traj =
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let result = traj.index_before_epoch(&epoch);
         assert!(result.is_err());
@@ -4974,7 +4168,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_index_before_epoch_error_before_all() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -4995,7 +4189,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_index_after_epoch_valid() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch1 = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let epoch2 = Epoch::from_datetime(2024, 1, 1, 12, 10, 0.0, 0.0, TimeSystem::UTC);
@@ -5013,7 +4207,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_index_after_epoch_exact_match() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -5026,8 +4220,9 @@ mod tests {
     #[test]
     #[parallel]
     fn test_dorbittrajectory_index_after_epoch_error_empty() {
-        let traj = DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
-            .unwrap();
+        let traj =
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let result = traj.index_after_epoch(&epoch);
         assert!(result.is_err());
@@ -5038,7 +4233,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_index_after_epoch_error_after_all() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -5054,7 +4249,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_set_eviction_policy_max_size() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         traj.set_eviction_policy_max_size(50).unwrap();
         assert_eq!(traj.eviction_policy, TrajectoryEvictionPolicy::KeepCount);
@@ -5065,7 +4260,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_set_eviction_policy_max_size_error_zero() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let result = traj.set_eviction_policy_max_size(0);
         assert!(result.is_err());
@@ -5076,7 +4271,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_set_eviction_policy_max_age() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         traj.set_eviction_policy_max_age(1800.0).unwrap();
         assert_eq!(
@@ -5090,7 +4285,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_set_eviction_policy_max_age_error_negative() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let result = traj.set_eviction_policy_max_age(-100.0);
         assert!(result.is_err());
@@ -5100,8 +4295,9 @@ mod tests {
     #[test]
     #[parallel]
     fn test_dorbittrajectory_get_eviction_policy() {
-        let traj = DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
-            .unwrap();
+        let traj =
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         assert_eq!(traj.get_eviction_policy(), TrajectoryEvictionPolicy::None);
 
         let traj2 = traj.with_eviction_policy_max_size(10).unwrap();
@@ -5117,7 +4313,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_interpolation_config_set_get() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
 
         // Default is HermiteCubic (orbit states carry velocity)
@@ -5151,9 +4347,10 @@ mod tests {
     #[test]
     #[parallel]
     fn test_dorbittrajectory_interpolation_config_with_builder() {
-        let traj = DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
-            .unwrap()
-            .with_interpolation_method(InterpolationMethod::Lagrange { degree: 7 });
+        let traj =
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap()
+                .with_interpolation_method(InterpolationMethod::Lagrange { degree: 7 });
 
         assert_eq!(
             traj.get_interpolation_method(),
@@ -5167,7 +4364,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_interpolate_linear_basic() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         // This test exercises linear interpolation of sparse points; the
         // default is now HermiteCubic, so request Linear explicitly.
@@ -5192,7 +4389,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_interpolate_exact_match() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 100.0, 200.0, 10.0, 7.5e3, 5.0]);
@@ -5208,7 +4405,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_interpolate_error_before_start() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -5229,7 +4426,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_interpolate_error_after_end() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -5250,7 +4447,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_interpolate_lagrange() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap()
                 .with_interpolation_method(InterpolationMethod::Lagrange { degree: 3 });
 
@@ -5281,7 +4478,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_interpolate_lagrange_error_insufficient_points() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap()
                 .with_interpolation_method(InterpolationMethod::Lagrange { degree: 5 });
 
@@ -5302,7 +4499,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_interpolate_hermite_cubic() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap()
                 .with_interpolation_method(InterpolationMethod::HermiteCubic);
 
@@ -5322,7 +4519,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_interpolate_hermite_cubic_error_non_6d() {
         let mut traj =
-            DOrbitTrajectory::new(9, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(9, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap()
                 .with_interpolation_method(InterpolationMethod::HermiteCubic);
 
@@ -5344,7 +4541,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_interpolate_hermite_quintic_with_accelerations() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap()
                 .with_interpolation_method(InterpolationMethod::HermiteQuintic);
         traj.enable_acceleration_storage(3).unwrap();
@@ -5370,7 +4567,7 @@ mod tests {
         // Without enabled acceleration storage, HermiteQuintic must error — even
         // when many points are available — since the FD fallback has been removed.
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap()
                 .with_interpolation_method(InterpolationMethod::HermiteQuintic);
 
@@ -5404,7 +4601,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_enable_stm_storage() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -5431,7 +4628,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_stm_at_idx_valid() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -5448,7 +4645,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_stm_at_idx_none_disabled() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -5463,7 +4660,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_set_stm_at() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -5484,7 +4681,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_set_stm_at_err_out_of_bounds() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let stm = DMatrix::identity(6, 6);
         assert!(traj.set_stm_at(0, stm).is_err()); // No states added yet
@@ -5494,7 +4691,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_set_stm_at_err_wrong_dimensions() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -5507,8 +4704,9 @@ mod tests {
     #[test]
     #[parallel]
     fn test_dorbittrajectory_stm_dimensions() {
-        let traj = DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
-            .unwrap();
+        let traj =
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         assert_eq!(traj.stm_dimensions(), (6, 6));
     }
 
@@ -5516,7 +4714,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_stm_storage_mut() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -5539,7 +4737,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_enable_sensitivity_storage() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -5560,7 +4758,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_enable_sensitivity_storage_err_zero() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         assert!(traj.enable_sensitivity_storage(0).is_err());
     }
@@ -5569,7 +4767,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_sensitivity_at_idx_valid() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -5586,7 +4784,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_sensitivity_at_idx_none_disabled() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -5601,7 +4799,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_set_sensitivity_at() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -5622,7 +4820,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_set_sensitivity_at_err_out_of_bounds() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let sens = DMatrix::zeros(6, 3);
         assert!(traj.set_sensitivity_at(0, sens).is_err()); // No states added yet
@@ -5632,7 +4830,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_set_sensitivity_at_err_wrong_rows() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -5646,7 +4844,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_set_sensitivity_at_err_wrong_cols() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch1 = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let epoch2 = Epoch::from_datetime(2024, 1, 1, 12, 1, 0.0, 0.0, TimeSystem::UTC);
@@ -5664,7 +4862,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_sensitivity_dimensions() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
 
         // Before enabling, should be None
@@ -5678,7 +4876,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_sensitivity_storage_mut() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -5700,9 +4898,12 @@ mod tests {
     #[test]
     #[parallel]
     fn test_dorbittrajectory_covariance_interpolation_with_builder() {
-        let traj = DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
-            .unwrap()
-            .with_covariance_interpolation_method(CovarianceInterpolationMethod::MatrixSquareRoot);
+        let traj =
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap()
+                .with_covariance_interpolation_method(
+                    CovarianceInterpolationMethod::MatrixSquareRoot,
+                );
 
         assert_eq!(
             traj.get_covariance_interpolation_method(),
@@ -5714,7 +4915,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_covariance_interpolation_set_get() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
 
         // Default is TwoWasserstein
@@ -5733,9 +4934,12 @@ mod tests {
     #[test]
     #[parallel]
     fn test_dorbittrajectory_covariance_interpolation_sqrt_method() {
-        let traj = DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
-            .unwrap()
-            .with_covariance_interpolation_method(CovarianceInterpolationMethod::MatrixSquareRoot);
+        let traj =
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap()
+                .with_covariance_interpolation_method(
+                    CovarianceInterpolationMethod::MatrixSquareRoot,
+                );
 
         assert_eq!(
             traj.get_covariance_interpolation_method(),
@@ -5746,9 +4950,12 @@ mod tests {
     #[test]
     #[parallel]
     fn test_dorbittrajectory_covariance_interpolation_wasserstein_method() {
-        let traj = DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
-            .unwrap()
-            .with_covariance_interpolation_method(CovarianceInterpolationMethod::TwoWasserstein);
+        let traj =
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap()
+                .with_covariance_interpolation_method(
+                    CovarianceInterpolationMethod::TwoWasserstein,
+                );
 
         assert_eq!(
             traj.get_covariance_interpolation_method(),
@@ -5773,7 +4980,7 @@ mod tests {
         let traj = DOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -5782,7 +4989,7 @@ mod tests {
 
         assert_eq!(traj.len(), 2);
         assert_eq!(traj.dimension(), 6);
-        assert_eq!(traj.frame, OrbitFrame::ECI);
+        assert_eq!(traj.frame, CelestialFrame::ECI);
         assert_eq!(traj.representation, OrbitRepresentation::Cartesian);
     }
 
@@ -5805,7 +5012,7 @@ mod tests {
         let traj = DOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             Some(covariances),
@@ -5825,7 +5032,7 @@ mod tests {
         let result = DOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -5851,7 +5058,7 @@ mod tests {
         let result = DOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -5874,7 +5081,7 @@ mod tests {
         let result = DOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -5900,7 +5107,7 @@ mod tests {
         let result = DOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            OrbitFrame::ECEF,
+            CelestialFrame::ECEF,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Radians),
             None,
@@ -5924,7 +5131,7 @@ mod tests {
         let result = DOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             Some(covariances),
@@ -5951,7 +5158,7 @@ mod tests {
         let result = DOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            OrbitFrame::ECEF,
+            CelestialFrame::ECEF,
             OrbitRepresentation::Cartesian,
             None,
             Some(covariances),
@@ -5967,7 +5174,7 @@ mod tests {
         setup_global_test_eop();
 
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -5975,7 +5182,7 @@ mod tests {
 
         let converted = traj.to_eci().unwrap();
 
-        assert_eq!(converted.frame, OrbitFrame::ECI);
+        assert_eq!(converted.frame, CelestialFrame::ECI);
         assert_eq!(converted.representation, OrbitRepresentation::Cartesian);
         for i in 0..6 {
             assert_abs_diff_eq!(converted.states[0][i], state[i], epsilon = 1e-6);
@@ -5987,9 +5194,13 @@ mod tests {
     fn test_dorbittrajectory_to_eci_already_gcrf() {
         setup_global_test_eop();
 
-        let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::GCRF, OrbitRepresentation::Cartesian, None)
-                .unwrap();
+        let mut traj = DOrbitTrajectory::new(
+            6,
+            CelestialFrame::GCRF,
+            OrbitRepresentation::Cartesian,
+            None,
+        )
+        .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
         traj.add(epoch, state.clone()).unwrap();
@@ -5997,7 +5208,7 @@ mod tests {
         let converted = traj.to_eci().unwrap();
 
         // GCRF and ECI are equivalent, so states should be the same
-        assert_eq!(converted.frame, OrbitFrame::ECI);
+        assert_eq!(converted.frame, CelestialFrame::ECI);
         for i in 0..6 {
             assert_abs_diff_eq!(converted.states[0][i], state[i], epsilon = 1e-6);
         }
@@ -6010,7 +5221,7 @@ mod tests {
 
         let mut traj = DOrbitTrajectory::new(
             6,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Radians),
         )
@@ -6022,7 +5233,7 @@ mod tests {
 
         let converted = traj.to_eci().unwrap();
 
-        assert_eq!(converted.frame, OrbitFrame::ECI);
+        assert_eq!(converted.frame, CelestialFrame::ECI);
         assert_eq!(converted.representation, OrbitRepresentation::Cartesian);
         // Cartesian state should have reasonable orbital values
         assert!(converted.states[0][0].abs() > 1e6); // Position should be in meters
@@ -6033,16 +5244,20 @@ mod tests {
     fn test_dorbittrajectory_to_eci_from_ecef() {
         setup_global_test_eop();
 
-        let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECEF, OrbitRepresentation::Cartesian, None)
-                .unwrap();
+        let mut traj = DOrbitTrajectory::new(
+            6,
+            CelestialFrame::ECEF,
+            OrbitRepresentation::Cartesian,
+            None,
+        )
+        .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
         traj.add(epoch, state).unwrap();
 
         let converted = traj.to_eci().unwrap();
 
-        assert_eq!(converted.frame, OrbitFrame::ECI);
+        assert_eq!(converted.frame, CelestialFrame::ECI);
         assert_eq!(converted.representation, OrbitRepresentation::Cartesian);
     }
 
@@ -6051,16 +5266,20 @@ mod tests {
     fn test_dorbittrajectory_to_gcrf_already_gcrf() {
         setup_global_test_eop();
 
-        let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::GCRF, OrbitRepresentation::Cartesian, None)
-                .unwrap();
+        let mut traj = DOrbitTrajectory::new(
+            6,
+            CelestialFrame::GCRF,
+            OrbitRepresentation::Cartesian,
+            None,
+        )
+        .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
         traj.add(epoch, state.clone()).unwrap();
 
         let converted = traj.to_gcrf().unwrap();
 
-        assert_eq!(converted.frame, OrbitFrame::GCRF);
+        assert_eq!(converted.frame, CelestialFrame::GCRF);
         for i in 0..6 {
             assert_abs_diff_eq!(converted.states[0][i], state[i], epsilon = 1e-6);
         }
@@ -6072,7 +5291,7 @@ mod tests {
         setup_global_test_eop();
 
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -6080,7 +5299,7 @@ mod tests {
 
         let converted = traj.to_gcrf().unwrap();
 
-        assert_eq!(converted.frame, OrbitFrame::GCRF);
+        assert_eq!(converted.frame, CelestialFrame::GCRF);
         // ECI and GCRF are equivalent
         for i in 0..6 {
             assert_abs_diff_eq!(converted.states[0][i], state[i], epsilon = 1e-6);
@@ -6092,16 +5311,20 @@ mod tests {
     fn test_dorbittrajectory_to_ecef_already_ecef() {
         setup_global_test_eop();
 
-        let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECEF, OrbitRepresentation::Cartesian, None)
-                .unwrap();
+        let mut traj = DOrbitTrajectory::new(
+            6,
+            CelestialFrame::ECEF,
+            OrbitRepresentation::Cartesian,
+            None,
+        )
+        .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
         traj.add(epoch, state.clone()).unwrap();
 
         let converted = traj.to_ecef().unwrap();
 
-        assert_eq!(converted.frame, OrbitFrame::ECEF);
+        assert_eq!(converted.frame, CelestialFrame::ECEF);
         for i in 0..6 {
             assert_abs_diff_eq!(converted.states[0][i], state[i], epsilon = 1e-6);
         }
@@ -6113,7 +5336,7 @@ mod tests {
         setup_global_test_eop();
 
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -6121,7 +5344,7 @@ mod tests {
 
         let converted = traj.to_ecef().unwrap();
 
-        assert_eq!(converted.frame, OrbitFrame::ECEF);
+        assert_eq!(converted.frame, CelestialFrame::ECEF);
         assert_eq!(converted.representation, OrbitRepresentation::Cartesian);
     }
 
@@ -6130,16 +5353,20 @@ mod tests {
     fn test_dorbittrajectory_to_itrf_already_itrf() {
         setup_global_test_eop();
 
-        let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ITRF, OrbitRepresentation::Cartesian, None)
-                .unwrap();
+        let mut traj = DOrbitTrajectory::new(
+            6,
+            CelestialFrame::ITRF,
+            OrbitRepresentation::Cartesian,
+            None,
+        )
+        .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
         traj.add(epoch, state.clone()).unwrap();
 
         let converted = traj.to_itrf().unwrap();
 
-        assert_eq!(converted.frame, OrbitFrame::ITRF);
+        assert_eq!(converted.frame, CelestialFrame::ITRF);
         for i in 0..6 {
             assert_abs_diff_eq!(converted.states[0][i], state[i], epsilon = 1e-6);
         }
@@ -6151,7 +5378,7 @@ mod tests {
         setup_global_test_eop();
 
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -6159,7 +5386,7 @@ mod tests {
 
         let converted = traj.to_itrf().unwrap();
 
-        assert_eq!(converted.frame, OrbitFrame::ITRF);
+        assert_eq!(converted.frame, CelestialFrame::ITRF);
     }
 
     #[test]
@@ -6167,16 +5394,20 @@ mod tests {
     fn test_dorbittrajectory_to_eme2000_already_eme2000() {
         setup_global_test_eop();
 
-        let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::EME2000, OrbitRepresentation::Cartesian, None)
-                .unwrap();
+        let mut traj = DOrbitTrajectory::new(
+            6,
+            CelestialFrame::EME2000,
+            OrbitRepresentation::Cartesian,
+            None,
+        )
+        .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
         traj.add(epoch, state.clone()).unwrap();
 
         let converted = traj.to_eme2000().unwrap();
 
-        assert_eq!(converted.frame, OrbitFrame::EME2000);
+        assert_eq!(converted.frame, CelestialFrame::EME2000);
         for i in 0..6 {
             assert_abs_diff_eq!(converted.states[0][i], state[i], epsilon = 1e-6);
         }
@@ -6188,7 +5419,7 @@ mod tests {
         setup_global_test_eop();
 
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -6196,7 +5427,7 @@ mod tests {
 
         let converted = traj.to_eme2000().unwrap();
 
-        assert_eq!(converted.frame, OrbitFrame::EME2000);
+        assert_eq!(converted.frame, CelestialFrame::EME2000);
     }
 
     #[test]
@@ -6205,7 +5436,7 @@ mod tests {
         setup_global_test_eop();
 
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -6226,7 +5457,7 @@ mod tests {
 
         let mut traj = DOrbitTrajectory::new(
             6,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Radians),
         )
@@ -6250,7 +5481,7 @@ mod tests {
 
         let mut traj = DOrbitTrajectory::new(
             6,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Radians),
         )
@@ -6279,9 +5510,10 @@ mod tests {
     #[test]
     #[parallel]
     fn test_dorbittrajectory_with_name() {
-        let traj = DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
-            .unwrap()
-            .with_name("TestTrajectory");
+        let traj =
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap()
+                .with_name("TestTrajectory");
 
         assert_eq!(traj.get_name(), Some("TestTrajectory"));
     }
@@ -6290,9 +5522,10 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_with_uuid() {
         let test_uuid = uuid::Uuid::now_v7();
-        let traj = DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
-            .unwrap()
-            .with_uuid(test_uuid);
+        let traj =
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap()
+                .with_uuid(test_uuid);
 
         assert_eq!(traj.get_uuid(), Some(test_uuid));
     }
@@ -6300,9 +5533,10 @@ mod tests {
     #[test]
     #[parallel]
     fn test_dorbittrajectory_with_new_uuid() {
-        let traj = DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
-            .unwrap()
-            .with_new_uuid();
+        let traj =
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap()
+                .with_new_uuid();
 
         assert!(traj.get_uuid().is_some());
     }
@@ -6310,9 +5544,10 @@ mod tests {
     #[test]
     #[parallel]
     fn test_dorbittrajectory_with_id() {
-        let traj = DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
-            .unwrap()
-            .with_id(42);
+        let traj =
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap()
+                .with_id(42);
 
         assert_eq!(traj.get_id(), Some(42));
     }
@@ -6321,9 +5556,10 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_with_identity() {
         let test_uuid = uuid::Uuid::now_v7();
-        let traj = DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
-            .unwrap()
-            .with_identity(Some("Name"), Some(test_uuid), Some(1));
+        let traj =
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap()
+                .with_identity(Some("Name"), Some(test_uuid), Some(1));
 
         assert_eq!(traj.get_id(), Some(1));
         assert_eq!(traj.get_name(), Some("Name"));
@@ -6334,7 +5570,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_set_identity() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let test_uuid = uuid::Uuid::now_v7();
         traj.set_identity(Some("NewName"), Some(test_uuid), Some(10));
@@ -6348,7 +5584,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_set_id() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         traj.set_id(Some(99));
         assert_eq!(traj.get_id(), Some(99));
@@ -6358,7 +5594,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_set_name() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         traj.set_name(Some("SetName"));
         assert_eq!(traj.get_name(), Some("SetName"));
@@ -6368,7 +5604,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_generate_uuid() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         assert!(traj.get_uuid().is_none());
         traj.generate_uuid();
@@ -6379,11 +5615,12 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_get_id_name_uuid() {
         let test_uuid = uuid::Uuid::now_v7();
-        let traj = DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
-            .unwrap()
-            .with_id(5)
-            .with_name("GetTest")
-            .with_uuid(test_uuid);
+        let traj =
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap()
+                .with_id(5)
+                .with_name("GetTest")
+                .with_uuid(test_uuid);
 
         assert_eq!(traj.get_id(), Some(5));
         assert_eq!(traj.get_name(), Some("GetTest"));
@@ -6396,7 +5633,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_state_provider_state() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 100.0, 200.0, 10.0, 7.5e3, 5.0]);
@@ -6412,13 +5649,14 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_state_provider_state_dim() {
         // state_dim returns dimension from first state, or 6 if empty
-        let traj = DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
-            .unwrap();
+        let traj =
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         assert_eq!(traj.state_dim(), 6); // default for empty
 
         // Add a 9D state to verify dimension is correctly detected
         let mut traj9 =
-            DOrbitTrajectory::new(9, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(9, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0, 0.1, 0.2, 0.3]);
@@ -6430,7 +5668,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_state_provider_state_error() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -6448,7 +5686,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_covariance_provider_basic() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         traj.covariances = Some(Vec::new());
 
@@ -6465,7 +5703,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_covariance_provider_error_not_enabled() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -6481,7 +5719,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_covariance_provider_error_before_start() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         traj.covariances = Some(Vec::new());
 
@@ -6499,7 +5737,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_covariance_provider_error_after_end() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         traj.covariances = Some(Vec::new());
 
@@ -6516,8 +5754,9 @@ mod tests {
     #[test]
     #[parallel]
     fn test_dorbittrajectory_covariance_provider_dim() {
-        let traj = DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
-            .unwrap();
+        let traj =
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         assert_eq!(traj.covariance_dim(), 6);
     }
 
@@ -6529,7 +5768,7 @@ mod tests {
         setup_global_test_eop();
 
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 100.0, 200.0, 10.0, 7.5e3, 5.0]);
@@ -6546,9 +5785,13 @@ mod tests {
     fn test_dorbittrajectory_state_eci_from_gcrf_cartesian() {
         setup_global_test_eop();
 
-        let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::GCRF, OrbitRepresentation::Cartesian, None)
-                .unwrap();
+        let mut traj = DOrbitTrajectory::new(
+            6,
+            CelestialFrame::GCRF,
+            OrbitRepresentation::Cartesian,
+            None,
+        )
+        .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
         traj.add(epoch, state.clone()).unwrap();
@@ -6567,7 +5810,7 @@ mod tests {
 
         let mut traj = DOrbitTrajectory::new(
             6,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Radians),
         )
@@ -6587,9 +5830,13 @@ mod tests {
     fn test_dorbittrajectory_state_eci_from_ecef_cartesian() {
         setup_global_test_eop();
 
-        let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECEF, OrbitRepresentation::Cartesian, None)
-                .unwrap();
+        let mut traj = DOrbitTrajectory::new(
+            6,
+            CelestialFrame::ECEF,
+            OrbitRepresentation::Cartesian,
+            None,
+        )
+        .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
         traj.add(epoch, state).unwrap();
@@ -6613,13 +5860,9 @@ mod tests {
         // auto-load latch (OnceLock) does not re-detect the clear.
         crate::spice::load_spice_kernel("moon_pa_de440").unwrap();
 
-        let mut traj = DOrbitTrajectory::new(
-            6,
-            OrbitFrame::BodyCenteredInertial(301),
-            OrbitRepresentation::Cartesian,
-            None,
-        )
-        .unwrap();
+        let mut traj =
+            DOrbitTrajectory::new(6, CelestialFrame::LCI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.covariances = Some(Vec::new());
         let epoch = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![2.0e6, 1.0e5, -3.0e5, 10.0, 1.6e3, -5.0]);
@@ -6668,10 +5911,10 @@ mod tests {
 
         // Batch conversions agree with the point queries and are relabeled.
         for (converted, expected, frame) in [
-            (traj.to_gcrf().unwrap(), gcrf, OrbitFrame::GCRF),
-            (traj.to_ecef().unwrap(), ecef, OrbitFrame::ECEF),
-            (traj.to_itrf().unwrap(), itrf, OrbitFrame::ITRF),
-            (traj.to_eme2000().unwrap(), eme, OrbitFrame::EME2000),
+            (traj.to_gcrf().unwrap(), gcrf, CelestialFrame::GCRF),
+            (traj.to_ecef().unwrap(), ecef, CelestialFrame::ECEF),
+            (traj.to_itrf().unwrap(), itrf, CelestialFrame::ITRF),
+            (traj.to_eme2000().unwrap(), eme, CelestialFrame::EME2000),
         ] {
             assert_eq!(converted.frame, frame);
             let s0 = &converted.states[0];
@@ -6689,9 +5932,13 @@ mod tests {
         }
 
         // state_in_frame on an Earth-frame trajectory routes from GCRF.
-        let mut traj_e =
-            DOrbitTrajectory::new(6, OrbitFrame::GCRF, OrbitRepresentation::Cartesian, None)
-                .unwrap();
+        let mut traj_e = DOrbitTrajectory::new(
+            6,
+            CelestialFrame::GCRF,
+            OrbitRepresentation::Cartesian,
+            None,
+        )
+        .unwrap();
         let state_e = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
         traj_e.add(epoch, state_e).unwrap();
         let in_itrf = traj_e.state_in_frame(CelestialFrame::ITRF, epoch).unwrap();
@@ -6716,7 +5963,7 @@ mod tests {
 
         let mut traj_emb = DOrbitTrajectory::new(
             6,
-            OrbitFrame::BodyCenteredInertial(3),
+            CelestialFrame::EMBI,
             OrbitRepresentation::Cartesian,
             None,
         )
@@ -6741,7 +5988,7 @@ mod tests {
 
         let mut traj_unknown = DOrbitTrajectory::new(
             6,
-            OrbitFrame::BodyCenteredInertial(-20001),
+            CelestialFrame::BodyCenteredICRF(-20001),
             OrbitRepresentation::Cartesian,
             None,
         )
@@ -6759,7 +6006,7 @@ mod tests {
         // Keplerian representation about a barycenter has no defined GM.
         let mut traj_kep = DOrbitTrajectory::new(
             6,
-            OrbitFrame::BodyCenteredInertial(3),
+            CelestialFrame::EMBI,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Degrees),
         )
@@ -6785,7 +6032,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_dorbittrajectory_body_centered_inertial_providers() {
-        // A BodyCenteredInertial(301) trajectory: state_bci returns the raw
+        // A Moon-centered (LCI) trajectory: state_bci returns the raw
         // LCI sample, state_in_frame(LCI) is the identity on it, state_eci
         // re-centers through SPK (LCI sample + Moon offset), and the batch
         // to_eci matches state_eci per epoch. Earth-frame trajectories keep
@@ -6794,13 +6041,9 @@ mod tests {
         setup_global_test_eop();
         crate::utils::testing::setup_global_test_spice();
 
-        let mut traj = DOrbitTrajectory::new(
-            6,
-            OrbitFrame::BodyCenteredInertial(301),
-            OrbitRepresentation::Cartesian,
-            None,
-        )
-        .unwrap();
+        let mut traj =
+            DOrbitTrajectory::new(6, CelestialFrame::LCI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         let epoch = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![2.0e6, 1.0e5, -3.0e5, 10.0, 1.6e3, -5.0]);
         traj.add(epoch, state.clone()).unwrap();
@@ -6823,16 +6066,20 @@ mod tests {
 
         // Batch conversion matches the per-epoch provider result.
         let traj_eci = traj.to_eci().unwrap();
-        assert_eq!(traj_eci.frame, OrbitFrame::ECI);
+        assert_eq!(traj_eci.frame, CelestialFrame::ECI);
         let batch = traj_eci.state_eci(epoch).unwrap();
         for i in 0..6 {
             assert_abs_diff_eq!(batch[i], eci[i], epsilon = 1e-6);
         }
 
         // Earth-frame trajectory: state_bci == state_gcrf.
-        let mut traj_e =
-            DOrbitTrajectory::new(6, OrbitFrame::GCRF, OrbitRepresentation::Cartesian, None)
-                .unwrap();
+        let mut traj_e = DOrbitTrajectory::new(
+            6,
+            CelestialFrame::GCRF,
+            OrbitRepresentation::Cartesian,
+            None,
+        )
+        .unwrap();
         let state_e = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
         traj_e.add(epoch, state_e).unwrap();
         let bci_e = traj_e.state_bci(epoch).unwrap();
@@ -6845,7 +6092,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_dorbittrajectory_bci_keplerian_to_eci_uses_center_gm() {
-        // A Keplerian BodyCenteredInertial(301) trajectory converts elements
+        // A Keplerian LCI trajectory converts elements
         // with the Moon's GM and re-centers through SPK, matching the
         // point-query provider result exactly.
         setup_global_test_eop();
@@ -6853,7 +6100,7 @@ mod tests {
 
         let mut traj = DOrbitTrajectory::new(
             6,
-            OrbitFrame::BodyCenteredInertial(301),
+            CelestialFrame::LCI,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Degrees),
         )
@@ -6871,7 +6118,7 @@ mod tests {
 
         let eci_point = traj.state_eci(epoch).unwrap();
         let traj_eci = traj.to_eci().unwrap();
-        assert_eq!(traj_eci.frame, OrbitFrame::ECI);
+        assert_eq!(traj_eci.frame, CelestialFrame::ECI);
         let eci_batch = traj_eci.state_eci(epoch).unwrap();
         for i in 0..6 {
             assert_abs_diff_eq!(eci_batch[i], eci_point[i], epsilon = 1e-6);
@@ -6885,9 +6132,13 @@ mod tests {
     fn test_dorbittrajectory_state_gcrf_from_gcrf_cartesian() {
         setup_global_test_eop();
 
-        let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::GCRF, OrbitRepresentation::Cartesian, None)
-                .unwrap();
+        let mut traj = DOrbitTrajectory::new(
+            6,
+            CelestialFrame::GCRF,
+            OrbitRepresentation::Cartesian,
+            None,
+        )
+        .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
         traj.add(epoch, state.clone()).unwrap();
@@ -6904,7 +6155,7 @@ mod tests {
         setup_global_test_eop();
 
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -6922,9 +6173,13 @@ mod tests {
     fn test_dorbittrajectory_state_ecef_from_ecef_cartesian() {
         setup_global_test_eop();
 
-        let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECEF, OrbitRepresentation::Cartesian, None)
-                .unwrap();
+        let mut traj = DOrbitTrajectory::new(
+            6,
+            CelestialFrame::ECEF,
+            OrbitRepresentation::Cartesian,
+            None,
+        )
+        .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
         traj.add(epoch, state.clone()).unwrap();
@@ -6941,7 +6196,7 @@ mod tests {
         setup_global_test_eop();
 
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -6956,9 +6211,13 @@ mod tests {
     fn test_dorbittrajectory_state_itrf_from_itrf_cartesian() {
         setup_global_test_eop();
 
-        let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ITRF, OrbitRepresentation::Cartesian, None)
-                .unwrap();
+        let mut traj = DOrbitTrajectory::new(
+            6,
+            CelestialFrame::ITRF,
+            OrbitRepresentation::Cartesian,
+            None,
+        )
+        .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
         traj.add(epoch, state.clone()).unwrap();
@@ -6974,9 +6233,13 @@ mod tests {
     fn test_dorbittrajectory_state_eme2000_from_eme2000_cartesian() {
         setup_global_test_eop();
 
-        let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::EME2000, OrbitRepresentation::Cartesian, None)
-                .unwrap();
+        let mut traj = DOrbitTrajectory::new(
+            6,
+            CelestialFrame::EME2000,
+            OrbitRepresentation::Cartesian,
+            None,
+        )
+        .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
         traj.add(epoch, state.clone()).unwrap();
@@ -6993,7 +6256,7 @@ mod tests {
         setup_global_test_eop();
 
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -7011,7 +6274,7 @@ mod tests {
 
         let mut traj = DOrbitTrajectory::new(
             6,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Radians),
         )
@@ -7034,7 +6297,7 @@ mod tests {
         setup_global_test_eop();
 
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         traj.covariances = Some(Vec::new());
 
@@ -7052,9 +6315,13 @@ mod tests {
     fn test_dorbittrajectory_covariance_eci_from_gcrf() {
         setup_global_test_eop();
 
-        let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::GCRF, OrbitRepresentation::Cartesian, None)
-                .unwrap();
+        let mut traj = DOrbitTrajectory::new(
+            6,
+            CelestialFrame::GCRF,
+            OrbitRepresentation::Cartesian,
+            None,
+        )
+        .unwrap();
         traj.covariances = Some(Vec::new());
 
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
@@ -7072,9 +6339,13 @@ mod tests {
     fn test_dorbittrajectory_covariance_eci_error_ecef() {
         setup_global_test_eop();
 
-        let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECEF, OrbitRepresentation::Cartesian, None)
-                .unwrap();
+        let mut traj = DOrbitTrajectory::new(
+            6,
+            CelestialFrame::ECEF,
+            OrbitRepresentation::Cartesian,
+            None,
+        )
+        .unwrap();
         traj.covariances = Some(Vec::new());
 
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
@@ -7092,9 +6363,13 @@ mod tests {
     fn test_dorbittrajectory_covariance_gcrf() {
         setup_global_test_eop();
 
-        let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::GCRF, OrbitRepresentation::Cartesian, None)
-                .unwrap();
+        let mut traj = DOrbitTrajectory::new(
+            6,
+            CelestialFrame::GCRF,
+            OrbitRepresentation::Cartesian,
+            None,
+        )
+        .unwrap();
         traj.covariances = Some(Vec::new());
 
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
@@ -7112,7 +6387,7 @@ mod tests {
         setup_global_test_eop();
 
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         traj.covariances = Some(Vec::new());
 
@@ -7131,7 +6406,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_index_valid() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 100.0, 200.0, 10.0, 7.5e3, 5.0]);
@@ -7148,8 +6423,9 @@ mod tests {
     #[should_panic]
     #[parallel]
     fn test_dorbittrajectory_index_panic_out_of_bounds() {
-        let traj = DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
-            .unwrap();
+        let traj =
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         let _ = &traj[0]; // Empty trajectory
     }
 
@@ -7157,7 +6433,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_into_iter() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch1 = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let epoch2 = Epoch::from_datetime(2024, 1, 1, 12, 1, 0.0, 0.0, TimeSystem::UTC);
@@ -7177,7 +6453,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_iterator_size_hint() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         for i in 0..5 {
             let epoch = Epoch::from_datetime(2024, 1, 1, 12, i, 0.0, 0.0, TimeSystem::UTC);
@@ -7193,7 +6469,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_iterator_len() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         for i in 0..3 {
             let epoch = Epoch::from_datetime(2024, 1, 1, 12, i, 0.0, 0.0, TimeSystem::UTC);
@@ -7209,7 +6485,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_iterator_next() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -7232,7 +6508,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_enable_acceleration_storage() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
 
         assert!(traj.accelerations.is_none());
@@ -7245,7 +6521,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_enable_acceleration_storage_err_mismatch() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         traj.enable_acceleration_storage(3).unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
@@ -7258,7 +6534,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_has_accelerations() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         assert!(!traj.has_accelerations());
 
@@ -7270,7 +6546,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_acceleration_dim() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         assert_eq!(traj.acceleration_dim(), None);
 
@@ -7282,7 +6558,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_acceleration_at_idx() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         traj.enable_acceleration_storage(3).unwrap();
 
@@ -7301,7 +6577,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_set_acceleration_at() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -7321,7 +6597,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_set_acceleration_at_err_dimension() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = DVector::from_vec(vec![7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]);
@@ -7336,7 +6612,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_add_with_acceleration() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         traj.enable_acceleration_storage(3).unwrap();
 
@@ -7356,7 +6632,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_enable_acceleration_storage_dimension_mismatch() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         traj.enable_acceleration_storage(3).unwrap();
         // Re-enabling with the same dimension is a no-op that returns Ok.
@@ -7370,7 +6646,7 @@ mod tests {
     #[parallel]
     fn test_dorbittrajectory_set_acceleration_at_index_out_of_bounds() {
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         traj.enable_acceleration_storage(3).unwrap();
         let acc = DVector::zeros(3);
@@ -7383,10 +6659,10 @@ mod tests {
     fn test_dorbittrajectory_bci_keplerian_barycenter_conversions_err() {
         // Keplerian elements about the Earth-Moon barycenter (NAIF 3) are
         // undefined; every batch conversion that redirects through
-        // bci_keplerian_to_cartesian must surface the barycenter error.
+        // native_cartesian must surface the barycenter error.
         let mut traj = DOrbitTrajectory::new(
             6,
-            OrbitFrame::BodyCenteredInertial(3),
+            CelestialFrame::EMBI,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Degrees),
         )
@@ -7406,7 +6682,7 @@ mod tests {
     fn test_dorbittrajectory_to_keplerian_missing_angle_format_err() {
         let mut traj = DOrbitTrajectory::new(
             6,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Degrees),
         )
@@ -7429,7 +6705,7 @@ mod tests {
         // convert_orbital_preserving_additional unchanged.
         let mut traj = DOrbitTrajectory::new(
             8,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Degrees),
         )
@@ -7452,7 +6728,7 @@ mod tests {
         // Matrix-square-root interpolation over a singular covariance cannot
         // compute the required matrix square root and must surface the error.
         let mut traj =
-            DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         traj.covariances = Some(Vec::new());
         traj.set_covariance_interpolation_method(CovarianceInterpolationMethod::MatrixSquareRoot);
@@ -7489,7 +6765,7 @@ mod tests {
             InterpolationMethod::HermiteQuintic,
         ] {
             let mut traj =
-                DOrbitTrajectory::new(6, OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+                DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
                     .unwrap();
             traj.enable_acceleration_storage(3).unwrap();
             // An impulsive maneuver at start + 60: x jumps from 1 to 10.
@@ -7526,6 +6802,223 @@ mod tests {
                 10.5,
                 epsilon = 1e-9
             );
+        }
+    }
+
+    // =========================================================================
+    // to_frame / ReferenceFrame Tests
+    // =========================================================================
+
+    /// Ten GCRF Cartesian samples over a quarter of a LEO orbit.
+    fn sample_leo_trajectory() -> DOrbitTrajectory {
+        let epoch = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+        let oe = Vector6::new(
+            crate::constants::R_EARTH + 500e3,
+            0.001,
+            97.8,
+            15.0,
+            30.0,
+            45.0,
+        );
+        let mut traj = DOrbitTrajectory::new(
+            6,
+            CelestialFrame::GCRF,
+            OrbitRepresentation::Cartesian,
+            None,
+        )
+        .unwrap();
+        for i in 0..10 {
+            let mut elements = oe;
+            elements[5] += 3.0 * i as f64;
+            let x = state_koe_to_eci(elements, AngleFormat::Degrees);
+            traj.add(epoch + 60.0 * i as f64, svec6_to_dvec(x)).unwrap();
+        }
+        traj
+    }
+
+    #[test]
+    #[serial]
+    fn test_dorbittrajectory_to_frame_matches_named_wrappers_bitwise() {
+        setup_global_test_eop();
+        let traj = sample_leo_trajectory();
+
+        let itrf = traj.to_frame(CelestialFrame::ITRF).unwrap();
+        assert_eq!(itrf.frame, CelestialFrame::ITRF);
+        assert_eq!(itrf.states, traj.to_itrf().unwrap().states);
+        assert_eq!(
+            traj.to_frame(CelestialFrame::EME2000).unwrap().states,
+            traj.to_eme2000().unwrap().states
+        );
+
+        // The wrappers agree with the pairwise functions they replaced.
+        for (i, (e, s)) in (&traj).into_iter().enumerate() {
+            let expected = state_gcrf_to_itrf(e, dvec_to_svec6(s.rows(0, 6).into_owned()));
+            for k in 0..6 {
+                assert_eq!(itrf.states[i][k], expected[k]);
+            }
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_dorbittrajectory_to_frame_tod_and_lunar_and_round_trip() {
+        setup_global_test_eop();
+        crate::utils::testing::setup_global_test_spice();
+        crate::spice::load_spice_kernel("moon_pa_de440").unwrap();
+        let traj = sample_leo_trajectory();
+
+        let tod = traj.to_frame(CelestialFrame::TOD).unwrap();
+        assert_eq!(tod.frame, CelestialFrame::TOD);
+        let back = tod.to_frame(CelestialFrame::GCRF).unwrap();
+        for i in 0..traj.len() {
+            for k in 0..3 {
+                assert_abs_diff_eq!(back.states[i][k], traj.states[i][k], epsilon = 1e-6);
+                assert_abs_diff_eq!(back.states[i][k + 3], traj.states[i][k + 3], epsilon = 1e-9);
+            }
+        }
+
+        // A non-Earth frame re-centers through the router.
+        let lci = traj.to_frame(CelestialFrame::LCI).unwrap();
+        assert_eq!(lci.frame, CelestialFrame::LCI);
+        assert!(lci.states[0].rows(0, 3).norm() > 3.0e8);
+        let lfpa = traj.to_frame(CelestialFrame::LFPA).unwrap();
+        assert_eq!(lfpa.frame, CelestialFrame::LFPA);
+    }
+
+    #[test]
+    #[serial]
+    fn test_dorbittrajectory_to_frame_orbit_relative_target_and_state_bci() {
+        setup_global_test_eop();
+        crate::frames::clear_object_registry();
+        let traj = sample_leo_trajectory();
+
+        // Register the trajectory itself and express it in its own RTN frame.
+        crate::frames::register_object(
+            "CHIEF",
+            crate::frames::DStateAdapter::new(traj.clone()).unwrap(),
+            CelestialFrame::GCRF,
+        )
+        .unwrap();
+        let rtn = traj.to_frame(ReferenceFrame::RTN("CHIEF")).unwrap();
+        assert_eq!(rtn.frame, ReferenceFrame::RTN("CHIEF"));
+
+        // The trajectory is its own chief, so its RTN position is zero.
+        for i in 0..traj.len() {
+            for k in 0..3 {
+                assert_abs_diff_eq!(rtn.states[i][k], 0.0, epsilon = 1e-6);
+            }
+        }
+
+        // state_bci on an orbit-relative trajectory resolves GCRF through the
+        // chief's declared frame.
+        let e = traj.epochs[3];
+        let bci = rtn.state_bci(e).unwrap();
+        let expected = traj.state_gcrf(e).unwrap();
+        for k in 0..3 {
+            assert_abs_diff_eq!(bci[k], expected[k], epsilon = 1e-3);
+        }
+
+        crate::frames::clear_object_registry();
+    }
+
+    #[test]
+    #[parallel]
+    fn test_dorbittrajectory_keplerian_frame_rule() {
+        assert!(
+            DOrbitTrajectory::new(
+                6,
+                CelestialFrame::ITRF,
+                OrbitRepresentation::Keplerian,
+                Some(AngleFormat::Degrees)
+            )
+            .is_err()
+        );
+        assert!(
+            DOrbitTrajectory::new(
+                6,
+                CelestialFrame::TOD,
+                OrbitRepresentation::Keplerian,
+                Some(AngleFormat::Degrees)
+            )
+            .is_err()
+        );
+        assert!(
+            DOrbitTrajectory::new(
+                6,
+                ReferenceFrame::RTN("SC"),
+                OrbitRepresentation::Keplerian,
+                Some(AngleFormat::Degrees)
+            )
+            .is_err()
+        );
+        assert!(
+            DOrbitTrajectory::new(
+                6,
+                CelestialFrame::EME2000,
+                OrbitRepresentation::Keplerian,
+                Some(AngleFormat::Degrees)
+            )
+            .is_ok()
+        );
+        assert!(
+            DOrbitTrajectory::new(
+                6,
+                CelestialFrame::LCI,
+                OrbitRepresentation::Keplerian,
+                Some(AngleFormat::Degrees)
+            )
+            .is_ok()
+        );
+        assert!(
+            DOrbitTrajectory::new(
+                6,
+                ReferenceFrame::RTN("SC"),
+                OrbitRepresentation::Cartesian,
+                None
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    #[parallel]
+    fn test_dorbittrajectory_frame_display_uses_celestial_names() {
+        let traj =
+            DOrbitTrajectory::new(6, CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
+        assert_eq!(traj.frame.to_string(), "GCRF");
+        assert!(traj.frame == CelestialFrame::GCRF);
+    }
+
+    #[test]
+    #[parallel]
+    fn test_dorbittrajectory_koe_to_inertial_gm_matches_koe_to_eci() {
+        // native_cartesian converts Earth-centered elements with
+        // CentralBody::Earth's GM; that must be the GM_EARTH state_koe_to_eci
+        // uses, bit for bit.
+        let oe = Vector6::new(
+            crate::constants::R_EARTH + 500e3,
+            0.001,
+            97.8,
+            15.0,
+            30.0,
+            45.0,
+        );
+        for format in [AngleFormat::Degrees, AngleFormat::Radians] {
+            let elements = if format == AngleFormat::Radians {
+                let mut x = oe;
+                for i in 2..6 {
+                    x[i] *= DEG2RAD;
+                }
+                x
+            } else {
+                oe
+            };
+            let with_gm = state_koe_to_inertial_gm(elements, CentralBody::Earth.gm(), format);
+            let with_eci = state_koe_to_eci(elements, format);
+            for k in 0..6 {
+                assert_eq!(with_gm[k], with_eci[k]);
+            }
         }
     }
 }

--- a/src/trajectories/mod.rs
+++ b/src/trajectories/mod.rs
@@ -13,7 +13,8 @@
  * # Examples
  * ```rust
  * use brahe::trajectories::{DTrajectory, STrajectory6, SOrbitTrajectory, DOrbitTrajectory};
- * use brahe::traits::{Trajectory, OrbitFrame, OrbitRepresentation};
+ * use brahe::traits::{Trajectory, OrbitRepresentation};
+ * use brahe::frames::CelestialFrame;
  *
  * // Dynamic trajectory - any dimension
  * let mut dyn_traj = DTrajectory::new(7).unwrap(); // 7-dimensional
@@ -23,7 +24,7 @@
  *
  * // Static orbital trajectory - 6D with orbital-specific features
  * let mut sorbit_traj = SOrbitTrajectory::new(
- *     OrbitFrame::ECI,
+ *     CelestialFrame::ECI,
  *     OrbitRepresentation::Cartesian,
  *     None,
  * );
@@ -31,7 +32,7 @@
  * // Dynamic orbital trajectory - 6D with orbital-specific features
  * let mut dorbit_traj = DOrbitTrajectory::new(
  *     6,  // dimension
- *     OrbitFrame::ECI,
+ *     CelestialFrame::ECI,
  *     OrbitRepresentation::Cartesian,
  *     None,
  * );

--- a/src/trajectories/sorbit_trajectory.rs
+++ b/src/trajectories/sorbit_trajectory.rs
@@ -15,14 +15,15 @@
  * # Examples
  * ```rust
  * use brahe::trajectories::SOrbitTrajectory;
- * use brahe::traits::{Trajectory, OrbitalTrajectory, OrbitFrame, OrbitRepresentation};
+ * use brahe::traits::{Trajectory, OrbitalTrajectory, OrbitRepresentation};
+ * use brahe::frames::CelestialFrame;
  * use brahe::AngleFormat;
  * use brahe::time::{Epoch, TimeSystem};
  * use nalgebra::Vector6;
  *
  * // Create orbital trajectory in ECI Cartesian coordinates
  * let mut traj = SOrbitTrajectory::new(
- *     OrbitFrame::ECI,
+ *     CelestialFrame::ECI,
  *     OrbitRepresentation::Cartesian,
  *     None,
  * ).unwrap();
@@ -46,27 +47,29 @@ use uuid::Uuid;
 
 use crate::constants::AngleFormat;
 use crate::constants::{DEG2RAD, RAD2DEG};
-use crate::coordinates::{state_eci_to_koe, state_koe_to_eci};
+use crate::coordinates::{state_eci_to_koe, state_inertial_to_koe_gm, state_koe_to_inertial_gm};
 use crate::frames::{
-    rotation_eme2000_to_gcrf, state_ecef_to_eci, state_eci_to_ecef, state_eme2000_to_gcrf,
-    state_gcrf_to_eme2000, state_gcrf_to_itrf, state_itrf_to_gcrf,
+    CelestialFrame, ReferenceFrame, celestial_root, icrf_aligned_inertial,
+    rotation_eme2000_to_gcrf, state_frame_to_frame,
 };
 use crate::math::{
     CovarianceInterpolationConfig, interpolate_covariance_sqrt_smatrix,
     interpolate_covariance_two_wasserstein_smatrix, interpolate_hermite_cubic_svector6,
     interpolate_hermite_quintic_svector6, interpolate_lagrange_svector,
 };
+use crate::propagators::CentralBody;
 use crate::propagators::traits::{
     SCovarianceProvider, SOrbitCovarianceProvider, SOrbitStateProvider, SStateProvider,
 };
 use crate::relative_motion::rotation_eci_to_rtn;
+use crate::spice::NAIFId;
 use crate::time::Epoch;
 use crate::utils::{BraheError, Identifiable};
 
 use super::traits::{
     CovarianceInterpolationMethod, InterpolatableTrajectory, InterpolationConfig,
-    InterpolationMethod, OrbitFrame, OrbitRepresentation, OrbitalTrajectory, Trajectory,
-    TrajectoryEvictionPolicy,
+    InterpolationMethod, OrbitRepresentation, OrbitalTrajectory, Trajectory,
+    TrajectoryEvictionPolicy, bci_fixed_frame, covariance_frame_allowed, keplerian_center,
 };
 
 /// Static (compile-time sized) orbital trajectory container.
@@ -133,11 +136,11 @@ pub struct SOrbitTrajectory {
     max_age: Option<f64>,
 
     /// Reference frame of the orbital states.
-    pub frame: OrbitFrame,
+    pub frame: ReferenceFrame,
 
     /// State representation (Cartesian or Keplerian).
-    /// Keplerian elements are always in ECI frame.
-    /// Cartesian can be in ECI or ECEF.
+    /// Keplerian elements require an inertial frame.
+    /// Cartesian states may be declared in any frame.
     pub representation: OrbitRepresentation,
 
     /// Angle format for angular elements
@@ -176,7 +179,7 @@ impl SOrbitTrajectory {
     /// Creates a new orbital trajectory with specified frame, representation, and angle format.
     ///
     /// # Arguments
-    /// * `frame` - Reference frame (ECI or ECEF)
+    /// * `frame` - Reference frame the states are declared in
     /// * `representation` - State representation (Cartesian or Keplerian)
     /// * `angle_format` - Angle format (None for Cartesian, Radians/Degrees for Keplerian)
     ///
@@ -187,20 +190,23 @@ impl SOrbitTrajectory {
     /// # Examples
     /// ```rust
     /// use brahe::trajectories::SOrbitTrajectory;
-    /// use brahe::traits::{OrbitFrame, OrbitRepresentation};
+    /// use brahe::traits::OrbitRepresentation;
+    /// use brahe::frames::CelestialFrame;
     /// use brahe::AngleFormat;
     ///
     /// let traj = SOrbitTrajectory::new(
-    ///     OrbitFrame::ECI,
+    ///     CelestialFrame::ECI,
     ///     OrbitRepresentation::Cartesian,
     ///     None,
     /// ).unwrap();
     /// ```
     pub fn new(
-        frame: OrbitFrame,
+        frame: impl Into<ReferenceFrame>,
         representation: OrbitRepresentation,
         angle_format: Option<AngleFormat>,
     ) -> Result<Self, BraheError> {
+        let frame = frame.into();
+
         // Validate angle_format for representation (check this first)
         if representation == OrbitRepresentation::Keplerian && angle_format.is_none() {
             return Err(BraheError::Error(
@@ -215,10 +221,8 @@ impl SOrbitTrajectory {
         }
 
         // Validate frame for representation
-        if frame == OrbitFrame::ECEF && representation == OrbitRepresentation::Keplerian {
-            return Err(BraheError::Error(
-                "Keplerian elements should be in ECI frame".to_string(),
-            ));
+        if representation == OrbitRepresentation::Keplerian {
+            keplerian_center(&frame)?;
         }
 
         Ok(Self {
@@ -258,8 +262,9 @@ impl SOrbitTrajectory {
     /// # Examples
     /// ```rust
     /// use brahe::trajectories::SOrbitTrajectory;
-    /// use brahe::traits::{OrbitFrame, OrbitRepresentation, InterpolationMethod};
-    /// let traj = SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+    /// use brahe::traits::{OrbitRepresentation, InterpolationMethod};
+    /// use brahe::frames::CelestialFrame;
+    /// let traj = SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
     ///     .unwrap()
     ///     .with_interpolation_method(InterpolationMethod::Linear);
     /// ```
@@ -286,8 +291,9 @@ impl SOrbitTrajectory {
     /// # Examples
     /// ```rust
     /// use brahe::trajectories::SOrbitTrajectory;
-    /// use brahe::traits::{OrbitFrame, OrbitRepresentation};
-    /// let traj = SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+    /// use brahe::traits::OrbitRepresentation;
+    /// use brahe::frames::CelestialFrame;
+    /// let traj = SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
     ///     .unwrap()
     ///     .with_eviction_policy_max_size(100)
     ///     .unwrap();
@@ -315,8 +321,9 @@ impl SOrbitTrajectory {
     /// # Examples
     /// ```rust
     /// use brahe::trajectories::SOrbitTrajectory;
-    /// use brahe::traits::{OrbitFrame, OrbitRepresentation};
-    /// let traj = SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+    /// use brahe::traits::OrbitRepresentation;
+    /// use brahe::frames::CelestialFrame;
+    /// let traj = SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
     ///     .unwrap()
     ///     .with_eviction_policy_max_age(3600.0)
     ///     .unwrap();
@@ -348,12 +355,13 @@ impl SOrbitTrajectory {
     /// # Examples
     /// ```
     /// use brahe::trajectories::SOrbitTrajectory;
-    /// use brahe::traits::{OrbitFrame, OrbitRepresentation};
+    /// use brahe::traits::OrbitRepresentation;
+    /// use brahe::frames::CelestialFrame;
     /// use brahe::time::{Epoch, TimeSystem};
     /// use nalgebra::{SMatrix, SVector};
     ///
     /// let mut traj = SOrbitTrajectory::new(
-    ///     OrbitFrame::ECI,
+    ///     CelestialFrame::ECI,
     ///     OrbitRepresentation::Cartesian,
     ///     None,
     /// ).unwrap();
@@ -872,10 +880,11 @@ impl SOrbitTrajectory {
     /// # Example
     /// ```rust
     /// use brahe::trajectories::SOrbitTrajectory;
-    /// use brahe::traits::{OrbitFrame, OrbitRepresentation};
+    /// use brahe::traits::OrbitRepresentation;
+    /// use brahe::frames::CelestialFrame;
     ///
     /// let mut traj = SOrbitTrajectory::new(
-    ///     OrbitFrame::ECI,
+    ///     CelestialFrame::ECI,
     ///     OrbitRepresentation::Cartesian,
     ///     None,
     /// ).unwrap();
@@ -923,12 +932,13 @@ impl SOrbitTrajectory {
     /// # Example
     /// ```rust
     /// use brahe::trajectories::SOrbitTrajectory;
-    /// use brahe::traits::{Trajectory, OrbitFrame, OrbitRepresentation};
+    /// use brahe::traits::{Trajectory, OrbitRepresentation};
+    /// use brahe::frames::CelestialFrame;
     /// use brahe::time::{Epoch, TimeSystem};
     /// use nalgebra::{SVector, Vector6};
     ///
     /// let mut traj = SOrbitTrajectory::new(
-    ///     OrbitFrame::ECI,
+    ///     CelestialFrame::ECI,
     ///     OrbitRepresentation::Cartesian,
     ///     None,
     /// ).unwrap();
@@ -974,12 +984,13 @@ impl SOrbitTrajectory {
     /// # Example
     /// ```rust
     /// use brahe::trajectories::SOrbitTrajectory;
-    /// use brahe::traits::{Trajectory, OrbitFrame, OrbitRepresentation};
+    /// use brahe::traits::{Trajectory, OrbitRepresentation};
+    /// use brahe::frames::CelestialFrame;
     /// use brahe::time::{Epoch, TimeSystem};
     /// use nalgebra::{SVector, Vector6};
     ///
     /// let mut traj = SOrbitTrajectory::new(
-    ///     OrbitFrame::ECI,
+    ///     CelestialFrame::ECI,
     ///     OrbitRepresentation::Cartesian,
     ///     None,
     /// ).unwrap();
@@ -1039,7 +1050,7 @@ impl Default for SOrbitTrajectory {
     /// Creates a default orbital trajectory in ECI Cartesian with no angle format.
     fn default() -> Self {
         Self::new(
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None, // angle_format is None for Cartesian
         )
@@ -1141,7 +1152,7 @@ impl Trajectory for SOrbitTrajectory {
             eviction_policy: TrajectoryEvictionPolicy::None,
             max_size: None,
             max_age: None,
-            frame: OrbitFrame::ECI, // Default to ECI Cartesian
+            frame: CelestialFrame::ECI.into(), // Default to ECI Cartesian
             representation: OrbitRepresentation::Cartesian,
             angle_format: None, // angle_format is not meaningful for Cartesian
             name: None,
@@ -1602,35 +1613,54 @@ impl CovarianceInterpolationConfig for SOrbitTrajectory {
     }
 }
 
-// Implementation of OrbitalTrajectory trait
 impl SOrbitTrajectory {
-    /// Cartesian twin of a Keplerian `BodyCenteredInertial` trajectory:
-    /// converts each element set to Cartesian about the center body using
-    /// that body's gravitational parameter. Errors for unknown centers and
-    /// barycenters.
-    fn bci_keplerian_to_cartesian(&self, center: i32) -> Result<Self, BraheError> {
-        let cb = crate::propagators::CentralBody::from_naif_id(center)?;
-        if cb.is_barycenter() {
-            return Err(BraheError::Error(format!(
-                "Keplerian elements are undefined about massless barycenter {}",
-                center
-            )));
-        }
-        let angle_fmt = self
-            .angle_format
-            .expect("Keplerian representation must have angle_format");
-        let mut out = self.clone();
-        out.states = self
-            .states
-            .iter()
-            .map(|s| crate::coordinates::state_koe_to_inertial_gm(*s, cb.gm(), angle_fmt))
-            .collect();
-        out.representation = OrbitRepresentation::Cartesian;
-        out.angle_format = None;
-        Ok(out)
+    /// Converts every sample to Cartesian coordinates in `frame`.
+    ///
+    /// Keplerian samples are first converted to Cartesian coordinates about
+    /// their own frame's center, using that body's gravitational parameter.
+    /// The result is then routed to `frame` by the reference frame router,
+    /// which resolves any center offset through the loaded SPK kernels.
+    /// Covariances, state transition matrices, sensitivities, and
+    /// accelerations are dropped.
+    ///
+    /// # Arguments
+    /// * `frame` - Target reference frame
+    ///
+    /// # Returns
+    /// * `Ok(SOrbitTrajectory)` - New Cartesian trajectory in `frame`
+    /// * `Err(BraheError)` - If a sample cannot be converted (unbound or
+    ///   unregistered frame, missing ephemeris, or Keplerian elements about
+    ///   a massless barycenter)
+    ///
+    /// # Examples
+    /// ```rust
+    /// use brahe::trajectories::SOrbitTrajectory;
+    /// use brahe::traits::{Trajectory, OrbitRepresentation};
+    /// use brahe::frames::CelestialFrame;
+    /// use brahe::time::{Epoch, TimeSystem};
+    /// use nalgebra::Vector6;
+    ///
+    /// brahe::eop::set_global_eop_provider(
+    ///     brahe::eop::StaticEOPProvider::from_values((0.0, 0.0, 0.0, 0.0, 0.0, 0.0))
+    /// );
+    ///
+    /// let mut traj = SOrbitTrajectory::new(
+    ///     CelestialFrame::GCRF,
+    ///     OrbitRepresentation::Cartesian,
+    ///     None,
+    /// ).unwrap();
+    /// let epoch = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
+    /// traj.add(epoch, Vector6::new(6.678e6, 0.0, 0.0, 0.0, 7.726e3, 0.0)).unwrap();
+    ///
+    /// let itrf = traj.to_frame(CelestialFrame::ITRF).unwrap();
+    /// assert!(itrf.frame == CelestialFrame::ITRF);
+    /// ```
+    pub fn to_frame(&self, frame: impl Into<ReferenceFrame>) -> Result<Self, BraheError> {
+        OrbitalTrajectory::to_frame(self, frame.into())
     }
 }
 
+// Implementation of OrbitalTrajectory trait
 impl OrbitalTrajectory for SOrbitTrajectory {
     /// Create orbital trajectory from data with specified orbital properties.
     ///
@@ -1647,21 +1677,19 @@ impl OrbitalTrajectory for SOrbitTrajectory {
     /// * `Err(BraheError)` - If parameters are invalid or data validation fails
     ///
     /// # Errors
-    /// * If covariances are provided but frame is not ECI or GCRF
+    /// * If covariances are provided but the frame is neither GCRF nor EME2000
     /// * If covariances length does not match states length
     fn from_orbital_data(
         epochs: Vec<Epoch>,
         states: Vec<Vector6<f64>>,
-        frame: OrbitFrame,
+        frame: ReferenceFrame,
         representation: OrbitRepresentation,
         angle_format: Option<AngleFormat>,
         covariances: Option<Vec<SMatrix<f64, 6, 6>>>,
     ) -> Result<Self, BraheError> {
         // Validate inputs
-        if frame == OrbitFrame::ECEF && representation == OrbitRepresentation::Keplerian {
-            return Err(BraheError::Error(
-                "Keplerian elements should be in ECI frame".to_string(),
-            ));
+        if representation == OrbitRepresentation::Keplerian {
+            keplerian_center(&frame)?;
         }
 
         // Validate covariances if provided
@@ -1676,8 +1704,7 @@ impl OrbitalTrajectory for SOrbitTrajectory {
             }
 
             // Check that frame is ECI, GCRF, or EME2000
-            if frame != OrbitFrame::ECI && frame != OrbitFrame::GCRF && frame != OrbitFrame::EME2000
-            {
+            if !covariance_frame_allowed(&frame) {
                 return Err(BraheError::Error(format!(
                     "Covariances are only supported for ECI, GCRF, and EME2000 frames. Got: {}",
                     frame
@@ -1711,79 +1738,17 @@ impl OrbitalTrajectory for SOrbitTrajectory {
         })
     }
 
-    fn to_eci(&self) -> Result<Self, BraheError>
-    where
-        Self: Sized,
-    {
-        // Keplerian samples about a non-Earth center would otherwise be
-        // converted with Earth's GM and no re-centering: convert to native
-        // Cartesian about the center first, then take the Cartesian path.
-        if let OrbitFrame::BodyCenteredInertial(center) = self.frame
-            && self.representation == OrbitRepresentation::Keplerian
-        {
-            return self.bci_keplerian_to_cartesian(center)?.to_eci();
+    fn to_frame(&self, frame: ReferenceFrame) -> Result<Self, BraheError> {
+        let mut states_converted = Vec::with_capacity(self.states.len());
+        for (e, s) in self.into_iter() {
+            let x = self.native_cartesian(s)?;
+            let converted = if self.frame == frame {
+                x
+            } else {
+                state_frame_to_frame(self.frame.clone(), frame.clone(), e, x)?
+            };
+            states_converted.push(converted);
         }
-        let states_converted = match self.representation {
-            OrbitRepresentation::Keplerian => {
-                let mut states_converted = Vec::with_capacity(self.states.len());
-                // Just need to convert to Cartesian below
-                for (_e, s) in self.into_iter() {
-                    let state_cartesian = state_koe_to_eci(
-                        s,
-                        self.angle_format
-                            .expect("Keplerian representation must have angle_format"),
-                    );
-                    states_converted.push(state_cartesian);
-                }
-                states_converted
-            }
-            OrbitRepresentation::Cartesian => {
-                match self.frame {
-                    OrbitFrame::BodyCenteredInertial(center) => {
-                        // Re-center through the frame router (SPK-resolved
-                        // center offset).
-                        let native = crate::trajectories::traits::bci_reference_frame(center);
-                        let mut states_converted = Vec::with_capacity(self.states.len());
-                        for (e, s) in self.into_iter() {
-                            let converted = crate::frames::state_frame_to_frame(
-                                native,
-                                crate::frames::CelestialFrame::GCRF,
-                                e,
-                                s,
-                            )?;
-                            states_converted.push(converted);
-                        }
-                        states_converted
-                    }
-                    OrbitFrame::EME2000 => {
-                        let mut states_converted = Vec::with_capacity(self.states.len());
-                        // EME2000 Cartesian to GCRF Cartesian (no epoch needed)
-                        for (_e, s) in self.into_iter() {
-                            let state_gcrf = state_eme2000_to_gcrf(s);
-                            states_converted.push(state_gcrf);
-                        }
-                        states_converted
-                    }
-                    OrbitFrame::ITRF | OrbitFrame::ECEF => {
-                        let mut states_converted = Vec::with_capacity(self.states.len());
-                        // ITRF/ECEF Cartesian to GCRF Cartesian (requires epoch)
-                        for (e, s) in self.into_iter() {
-                            let state_gcrf = state_itrf_to_gcrf(e, s);
-                            states_converted.push(state_gcrf);
-                        }
-                        states_converted
-                    }
-                    OrbitFrame::ECI => {
-                        // No need to convert ECI to GCRF, they are equivalent for our purposes
-                        self.states.clone()
-                    }
-                    OrbitFrame::GCRF => {
-                        // Already in GCRF frame
-                        self.states.clone()
-                    }
-                }
-            }
-        };
 
         Ok(Self {
             epochs: self.epochs.clone(),
@@ -1798,7 +1763,7 @@ impl OrbitalTrajectory for SOrbitTrajectory {
             eviction_policy: self.eviction_policy,
             max_size: self.max_size,
             max_age: self.max_age,
-            frame: OrbitFrame::ECI,
+            frame,
             representation: OrbitRepresentation::Cartesian,
             angle_format: None,
             name: self.name.clone(),
@@ -1806,383 +1771,41 @@ impl OrbitalTrajectory for SOrbitTrajectory {
             uuid: self.uuid,
             metadata: self.metadata.clone(),
         })
+    }
+
+    fn to_eci(&self) -> Result<Self, BraheError>
+    where
+        Self: Sized,
+    {
+        self.to_frame(CelestialFrame::GCRF)
     }
 
     fn to_gcrf(&self) -> Result<Self, BraheError>
     where
         Self: Sized,
     {
-        // Keplerian samples about a non-Earth center would otherwise be
-        // converted with Earth's GM and no re-centering: convert to native
-        // Cartesian about the center first, then take the Cartesian path.
-        if let OrbitFrame::BodyCenteredInertial(center) = self.frame
-            && self.representation == OrbitRepresentation::Keplerian
-        {
-            return self.bci_keplerian_to_cartesian(center)?.to_gcrf();
-        }
-        let states_converted = match self.representation {
-            OrbitRepresentation::Keplerian => {
-                let mut states_converted = Vec::with_capacity(self.states.len());
-                // Just need to convert to Cartesian below
-                for (_e, s) in self.into_iter() {
-                    let state_cartesian = state_koe_to_eci(
-                        s,
-                        self.angle_format
-                            .expect("Keplerian representation must have angle_format"),
-                    );
-                    states_converted.push(state_cartesian);
-                }
-                states_converted
-            }
-            OrbitRepresentation::Cartesian => {
-                match self.frame {
-                    OrbitFrame::BodyCenteredInertial(center) => {
-                        // Re-center through the frame router (SPK-resolved
-                        // center offset).
-                        let native = crate::trajectories::traits::bci_reference_frame(center);
-                        let mut states_converted = Vec::with_capacity(self.states.len());
-                        for (e, s) in self.into_iter() {
-                            let converted = crate::frames::state_frame_to_frame(
-                                native,
-                                crate::frames::CelestialFrame::GCRF,
-                                e,
-                                s,
-                            )?;
-                            states_converted.push(converted);
-                        }
-                        states_converted
-                    }
-                    OrbitFrame::EME2000 => {
-                        let mut states_converted = Vec::with_capacity(self.states.len());
-                        // EME2000 Cartesian to GCRF Cartesian (no epoch needed)
-                        for (_e, s) in self.into_iter() {
-                            let state_gcrf = state_eme2000_to_gcrf(s);
-                            states_converted.push(state_gcrf);
-                        }
-                        states_converted
-                    }
-                    OrbitFrame::ITRF | OrbitFrame::ECEF => {
-                        let mut states_converted = Vec::with_capacity(self.states.len());
-                        // ITRF/ECEF Cartesian to GCRF Cartesian (requires epoch)
-                        for (e, s) in self.into_iter() {
-                            let state_gcrf = state_itrf_to_gcrf(e, s);
-                            states_converted.push(state_gcrf);
-                        }
-                        states_converted
-                    }
-                    OrbitFrame::ECI => {
-                        // No need to convert ECI to GCRF, they are equivalent for our purposes
-                        self.states.clone()
-                    }
-                    OrbitFrame::GCRF => {
-                        // Already in GCRF frame
-                        self.states.clone()
-                    }
-                }
-            }
-        };
-
-        Ok(Self {
-            epochs: self.epochs.clone(),
-            states: states_converted,
-            covariances: None,   // Covariances are dropped during frame conversions
-            stms: None,          // STMs are dropped during frame conversions
-            sensitivities: None, // Sensitivities are dropped during frame conversions
-            sensitivity_param_dim: None,
-            accelerations: None, // Accelerations are dropped during frame conversions
-            interpolation_method: self.interpolation_method,
-            covariance_interpolation_method: self.covariance_interpolation_method,
-            eviction_policy: self.eviction_policy,
-            max_size: self.max_size,
-            max_age: self.max_age,
-            frame: OrbitFrame::GCRF,
-            representation: OrbitRepresentation::Cartesian,
-            angle_format: None,
-            name: self.name.clone(),
-            id: self.id,
-            uuid: self.uuid,
-            metadata: self.metadata.clone(),
-        })
+        self.to_frame(CelestialFrame::GCRF)
     }
 
     fn to_ecef(&self) -> Result<Self, BraheError>
     where
         Self: Sized,
     {
-        // Keplerian samples about a non-Earth center would otherwise be
-        // converted with Earth's GM and no re-centering: convert to native
-        // Cartesian about the center first, then take the Cartesian path.
-        if let OrbitFrame::BodyCenteredInertial(center) = self.frame
-            && self.representation == OrbitRepresentation::Keplerian
-        {
-            return self.bci_keplerian_to_cartesian(center)?.to_ecef();
-        }
-        let states_converted = match self.representation {
-            OrbitRepresentation::Keplerian => {
-                let mut states_converted = Vec::with_capacity(self.states.len());
-                // Just need to convert to Cartesian below
-                for (e, s) in self.into_iter() {
-                    let state_eci = state_koe_to_eci(
-                        s,
-                        self.angle_format
-                            .expect("Keplerian representation must have angle_format"),
-                    );
-                    states_converted.push(state_eci_to_ecef(e, state_eci));
-                }
-                states_converted
-            }
-            OrbitRepresentation::Cartesian => {
-                match self.frame {
-                    OrbitFrame::BodyCenteredInertial(center) => {
-                        // Re-center through the frame router (SPK-resolved
-                        // center offset).
-                        let native = crate::trajectories::traits::bci_reference_frame(center);
-                        let mut states_converted = Vec::with_capacity(self.states.len());
-                        for (e, s) in self.into_iter() {
-                            let converted = crate::frames::state_frame_to_frame(
-                                native,
-                                crate::frames::CelestialFrame::ITRF,
-                                e,
-                                s,
-                            )?;
-                            states_converted.push(converted);
-                        }
-                        states_converted
-                    }
-                    OrbitFrame::EME2000 => {
-                        let mut states_converted = Vec::with_capacity(self.states.len());
-                        // EME2000 Cartesian to GCRF Cartesian (no epoch needed)
-                        for (e, s) in self.into_iter() {
-                            let state_itrf = state_gcrf_to_itrf(e, state_eme2000_to_gcrf(s));
-                            states_converted.push(state_itrf);
-                        }
-                        states_converted
-                    }
-                    OrbitFrame::ITRF | OrbitFrame::ECEF => {
-                        // Already in ITRF frame
-                        self.states.clone()
-                    }
-                    OrbitFrame::ECI | OrbitFrame::GCRF => {
-                        let mut states_converted = Vec::with_capacity(self.states.len());
-                        // ITRF/ECEF Cartesian to GCRF Cartesian (requires epoch)
-                        for (e, s) in self.into_iter() {
-                            let state_itrf = state_gcrf_to_itrf(e, s);
-                            states_converted.push(state_itrf);
-                        }
-                        states_converted
-                    }
-                }
-            }
-        };
-
-        Ok(Self {
-            epochs: self.epochs.clone(),
-            states: states_converted,
-            covariances: None,   // Covariances are dropped during frame conversions
-            stms: None,          // STMs are dropped during frame conversions
-            sensitivities: None, // Sensitivities are dropped during frame conversions
-            sensitivity_param_dim: None,
-            accelerations: None, // Accelerations are dropped during frame conversions
-            interpolation_method: self.interpolation_method,
-            covariance_interpolation_method: self.covariance_interpolation_method,
-            eviction_policy: self.eviction_policy,
-            max_size: self.max_size,
-            max_age: self.max_age,
-            frame: OrbitFrame::ECEF,
-            representation: OrbitRepresentation::Cartesian,
-            angle_format: None,
-            name: self.name.clone(),
-            id: self.id,
-            uuid: self.uuid,
-            metadata: self.metadata.clone(),
-        })
+        self.to_frame(CelestialFrame::ITRF)
     }
 
     fn to_itrf(&self) -> Result<Self, BraheError>
     where
         Self: Sized,
     {
-        // Keplerian samples about a non-Earth center would otherwise be
-        // converted with Earth's GM and no re-centering: convert to native
-        // Cartesian about the center first, then take the Cartesian path.
-        if let OrbitFrame::BodyCenteredInertial(center) = self.frame
-            && self.representation == OrbitRepresentation::Keplerian
-        {
-            return self.bci_keplerian_to_cartesian(center)?.to_itrf();
-        }
-        let states_converted = match self.representation {
-            OrbitRepresentation::Keplerian => {
-                let mut states_converted = Vec::with_capacity(self.states.len());
-                // Keplerian to Cartesian (in GCRF/ECI), then GCRF to ITRF
-                for (e, s) in self.into_iter() {
-                    let state_cartesian = state_koe_to_eci(
-                        s,
-                        self.angle_format
-                            .expect("Keplerian representation must have angle_format"),
-                    );
-                    let state_itrf = state_gcrf_to_itrf(e, state_cartesian);
-                    states_converted.push(state_itrf);
-                }
-                states_converted
-            }
-            OrbitRepresentation::Cartesian => {
-                match self.frame {
-                    OrbitFrame::BodyCenteredInertial(center) => {
-                        // Re-center through the frame router (SPK-resolved
-                        // center offset).
-                        let native = crate::trajectories::traits::bci_reference_frame(center);
-                        let mut states_converted = Vec::with_capacity(self.states.len());
-                        for (e, s) in self.into_iter() {
-                            let converted = crate::frames::state_frame_to_frame(
-                                native,
-                                crate::frames::CelestialFrame::ITRF,
-                                e,
-                                s,
-                            )?;
-                            states_converted.push(converted);
-                        }
-                        states_converted
-                    }
-                    OrbitFrame::EME2000 => {
-                        let mut states_converted = Vec::with_capacity(self.states.len());
-                        // EME2000 Cartesian to GCRF Cartesian (no epoch needed)
-                        for (e, s) in self.into_iter() {
-                            let state_itrf = state_gcrf_to_itrf(e, state_eme2000_to_gcrf(s));
-                            states_converted.push(state_itrf);
-                        }
-                        states_converted
-                    }
-                    OrbitFrame::ITRF | OrbitFrame::ECEF => {
-                        // Already in ITRF frame
-                        self.states.clone()
-                    }
-                    OrbitFrame::ECI | OrbitFrame::GCRF => {
-                        let mut states_converted = Vec::with_capacity(self.states.len());
-                        // ITRF/ECEF Cartesian to GCRF Cartesian (requires epoch)
-                        for (e, s) in self.into_iter() {
-                            let state_itrf = state_gcrf_to_itrf(e, s);
-                            states_converted.push(state_itrf);
-                        }
-                        states_converted
-                    }
-                }
-            }
-        };
-
-        Ok(Self {
-            epochs: self.epochs.clone(),
-            states: states_converted,
-            covariances: None,   // Covariances are dropped during frame conversions
-            stms: None,          // STMs are dropped during frame conversions
-            sensitivities: None, // Sensitivities are dropped during frame conversions
-            sensitivity_param_dim: None,
-            accelerations: None, // Accelerations are dropped during frame conversions
-            interpolation_method: self.interpolation_method,
-            covariance_interpolation_method: self.covariance_interpolation_method,
-            eviction_policy: self.eviction_policy,
-            max_size: self.max_size,
-            max_age: self.max_age,
-            frame: OrbitFrame::ITRF,
-            representation: OrbitRepresentation::Cartesian,
-            angle_format: None,
-            name: self.name.clone(),
-            id: self.id,
-            uuid: self.uuid,
-            metadata: self.metadata.clone(),
-        })
+        self.to_frame(CelestialFrame::ITRF)
     }
 
     fn to_eme2000(&self) -> Result<Self, BraheError>
     where
         Self: Sized,
     {
-        // Keplerian samples about a non-Earth center would otherwise be
-        // converted with Earth's GM and no re-centering: convert to native
-        // Cartesian about the center first, then take the Cartesian path.
-        if let OrbitFrame::BodyCenteredInertial(center) = self.frame
-            && self.representation == OrbitRepresentation::Keplerian
-        {
-            return self.bci_keplerian_to_cartesian(center)?.to_eme2000();
-        }
-        let states_converted = match self.representation {
-            OrbitRepresentation::Keplerian => {
-                let mut states_converted = Vec::with_capacity(self.states.len());
-                // Just need to convert to Cartesian below
-                for (_e, s) in self.into_iter() {
-                    let state_cartesian = state_gcrf_to_eme2000(state_koe_to_eci(
-                        s,
-                        self.angle_format
-                            .expect("Keplerian representation must have angle_format"),
-                    ));
-                    states_converted.push(state_cartesian);
-                }
-                states_converted
-            }
-            OrbitRepresentation::Cartesian => {
-                match self.frame {
-                    OrbitFrame::BodyCenteredInertial(center) => {
-                        // Re-center through the frame router (SPK-resolved
-                        // center offset).
-                        let native = crate::trajectories::traits::bci_reference_frame(center);
-                        let mut states_converted = Vec::with_capacity(self.states.len());
-                        for (e, s) in self.into_iter() {
-                            let converted = crate::frames::state_frame_to_frame(
-                                native,
-                                crate::frames::CelestialFrame::EME2000,
-                                e,
-                                s,
-                            )?;
-                            states_converted.push(converted);
-                        }
-                        states_converted
-                    }
-                    OrbitFrame::EME2000 => {
-                        // Already in EME2000 frame
-                        self.states.clone()
-                    }
-                    OrbitFrame::ITRF | OrbitFrame::ECEF => {
-                        let mut states_converted = Vec::with_capacity(self.states.len());
-                        // ITRF/ECEF Cartesian to GCRF Cartesian (requires epoch)
-                        for (e, s) in self.into_iter() {
-                            let state_gcrf = state_gcrf_to_eme2000(state_itrf_to_gcrf(e, s));
-                            states_converted.push(state_gcrf);
-                        }
-                        states_converted
-                    }
-                    OrbitFrame::ECI | OrbitFrame::GCRF => {
-                        let mut states_converted = Vec::with_capacity(self.states.len());
-                        // ECI/GCRF Cartesian to EME2000 Cartesian (no epoch needed)
-                        for (_e, s) in self.into_iter() {
-                            let state_eme2000 = state_gcrf_to_eme2000(s);
-                            states_converted.push(state_eme2000);
-                        }
-                        states_converted
-                    }
-                }
-            }
-        };
-
-        Ok(Self {
-            epochs: self.epochs.clone(),
-            states: states_converted,
-            covariances: None,   // Covariances are dropped during frame conversions
-            stms: None,          // STMs are dropped during frame conversions
-            sensitivities: None, // Sensitivities are dropped during frame conversions
-            sensitivity_param_dim: None,
-            accelerations: None, // Accelerations are dropped during frame conversions
-            interpolation_method: self.interpolation_method,
-            covariance_interpolation_method: self.covariance_interpolation_method,
-            eviction_policy: self.eviction_policy,
-            max_size: self.max_size,
-            max_age: self.max_age,
-            frame: OrbitFrame::EME2000,
-            representation: OrbitRepresentation::Cartesian,
-            angle_format: None,
-            name: self.name.clone(),
-            id: self.id,
-            uuid: self.uuid,
-            metadata: self.metadata.clone(),
-        })
+        self.to_frame(CelestialFrame::EME2000)
     }
 
     fn to_keplerian(&self, angle_format: AngleFormat) -> Result<Self, BraheError>
@@ -2231,44 +1854,29 @@ impl OrbitalTrajectory for SOrbitTrajectory {
                 }
             }
             OrbitRepresentation::Cartesian => {
-                match self.frame {
-                    OrbitFrame::BodyCenteredInertial(_) => {
-                        return Err(BraheError::Error(
-                            "to_keplerian labels its result ECI, which is undefined for a \
-                             body-centered inertial trajectory; use state_koe_osc for \
-                             per-epoch elements about the trajectory's own center"
-                                .to_string(),
-                        ));
-                    }
-                    OrbitFrame::EME2000 => {
-                        let mut states_converted = Vec::with_capacity(self.states.len());
-                        // ITRF/ECEF Cartesian to GCRF Cartesian (requires epoch)
-                        for (_e, s) in self.into_iter() {
-                            let state = state_eci_to_koe(state_eme2000_to_gcrf(s), angle_format);
-                            states_converted.push(state);
-                        }
-                        states_converted
-                    }
-                    OrbitFrame::ITRF | OrbitFrame::ECEF => {
-                        let mut states_converted = Vec::with_capacity(self.states.len());
-                        // ITRF/ECEF Cartesian to GCRF Cartesian (requires epoch)
-                        for (e, s) in self.into_iter() {
-                            let state = state_eci_to_koe(state_ecef_to_eci(e, s), angle_format);
-                            states_converted.push(state);
-                        }
-                        states_converted
-                    }
-                    OrbitFrame::ECI | OrbitFrame::GCRF => {
-                        let mut states_converted = Vec::with_capacity(self.states.len());
-                        // ITRF/ECEF Cartesian to GCRF Cartesian (requires epoch)
-                        for (_e, s) in self.into_iter() {
-                            let state = state_eci_to_koe(s, angle_format);
-                            states_converted.push(state);
-                        }
-                        states_converted
-                    }
+                if celestial_root(&self.frame)?.center_naif_id() != NAIFId::Earth.id() {
+                    return Err(BraheError::Error(
+                        "to_keplerian labels its result ECI, which is undefined for a \
+                         trajectory centered on another body; use state_koe_osc for \
+                         per-epoch elements about the trajectory's own center"
+                            .to_string(),
+                    ));
                 }
+                // Route to GCRF, then take two-body elements about the Earth.
+                let gcrf = self.to_frame(CelestialFrame::GCRF)?;
+                gcrf.states
+                    .iter()
+                    .map(|s| state_eci_to_koe(*s, angle_format))
+                    .collect()
             }
+        };
+
+        // Cartesian samples are relabeled GCRF; element samples keep the
+        // frame their elements are already referenced to.
+        let frame = if self.representation == OrbitRepresentation::Cartesian {
+            CelestialFrame::GCRF.into()
+        } else {
+            self.frame.clone()
         };
 
         Ok(Self {
@@ -2284,7 +1892,7 @@ impl OrbitalTrajectory for SOrbitTrajectory {
             eviction_policy: self.eviction_policy,
             max_size: self.max_size,
             max_age: self.max_age,
-            frame: OrbitFrame::ECI,
+            frame,
             representation: OrbitRepresentation::Keplerian,
             angle_format: Some(angle_format),
             name: self.name.clone(),
@@ -2303,26 +1911,30 @@ impl SStateProvider for SOrbitTrajectory {
 }
 
 impl SOrbitTrajectory {
-    /// Native Cartesian orbital state about this BodyCenteredInertial
-    /// trajectory's own center: identity for Cartesian representation,
-    /// elements-to-Cartesian about the center body (using its GM) for
-    /// Keplerian representation.
-    fn bci_native_cartesian(
-        &self,
-        center: i32,
-        state: Vector6<f64>,
-    ) -> Result<Vector6<f64>, BraheError> {
+    /// `state` as a Cartesian state in this trajectory's own frame:
+    /// unchanged for Cartesian samples, converted from Keplerian elements
+    /// with the gravitational parameter of the frame's center otherwise.
+    ///
+    /// # Arguments
+    /// * `state` - Orbital state in this trajectory's native representation
+    ///
+    /// # Returns
+    /// * `Ok(Vector6<f64>)`: Cartesian state in this trajectory's frame. Units: (*m*; *m/s*)
+    /// * `Err(BraheError)`: If the frame does not admit Keplerian elements,
+    ///   or its center is an unknown body or a massless barycenter
+    fn native_cartesian(&self, state: Vector6<f64>) -> Result<Vector6<f64>, BraheError> {
         match self.representation {
             OrbitRepresentation::Cartesian => Ok(state),
             OrbitRepresentation::Keplerian => {
-                let cb = crate::propagators::CentralBody::from_naif_id(center)?;
+                let center = keplerian_center(&self.frame)?;
+                let cb = CentralBody::from_naif_id(center)?;
                 if cb.is_barycenter() {
                     return Err(BraheError::Error(format!(
                         "Keplerian elements are undefined about massless barycenter {}",
                         center
                     )));
                 }
-                Ok(crate::coordinates::state_koe_to_inertial_gm(
+                Ok(state_koe_to_inertial_gm(
                     state,
                     cb.gm(),
                     self.angle_format
@@ -2334,339 +1946,60 @@ impl SOrbitTrajectory {
 }
 
 impl SOrbitStateProvider for SOrbitTrajectory {
-    /// Returns the state in this trajectory's own body-centered inertial
-    /// frame: the raw interpolated state for a `BodyCenteredInertial`
-    /// trajectory (converted from elements if Keplerian), `GCRF` for
-    /// Earth-frame trajectories.
+    /// Returns the state in the ICRF-aligned inertial frame centered on this
+    /// trajectory's own central body, found from the trajectory's frame via
+    /// its celestial root.
     fn state_bci(&self, epoch: Epoch) -> Result<Vector6<f64>, BraheError> {
-        match self.frame {
-            OrbitFrame::BodyCenteredInertial(center) => {
-                let state = self.interpolate(&epoch)?;
-                self.bci_native_cartesian(center, state)
-            }
-            _ => self.state_gcrf(epoch),
-        }
+        let root = celestial_root(&self.frame)?;
+        self.state_in_frame(icrf_aligned_inertial(root), epoch)
     }
 
-    /// Returns the state in this trajectory's central body's body-fixed
-    /// frame (`ITRF` for Earth-frame trajectories, `LFPA`/`MCMF`/IAU frame
-    /// for a `BodyCenteredInertial` trajectory); errors for centers without
-    /// a body-fixed frame (barycenters, uncatalogued bodies).
+    /// Returns the state in the body-fixed frame of this trajectory's central
+    /// body (`ITRF` for Earth-centered trajectories, `LFPA`/`MCMF`/the IAU
+    /// frame otherwise); errors for centers without a body-fixed frame
+    /// (barycenters, uncatalogued bodies).
     fn state_bcbf(&self, epoch: Epoch) -> Result<Vector6<f64>, BraheError> {
-        match self.frame {
-            OrbitFrame::BodyCenteredInertial(center) => {
-                let fixed =
-                    crate::trajectories::traits::bci_fixed_frame(center).ok_or_else(|| {
-                        BraheError::Error(format!(
-                            "central body {} has no body-fixed frame",
-                            center
-                        ))
-                    })?;
-                let x = self.state_bci(epoch)?;
-                crate::frames::state_frame_to_frame(
-                    crate::trajectories::traits::bci_reference_frame(center),
-                    fixed,
-                    epoch,
-                    x,
-                )
-            }
-            _ => self.state_itrf(epoch),
-        }
+        let root = celestial_root(&self.frame)?;
+        let center = root.center_naif_id();
+        let fixed = bci_fixed_frame(center).ok_or_else(|| {
+            BraheError::Error(format!("central body {} has no body-fixed frame", center))
+        })?;
+        self.state_in_frame(fixed, epoch)
     }
 
-    /// Returns the state expressed in an arbitrary reference frame,
-    /// converting directly from this trajectory's own native frame (no
-    /// Earth round trip for `BodyCenteredInertial` trajectories).
+    /// Returns the state expressed in an arbitrary celestial frame,
+    /// converting directly from this trajectory's own declared frame.
     fn state_in_frame(
         &self,
-        frame: crate::frames::CelestialFrame,
+        frame: CelestialFrame,
         epoch: Epoch,
     ) -> Result<Vector6<f64>, BraheError> {
-        let x = self.state_bci(epoch)?;
-        let native = match self.frame {
-            OrbitFrame::BodyCenteredInertial(center) => {
-                crate::trajectories::traits::bci_reference_frame(center)
-            }
-            _ => crate::frames::CelestialFrame::GCRF,
-        };
-        crate::frames::state_frame_to_frame(native, frame, epoch, x)
+        let state = self.interpolate(&epoch)?;
+        let x = self.native_cartesian(state)?;
+        if self.frame == frame {
+            return Ok(x);
+        }
+        state_frame_to_frame(self.frame.clone(), frame, epoch, x)
     }
 
     fn state_eci(&self, epoch: Epoch) -> Result<Vector6<f64>, BraheError> {
-        // Get state in native format then convert to ECI Cartesian
-        let state = self.interpolate(&epoch)?;
-
-        Ok(match (self.frame, self.representation) {
-            (OrbitFrame::BodyCenteredInertial(center), _) => {
-                let x = self.bci_native_cartesian(center, state)?;
-                return crate::frames::state_frame_to_frame(
-                    crate::trajectories::traits::bci_reference_frame(center),
-                    crate::frames::CelestialFrame::GCRF,
-                    epoch,
-                    x,
-                );
-            }
-            (OrbitFrame::ECI, OrbitRepresentation::Cartesian) => state,
-            (OrbitFrame::GCRF, OrbitRepresentation::Cartesian) => state,
-            (OrbitFrame::ECI, OrbitRepresentation::Keplerian) => state_koe_to_eci(
-                state,
-                self.angle_format
-                    .expect("Keplerian representation must have angle_format"),
-            ),
-            (OrbitFrame::GCRF, OrbitRepresentation::Keplerian) => state_koe_to_eci(
-                state,
-                self.angle_format
-                    .expect("Keplerian representation must have angle_format"),
-            ),
-            (OrbitFrame::EME2000, OrbitRepresentation::Keplerian) => {
-                state_eme2000_to_gcrf(state_koe_to_eci(
-                    state,
-                    self.angle_format
-                        .expect("Keplerian representation must have angle_format"),
-                ))
-            }
-            (OrbitFrame::ECEF, OrbitRepresentation::Cartesian) => state_ecef_to_eci(epoch, state),
-            (OrbitFrame::ITRF, OrbitRepresentation::Cartesian) => state_itrf_to_gcrf(epoch, state),
-            (OrbitFrame::EME2000, OrbitRepresentation::Cartesian) => state_eme2000_to_gcrf(state),
-            (OrbitFrame::ECEF, OrbitRepresentation::Keplerian) => {
-                return Err(BraheError::Error(
-                    "Keplerian element trajectories should be in an inertial frame".to_string(),
-                ));
-            }
-            (OrbitFrame::ITRF, OrbitRepresentation::Keplerian) => {
-                return Err(BraheError::Error(
-                    "Keplerian element trajectories should be in an inertial frame".to_string(),
-                ));
-            }
-        })
+        self.state_in_frame(CelestialFrame::GCRF, epoch)
     }
 
     fn state_gcrf(&self, epoch: Epoch) -> Result<Vector6<f64>, BraheError> {
-        // Get state in native format then convert to GCRF Cartesian
-        let state = self.interpolate(&epoch)?;
-
-        Ok(match (self.frame, self.representation) {
-            (OrbitFrame::BodyCenteredInertial(center), _) => {
-                let x = self.bci_native_cartesian(center, state)?;
-                return crate::frames::state_frame_to_frame(
-                    crate::trajectories::traits::bci_reference_frame(center),
-                    crate::frames::CelestialFrame::GCRF,
-                    epoch,
-                    x,
-                );
-            }
-            (OrbitFrame::GCRF, OrbitRepresentation::Cartesian) => state,
-            (OrbitFrame::ECI, OrbitRepresentation::Cartesian) => state, // ECI treated as GCRF
-            (OrbitFrame::GCRF, OrbitRepresentation::Keplerian) => state_koe_to_eci(
-                state,
-                self.angle_format
-                    .expect("Keplerian representation must have angle_format"),
-            ),
-            (OrbitFrame::ECI, OrbitRepresentation::Keplerian) => state_koe_to_eci(
-                state,
-                self.angle_format
-                    .expect("Keplerian representation must have angle_format"),
-            ),
-            (OrbitFrame::EME2000, OrbitRepresentation::Keplerian) => {
-                state_eme2000_to_gcrf(state_koe_to_eci(
-                    state,
-                    self.angle_format
-                        .expect("Keplerian representation must have angle_format"),
-                ))
-            }
-            (OrbitFrame::EME2000, OrbitRepresentation::Cartesian) => state_eme2000_to_gcrf(state),
-            (OrbitFrame::ITRF, OrbitRepresentation::Cartesian) => state_itrf_to_gcrf(epoch, state),
-            (OrbitFrame::ECEF, OrbitRepresentation::Cartesian) => state_itrf_to_gcrf(epoch, state),
-            (OrbitFrame::ECEF, OrbitRepresentation::Keplerian) => {
-                return Err(BraheError::Error(
-                    "Keplerian element trajectories should be in an inertial frame".to_string(),
-                ));
-            }
-            (OrbitFrame::ITRF, OrbitRepresentation::Keplerian) => {
-                return Err(BraheError::Error(
-                    "Keplerian element trajectories should be in an inertial frame".to_string(),
-                ));
-            }
-        })
+        self.state_in_frame(CelestialFrame::GCRF, epoch)
     }
 
     fn state_ecef(&self, epoch: Epoch) -> Result<Vector6<f64>, BraheError> {
-        // Get state in native format then convert to ECEF Cartesian
-        let state = self.interpolate(&epoch)?;
-
-        Ok(match (self.frame, self.representation) {
-            (OrbitFrame::BodyCenteredInertial(center), _) => {
-                let x = self.bci_native_cartesian(center, state)?;
-                return crate::frames::state_frame_to_frame(
-                    crate::trajectories::traits::bci_reference_frame(center),
-                    crate::frames::CelestialFrame::ITRF,
-                    epoch,
-                    x,
-                );
-            }
-            (OrbitFrame::ECEF, OrbitRepresentation::Cartesian) => state,
-            (OrbitFrame::ITRF, OrbitRepresentation::Cartesian) => state,
-            (OrbitFrame::ECI, OrbitRepresentation::Cartesian) => state_eci_to_ecef(epoch, state),
-            (OrbitFrame::GCRF, OrbitRepresentation::Cartesian) => state_gcrf_to_itrf(epoch, state),
-            (OrbitFrame::EME2000, OrbitRepresentation::Cartesian) => {
-                let state_gcrf = state_eme2000_to_gcrf(state);
-                state_gcrf_to_itrf(epoch, state_gcrf)
-            }
-            (OrbitFrame::ECI, OrbitRepresentation::Keplerian) => {
-                let state_eci_cart = state_koe_to_eci(
-                    state,
-                    self.angle_format
-                        .expect("Keplerian representation must have angle_format"),
-                );
-                state_eci_to_ecef(epoch, state_eci_cart)
-            }
-            (OrbitFrame::EME2000, OrbitRepresentation::Keplerian) => {
-                let state_eme2000_cart = state_koe_to_eci(
-                    state,
-                    self.angle_format
-                        .expect("Keplerian representation must have angle_format"),
-                );
-                let state_gcrf = state_eme2000_to_gcrf(state_eme2000_cart);
-                state_gcrf_to_itrf(epoch, state_gcrf)
-            }
-            (OrbitFrame::GCRF, OrbitRepresentation::Keplerian) => {
-                let state_gcrf_cart = state_koe_to_eci(
-                    state,
-                    self.angle_format
-                        .expect("Keplerian representation must have angle_format"),
-                );
-                state_gcrf_to_itrf(epoch, state_gcrf_cart)
-            }
-            (OrbitFrame::ECEF, OrbitRepresentation::Keplerian) => {
-                return Err(BraheError::Error(
-                    "Keplerian element trajectories should be in an inertial frame".to_string(),
-                ));
-            }
-            (OrbitFrame::ITRF, OrbitRepresentation::Keplerian) => {
-                return Err(BraheError::Error(
-                    "Keplerian element trajectories should be in an inertial frame".to_string(),
-                ));
-            }
-        })
+        self.state_in_frame(CelestialFrame::ITRF, epoch)
     }
 
     fn state_itrf(&self, epoch: Epoch) -> Result<Vector6<f64>, BraheError> {
-        // Get state in native format then convert to ECEF Cartesian
-        let state = self.interpolate(&epoch)?;
-
-        Ok(match (self.frame, self.representation) {
-            (OrbitFrame::BodyCenteredInertial(center), _) => {
-                let x = self.bci_native_cartesian(center, state)?;
-                return crate::frames::state_frame_to_frame(
-                    crate::trajectories::traits::bci_reference_frame(center),
-                    crate::frames::CelestialFrame::ITRF,
-                    epoch,
-                    x,
-                );
-            }
-            (OrbitFrame::ECEF, OrbitRepresentation::Cartesian) => state,
-            (OrbitFrame::ITRF, OrbitRepresentation::Cartesian) => state,
-            (OrbitFrame::ECI, OrbitRepresentation::Cartesian) => state_eci_to_ecef(epoch, state),
-            (OrbitFrame::GCRF, OrbitRepresentation::Cartesian) => state_gcrf_to_itrf(epoch, state),
-            (OrbitFrame::EME2000, OrbitRepresentation::Cartesian) => {
-                let state_gcrf = state_eme2000_to_gcrf(state);
-                state_gcrf_to_itrf(epoch, state_gcrf)
-            }
-            (OrbitFrame::ECI, OrbitRepresentation::Keplerian) => {
-                let state_eci_cart = state_koe_to_eci(
-                    state,
-                    self.angle_format
-                        .expect("Keplerian representation must have angle_format"),
-                );
-                state_eci_to_ecef(epoch, state_eci_cart)
-            }
-            (OrbitFrame::GCRF, OrbitRepresentation::Keplerian) => {
-                let state_gcrf_cart = state_koe_to_eci(
-                    state,
-                    self.angle_format
-                        .expect("Keplerian representation must have angle_format"),
-                );
-                state_gcrf_to_itrf(epoch, state_gcrf_cart)
-            }
-            (OrbitFrame::EME2000, OrbitRepresentation::Keplerian) => {
-                let state_eme2000_cart = state_koe_to_eci(
-                    state,
-                    self.angle_format
-                        .expect("Keplerian representation must have angle_format"),
-                );
-                let state_gcrf = state_eme2000_to_gcrf(state_eme2000_cart);
-                state_gcrf_to_itrf(epoch, state_gcrf)
-            }
-            (OrbitFrame::ECEF, OrbitRepresentation::Keplerian) => {
-                return Err(BraheError::Error(
-                    "Keplerian element trajectories should be in an inertial frame".to_string(),
-                ));
-            }
-            (OrbitFrame::ITRF, OrbitRepresentation::Keplerian) => {
-                return Err(BraheError::Error(
-                    "Keplerian element trajectories should be in an inertial frame".to_string(),
-                ));
-            }
-        })
+        self.state_in_frame(CelestialFrame::ITRF, epoch)
     }
 
     fn state_eme2000(&self, epoch: Epoch) -> Result<Vector6<f64>, BraheError> {
-        // Get state in native format then convert to EME2000 Cartesian
-        let state = self.interpolate(&epoch)?;
-
-        Ok(match (self.frame, self.representation) {
-            (OrbitFrame::BodyCenteredInertial(center), _) => {
-                let x = self.bci_native_cartesian(center, state)?;
-                return crate::frames::state_frame_to_frame(
-                    crate::trajectories::traits::bci_reference_frame(center),
-                    crate::frames::CelestialFrame::EME2000,
-                    epoch,
-                    x,
-                );
-            }
-            (OrbitFrame::EME2000, OrbitRepresentation::Cartesian) => state,
-            (OrbitFrame::GCRF, OrbitRepresentation::Cartesian) => state_gcrf_to_eme2000(state),
-            (OrbitFrame::ECI, OrbitRepresentation::Cartesian) => state_gcrf_to_eme2000(state), // ECI treated as GCRF
-            (OrbitFrame::GCRF, OrbitRepresentation::Keplerian) => {
-                let state_gcrf_cart = state_koe_to_eci(
-                    state,
-                    self.angle_format
-                        .expect("Keplerian representation must have angle_format"),
-                );
-                state_gcrf_to_eme2000(state_gcrf_cart)
-            }
-            (OrbitFrame::ECI, OrbitRepresentation::Keplerian) => {
-                let state_eci_cart = state_koe_to_eci(
-                    state,
-                    self.angle_format
-                        .expect("Keplerian representation must have angle_format"),
-                );
-                state_gcrf_to_eme2000(state_eci_cart)
-            }
-            (OrbitFrame::EME2000, OrbitRepresentation::Keplerian) => state_koe_to_eci(
-                state,
-                self.angle_format
-                    .expect("Keplerian representation must have angle_format"),
-            ),
-            (OrbitFrame::ITRF, OrbitRepresentation::Cartesian) => {
-                let state_gcrf = state_itrf_to_gcrf(epoch, state);
-                state_gcrf_to_eme2000(state_gcrf)
-            }
-            (OrbitFrame::ECEF, OrbitRepresentation::Cartesian) => {
-                let state_gcrf = state_itrf_to_gcrf(epoch, state);
-                state_gcrf_to_eme2000(state_gcrf)
-            }
-            (OrbitFrame::ECEF, OrbitRepresentation::Keplerian) => {
-                return Err(BraheError::Error(
-                    "Keplerian element trajectories should be in an inertial frame".to_string(),
-                ));
-            }
-            (OrbitFrame::ITRF, OrbitRepresentation::Keplerian) => {
-                return Err(BraheError::Error(
-                    "Keplerian element trajectories should be in an inertial frame".to_string(),
-                ));
-            }
-        })
+        self.state_in_frame(CelestialFrame::EME2000, epoch)
     }
 
     fn state_koe_osc(
@@ -2674,106 +2007,38 @@ impl SOrbitStateProvider for SOrbitTrajectory {
         epoch: Epoch,
         angle_format: AngleFormat,
     ) -> Result<Vector6<f64>, BraheError> {
-        // Get state in native format then convert to osculating elements
-        let state = self.interpolate(&epoch)?;
+        let root = celestial_root(&self.frame)?;
+        let center = root.center_naif_id();
+        let cb = CentralBody::from_naif_id(center)?;
+        if cb.is_barycenter() {
+            return Err(BraheError::Error(format!(
+                "osculating elements are undefined about massless barycenter {}",
+                center
+            )));
+        }
 
-        Ok(match (self.frame, self.representation) {
-            (OrbitFrame::BodyCenteredInertial(center), _) => {
-                // Osculating elements about the trajectory's own center,
-                // using that body's gravitational parameter.
-                let cb = crate::propagators::CentralBody::from_naif_id(center)?;
-                if cb.is_barycenter() {
-                    return Err(BraheError::Error(format!(
-                        "osculating elements are undefined about massless barycenter {}",
-                        center
-                    )));
-                }
-                let x = self.bci_native_cartesian(center, state)?;
-                return Ok(crate::coordinates::state_inertial_to_koe_gm(
-                    x,
-                    cb.gm(),
-                    angle_format,
-                ));
-            }
-            (OrbitFrame::ECI, OrbitRepresentation::Keplerian) => {
-                // Already in Keplerian, just convert angle format if needed
-                let native_format = self.angle_format.unwrap_or(AngleFormat::Radians);
-                if native_format == angle_format {
-                    state
+        let inertial = icrf_aligned_inertial(root);
+        if self.representation == OrbitRepresentation::Keplerian && self.frame == inertial {
+            // Elements already reference this center's inertial axes: only
+            // the angle format may differ.
+            let mut state = self.interpolate(&epoch)?;
+            let native_format = self.angle_format.unwrap_or(AngleFormat::Radians);
+            if native_format != angle_format {
+                let factor = if angle_format == AngleFormat::Degrees {
+                    RAD2DEG
                 } else {
-                    // Convert angles
-                    let mut converted = state;
-                    let factor = if angle_format == AngleFormat::Degrees {
-                        RAD2DEG
-                    } else {
-                        DEG2RAD
-                    };
-                    converted[2] *= factor; // inclination
-                    converted[3] *= factor; // RAAN
-                    converted[4] *= factor; // arg periapsis
-                    converted[5] *= factor; // mean anomaly
-                    converted
-                }
+                    DEG2RAD
+                };
+                state[2] *= factor; // inclination
+                state[3] *= factor; // RAAN
+                state[4] *= factor; // argument of periapsis
+                state[5] *= factor; // mean anomaly
             }
-            (OrbitFrame::GCRF, OrbitRepresentation::Keplerian) => {
-                // Already in Keplerian, just convert angle format if needed
-                let native_format = self.angle_format.unwrap_or(AngleFormat::Radians);
-                if native_format == angle_format {
-                    state
-                } else {
-                    // Convert angles
-                    let mut converted = state;
-                    let factor = if angle_format == AngleFormat::Degrees {
-                        RAD2DEG
-                    } else {
-                        DEG2RAD
-                    };
-                    converted[2] *= factor; // inclination
-                    converted[3] *= factor; // RAAN
-                    converted[4] *= factor; // arg periapsis
-                    converted[5] *= factor; // mean anomaly
-                    converted
-                }
-            }
-            (OrbitFrame::EME2000, OrbitRepresentation::Keplerian) => {
-                // Convert back to Cartesian, to GCRF, then to osculating elements
-                let state_eme2000_cart = state_koe_to_eci(
-                    state,
-                    self.angle_format
-                        .expect("Keplerian representation must have angle_format"),
-                );
-                let state_gcrf = state_eme2000_to_gcrf(state_eme2000_cart);
-                state_eci_to_koe(state_gcrf, angle_format)
-            }
-            (OrbitFrame::ECI, OrbitRepresentation::Cartesian) => {
-                state_eci_to_koe(state, angle_format)
-            }
-            (OrbitFrame::GCRF, OrbitRepresentation::Cartesian) => {
-                state_eci_to_koe(state, angle_format)
-            }
-            (OrbitFrame::EME2000, OrbitRepresentation::Cartesian) => {
-                let state_gcrf = state_eme2000_to_gcrf(state);
-                state_eci_to_koe(state_gcrf, angle_format)
-            }
-            (OrbitFrame::ECEF, OrbitRepresentation::Cartesian) => {
-                let state_eci = state_ecef_to_eci(epoch, state);
-                state_eci_to_koe(state_eci, angle_format)
-            }
-            (OrbitFrame::ITRF, OrbitRepresentation::Cartesian) => {
-                let state_gcrf = state_itrf_to_gcrf(epoch, state);
-                state_eci_to_koe(state_gcrf, angle_format)
-            }
-            (OrbitFrame::ECEF, OrbitRepresentation::Keplerian) => {
-                return Err(BraheError::Error(
-                    "Keplerian element trajectories should be in an inertial frame".to_string(),
-                ));
-            }
-            (OrbitFrame::ITRF, OrbitRepresentation::Keplerian) => {
-                return Err(BraheError::Error(
-                    "Keplerian element trajectories should be in an inertial frame".to_string(),
-                ));
-            }
-        })
+            return Ok(state);
+        }
+
+        let x = self.state_in_frame(inertial, epoch)?;
+        Ok(state_inertial_to_koe_gm(x, cb.gm(), angle_format))
     }
 }
 
@@ -2867,32 +2132,33 @@ impl SOrbitCovarianceProvider for SOrbitTrajectory {
         let cov_native = self.covariance(epoch)?;
 
         // Transform to ECI if needed
-        match self.frame {
-            // Body-centered inertial axes are ICRF-aligned, so the covariance
-            // is identical under the identity rotation (the center offset is a
-            // translation, which does not affect covariance).
-            OrbitFrame::BodyCenteredInertial(_) => Ok(cov_native),
-            OrbitFrame::ECI | OrbitFrame::GCRF => Ok(cov_native),
-            OrbitFrame::ECEF | OrbitFrame::ITRF => Err(BraheError::Error(
-                "Covariance transformation from ECEF/ITRF to ECI not implemented".to_string(),
-            )),
-            OrbitFrame::EME2000 => {
-                // We just construct a block diagonal rotation matrix using the
-                // EME2000 to GCRF rotation matrix
-                let rot_eme2000_to_gcrf = rotation_eme2000_to_gcrf();
+        let root = celestial_root(&self.frame)?;
 
-                let mut rot = nalgebra::Matrix6::zeros();
-                // Position part (3x3 upper-left block)
-                for i in 0..3 {
-                    for j in 0..3 {
-                        rot[(i, j)] = rot_eme2000_to_gcrf[(i, j)];
-                        rot[(3 + i, 3 + j)] = rot_eme2000_to_gcrf[(i, j)];
-                    }
+        if self.frame == CelestialFrame::EME2000 {
+            // We just construct a block diagonal rotation matrix using the
+            // EME2000 to GCRF rotation matrix
+            let rot_eme2000_to_gcrf = rotation_eme2000_to_gcrf();
+
+            let mut rot = nalgebra::Matrix6::zeros();
+            // Position part (3x3 upper-left block)
+            for i in 0..3 {
+                for j in 0..3 {
+                    rot[(i, j)] = rot_eme2000_to_gcrf[(i, j)];
+                    rot[(3 + i, 3 + j)] = rot_eme2000_to_gcrf[(i, j)];
                 }
-                // Transform covariance: C_ECI = R * C_EME2000 * R^T
-                let cov_eci = rot * cov_native * rot.transpose();
-                Ok(cov_eci)
             }
+            // Transform covariance: C_ECI = R * C_EME2000 * R^T
+            Ok(rot * cov_native * rot.transpose())
+        } else if self.frame == icrf_aligned_inertial(root) {
+            // ICRF-aligned axes leave the covariance unchanged under the
+            // identity rotation (a center offset is a translation, which does
+            // not affect covariance).
+            Ok(cov_native)
+        } else {
+            Err(BraheError::Error(format!(
+                "Covariance transformation from {} to ECI not implemented",
+                self.frame
+            )))
         }
     }
 
@@ -3016,6 +2282,11 @@ impl Identifiable for SOrbitTrajectory {
 mod tests {
     use super::*;
     use crate::constants::{DEGREES, R_EARTH, RADIANS};
+    use crate::coordinates::state_koe_to_eci;
+    use crate::frames::{
+        state_ecef_to_eci, state_eci_to_ecef, state_eme2000_to_gcrf, state_gcrf_to_eme2000,
+        state_gcrf_to_itrf, state_itrf_to_gcrf,
+    };
     use crate::time::{Epoch, TimeSystem};
     use crate::utils::testing::setup_global_test_eop;
     use approx::assert_abs_diff_eq;
@@ -3036,12 +2307,9 @@ mod tests {
         // auto-load latch (OnceLock) does not re-detect the clear.
         crate::spice::load_spice_kernel("moon_pa_de440").unwrap();
 
-        let mut traj = SOrbitTrajectory::new(
-            OrbitFrame::BodyCenteredInertial(301),
-            OrbitRepresentation::Cartesian,
-            None,
-        )
-        .unwrap();
+        let mut traj =
+            SOrbitTrajectory::new(CelestialFrame::LCI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.covariances = Some(Vec::new());
         let epoch = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = Vector6::new(2.0e6, 1.0e5, -3.0e5, 10.0, 1.6e3, -5.0);
@@ -3100,11 +2368,11 @@ mod tests {
 
         // Batch conversions agree with the point queries and are relabeled.
         for (converted, expected, frame) in [
-            (traj.to_eci().unwrap(), eci, OrbitFrame::ECI),
-            (traj.to_gcrf().unwrap(), gcrf, OrbitFrame::GCRF),
-            (traj.to_ecef().unwrap(), ecef, OrbitFrame::ECEF),
-            (traj.to_itrf().unwrap(), itrf, OrbitFrame::ITRF),
-            (traj.to_eme2000().unwrap(), eme, OrbitFrame::EME2000),
+            (traj.to_eci().unwrap(), eci, CelestialFrame::ECI),
+            (traj.to_gcrf().unwrap(), gcrf, CelestialFrame::GCRF),
+            (traj.to_ecef().unwrap(), ecef, CelestialFrame::ECEF),
+            (traj.to_itrf().unwrap(), itrf, CelestialFrame::ITRF),
+            (traj.to_eme2000().unwrap(), eme, CelestialFrame::EME2000),
         ] {
             assert_eq!(converted.frame, frame);
             let s0 = converted.states[0];
@@ -3124,7 +2392,7 @@ mod tests {
         // Keplerian-representation BCI trajectory: elements converted with
         // the Moon's GM, both point queries and the batch path.
         let mut traj_kep = SOrbitTrajectory::new(
-            OrbitFrame::BodyCenteredInertial(301),
+            CelestialFrame::LCI,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Degrees),
         )
@@ -3149,7 +2417,7 @@ mod tests {
         }
         let eci_kep_point = traj_kep.state_eci(epoch).unwrap();
         let traj_kep_eci = traj_kep.to_eci().unwrap();
-        assert_eq!(traj_kep_eci.frame, OrbitFrame::ECI);
+        assert_eq!(traj_kep_eci.frame, CelestialFrame::ECI);
         let eci_kep_batch = traj_kep_eci.state_eci(epoch).unwrap();
         for i in 0..6 {
             assert_abs_diff_eq!(eci_kep_batch[i], eci_kep_point[i], epsilon = 1e-6);
@@ -3157,7 +2425,8 @@ mod tests {
 
         // Earth-frame trajectory keeps Earth semantics for the accessors.
         let mut traj_e =
-            SOrbitTrajectory::new(OrbitFrame::GCRF, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::GCRF, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         let state_e = Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0);
         traj_e.add(epoch, state_e).unwrap();
         let gcrf_e = traj_e.state_gcrf(epoch).unwrap();
@@ -3181,12 +2450,9 @@ mod tests {
         // to_keplerian rejection.
         let epoch = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
 
-        let mut traj_emb = SOrbitTrajectory::new(
-            OrbitFrame::BodyCenteredInertial(3),
-            OrbitRepresentation::Cartesian,
-            None,
-        )
-        .unwrap();
+        let mut traj_emb =
+            SOrbitTrajectory::new(CelestialFrame::EMBI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj_emb
             .add(epoch, Vector6::new(1e8, 0.0, 0.0, 0.0, 1e3, 0.0))
             .unwrap();
@@ -3206,7 +2472,7 @@ mod tests {
         );
 
         let mut traj_unknown = SOrbitTrajectory::new(
-            OrbitFrame::BodyCenteredInertial(-20001),
+            CelestialFrame::BodyCenteredICRF(-20001),
             OrbitRepresentation::Cartesian,
             None,
         )
@@ -3222,7 +2488,7 @@ mod tests {
         );
 
         let mut traj_kep = SOrbitTrajectory::new(
-            OrbitFrame::BodyCenteredInertial(3),
+            CelestialFrame::EMBI,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Degrees),
         )
@@ -3243,7 +2509,7 @@ mod tests {
 
     fn create_test_trajectory() -> SOrbitTrajectory {
         let mut traj = SOrbitTrajectory::new(
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Degrees),
         )
@@ -3267,11 +2533,11 @@ mod tests {
     #[test]
     #[parallel]
     fn test_orbittrajectory_new() {
-        let traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+        let traj = SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+            .unwrap();
 
         assert_eq!(traj.len(), 0);
-        assert_eq!(traj.frame, OrbitFrame::ECI);
+        assert_eq!(traj.frame, CelestialFrame::ECI);
         assert_eq!(traj.representation, OrbitRepresentation::Cartesian);
         assert_eq!(traj.angle_format, None);
     }
@@ -3279,7 +2545,8 @@ mod tests {
     #[test]
     #[parallel]
     fn test_orbittrajectory_new_invalid_keplerian_none() {
-        let result = SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Keplerian, None);
+        let result =
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Keplerian, None);
         assert!(result.is_err());
     }
 
@@ -3287,7 +2554,7 @@ mod tests {
     #[parallel]
     fn test_orbittrajectory_new_invalid_cartesian_degrees() {
         let result = SOrbitTrajectory::new(
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             Some(AngleFormat::Degrees),
         );
@@ -3298,7 +2565,7 @@ mod tests {
     #[parallel]
     fn test_orbittrajectory_new_invalid_cartesian_radians() {
         let result = SOrbitTrajectory::new(
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             Some(AngleFormat::Radians),
         );
@@ -3309,7 +2576,7 @@ mod tests {
     #[parallel]
     fn test_orbittrajectory_new_invalid_keplerian_ecef_degrees() {
         let result = SOrbitTrajectory::new(
-            OrbitFrame::ECEF,
+            CelestialFrame::ECEF,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Degrees),
         );
@@ -3320,7 +2587,7 @@ mod tests {
     #[parallel]
     fn test_orbittrajectory_new_invalid_keplerian_ecef_radians() {
         let result = SOrbitTrajectory::new(
-            OrbitFrame::ECEF,
+            CelestialFrame::ECEF,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Radians),
         );
@@ -3330,7 +2597,8 @@ mod tests {
     #[test]
     #[parallel]
     fn test_orbittrajectory_new_invalid_keplerian_ecef_none() {
-        let result = SOrbitTrajectory::new(OrbitFrame::ECEF, OrbitRepresentation::Keplerian, None);
+        let result =
+            SOrbitTrajectory::new(CelestialFrame::ECEF, OrbitRepresentation::Keplerian, None);
         assert!(result.is_err());
     }
 
@@ -3357,7 +2625,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             epochs,
             states.clone(),
-            OrbitFrame::ECI,
+            CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -3407,7 +2675,8 @@ mod tests {
     #[parallel]
     fn test_orbittrajectory_trajectory_add() {
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
 
         // Add states in order
         let epoch1 = Epoch::from_jd(2451545.0, TimeSystem::UTC);
@@ -3446,7 +2715,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -3483,7 +2752,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -3520,7 +2789,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             epochs.clone(),
             states,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -3562,7 +2831,8 @@ mod tests {
     #[parallel]
     fn test_orbittrajectory_trajectory_len() {
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
 
         assert_eq!(traj.len(), 0);
         assert!(traj.is_empty());
@@ -3579,7 +2849,8 @@ mod tests {
     #[parallel]
     fn test_orbittrajectory_trajectory_is_empty() {
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
 
         assert!(traj.is_empty());
 
@@ -3594,7 +2865,8 @@ mod tests {
     #[parallel]
     fn test_orbittrajectory_trajectory_start_epoch() {
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
 
         assert!(traj.start_epoch().is_none());
 
@@ -3609,7 +2881,8 @@ mod tests {
     #[parallel]
     fn test_orbittrajectory_trajectory_end_epoch() {
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
 
         assert!(traj.end_epoch().is_none());
 
@@ -3636,7 +2909,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -3661,7 +2934,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             epochs.clone(),
             states.clone(),
-            OrbitFrame::ECI,
+            CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -3687,7 +2960,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             epochs.clone(),
             states.clone(),
-            OrbitFrame::ECI,
+            CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -3703,7 +2976,8 @@ mod tests {
     #[parallel]
     fn test_orbittrajectory_trajectory_clear() {
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
 
         let epoch = Epoch::from_jd(2451545.0, TimeSystem::UTC);
         let state = Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0);
@@ -3728,7 +3002,7 @@ mod tests {
         let mut traj = SOrbitTrajectory::from_orbital_data(
             epochs.clone(),
             states,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -3754,7 +3028,7 @@ mod tests {
         let mut traj = SOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -3781,7 +3055,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -3810,7 +3084,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -3857,7 +3131,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -3907,7 +3181,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -3952,7 +3226,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -3984,7 +3258,8 @@ mod tests {
     #[parallel]
     fn test_orbittrajectory_trajectory_set_eviction_policy_max_size() {
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
 
         // Add 5 states
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
@@ -4021,7 +3296,8 @@ mod tests {
     #[parallel]
     fn test_orbittrajectory_trajectory_set_eviction_policy_max_age() {
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
 
         // Add states spanning 5 minutes
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
@@ -4060,7 +3336,7 @@ mod tests {
         let traj = SOrbitTrajectory::default();
         assert_eq!(traj.len(), 0);
         assert!(traj.is_empty());
-        assert_eq!(traj.frame, OrbitFrame::ECI);
+        assert_eq!(traj.frame, CelestialFrame::ECI);
         assert_eq!(traj.representation, OrbitRepresentation::Cartesian);
         assert_eq!(traj.angle_format, None);
     }
@@ -4083,7 +3359,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -4110,7 +3386,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -4138,7 +3414,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -4170,8 +3446,8 @@ mod tests {
     #[test]
     #[parallel]
     fn test_orbittrajectory_intoiterator_into_iter_empty() {
-        let traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+        let traj = SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+            .unwrap();
 
         let mut count = 0;
         for _ in &traj {
@@ -4196,7 +3472,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -4225,7 +3501,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -4242,7 +3518,8 @@ mod tests {
     #[parallel]
     fn test_orbittrajectory_interpolatable_set_interpolation_method() {
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
 
         // Default is HermiteCubic (orbit states carry velocity)
         assert_eq!(
@@ -4258,7 +3535,8 @@ mod tests {
     #[parallel]
     fn test_orbittrajectory_interpolatable_get_interpolation_method() {
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
 
         // Default is HermiteCubic (orbit states carry velocity)
         assert_eq!(
@@ -4289,7 +3567,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -4329,7 +3607,7 @@ mod tests {
         let single_traj = SOrbitTrajectory::from_orbital_data(
             single_epoch,
             single_state,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -4358,7 +3636,7 @@ mod tests {
         let mut traj = SOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -4399,7 +3677,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -4441,7 +3719,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -4483,7 +3761,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -4491,7 +3769,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(traj.len(), 2);
-        assert_eq!(traj.frame, OrbitFrame::ECI);
+        assert_eq!(traj.frame, CelestialFrame::ECI);
         assert_eq!(traj.representation, OrbitRepresentation::Cartesian);
     }
 
@@ -4514,13 +3792,14 @@ mod tests {
 
         // No transformation needed if already in ECI
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
 
         let epoch = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         traj.add(epoch, state_base).unwrap();
 
         let eci_traj = traj.to_eci().unwrap();
-        assert_eq!(eci_traj.frame, OrbitFrame::ECI);
+        assert_eq!(eci_traj.frame, CelestialFrame::ECI);
         assert_eq!(eci_traj.representation, OrbitRepresentation::Cartesian);
         assert_eq!(eci_traj.angle_format, None);
         assert_eq!(eci_traj.len(), 1);
@@ -4532,7 +3811,7 @@ mod tests {
 
         // Convert Keplerian to ECI - Radians
         let mut kep_traj = SOrbitTrajectory::new(
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Radians),
         )
@@ -4541,7 +3820,7 @@ mod tests {
         kep_traj.add(epoch, kep_state_rad).unwrap();
 
         let eci_from_kep_rad = kep_traj.to_eci().unwrap();
-        assert_eq!(eci_from_kep_rad.frame, OrbitFrame::ECI);
+        assert_eq!(eci_from_kep_rad.frame, CelestialFrame::ECI);
         assert_eq!(
             eci_from_kep_rad.representation,
             OrbitRepresentation::Cartesian
@@ -4556,7 +3835,7 @@ mod tests {
 
         // Convert Keplerian to ECI - Degrees
         let mut kep_traj_deg = SOrbitTrajectory::new(
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Degrees),
         )
@@ -4564,7 +3843,7 @@ mod tests {
         let kep_state_deg = state_eci_to_koe(state_base, DEGREES);
         kep_traj_deg.add(epoch, kep_state_deg).unwrap();
         let eci_from_kep_deg = kep_traj_deg.to_eci().unwrap();
-        assert_eq!(eci_from_kep_deg.frame, OrbitFrame::ECI);
+        assert_eq!(eci_from_kep_deg.frame, CelestialFrame::ECI);
         assert_eq!(
             eci_from_kep_deg.representation,
             OrbitRepresentation::Cartesian
@@ -4579,11 +3858,12 @@ mod tests {
 
         // Convert ECEF to ECI
         let mut ecef_traj =
-            SOrbitTrajectory::new(OrbitFrame::ECEF, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECEF, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         let ecef_state = state_eci_to_ecef(epoch, state_base);
         ecef_traj.add(epoch, ecef_state).unwrap();
         let eci_from_ecef = ecef_traj.to_eci().unwrap();
-        assert_eq!(eci_from_ecef.frame, OrbitFrame::ECI);
+        assert_eq!(eci_from_ecef.frame, CelestialFrame::ECI);
         assert_eq!(eci_from_ecef.representation, OrbitRepresentation::Cartesian);
         assert_eq!(eci_from_ecef.angle_format, None);
         assert_eq!(eci_from_ecef.len(), 1);
@@ -4611,11 +3891,12 @@ mod tests {
 
         // No transformation needed if already in ECEF
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECEF, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECEF, OrbitRepresentation::Cartesian, None)
+                .unwrap();
 
         traj.add(epoch, state_base).unwrap();
         let ecef_traj = traj.to_ecef().unwrap();
-        assert_eq!(ecef_traj.frame, OrbitFrame::ECEF);
+        assert_eq!(ecef_traj.frame, CelestialFrame::ECEF);
         assert_eq!(ecef_traj.representation, OrbitRepresentation::Cartesian);
         assert_eq!(ecef_traj.angle_format, None);
         assert_eq!(ecef_traj.len(), 1);
@@ -4627,11 +3908,12 @@ mod tests {
 
         // Convert ECI to ECEF
         let mut eci_traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         let eci_state = state_ecef_to_eci(epoch, state_base);
         eci_traj.add(epoch, eci_state).unwrap();
         let ecef_from_eci = eci_traj.to_ecef().unwrap();
-        assert_eq!(ecef_from_eci.frame, OrbitFrame::ECEF);
+        assert_eq!(ecef_from_eci.frame, CelestialFrame::ECEF);
         assert_eq!(ecef_from_eci.representation, OrbitRepresentation::Cartesian);
         assert_eq!(ecef_from_eci.angle_format, None);
         assert_eq!(ecef_from_eci.len(), 1);
@@ -4643,7 +3925,7 @@ mod tests {
 
         // Convert Keplerian to ECEF - Radians
         let mut kep_traj = SOrbitTrajectory::new(
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Radians),
         )
@@ -4651,7 +3933,7 @@ mod tests {
         let kep_state_rad = state_eci_to_koe(eci_state, RADIANS);
         kep_traj.add(epoch, kep_state_rad).unwrap();
         let ecef_from_kep_rad = kep_traj.to_ecef().unwrap();
-        assert_eq!(ecef_from_kep_rad.frame, OrbitFrame::ECEF);
+        assert_eq!(ecef_from_kep_rad.frame, CelestialFrame::ECEF);
         assert_eq!(
             ecef_from_kep_rad.representation,
             OrbitRepresentation::Cartesian
@@ -4666,7 +3948,7 @@ mod tests {
 
         // Convert Keplerian to ECEF - Degrees
         let mut kep_traj_deg = SOrbitTrajectory::new(
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Degrees),
         )
@@ -4674,7 +3956,7 @@ mod tests {
         let kep_state_deg = state_eci_to_koe(eci_state, DEGREES);
         kep_traj_deg.add(epoch, kep_state_deg).unwrap();
         let ecef_from_kep_deg = kep_traj_deg.to_ecef().unwrap();
-        assert_eq!(ecef_from_kep_deg.frame, OrbitFrame::ECEF);
+        assert_eq!(ecef_from_kep_deg.frame, CelestialFrame::ECEF);
         assert_eq!(
             ecef_from_kep_deg.representation,
             OrbitRepresentation::Cartesian
@@ -4705,11 +3987,12 @@ mod tests {
 
         // No transformation needed if already in ITRF
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ITRF, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ITRF, OrbitRepresentation::Cartesian, None)
+                .unwrap();
 
         traj.add(epoch, state_base).unwrap();
         let itrf_traj = traj.to_itrf().unwrap();
-        assert_eq!(itrf_traj.frame, OrbitFrame::ITRF);
+        assert_eq!(itrf_traj.frame, CelestialFrame::ITRF);
         assert_eq!(itrf_traj.representation, OrbitRepresentation::Cartesian);
         assert_eq!(itrf_traj.angle_format, None);
         assert_eq!(itrf_traj.len(), 1);
@@ -4721,11 +4004,12 @@ mod tests {
 
         // Convert ECI to ITRF
         let mut eci_traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         let eci_state = state_ecef_to_eci(epoch, state_base);
         eci_traj.add(epoch, eci_state).unwrap();
         let itrf_from_eci = eci_traj.to_itrf().unwrap();
-        assert_eq!(itrf_from_eci.frame, OrbitFrame::ITRF);
+        assert_eq!(itrf_from_eci.frame, CelestialFrame::ITRF);
         assert_eq!(itrf_from_eci.representation, OrbitRepresentation::Cartesian);
         assert_eq!(itrf_from_eci.angle_format, None);
         assert_eq!(itrf_from_eci.len(), 1);
@@ -4737,11 +4021,12 @@ mod tests {
 
         // Convert GCRF to ITRF
         let mut gcrf_traj =
-            SOrbitTrajectory::new(OrbitFrame::GCRF, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::GCRF, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         let gcrf_state = state_itrf_to_gcrf(epoch, state_base);
         gcrf_traj.add(epoch, gcrf_state).unwrap();
         let itrf_from_gcrf = gcrf_traj.to_itrf().unwrap();
-        assert_eq!(itrf_from_gcrf.frame, OrbitFrame::ITRF);
+        assert_eq!(itrf_from_gcrf.frame, CelestialFrame::ITRF);
         assert_eq!(
             itrf_from_gcrf.representation,
             OrbitRepresentation::Cartesian
@@ -4756,7 +4041,7 @@ mod tests {
 
         // Convert Keplerian to ITRF - Radians
         let mut kep_traj = SOrbitTrajectory::new(
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Radians),
         )
@@ -4764,7 +4049,7 @@ mod tests {
         let kep_state_rad = state_eci_to_koe(eci_state, RADIANS);
         kep_traj.add(epoch, kep_state_rad).unwrap();
         let itrf_from_kep_rad = kep_traj.to_itrf().unwrap();
-        assert_eq!(itrf_from_kep_rad.frame, OrbitFrame::ITRF);
+        assert_eq!(itrf_from_kep_rad.frame, CelestialFrame::ITRF);
         assert_eq!(
             itrf_from_kep_rad.representation,
             OrbitRepresentation::Cartesian
@@ -4779,7 +4064,7 @@ mod tests {
 
         // Convert Keplerian to itrf - Degrees
         let mut kep_traj_deg = SOrbitTrajectory::new(
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Degrees),
         )
@@ -4787,7 +4072,7 @@ mod tests {
         let kep_state_deg = state_eci_to_koe(eci_state, DEGREES);
         kep_traj_deg.add(epoch, kep_state_deg).unwrap();
         let itrf_from_kep_deg = kep_traj_deg.to_itrf().unwrap();
-        assert_eq!(itrf_from_kep_deg.frame, OrbitFrame::ITRF);
+        assert_eq!(itrf_from_kep_deg.frame, CelestialFrame::ITRF);
         assert_eq!(
             itrf_from_kep_deg.representation,
             OrbitRepresentation::Cartesian
@@ -4812,14 +4097,14 @@ mod tests {
 
         // No transformation needed if already in Keplerian Degrees
         let mut traj = SOrbitTrajectory::new(
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Degrees),
         )
         .unwrap();
         traj.add(epoch, state_kep_deg).unwrap();
         let kep_traj = traj.to_keplerian(AngleFormat::Degrees).unwrap();
-        assert_eq!(kep_traj.frame, OrbitFrame::ECI);
+        assert_eq!(kep_traj.frame, CelestialFrame::ECI);
         assert_eq!(kep_traj.representation, OrbitRepresentation::Keplerian);
         assert_eq!(kep_traj.angle_format, Some(AngleFormat::Degrees));
         assert_eq!(kep_traj.len(), 1);
@@ -4831,7 +4116,7 @@ mod tests {
 
         // Convert Keplerian Radians to Keplerian Degrees
         let mut kep_rad_traj = SOrbitTrajectory::new(
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Radians),
         )
@@ -4842,7 +4127,7 @@ mod tests {
         }
         kep_rad_traj.add(epoch, state_kep_rad).unwrap();
         let kep_from_rad = kep_rad_traj.to_keplerian(AngleFormat::Degrees).unwrap();
-        assert_eq!(kep_from_rad.frame, OrbitFrame::ECI);
+        assert_eq!(kep_from_rad.frame, CelestialFrame::ECI);
         assert_eq!(kep_from_rad.representation, OrbitRepresentation::Keplerian);
         assert_eq!(kep_from_rad.angle_format, Some(AngleFormat::Degrees));
         assert_eq!(kep_from_rad.len(), 1);
@@ -4854,11 +4139,12 @@ mod tests {
 
         // Convert ECI to Keplerian Degrees
         let mut cart_traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         let cart_state = state_koe_to_eci(state_kep_deg, DEGREES);
         cart_traj.add(epoch, cart_state).unwrap();
         let kep_from_cart = cart_traj.to_keplerian(AngleFormat::Degrees).unwrap();
-        assert_eq!(kep_from_cart.frame, OrbitFrame::ECI);
+        assert_eq!(kep_from_cart.frame, CelestialFrame::ECI);
         assert_eq!(kep_from_cart.representation, OrbitRepresentation::Keplerian);
         assert_eq!(kep_from_cart.angle_format, Some(AngleFormat::Degrees));
         assert_eq!(kep_from_cart.len(), 1);
@@ -4870,11 +4156,12 @@ mod tests {
 
         // Convert ECEF to Keplerian Degrees
         let mut ecef_traj =
-            SOrbitTrajectory::new(OrbitFrame::ECEF, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECEF, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         let ecef_state = state_eci_to_ecef(epoch, cart_state);
         ecef_traj.add(epoch, ecef_state).unwrap();
         let kep_from_ecef = ecef_traj.to_keplerian(AngleFormat::Degrees).unwrap();
-        assert_eq!(kep_from_ecef.frame, OrbitFrame::ECI);
+        assert_eq!(kep_from_ecef.frame, CelestialFrame::ECI);
         assert_eq!(kep_from_ecef.representation, OrbitRepresentation::Keplerian);
         assert_eq!(kep_from_ecef.angle_format, Some(AngleFormat::Degrees));
         assert_eq!(kep_from_ecef.len(), 1);
@@ -4900,14 +4187,14 @@ mod tests {
 
         // No transformation needed if already in Keplerian Radians
         let mut traj = SOrbitTrajectory::new(
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Radians),
         )
         .unwrap();
         traj.add(epoch, state_kep_rad).unwrap();
         let kep_traj = traj.to_keplerian(AngleFormat::Radians).unwrap();
-        assert_eq!(kep_traj.frame, OrbitFrame::ECI);
+        assert_eq!(kep_traj.frame, CelestialFrame::ECI);
         assert_eq!(kep_traj.representation, OrbitRepresentation::Keplerian);
         assert_eq!(kep_traj.angle_format, Some(AngleFormat::Radians));
         assert_eq!(kep_traj.len(), 1);
@@ -4919,14 +4206,14 @@ mod tests {
 
         // Convert Keplerian Degrees to Keplerian Radians
         let mut kep_deg_traj = SOrbitTrajectory::new(
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Degrees),
         )
         .unwrap();
         kep_deg_traj.add(epoch, state_kep_deg).unwrap();
         let kep_from_deg = kep_deg_traj.to_keplerian(AngleFormat::Radians).unwrap();
-        assert_eq!(kep_from_deg.frame, OrbitFrame::ECI);
+        assert_eq!(kep_from_deg.frame, CelestialFrame::ECI);
         assert_eq!(kep_from_deg.representation, OrbitRepresentation::Keplerian);
         assert_eq!(kep_from_deg.angle_format, Some(AngleFormat::Radians));
         assert_eq!(kep_from_deg.len(), 1);
@@ -4938,11 +4225,12 @@ mod tests {
 
         // Convert ECI to Keplerian Radians
         let mut cart_traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         let cart_state = state_koe_to_eci(state_kep_deg, DEGREES);
         cart_traj.add(epoch, cart_state).unwrap();
         let kep_from_cart = cart_traj.to_keplerian(AngleFormat::Radians).unwrap();
-        assert_eq!(kep_from_cart.frame, OrbitFrame::ECI);
+        assert_eq!(kep_from_cart.frame, CelestialFrame::ECI);
         assert_eq!(kep_from_cart.representation, OrbitRepresentation::Keplerian);
         assert_eq!(kep_from_cart.angle_format, Some(AngleFormat::Radians));
         assert_eq!(kep_from_cart.len(), 1);
@@ -4954,11 +4242,12 @@ mod tests {
 
         // Convert ECEF to Keplerian Radians
         let mut ecef_traj =
-            SOrbitTrajectory::new(OrbitFrame::ECEF, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECEF, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         let ecef_state = state_eci_to_ecef(epoch, cart_state);
         ecef_traj.add(epoch, ecef_state).unwrap();
         let kep_from_ecef = ecef_traj.to_keplerian(AngleFormat::Radians).unwrap();
-        assert_eq!(kep_from_ecef.frame, OrbitFrame::ECI);
+        assert_eq!(kep_from_ecef.frame, CelestialFrame::ECI);
         assert_eq!(kep_from_ecef.representation, OrbitRepresentation::Keplerian);
         assert_eq!(kep_from_ecef.angle_format, Some(AngleFormat::Radians));
         assert_eq!(kep_from_ecef.len(), 1);
@@ -4983,10 +4272,11 @@ mod tests {
 
         // No transformation needed if already in GCRF
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::GCRF, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::GCRF, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.add(epoch, state_base).unwrap();
         let gcrf_traj = traj.to_gcrf().unwrap();
-        assert_eq!(gcrf_traj.frame, OrbitFrame::GCRF);
+        assert_eq!(gcrf_traj.frame, CelestialFrame::GCRF);
         assert_eq!(gcrf_traj.representation, OrbitRepresentation::Cartesian);
         assert_eq!(gcrf_traj.angle_format, None);
         assert_eq!(gcrf_traj.len(), 1);
@@ -4998,10 +4288,11 @@ mod tests {
 
         // Convert ECI to GCRF (should be same since ECI is treated as GCRF)
         let mut eci_traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         eci_traj.add(epoch, state_base).unwrap();
         let gcrf_from_eci = eci_traj.to_gcrf().unwrap();
-        assert_eq!(gcrf_from_eci.frame, OrbitFrame::GCRF);
+        assert_eq!(gcrf_from_eci.frame, CelestialFrame::GCRF);
         assert_eq!(gcrf_from_eci.representation, OrbitRepresentation::Cartesian);
         assert_eq!(gcrf_from_eci.angle_format, None);
         assert_eq!(gcrf_from_eci.len(), 1);
@@ -5012,13 +4303,16 @@ mod tests {
         }
 
         // Convert EME2000 to GCRF
-        let mut eme2000_traj =
-            SOrbitTrajectory::new(OrbitFrame::EME2000, OrbitRepresentation::Cartesian, None)
-                .unwrap();
+        let mut eme2000_traj = SOrbitTrajectory::new(
+            CelestialFrame::EME2000,
+            OrbitRepresentation::Cartesian,
+            None,
+        )
+        .unwrap();
         let eme2000_state = state_gcrf_to_eme2000(state_base);
         eme2000_traj.add(epoch, eme2000_state).unwrap();
         let gcrf_from_eme2000 = eme2000_traj.to_gcrf().unwrap();
-        assert_eq!(gcrf_from_eme2000.frame, OrbitFrame::GCRF);
+        assert_eq!(gcrf_from_eme2000.frame, CelestialFrame::GCRF);
         assert_eq!(
             gcrf_from_eme2000.representation,
             OrbitRepresentation::Cartesian
@@ -5033,11 +4327,12 @@ mod tests {
 
         // Convert ITRF to GCRF
         let mut itrf_traj =
-            SOrbitTrajectory::new(OrbitFrame::ITRF, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ITRF, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         let itrf_state = state_gcrf_to_itrf(epoch, state_base);
         itrf_traj.add(epoch, itrf_state).unwrap();
         let gcrf_from_itrf = itrf_traj.to_gcrf().unwrap();
-        assert_eq!(gcrf_from_itrf.frame, OrbitFrame::GCRF);
+        assert_eq!(gcrf_from_itrf.frame, CelestialFrame::GCRF);
         assert_eq!(
             gcrf_from_itrf.representation,
             OrbitRepresentation::Cartesian
@@ -5052,7 +4347,7 @@ mod tests {
 
         // Convert Keplerian to GCRF - Radians
         let mut kep_traj = SOrbitTrajectory::new(
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Radians),
         )
@@ -5060,7 +4355,7 @@ mod tests {
         let kep_state_rad = state_eci_to_koe(state_base, RADIANS);
         kep_traj.add(epoch, kep_state_rad).unwrap();
         let gcrf_from_kep_rad = kep_traj.to_gcrf().unwrap();
-        assert_eq!(gcrf_from_kep_rad.frame, OrbitFrame::GCRF);
+        assert_eq!(gcrf_from_kep_rad.frame, CelestialFrame::GCRF);
         assert_eq!(
             gcrf_from_kep_rad.representation,
             OrbitRepresentation::Cartesian
@@ -5075,7 +4370,7 @@ mod tests {
 
         // Convert Keplerian to GCRF - Degrees
         let mut kep_traj_deg = SOrbitTrajectory::new(
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Degrees),
         )
@@ -5083,7 +4378,7 @@ mod tests {
         let kep_state_deg = state_eci_to_koe(state_base, DEGREES);
         kep_traj_deg.add(epoch, kep_state_deg).unwrap();
         let gcrf_from_kep_deg = kep_traj_deg.to_gcrf().unwrap();
-        assert_eq!(gcrf_from_kep_deg.frame, OrbitFrame::GCRF);
+        assert_eq!(gcrf_from_kep_deg.frame, CelestialFrame::GCRF);
         assert_eq!(
             gcrf_from_kep_deg.representation,
             OrbitRepresentation::Cartesian
@@ -5110,12 +4405,15 @@ mod tests {
         ));
 
         // No transformation needed if already in EME2000
-        let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::EME2000, OrbitRepresentation::Cartesian, None)
-                .unwrap();
+        let mut traj = SOrbitTrajectory::new(
+            CelestialFrame::EME2000,
+            OrbitRepresentation::Cartesian,
+            None,
+        )
+        .unwrap();
         traj.add(epoch, state_base).unwrap();
         let eme2000_traj = traj.to_eme2000().unwrap();
-        assert_eq!(eme2000_traj.frame, OrbitFrame::EME2000);
+        assert_eq!(eme2000_traj.frame, CelestialFrame::EME2000);
         assert_eq!(eme2000_traj.representation, OrbitRepresentation::Cartesian);
         assert_eq!(eme2000_traj.angle_format, None);
         assert_eq!(eme2000_traj.len(), 1);
@@ -5127,11 +4425,12 @@ mod tests {
 
         // Convert GCRF to EME2000
         let mut gcrf_traj =
-            SOrbitTrajectory::new(OrbitFrame::GCRF, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::GCRF, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         let gcrf_state = state_eme2000_to_gcrf(state_base);
         gcrf_traj.add(epoch, gcrf_state).unwrap();
         let eme2000_from_gcrf = gcrf_traj.to_eme2000().unwrap();
-        assert_eq!(eme2000_from_gcrf.frame, OrbitFrame::EME2000);
+        assert_eq!(eme2000_from_gcrf.frame, CelestialFrame::EME2000);
         assert_eq!(
             eme2000_from_gcrf.representation,
             OrbitRepresentation::Cartesian
@@ -5146,10 +4445,11 @@ mod tests {
 
         // Convert ECI to EME2000
         let mut eci_traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         eci_traj.add(epoch, gcrf_state).unwrap();
         let eme2000_from_eci = eci_traj.to_eme2000().unwrap();
-        assert_eq!(eme2000_from_eci.frame, OrbitFrame::EME2000);
+        assert_eq!(eme2000_from_eci.frame, CelestialFrame::EME2000);
         assert_eq!(
             eme2000_from_eci.representation,
             OrbitRepresentation::Cartesian
@@ -5164,11 +4464,12 @@ mod tests {
 
         // Convert ITRF to EME2000
         let mut itrf_traj =
-            SOrbitTrajectory::new(OrbitFrame::ITRF, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ITRF, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         let itrf_state = state_gcrf_to_itrf(epoch, gcrf_state);
         itrf_traj.add(epoch, itrf_state).unwrap();
         let eme2000_from_itrf = itrf_traj.to_eme2000().unwrap();
-        assert_eq!(eme2000_from_itrf.frame, OrbitFrame::EME2000);
+        assert_eq!(eme2000_from_itrf.frame, CelestialFrame::EME2000);
         assert_eq!(
             eme2000_from_itrf.representation,
             OrbitRepresentation::Cartesian
@@ -5183,7 +4484,7 @@ mod tests {
 
         // Convert Keplerian to EME2000 - Radians
         let mut kep_traj = SOrbitTrajectory::new(
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Radians),
         )
@@ -5191,7 +4492,7 @@ mod tests {
         let kep_state_rad = state_eci_to_koe(gcrf_state, RADIANS);
         kep_traj.add(epoch, kep_state_rad).unwrap();
         let eme2000_from_kep_rad = kep_traj.to_eme2000().unwrap();
-        assert_eq!(eme2000_from_kep_rad.frame, OrbitFrame::EME2000);
+        assert_eq!(eme2000_from_kep_rad.frame, CelestialFrame::EME2000);
         assert_eq!(
             eme2000_from_kep_rad.representation,
             OrbitRepresentation::Cartesian
@@ -5206,7 +4507,7 @@ mod tests {
 
         // Convert Keplerian to EME2000 - Degrees
         let mut kep_traj_deg = SOrbitTrajectory::new(
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Degrees),
         )
@@ -5214,7 +4515,7 @@ mod tests {
         let kep_state_deg = state_eci_to_koe(gcrf_state, DEGREES);
         kep_traj_deg.add(epoch, kep_state_deg).unwrap();
         let eme2000_from_kep_deg = kep_traj_deg.to_eme2000().unwrap();
-        assert_eq!(eme2000_from_kep_deg.frame, OrbitFrame::EME2000);
+        assert_eq!(eme2000_from_kep_deg.frame, CelestialFrame::EME2000);
         assert_eq!(
             eme2000_from_kep_deg.representation,
             OrbitRepresentation::Cartesian
@@ -5235,7 +4536,8 @@ mod tests {
     fn test_orbittrajectory_stateprovider_state_eci_cartesian() {
         // Test SOrbitStateProvider::state() for ECI Cartesian trajectory
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         // Sparse points half a day apart: HermiteCubic (the new default)
         // overshoots wildly, so request Linear for this midpoint-bracket check.
         traj.set_interpolation_method(InterpolationMethod::Linear);
@@ -5268,7 +4570,8 @@ mod tests {
 
         // Test SOrbitStateProvider::state_eci() for ECI Cartesian trajectory
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
 
         let epoch = Epoch::from_jd(2451545.0, TimeSystem::UTC);
         let state_eci = Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0);
@@ -5286,7 +4589,7 @@ mod tests {
     fn test_orbittrajectory_stateprovider_state_eci_from_keplerian() {
         // Test SOrbitStateProvider::state_eci() for Keplerian trajectory
         let mut traj = SOrbitTrajectory::new(
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Degrees),
         )
@@ -5314,7 +4617,8 @@ mod tests {
 
         // Test SOrbitStateProvider::state_eci() for ECEF Cartesian trajectory
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECEF, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECEF, OrbitRepresentation::Cartesian, None)
+                .unwrap();
 
         let epoch = Epoch::from_jd(2451545.0, TimeSystem::UTC);
         let state_ecef = Vector6::new(7000e3, 0.0, 0.0, 0.0, 0.0, 7.5e3);
@@ -5336,7 +4640,8 @@ mod tests {
     fn test_orbittrajectory_stateprovider_state_gcrf_cartesian() {
         // Test SOrbitStateProvider::state() for ECI Cartesian trajectory
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::GCRF, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::GCRF, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         // Sparse points half a day apart: HermiteCubic (the new default)
         // overshoots wildly, so request Linear for this midpoint-bracket check.
         traj.set_interpolation_method(InterpolationMethod::Linear);
@@ -5369,7 +4674,8 @@ mod tests {
 
         // Test SOrbitStateProvider::state_gcrf() for ECI Cartesian trajectory
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::GCRF, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::GCRF, OrbitRepresentation::Cartesian, None)
+                .unwrap();
 
         let epoch = Epoch::from_jd(2451545.0, TimeSystem::UTC);
         let state_gcrf = Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0);
@@ -5387,7 +4693,7 @@ mod tests {
     fn test_orbittrajectory_stateprovider_state_gcrf_from_keplerian() {
         // Test SOrbitStateProvider::state_gcrf() for Keplerian trajectory
         let mut traj = SOrbitTrajectory::new(
-            OrbitFrame::GCRF,
+            CelestialFrame::GCRF,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Degrees),
         )
@@ -5415,7 +4721,8 @@ mod tests {
 
         // Test SOrbitStateProvider::state_gcrf() for ITRF Cartesian trajectory
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ITRF, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ITRF, OrbitRepresentation::Cartesian, None)
+                .unwrap();
 
         let epoch = Epoch::from_jd(2451545.0, TimeSystem::UTC);
         let state_itrf = Vector6::new(7000e3, 0.0, 0.0, 0.0, 0.0, 7.5e3);
@@ -5439,7 +4746,8 @@ mod tests {
 
         // Test SOrbitStateProvider::state_ecef() for ECEF Cartesian trajectory
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECEF, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECEF, OrbitRepresentation::Cartesian, None)
+                .unwrap();
 
         let epoch = Epoch::from_jd(2451545.0, TimeSystem::UTC);
         let state_ecef = Vector6::new(7000e3, 0.0, 0.0, 0.0, 0.0, 7.5e3);
@@ -5460,7 +4768,8 @@ mod tests {
 
         // Test SOrbitStateProvider::state_ecef() for ECI Cartesian trajectory
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
 
         let epoch = Epoch::from_jd(2451545.0, TimeSystem::UTC);
         let state_eci = Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0);
@@ -5484,7 +4793,7 @@ mod tests {
 
         // Test SOrbitStateProvider::state_ecef() for Keplerian trajectory
         let mut traj = SOrbitTrajectory::new(
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Degrees),
         )
@@ -5513,7 +4822,8 @@ mod tests {
 
         // Test SOrbitStateProvider::state_itrf() for ECEF Cartesian trajectory
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ITRF, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ITRF, OrbitRepresentation::Cartesian, None)
+                .unwrap();
 
         let epoch = Epoch::from_jd(2451545.0, TimeSystem::UTC);
         let state_itrf = Vector6::new(7000e3, 0.0, 0.0, 0.0, 0.0, 7.5e3);
@@ -5534,7 +4844,8 @@ mod tests {
 
         // Test SOrbitStateProvider::state_itrf() for ECI Cartesian trajectory
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::GCRF, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::GCRF, OrbitRepresentation::Cartesian, None)
+                .unwrap();
 
         let epoch = Epoch::from_jd(2451545.0, TimeSystem::UTC);
         let state_eci = Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0);
@@ -5558,7 +4869,7 @@ mod tests {
 
         // Test SOrbitStateProvider::state_itrf() for Keplerian trajectory
         let mut traj = SOrbitTrajectory::new(
-            OrbitFrame::GCRF,
+            CelestialFrame::GCRF,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Degrees),
         )
@@ -5584,9 +4895,12 @@ mod tests {
     #[parallel]
     fn test_orbittrajectory_stateprovider_state_eme2000() {
         // Test SOrbitStateProvider::state_eme2000() for EME2000 Cartesian trajectory
-        let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::EME2000, OrbitRepresentation::Cartesian, None)
-                .unwrap();
+        let mut traj = SOrbitTrajectory::new(
+            CelestialFrame::EME2000,
+            OrbitRepresentation::Cartesian,
+            None,
+        )
+        .unwrap();
 
         let epoch = Epoch::from_jd(2451545.0, TimeSystem::UTC);
         let state_eme2000 = Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0);
@@ -5605,7 +4919,7 @@ mod tests {
     fn test_orbittrajectory_stateprovider_state_eme2000_from_keplerian() {
         // Test SOrbitStateProvider::state_eme2000() for Keplerian trajectory
         let mut traj = SOrbitTrajectory::new(
-            OrbitFrame::GCRF,
+            CelestialFrame::GCRF,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Degrees),
         )
@@ -5632,7 +4946,8 @@ mod tests {
     fn test_orbittrajectory_stateprovider_state_eme2000_from_gcrf() {
         // Test SOrbitStateProvider::state_eme2000() for GCRF Cartesian trajectory
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::GCRF, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::GCRF, OrbitRepresentation::Cartesian, None)
+                .unwrap();
 
         let epoch = Epoch::from_jd(2451545.0, TimeSystem::UTC);
         let state_gcrf = Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0);
@@ -5656,7 +4971,8 @@ mod tests {
 
         // Test SOrbitStateProvider::state_eme2000() for ITRF Cartesian trajectory
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ITRF, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ITRF, OrbitRepresentation::Cartesian, None)
+                .unwrap();
 
         let epoch = Epoch::from_jd(2451545.0, TimeSystem::UTC);
         let state_itrf = Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0);
@@ -5679,7 +4995,8 @@ mod tests {
     fn test_orbittrajectory_stateprovider_state_koe_from_cartesian() {
         // Test SOrbitStateProvider::state_koe_osc() for ECI Cartesian trajectory
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
 
         let epoch = Epoch::from_jd(2451545.0, TimeSystem::UTC);
         let state_cart = Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0);
@@ -5709,7 +5026,7 @@ mod tests {
     fn test_orbittrajectory_stateprovider_state_koe_from_keplerian() {
         // Test SOrbitStateProvider::state_koe_osc() for Keplerian trajectory
         let mut traj = SOrbitTrajectory::new(
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Degrees),
         )
@@ -5753,7 +5070,8 @@ mod tests {
 
         // Test SOrbitStateProvider::state_koe_osc() for ECEF Cartesian trajectory
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECEF, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECEF, OrbitRepresentation::Cartesian, None)
+                .unwrap();
 
         let epoch = Epoch::from_jd(2451545.0, TimeSystem::UTC);
         let state_ecef = Vector6::new(7000e3, 0.0, 0.0, 0.0, 0.0, 7.5e3);
@@ -5774,8 +5092,8 @@ mod tests {
     #[test]
     #[parallel]
     fn test_orbittrajectory_identifiable_with_name() {
-        let traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+        let traj = SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+            .unwrap();
         let traj = traj.with_name("Test Trajectory");
 
         assert_eq!(traj.get_name(), Some("Test Trajectory"));
@@ -5784,8 +5102,8 @@ mod tests {
     #[test]
     #[parallel]
     fn test_orbittrajectory_identifiable_with_id() {
-        let traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+        let traj = SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+            .unwrap();
         let traj = traj.with_id(12345);
 
         assert_eq!(traj.get_id(), Some(12345));
@@ -5794,8 +5112,8 @@ mod tests {
     #[test]
     #[parallel]
     fn test_orbittrajectory_identifiable_with_uuid() {
-        let traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+        let traj = SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+            .unwrap();
         let traj = traj.with_new_uuid();
 
         assert!(traj.get_uuid().is_some());
@@ -5805,8 +5123,8 @@ mod tests {
     #[parallel]
     fn test_orbittrajectory_identifiable_with_identity() {
         let uuid = Uuid::now_v7();
-        let traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+        let traj = SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+            .unwrap();
         let traj = traj.with_identity(Some("Test"), Some(uuid), Some(999));
 
         assert_eq!(traj.get_name(), Some("Test"));
@@ -5818,7 +5136,8 @@ mod tests {
     #[parallel]
     fn test_orbittrajectory_identifiable_set_methods() {
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
 
         traj.set_name(Some("Updated Name"));
         assert_eq!(traj.get_name(), Some("Updated Name"));
@@ -5848,7 +5167,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             vec![epoch1, epoch2],
             vec![state1, state2],
-            OrbitFrame::ECI,
+            CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![cov1, cov2]),
@@ -5872,7 +5191,7 @@ mod tests {
         let result = SOrbitTrajectory::from_orbital_data(
             vec![epoch1, epoch2],
             vec![state1, state2],
-            OrbitFrame::ECI,
+            CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![cov1]),
@@ -5890,7 +5209,7 @@ mod tests {
         let result = SOrbitTrajectory::from_orbital_data(
             vec![epoch],
             vec![state],
-            OrbitFrame::ITRF,
+            CelestialFrame::ITRF.into(),
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![cov]),
@@ -5908,7 +5227,7 @@ mod tests {
         let result = SOrbitTrajectory::from_orbital_data(
             vec![epoch],
             vec![state],
-            OrbitFrame::ECEF,
+            CelestialFrame::ECEF.into(),
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![cov]),
@@ -5922,7 +5241,8 @@ mod tests {
         setup_global_test_eop();
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.covariances = Some(Vec::new());
 
         let epoch = Epoch::from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
@@ -5952,7 +5272,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             vec![epoch],
             vec![state],
-            OrbitFrame::ECI,
+            CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![cov]),
@@ -5976,7 +5296,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             vec![epoch],
             vec![state],
-            OrbitFrame::ECI,
+            CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![cov]),
@@ -6004,7 +5324,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             vec![epoch],
             vec![state],
-            OrbitFrame::ECI,
+            CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![cov]),
@@ -6032,7 +5352,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             vec![epoch],
             vec![state],
-            OrbitFrame::GCRF,
+            CelestialFrame::GCRF.into(),
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![cov]),
@@ -6062,7 +5382,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             vec![epoch],
             vec![state],
-            OrbitFrame::EME2000,
+            CelestialFrame::EME2000.into(),
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![cov_eme2000]),
@@ -6108,7 +5428,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             vec![epoch],
             vec![state],
-            OrbitFrame::EME2000,
+            CelestialFrame::EME2000.into(),
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![cov_eme2000]),
@@ -6145,7 +5465,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             vec![epoch],
             vec![state],
-            OrbitFrame::EME2000,
+            CelestialFrame::EME2000.into(),
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![cov_eme2000]),
@@ -6191,7 +5511,7 @@ mod tests {
         let mut traj = SOrbitTrajectory::from_orbital_data(
             vec![epoch],
             vec![state],
-            OrbitFrame::ECI,
+            CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![cov]),
@@ -6240,7 +5560,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             vec![epoch1, epoch2, epoch3],
             vec![state1, state2, state3],
-            OrbitFrame::ECI,
+            CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![cov1, cov2, cov3]),
@@ -6292,7 +5612,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             vec![epoch1, epoch2, epoch3],
             vec![state1, state2, state3],
-            OrbitFrame::ECI,
+            CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![cov1, cov2, cov3]),
@@ -6342,7 +5662,7 @@ mod tests {
         let traj_wasserstein = SOrbitTrajectory::from_orbital_data(
             vec![epoch1, epoch2],
             vec![state1, state2],
-            OrbitFrame::ECI,
+            CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![cov1, cov2]),
@@ -6353,7 +5673,7 @@ mod tests {
         let traj_matrix_sqrt = SOrbitTrajectory::from_orbital_data(
             vec![epoch1, epoch2],
             vec![state1, state2],
-            OrbitFrame::ECI,
+            CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![cov1, cov2]),
@@ -6409,7 +5729,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             vec![epoch],
             vec![state],
-            OrbitFrame::ECI,
+            CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![cov]),
@@ -6453,7 +5773,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             vec![epoch],
             vec![state],
-            OrbitFrame::ECI,
+            CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![cov]),
@@ -6491,12 +5811,12 @@ mod tests {
     #[test]
     #[parallel]
     fn test_orbittrajectory_display() {
-        let traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+        let traj = SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+            .unwrap();
         let display = format!("{}", traj);
         assert_eq!(
             display,
-            "SOrbitTrajectory(frame=ECI, representation=Cartesian, states=0)"
+            "SOrbitTrajectory(frame=GCRF, representation=Cartesian, states=0)"
         );
 
         // Add some states and check display changes
@@ -6510,14 +5830,14 @@ mod tests {
         let display = format!("{}", traj);
         assert_eq!(
             display,
-            "SOrbitTrajectory(frame=ECI, representation=Cartesian, states=2)"
+            "SOrbitTrajectory(frame=GCRF, representation=Cartesian, states=2)"
         );
     }
 
     #[test]
     #[parallel]
     fn test_orbittrajectory_with_interpolation_method() {
-        let traj = SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+        let traj = SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
             .unwrap()
             .with_interpolation_method(InterpolationMethod::Linear);
 
@@ -6527,7 +5847,7 @@ mod tests {
     #[test]
     #[parallel]
     fn test_orbittrajectory_with_eviction_policy_max_size() {
-        let traj = SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+        let traj = SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
             .unwrap()
             .with_eviction_policy_max_size(10)
             .unwrap();
@@ -6541,16 +5861,17 @@ mod tests {
     #[test]
     #[parallel]
     fn test_orbittrajectory_with_eviction_policy_max_size_zero_err() {
-        let result = SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
-            .unwrap()
-            .with_eviction_policy_max_size(0);
+        let result =
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap()
+                .with_eviction_policy_max_size(0);
         assert!(result.is_err());
     }
 
     #[test]
     #[parallel]
     fn test_orbittrajectory_with_eviction_policy_max_age() {
-        let traj = SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+        let traj = SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
             .unwrap()
             .with_eviction_policy_max_age(3600.0)
             .unwrap();
@@ -6564,18 +5885,20 @@ mod tests {
     #[test]
     #[parallel]
     fn test_orbittrajectory_with_eviction_policy_max_age_zero_err() {
-        let result = SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
-            .unwrap()
-            .with_eviction_policy_max_age(0.0);
+        let result =
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap()
+                .with_eviction_policy_max_age(0.0);
         assert!(result.is_err());
     }
 
     #[test]
     #[parallel]
     fn test_orbittrajectory_with_eviction_policy_max_age_negative_err() {
-        let result = SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
-            .unwrap()
-            .with_eviction_policy_max_age(-100.0);
+        let result =
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap()
+                .with_eviction_policy_max_age(-100.0);
         assert!(result.is_err());
     }
 
@@ -6597,7 +5920,7 @@ mod tests {
         let mut traj = SOrbitTrajectory::from_orbital_data(
             vec![t0, t1],
             vec![state1, state2],
-            OrbitFrame::ECI,
+            CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![cov1, cov2]),
@@ -6642,7 +5965,7 @@ mod tests {
         let mut traj = SOrbitTrajectory::from_orbital_data(
             vec![t0, t1],
             vec![state1, state2],
-            OrbitFrame::ECI,
+            CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![cov1, cov2]),
@@ -6715,8 +6038,8 @@ mod tests {
     #[test]
     #[parallel]
     fn test_orbittrajectory_nearest_state_empty_trajectory() {
-        let traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+        let traj = SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+            .unwrap();
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let result = traj.nearest_state(&t0);
@@ -6727,7 +6050,7 @@ mod tests {
     #[parallel]
     fn test_orbittrajectory_with_uuid() {
         let uuid = Uuid::now_v7();
-        let traj = SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None)
+        let traj = SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
             .unwrap()
             .with_uuid(uuid);
 
@@ -6737,16 +6060,16 @@ mod tests {
     #[test]
     #[parallel]
     fn test_orbittrajectory_get_eviction_policy_default() {
-        let traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+        let traj = SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+            .unwrap();
         assert_eq!(traj.get_eviction_policy(), TrajectoryEvictionPolicy::None);
     }
 
     #[test]
     #[parallel]
     fn test_orbittrajectory_timespan_empty() {
-        let traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+        let traj = SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+            .unwrap();
         assert!(traj.timespan().is_none());
     }
 
@@ -6755,7 +6078,8 @@ mod tests {
     fn test_orbittrajectory_timespan_single_state() {
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.add(t0, Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0))
             .unwrap();
 
@@ -6765,16 +6089,16 @@ mod tests {
     #[test]
     #[parallel]
     fn test_orbittrajectory_first_empty() {
-        let traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+        let traj = SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+            .unwrap();
         assert!(traj.first().is_none());
     }
 
     #[test]
     #[parallel]
     fn test_orbittrajectory_last_empty() {
-        let traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+        let traj = SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+            .unwrap();
         assert!(traj.last().is_none());
     }
 
@@ -6786,7 +6110,8 @@ mod tests {
         let t_not_in = t0 + 30.0;
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.add(t0, Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0))
             .unwrap();
         traj.add(t1, Vector6::new(7100e3, 0.0, 0.0, 0.0, 7.5e3, 0.0))
@@ -6801,7 +6126,8 @@ mod tests {
     fn test_orbittrajectory_remove_out_of_bounds() {
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.add(t0, Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0))
             .unwrap();
 
@@ -6814,7 +6140,8 @@ mod tests {
     fn test_orbittrajectory_get_out_of_bounds() {
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.add(t0, Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0))
             .unwrap();
 
@@ -6825,8 +6152,8 @@ mod tests {
     #[test]
     #[parallel]
     fn test_orbittrajectory_index_before_epoch_empty() {
-        let traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+        let traj = SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+            .unwrap();
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let result = traj.index_before_epoch(&t0);
@@ -6840,7 +6167,8 @@ mod tests {
         let t_before = t0 - 60.0;
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.add(t0, Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0))
             .unwrap();
 
@@ -6851,8 +6179,8 @@ mod tests {
     #[test]
     #[parallel]
     fn test_orbittrajectory_index_after_epoch_empty() {
-        let traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+        let traj = SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+            .unwrap();
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let result = traj.index_after_epoch(&t0);
@@ -6866,7 +6194,8 @@ mod tests {
         let t_after = t0 + 60.0;
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.add(t0, Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0))
             .unwrap();
 
@@ -6885,7 +6214,8 @@ mod tests {
         let t1 = t0 + 60.0;
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.set_interpolation_method(InterpolationMethod::Linear);
         traj.add(t0, Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0))
             .unwrap();
@@ -6906,7 +6236,8 @@ mod tests {
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.set_interpolation_method(InterpolationMethod::Lagrange { degree: 2 });
 
         // Add 3 points with quadratic position profile: x = 7000e3 + 1000*t + 0.5*t^2
@@ -6933,7 +6264,8 @@ mod tests {
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.set_interpolation_method(InterpolationMethod::Lagrange { degree: 3 });
 
         // Add 4 points with cubic position profile: x = 7000e3 + 100*t + 0.1*t^2 + 0.001*t^3
@@ -6961,7 +6293,8 @@ mod tests {
         let t1 = t0 + 60.0;
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.set_interpolation_method(InterpolationMethod::HermiteCubic);
 
         // State 0: position = (7000e3, 0, 0), velocity = (100, 7500, 0)
@@ -6989,7 +6322,8 @@ mod tests {
         let t1 = t0 + 60.0;
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.enable_acceleration_storage();
         traj.set_interpolation_method(InterpolationMethod::HermiteQuintic);
 
@@ -7022,7 +6356,8 @@ mod tests {
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.set_interpolation_method(InterpolationMethod::HermiteQuintic);
 
         for i in 0..3 {
@@ -7050,9 +6385,11 @@ mod tests {
 
         // Create trajectory with non-linear position profile
         let mut traj_linear =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         let mut traj_lagrange =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
 
         traj_linear.set_interpolation_method(InterpolationMethod::Linear);
         traj_lagrange.set_interpolation_method(InterpolationMethod::Lagrange { degree: 2 });
@@ -7095,8 +6432,8 @@ mod tests {
     #[test]
     #[parallel]
     fn test_orbittrajectory_acceleration_storage_disabled_by_default() {
-        let traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+        let traj = SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+            .unwrap();
         assert!(!traj.has_accelerations());
     }
 
@@ -7104,7 +6441,8 @@ mod tests {
     #[parallel]
     fn test_orbittrajectory_enable_acceleration_storage() {
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.enable_acceleration_storage();
         assert!(traj.has_accelerations());
     }
@@ -7115,7 +6453,8 @@ mod tests {
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.enable_acceleration_storage();
 
         let state = Vector6::new(7000e3, 0.0, 0.0, 0.0, 7500.0, 0.0);
@@ -7136,7 +6475,8 @@ mod tests {
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.enable_acceleration_storage();
 
         let state = Vector6::new(7000e3, 0.0, 0.0, 0.0, 7500.0, 0.0);
@@ -7162,7 +6502,8 @@ mod tests {
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         // Acceleration storage NOT enabled
         traj.add(t0, Vector6::new(7000e3, 0.0, 0.0, 0.0, 7500.0, 0.0))
             .unwrap();
@@ -7177,7 +6518,8 @@ mod tests {
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.enable_acceleration_storage();
         traj.set_eviction_policy_max_size(2).unwrap();
 
@@ -7208,7 +6550,8 @@ mod tests {
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.set_interpolation_method(InterpolationMethod::HermiteQuintic);
 
         traj.add(t0, Vector6::new(7000e3, 0.0, 0.0, 0.0, 7500.0, 0.0))
@@ -7232,7 +6575,8 @@ mod tests {
     #[parallel]
     fn test_orbittrajectory_stm_enable_stm_storage_empty() {
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         assert!(traj.stms.is_none());
 
         traj.enable_stm_storage();
@@ -7247,7 +6591,8 @@ mod tests {
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.add(t0, Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0))
             .unwrap();
         traj.add(t0 + 60.0, Vector6::new(7100e3, 0.0, 0.0, 0.0, 7.5e3, 0.0))
@@ -7276,7 +6621,8 @@ mod tests {
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.add(t0, Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0))
             .unwrap();
 
@@ -7302,7 +6648,8 @@ mod tests {
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.add(t0, Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0))
             .unwrap();
         traj.enable_stm_storage();
@@ -7320,7 +6667,8 @@ mod tests {
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.add(t0, Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0))
             .unwrap();
         assert!(traj.stms.is_none());
@@ -7340,7 +6688,8 @@ mod tests {
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.add(t0, Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0))
             .unwrap();
 
@@ -7354,7 +6703,8 @@ mod tests {
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.add(t0, Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0))
             .unwrap();
         traj.enable_stm_storage();
@@ -7374,7 +6724,8 @@ mod tests {
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.add(t0, Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0))
             .unwrap();
         // STM storage not enabled
@@ -7389,7 +6740,8 @@ mod tests {
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.add(t0, Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0))
             .unwrap();
         traj.enable_stm_storage();
@@ -7405,7 +6757,8 @@ mod tests {
         let t1 = t0 + 60.0;
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.add(t0, Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0))
             .unwrap();
         traj.add(t1, Vector6::new(7100e3, 0.0, 0.0, 0.0, 7.5e3, 0.0))
@@ -7434,7 +6787,8 @@ mod tests {
         let t1 = t0 + 60.0;
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.add(t0, Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0))
             .unwrap();
         traj.add(t1, Vector6::new(7100e3, 0.0, 0.0, 0.0, 7.5e3, 0.0))
@@ -7462,7 +6816,8 @@ mod tests {
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.enable_stm_storage();
 
         let result = traj.stm_at(t0);
@@ -7475,7 +6830,8 @@ mod tests {
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.add(t0, Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0))
             .unwrap();
         // STM storage not enabled
@@ -7491,7 +6847,8 @@ mod tests {
         let t1 = t0 + 60.0;
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.add(t0, Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0))
             .unwrap();
         traj.add(t1, Vector6::new(7100e3, 0.0, 0.0, 0.0, 7.5e3, 0.0))
@@ -7515,7 +6872,8 @@ mod tests {
     #[parallel]
     fn test_orbittrajectory_sensitivity_enable_sensitivity_storage_empty() {
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         assert!(traj.sensitivities.is_none());
 
         traj.enable_sensitivity_storage(3).unwrap(); // 3 parameters
@@ -7531,7 +6889,8 @@ mod tests {
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.add(t0, Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0))
             .unwrap();
         traj.add(t0 + 60.0, Vector6::new(7100e3, 0.0, 0.0, 0.0, 7.5e3, 0.0))
@@ -7561,7 +6920,8 @@ mod tests {
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.add(t0, Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0))
             .unwrap();
 
@@ -7588,7 +6948,8 @@ mod tests {
     #[parallel]
     fn test_orbittrajectory_sensitivity_enable_sensitivity_storage_zero_param_dim() {
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         assert!(traj.enable_sensitivity_storage(0).is_err());
     }
 
@@ -7598,7 +6959,8 @@ mod tests {
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.add(t0, Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0))
             .unwrap();
         traj.enable_sensitivity_storage(3).unwrap();
@@ -7619,7 +6981,8 @@ mod tests {
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.add(t0, Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0))
             .unwrap();
         assert!(traj.sensitivities.is_none());
@@ -7643,7 +7006,8 @@ mod tests {
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.add(t0, Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0))
             .unwrap();
 
@@ -7657,7 +7021,8 @@ mod tests {
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.add(t0, Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0))
             .unwrap();
 
@@ -7672,7 +7037,8 @@ mod tests {
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.add(t0, Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0))
             .unwrap();
 
@@ -7690,7 +7056,8 @@ mod tests {
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.add(t0, Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0))
             .unwrap();
         traj.enable_sensitivity_storage(3).unwrap();
@@ -7709,7 +7076,8 @@ mod tests {
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.add(t0, Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0))
             .unwrap();
         // Sensitivity storage not enabled
@@ -7724,7 +7092,8 @@ mod tests {
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.add(t0, Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0))
             .unwrap();
         traj.enable_sensitivity_storage(3).unwrap();
@@ -7740,7 +7109,8 @@ mod tests {
         let t1 = t0 + 60.0;
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.add(t0, Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0))
             .unwrap();
         traj.add(t1, Vector6::new(7100e3, 0.0, 0.0, 0.0, 7.5e3, 0.0))
@@ -7769,7 +7139,8 @@ mod tests {
         let t1 = t0 + 60.0;
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.add(t0, Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0))
             .unwrap();
         traj.add(t1, Vector6::new(7100e3, 0.0, 0.0, 0.0, 7.5e3, 0.0))
@@ -7795,7 +7166,8 @@ mod tests {
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.enable_sensitivity_storage(3).unwrap();
 
         let result = traj.sensitivity_at(t0);
@@ -7808,7 +7180,8 @@ mod tests {
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.add(t0, Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0))
             .unwrap();
         // Sensitivity storage not enabled
@@ -7824,7 +7197,8 @@ mod tests {
         let t1 = t0 + 60.0;
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.add(t0, Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0))
             .unwrap();
         traj.add(t1, Vector6::new(7100e3, 0.0, 0.0, 0.0, 7.5e3, 0.0))
@@ -7850,7 +7224,8 @@ mod tests {
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         let state = Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0);
 
         // Add with all None options
@@ -7868,7 +7243,8 @@ mod tests {
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         let state = Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0);
         let cov = SMatrix::<f64, 6, 6>::identity();
         let stm = SMatrix::<f64, 6, 6>::from_diagonal(&Vector6::new(2.0, 2.0, 2.0, 2.0, 2.0, 2.0));
@@ -7900,7 +7276,8 @@ mod tests {
         let t2 = t0 + 30.0; // Middle epoch
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
 
         // Add out of order
         traj.add_full(
@@ -7945,7 +7322,8 @@ mod tests {
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         assert!(traj.covariances.is_none());
 
         let state = Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0);
@@ -7965,7 +7343,8 @@ mod tests {
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         let state = Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0);
         traj.add(t0, state).unwrap();
 
@@ -8003,7 +7382,8 @@ mod tests {
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         assert!(traj.stms.is_none());
 
         let state = Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0);
@@ -8020,7 +7400,8 @@ mod tests {
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         assert!(traj.sensitivities.is_none());
         assert!(traj.sensitivity_param_dim.is_none());
 
@@ -8039,7 +7420,8 @@ mod tests {
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         let state = Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0);
 
         // Sensitivity with wrong row count (should be 6)
@@ -8054,7 +7436,8 @@ mod tests {
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
 
         // First add with 3 columns to establish param_dim
         let state1 = Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0);
@@ -8076,8 +7459,8 @@ mod tests {
     #[test]
     #[parallel]
     fn test_orbittrajectory_to_matrix_empty() {
-        let traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+        let traj = SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+            .unwrap();
 
         let result = traj.to_matrix();
         assert!(result.is_err());
@@ -8089,7 +7472,8 @@ mod tests {
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.add(t0, Vector6::new(7000e3, 100.0, 200.0, 300.0, 7.5e3, 0.5e3))
             .unwrap();
         traj.add(
@@ -8116,7 +7500,8 @@ mod tests {
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         // Covariances not initialized
         assert!(traj.covariances.is_none());
 
@@ -8137,7 +7522,7 @@ mod tests {
         let mut traj = SOrbitTrajectory::from_orbital_data(
             vec![t0 - 60.0],
             vec![initial_state],
-            OrbitFrame::ECI,
+            CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![initial_cov]),
@@ -8164,7 +7549,8 @@ mod tests {
         let t0 = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
 
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.add(t0, Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0))
             .unwrap();
         // Covariances not initialized
@@ -8180,7 +7566,8 @@ mod tests {
 
         // Create trajectory with empty covariances storage enabled
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         traj.covariances = Some(vec![]); // Enabled but empty
 
         let result = traj.covariance(t0);
@@ -8198,7 +7585,7 @@ mod tests {
         let mut traj = SOrbitTrajectory::from_orbital_data(
             vec![t0],
             vec![initial_state],
-            OrbitFrame::ECI,
+            CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![initial_cov]),
@@ -8230,7 +7617,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             vec![t0],
             vec![initial_state],
-            OrbitFrame::ECI,
+            CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![initial_cov]),
@@ -8253,7 +7640,7 @@ mod tests {
         let mut traj = SOrbitTrajectory::from_orbital_data(
             vec![t0],
             vec![initial_state],
-            OrbitFrame::ECI,
+            CelestialFrame::ECI.into(),
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![initial_cov]),
@@ -8284,7 +7671,8 @@ mod tests {
     #[parallel]
     fn test_sorbittrajectory_set_acceleration_at_index_out_of_bounds() {
         let mut traj =
-            SOrbitTrajectory::new(OrbitFrame::ECI, OrbitRepresentation::Cartesian, None).unwrap();
+            SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         let acc = SVector::<f64, 3>::new(0.0, 0.0, 0.0);
         let result = traj.set_acceleration_at(5, acc);
         assert!(matches!(result, Err(BraheError::OutOfBoundsError(_))));
@@ -8297,7 +7685,7 @@ mod tests {
         let result = SOrbitTrajectory::from_orbital_data(
             vec![epoch],
             vec![Vector6::zeros()],
-            OrbitFrame::ECEF,
+            CelestialFrame::ECEF.into(),
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Degrees),
             None,
@@ -8310,9 +7698,9 @@ mod tests {
     fn test_sorbittrajectory_bci_keplerian_barycenter_conversions_err() {
         // Keplerian elements about the Earth-Moon barycenter (NAIF 3) are
         // undefined; every batch conversion that redirects through
-        // bci_keplerian_to_cartesian must surface the barycenter error.
+        // native_cartesian must surface the barycenter error.
         let mut traj = SOrbitTrajectory::new(
-            OrbitFrame::BodyCenteredInertial(3),
+            CelestialFrame::EMBI,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Degrees),
         )
@@ -8331,7 +7719,7 @@ mod tests {
     #[parallel]
     fn test_sorbittrajectory_to_keplerian_missing_angle_format_err() {
         let mut traj = SOrbitTrajectory::new(
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Degrees),
         )
@@ -8349,18 +7737,14 @@ mod tests {
     #[test]
     #[parallel]
     fn test_sorbittrajectory_earth_bci_cartesian_conversions_ok() {
-        // An Earth-centered (NAIF 399) BodyCenteredInertial Cartesian
-        // trajectory routes each batch conversion through the Cartesian
-        // re-centering arm (state_frame_to_frame against GCRF). Earth's
-        // native frame is GCRF, so these run offline against the test EOP.
+        // An Earth-centered Cartesian trajectory routes each batch
+        // conversion through the frame router against GCRF, so these run
+        // offline against the test EOP.
         setup_global_test_eop();
 
-        let mut traj = SOrbitTrajectory::new(
-            OrbitFrame::BodyCenteredInertial(399),
-            OrbitRepresentation::Cartesian,
-            None,
-        )
-        .unwrap();
+        let mut traj =
+            SOrbitTrajectory::new(CelestialFrame::GCRF, OrbitRepresentation::Cartesian, None)
+                .unwrap();
         let epoch = Epoch::from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
         let state = Vector6::new(7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0);
         traj.add(epoch, state).unwrap();
@@ -8370,5 +7754,167 @@ mod tests {
         assert_eq!(traj.to_ecef().unwrap().len(), 1);
         assert_eq!(traj.to_itrf().unwrap().len(), 1);
         assert_eq!(traj.to_eme2000().unwrap().len(), 1);
+    }
+
+    // =========================================================================
+    // to_frame / ReferenceFrame Tests
+    // =========================================================================
+
+    /// Ten GCRF Cartesian samples over a quarter of a LEO orbit.
+    fn sample_leo_trajectory() -> SOrbitTrajectory {
+        let epoch = Epoch::from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+        let oe = Vector6::new(R_EARTH + 500e3, 0.001, 97.8, 15.0, 30.0, 45.0);
+        let mut traj =
+            SOrbitTrajectory::new(CelestialFrame::GCRF, OrbitRepresentation::Cartesian, None)
+                .unwrap();
+        for i in 0..10 {
+            let mut elements = oe;
+            elements[5] += 3.0 * i as f64;
+            traj.add(epoch + 60.0 * i as f64, state_koe_to_eci(elements, DEGREES))
+                .unwrap();
+        }
+        traj
+    }
+
+    #[test]
+    #[serial]
+    fn test_sorbittrajectory_to_frame_matches_named_wrappers_bitwise() {
+        setup_global_test_eop();
+        let traj = sample_leo_trajectory();
+
+        let itrf = traj.to_frame(CelestialFrame::ITRF).unwrap();
+        assert_eq!(itrf.frame, CelestialFrame::ITRF);
+        assert_eq!(itrf.states, traj.to_itrf().unwrap().states);
+        assert_eq!(
+            traj.to_frame(CelestialFrame::EME2000).unwrap().states,
+            traj.to_eme2000().unwrap().states
+        );
+
+        // The wrappers agree with the pairwise functions they replaced.
+        for (i, (e, s)) in (&traj).into_iter().enumerate() {
+            let expected = state_gcrf_to_itrf(e, s);
+            for k in 0..6 {
+                assert_eq!(itrf.states[i][k], expected[k]);
+            }
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_sorbittrajectory_to_frame_tod_and_lunar_and_round_trip() {
+        setup_global_test_eop();
+        crate::utils::testing::setup_global_test_spice();
+        crate::spice::load_spice_kernel("moon_pa_de440").unwrap();
+        let traj = sample_leo_trajectory();
+
+        let tod = traj.to_frame(CelestialFrame::TOD).unwrap();
+        assert_eq!(tod.frame, CelestialFrame::TOD);
+        let back = tod.to_frame(CelestialFrame::GCRF).unwrap();
+        for i in 0..traj.len() {
+            for k in 0..3 {
+                assert_abs_diff_eq!(back.states[i][k], traj.states[i][k], epsilon = 1e-6);
+                assert_abs_diff_eq!(back.states[i][k + 3], traj.states[i][k + 3], epsilon = 1e-9);
+            }
+        }
+
+        // A non-Earth frame re-centers through the router.
+        let lci = traj.to_frame(CelestialFrame::LCI).unwrap();
+        assert_eq!(lci.frame, CelestialFrame::LCI);
+        assert!(lci.states[0].fixed_rows::<3>(0).norm() > 3.0e8);
+        let lfpa = traj.to_frame(CelestialFrame::LFPA).unwrap();
+        assert_eq!(lfpa.frame, CelestialFrame::LFPA);
+    }
+
+    #[test]
+    #[serial]
+    fn test_sorbittrajectory_to_frame_orbit_relative_target_and_state_bci() {
+        setup_global_test_eop();
+        crate::frames::clear_object_registry();
+        let traj = sample_leo_trajectory();
+
+        // Register the trajectory itself and express it in its own RTN frame.
+        crate::frames::register_object("CHIEF", traj.clone(), CelestialFrame::GCRF).unwrap();
+        let rtn = traj.to_frame(ReferenceFrame::RTN("CHIEF")).unwrap();
+        assert_eq!(rtn.frame, ReferenceFrame::RTN("CHIEF"));
+
+        // The trajectory is its own chief, so its RTN position is zero.
+        for i in 0..traj.len() {
+            for k in 0..3 {
+                assert_abs_diff_eq!(rtn.states[i][k], 0.0, epsilon = 1e-6);
+            }
+        }
+
+        // state_bci on an orbit-relative trajectory resolves GCRF through the
+        // chief's declared frame.
+        let e = traj.epochs[3];
+        let bci = rtn.state_bci(e).unwrap();
+        let expected = traj.state_gcrf(e).unwrap();
+        for k in 0..3 {
+            assert_abs_diff_eq!(bci[k], expected[k], epsilon = 1e-3);
+        }
+
+        crate::frames::clear_object_registry();
+    }
+
+    #[test]
+    #[parallel]
+    fn test_sorbittrajectory_keplerian_frame_rule() {
+        assert!(
+            SOrbitTrajectory::new(
+                CelestialFrame::ITRF,
+                OrbitRepresentation::Keplerian,
+                Some(DEGREES)
+            )
+            .is_err()
+        );
+        assert!(
+            SOrbitTrajectory::new(
+                CelestialFrame::TOD,
+                OrbitRepresentation::Keplerian,
+                Some(DEGREES)
+            )
+            .is_err()
+        );
+        assert!(
+            SOrbitTrajectory::new(
+                ReferenceFrame::RTN("SC"),
+                OrbitRepresentation::Keplerian,
+                Some(DEGREES)
+            )
+            .is_err()
+        );
+        assert!(
+            SOrbitTrajectory::new(
+                CelestialFrame::EME2000,
+                OrbitRepresentation::Keplerian,
+                Some(DEGREES)
+            )
+            .is_ok()
+        );
+        assert!(
+            SOrbitTrajectory::new(
+                CelestialFrame::LCI,
+                OrbitRepresentation::Keplerian,
+                Some(DEGREES)
+            )
+            .is_ok()
+        );
+        assert!(
+            SOrbitTrajectory::new(
+                ReferenceFrame::RTN("SC"),
+                OrbitRepresentation::Cartesian,
+                None
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    #[parallel]
+    fn test_sorbittrajectory_frame_display_uses_celestial_names() {
+        let traj = SOrbitTrajectory::new(CelestialFrame::ECI, OrbitRepresentation::Cartesian, None)
+            .unwrap();
+        assert_eq!(traj.frame.to_string(), "GCRF");
+        assert!(traj.frame == CelestialFrame::GCRF);
     }
 }

--- a/src/trajectories/sorbit_trajectory.rs
+++ b/src/trajectories/sorbit_trajectory.rs
@@ -5065,6 +5065,32 @@ mod tests {
 
     #[test]
     #[parallel]
+    fn test_orbittrajectory_stateprovider_state_koe_from_keplerian_radians_to_degrees() {
+        // Test SOrbitStateProvider::state_koe_osc() converting native radians to degrees
+        let mut traj = SOrbitTrajectory::new(
+            CelestialFrame::ECI,
+            OrbitRepresentation::Keplerian,
+            Some(AngleFormat::Radians),
+        )
+        .unwrap();
+
+        let epoch = Epoch::from_jd(2451545.0, TimeSystem::UTC);
+        let state_kep_rad = Vector6::new(R_EARTH + 500e3, 0.001, 1.71, 0.26, 0.52, 0.79);
+        traj.add(epoch, state_kep_rad).unwrap();
+
+        let result_deg = traj.state_koe_osc(epoch, AngleFormat::Degrees).unwrap();
+
+        assert_abs_diff_eq!(result_deg[0], state_kep_rad[0], epsilon = 1e-6);
+        assert_abs_diff_eq!(result_deg[1], state_kep_rad[1], epsilon = 1e-9);
+
+        use crate::constants::math::RAD2DEG;
+        for i in 2..6 {
+            assert_abs_diff_eq!(result_deg[i], state_kep_rad[i] * RAD2DEG, epsilon = 1e-9);
+        }
+    }
+
+    #[test]
+    #[parallel]
     fn test_orbittrajectory_stateprovider_state_koe_from_ecef() {
         setup_global_test_eop();
 
@@ -5414,6 +5440,26 @@ mod tests {
         for i in 0..6 {
             assert_abs_diff_eq!(cov_eci[(i, i)], 100.0, epsilon = 1e-3);
         }
+    }
+
+    #[test]
+    #[parallel]
+    fn test_covariance_eci_error_ecef() {
+        setup_global_test_eop();
+
+        let mut traj =
+            SOrbitTrajectory::new(CelestialFrame::ECEF, OrbitRepresentation::Cartesian, None)
+                .unwrap();
+        traj.covariances = Some(Vec::new());
+
+        let epoch = Epoch::from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, TimeSystem::UTC);
+        let state = Vector6::new(R_EARTH + 500e3, 0.0, 0.0, 0.0, 0.0, 7500.0);
+        let cov = SMatrix::<f64, 6, 6>::identity();
+        traj.add_state_and_covariance(epoch, state, cov).unwrap();
+
+        // ECEF covariances cannot be transformed to ECI
+        let result = traj.covariance_eci(epoch);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/src/trajectories/sorbit_trajectory.rs
+++ b/src/trajectories/sorbit_trajectory.rs
@@ -47,7 +47,7 @@ use uuid::Uuid;
 
 use crate::constants::AngleFormat;
 use crate::constants::{DEG2RAD, RAD2DEG};
-use crate::coordinates::{state_eci_to_koe, state_inertial_to_koe_gm, state_koe_to_inertial_gm};
+use crate::coordinates::{state_inertial_to_koe_gm, state_koe_to_inertial_gm};
 use crate::frames::{
     CelestialFrame, ReferenceFrame, celestial_root, icrf_aligned_inertial,
     rotation_eme2000_to_gcrf, state_frame_to_frame,
@@ -62,7 +62,6 @@ use crate::propagators::traits::{
     SCovarianceProvider, SOrbitCovarianceProvider, SOrbitStateProvider, SStateProvider,
 };
 use crate::relative_motion::rotation_eci_to_rtn;
-use crate::spice::NAIFId;
 use crate::time::Epoch;
 use crate::utils::{BraheError, Identifiable};
 
@@ -1854,29 +1853,20 @@ impl OrbitalTrajectory for SOrbitTrajectory {
                 }
             }
             OrbitRepresentation::Cartesian => {
-                if celestial_root(&self.frame)?.center_naif_id() != NAIFId::Earth.id() {
-                    return Err(BraheError::Error(
-                        "to_keplerian labels its result ECI, which is undefined for a \
-                         trajectory centered on another body; use state_koe_osc for \
-                         per-epoch elements about the trajectory's own center"
-                            .to_string(),
-                    ));
+                let center = keplerian_center(&self.frame)?;
+                let cb = CentralBody::from_naif_id(center)?;
+                if cb.is_barycenter() {
+                    return Err(BraheError::Error(format!(
+                        "Keplerian elements are undefined about massless barycenter {}",
+                        center
+                    )));
                 }
-                // Route to GCRF, then take two-body elements about the Earth.
-                let gcrf = self.to_frame(CelestialFrame::GCRF)?;
-                gcrf.states
+                let gm = cb.gm();
+                self.states
                     .iter()
-                    .map(|s| state_eci_to_koe(*s, angle_format))
+                    .map(|s| state_inertial_to_koe_gm(*s, gm, angle_format))
                     .collect()
             }
-        };
-
-        // Cartesian samples are relabeled GCRF; element samples keep the
-        // frame their elements are already referenced to.
-        let frame = if self.representation == OrbitRepresentation::Cartesian {
-            CelestialFrame::GCRF.into()
-        } else {
-            self.frame.clone()
         };
 
         Ok(Self {
@@ -1892,7 +1882,7 @@ impl OrbitalTrajectory for SOrbitTrajectory {
             eviction_policy: self.eviction_policy,
             max_size: self.max_size,
             max_age: self.max_age,
-            frame,
+            frame: self.frame.clone(),
             representation: OrbitRepresentation::Keplerian,
             angle_format: Some(angle_format),
             name: self.name.clone(),
@@ -2281,8 +2271,9 @@ impl Identifiable for SOrbitTrajectory {
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
-    use crate::constants::{DEGREES, R_EARTH, RADIANS};
-    use crate::coordinates::state_koe_to_eci;
+    use crate::constants::math::RAD2DEG;
+    use crate::constants::{DEGREES, GM_MOON, R_EARTH, R_MOON, RADIANS};
+    use crate::coordinates::{state_eci_to_koe, state_koe_to_eci};
     use crate::frames::{
         state_ecef_to_eci, state_eci_to_ecef, state_eme2000_to_gcrf, state_gcrf_to_eme2000,
         state_gcrf_to_itrf, state_itrf_to_gcrf,
@@ -2296,9 +2287,9 @@ mod tests {
     #[test]
     #[serial]
     fn test_sorbittrajectory_bci_all_frame_conversions() {
-        // BCI(301) arms: provider trait accessors, state_eci/gcrf/ecef/itrf/
+        // LCI arms: provider trait accessors, state_eci/gcrf/ecef/itrf/
         // eme2000/koe_osc, all five to_* batch conversions, and covariance
-        // passthrough. Mirrors the DOrbitTrajectory BCI tests.
+        // passthrough. Mirrors the DOrbitTrajectory LCI tests.
         use crate::frames::CelestialFrame;
         setup_global_test_eop();
         crate::utils::testing::setup_global_test_spice();
@@ -2504,7 +2495,14 @@ mod tests {
                 .contains("barycenter")
         );
 
-        assert!(traj_emb.to_keplerian(AngleFormat::Degrees).is_err());
+        // to_keplerian is undefined about a massless barycenter.
+        assert!(
+            traj_emb
+                .to_keplerian(AngleFormat::Degrees)
+                .unwrap_err()
+                .to_string()
+                .contains("barycenter")
+        );
     }
 
     fn create_test_trajectory() -> SOrbitTrajectory {
@@ -4154,21 +4152,70 @@ mod tests {
             assert_abs_diff_eq!(state_out[i], state_kep_deg[i], epsilon = tol);
         }
 
-        // Convert ECEF to Keplerian Degrees
+        // ECEF is Earth-fixed, so it admits no Keplerian elements.
         let mut ecef_traj =
             SOrbitTrajectory::new(CelestialFrame::ECEF, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let ecef_state = state_eci_to_ecef(epoch, cart_state);
         ecef_traj.add(epoch, ecef_state).unwrap();
-        let kep_from_ecef = ecef_traj.to_keplerian(AngleFormat::Degrees).unwrap();
-        assert_eq!(kep_from_ecef.frame, CelestialFrame::ECI);
-        assert_eq!(kep_from_ecef.representation, OrbitRepresentation::Keplerian);
-        assert_eq!(kep_from_ecef.angle_format, Some(AngleFormat::Degrees));
-        assert_eq!(kep_from_ecef.len(), 1);
-        let (epoch_out, state_out) = kep_from_ecef.get(0).unwrap();
-        assert_eq!(epoch_out, epoch);
+        assert!(
+            ecef_traj
+                .to_keplerian(AngleFormat::Degrees)
+                .unwrap_err()
+                .to_string()
+                .contains("inertial frame")
+        );
+    }
+
+    #[test]
+    #[parallel]
+    fn test_sorbittrajectory_to_keplerian_uses_the_frame_center() {
+        setup_global_test_eop();
+
+        let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
+
+        // A circular lunar orbit declared in LCI: elements are taken about the
+        // Moon and keep the trajectory's own frame.
+        let r_moon = R_MOON + 100e3;
+        let v_moon = (GM_MOON / r_moon).sqrt();
+        let mut lci =
+            SOrbitTrajectory::new(CelestialFrame::LCI, OrbitRepresentation::Cartesian, None)
+                .unwrap();
+        lci.add(epoch, Vector6::new(r_moon, 0.0, 0.0, 0.0, v_moon, 0.0))
+            .unwrap();
+
+        let lci_kep = lci.to_keplerian(AngleFormat::Degrees).unwrap();
+        assert_eq!(lci_kep.frame, CelestialFrame::LCI);
+        assert_eq!(lci_kep.representation, OrbitRepresentation::Keplerian);
+        assert_abs_diff_eq!(lci_kep.states[0][0], r_moon, epsilon = 1e-6);
+        assert_abs_diff_eq!(lci_kep.states[0][1], 0.0, epsilon = 1e-9);
+
+        // Earth-centered Cartesian input matches the pairwise Earth conversion
+        // exactly and keeps its GCRF label.
+        let x_gcrf = Vector6::new(R_EARTH + 500e3, 0.0, 0.0, 0.0, 7.6e3, 10.0);
+        let mut gcrf =
+            SOrbitTrajectory::new(CelestialFrame::GCRF, OrbitRepresentation::Cartesian, None)
+                .unwrap();
+        gcrf.add(epoch, x_gcrf).unwrap();
+
+        let gcrf_kep = gcrf.to_keplerian(AngleFormat::Degrees).unwrap();
+        assert_eq!(gcrf_kep.frame, CelestialFrame::GCRF);
+        let expected = state_eci_to_koe(x_gcrf, AngleFormat::Degrees);
         for i in 0..6 {
-            assert_abs_diff_eq!(state_out[i], state_kep_deg[i], epsilon = tol);
+            assert_eq!(gcrf_kep.states[0][i], expected[i]);
+        }
+
+        // Earth-fixed and of-date frames admit no Keplerian elements.
+        for frame in [CelestialFrame::ITRF, CelestialFrame::TOD] {
+            let mut traj =
+                SOrbitTrajectory::new(frame, OrbitRepresentation::Cartesian, None).unwrap();
+            traj.add(epoch, x_gcrf).unwrap();
+            assert!(
+                traj.to_keplerian(AngleFormat::Degrees)
+                    .unwrap_err()
+                    .to_string()
+                    .contains("inertial frame")
+            );
         }
     }
 
@@ -4240,22 +4287,19 @@ mod tests {
             assert_abs_diff_eq!(state_out[i], state_kep_rad[i], epsilon = tol);
         }
 
-        // Convert ECEF to Keplerian Radians
+        // ECEF is Earth-fixed, so it admits no Keplerian elements.
         let mut ecef_traj =
             SOrbitTrajectory::new(CelestialFrame::ECEF, OrbitRepresentation::Cartesian, None)
                 .unwrap();
         let ecef_state = state_eci_to_ecef(epoch, cart_state);
         ecef_traj.add(epoch, ecef_state).unwrap();
-        let kep_from_ecef = ecef_traj.to_keplerian(AngleFormat::Radians).unwrap();
-        assert_eq!(kep_from_ecef.frame, CelestialFrame::ECI);
-        assert_eq!(kep_from_ecef.representation, OrbitRepresentation::Keplerian);
-        assert_eq!(kep_from_ecef.angle_format, Some(AngleFormat::Radians));
-        assert_eq!(kep_from_ecef.len(), 1);
-        let (epoch_out, state_out) = kep_from_ecef.get(0).unwrap();
-        assert_eq!(epoch_out, epoch);
-        for i in 0..6 {
-            assert_abs_diff_eq!(state_out[i], state_kep_rad[i], epsilon = tol);
-        }
+        assert!(
+            ecef_traj
+                .to_keplerian(AngleFormat::Radians)
+                .unwrap_err()
+                .to_string()
+                .contains("inertial frame")
+        );
     }
 
     #[test]
@@ -5083,7 +5127,6 @@ mod tests {
         assert_abs_diff_eq!(result_deg[0], state_kep_rad[0], epsilon = 1e-6);
         assert_abs_diff_eq!(result_deg[1], state_kep_rad[1], epsilon = 1e-9);
 
-        use crate::constants::math::RAD2DEG;
         for i in 2..6 {
             assert_abs_diff_eq!(result_deg[i], state_kep_rad[i] * RAD2DEG, epsilon = 1e-9);
         }
@@ -7883,20 +7926,23 @@ mod tests {
         let rtn = traj.to_frame(ReferenceFrame::RTN("CHIEF")).unwrap();
         assert_eq!(rtn.frame, ReferenceFrame::RTN("CHIEF"));
 
-        // The trajectory is its own chief, so its RTN position is zero.
+        // The trajectory is its own chief, so both its RTN position and its
+        // RTN velocity, which includes the angular-velocity transport term,
+        // are zero.
         for i in 0..traj.len() {
-            for k in 0..3 {
+            for k in 0..6 {
                 assert_abs_diff_eq!(rtn.states[i][k], 0.0, epsilon = 1e-6);
             }
         }
 
         // state_bci on an orbit-relative trajectory resolves GCRF through the
-        // chief's declared frame.
+        // chief's declared frame, recovering the full Cartesian state.
         let e = traj.epochs[3];
         let bci = rtn.state_bci(e).unwrap();
         let expected = traj.state_gcrf(e).unwrap();
-        for k in 0..3 {
-            assert_abs_diff_eq!(bci[k], expected[k], epsilon = 1e-3);
+        for k in 0..6 {
+            let tol = if k < 3 { 1e-3 } else { 1e-6 };
+            assert_abs_diff_eq!(bci[k], expected[k], epsilon = tol);
         }
 
         crate::frames::clear_object_registry();

--- a/src/trajectories/sorbit_trajectory.rs
+++ b/src/trajectories/sorbit_trajectory.rs
@@ -1681,11 +1681,13 @@ impl OrbitalTrajectory for SOrbitTrajectory {
     fn from_orbital_data(
         epochs: Vec<Epoch>,
         states: Vec<Vector6<f64>>,
-        frame: ReferenceFrame,
+        frame: impl Into<ReferenceFrame>,
         representation: OrbitRepresentation,
         angle_format: Option<AngleFormat>,
         covariances: Option<Vec<SMatrix<f64, 6, 6>>>,
     ) -> Result<Self, BraheError> {
+        let frame = frame.into();
+
         // Validate inputs
         if representation == OrbitRepresentation::Keplerian {
             keplerian_center(&frame)?;
@@ -2623,7 +2625,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             epochs,
             states.clone(),
-            CelestialFrame::ECI.into(),
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -2713,7 +2715,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            CelestialFrame::ECI.into(),
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -2750,7 +2752,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            CelestialFrame::ECI.into(),
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -2787,7 +2789,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             epochs.clone(),
             states,
-            CelestialFrame::ECI.into(),
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -2907,7 +2909,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            CelestialFrame::ECI.into(),
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -2932,7 +2934,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             epochs.clone(),
             states.clone(),
-            CelestialFrame::ECI.into(),
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -2958,7 +2960,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             epochs.clone(),
             states.clone(),
-            CelestialFrame::ECI.into(),
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -3000,7 +3002,7 @@ mod tests {
         let mut traj = SOrbitTrajectory::from_orbital_data(
             epochs.clone(),
             states,
-            CelestialFrame::ECI.into(),
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -3026,7 +3028,7 @@ mod tests {
         let mut traj = SOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            CelestialFrame::ECI.into(),
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -3053,7 +3055,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            CelestialFrame::ECI.into(),
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -3082,7 +3084,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            CelestialFrame::ECI.into(),
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -3129,7 +3131,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            CelestialFrame::ECI.into(),
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -3179,7 +3181,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            CelestialFrame::ECI.into(),
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -3224,7 +3226,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            CelestialFrame::ECI.into(),
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -3357,7 +3359,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            CelestialFrame::ECI.into(),
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -3384,7 +3386,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            CelestialFrame::ECI.into(),
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -3412,7 +3414,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            CelestialFrame::ECI.into(),
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -3470,7 +3472,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            CelestialFrame::ECI.into(),
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -3499,7 +3501,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            CelestialFrame::ECI.into(),
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -3565,7 +3567,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            CelestialFrame::ECI.into(),
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -3605,7 +3607,7 @@ mod tests {
         let single_traj = SOrbitTrajectory::from_orbital_data(
             single_epoch,
             single_state,
-            CelestialFrame::ECI.into(),
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -3634,7 +3636,7 @@ mod tests {
         let mut traj = SOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            CelestialFrame::ECI.into(),
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -3675,7 +3677,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            CelestialFrame::ECI.into(),
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -3717,7 +3719,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            CelestialFrame::ECI.into(),
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -3759,7 +3761,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             epochs,
             states,
-            CelestialFrame::ECI.into(),
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             None,
@@ -5236,7 +5238,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             vec![epoch1, epoch2],
             vec![state1, state2],
-            CelestialFrame::ECI.into(),
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![cov1, cov2]),
@@ -5260,7 +5262,7 @@ mod tests {
         let result = SOrbitTrajectory::from_orbital_data(
             vec![epoch1, epoch2],
             vec![state1, state2],
-            CelestialFrame::ECI.into(),
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![cov1]),
@@ -5278,7 +5280,7 @@ mod tests {
         let result = SOrbitTrajectory::from_orbital_data(
             vec![epoch],
             vec![state],
-            CelestialFrame::ITRF.into(),
+            CelestialFrame::ITRF,
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![cov]),
@@ -5296,7 +5298,7 @@ mod tests {
         let result = SOrbitTrajectory::from_orbital_data(
             vec![epoch],
             vec![state],
-            CelestialFrame::ECEF.into(),
+            CelestialFrame::ECEF,
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![cov]),
@@ -5341,7 +5343,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             vec![epoch],
             vec![state],
-            CelestialFrame::ECI.into(),
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![cov]),
@@ -5365,7 +5367,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             vec![epoch],
             vec![state],
-            CelestialFrame::ECI.into(),
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![cov]),
@@ -5393,7 +5395,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             vec![epoch],
             vec![state],
-            CelestialFrame::ECI.into(),
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![cov]),
@@ -5421,7 +5423,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             vec![epoch],
             vec![state],
-            CelestialFrame::GCRF.into(),
+            CelestialFrame::GCRF,
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![cov]),
@@ -5451,7 +5453,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             vec![epoch],
             vec![state],
-            CelestialFrame::EME2000.into(),
+            CelestialFrame::EME2000,
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![cov_eme2000]),
@@ -5517,7 +5519,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             vec![epoch],
             vec![state],
-            CelestialFrame::EME2000.into(),
+            CelestialFrame::EME2000,
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![cov_eme2000]),
@@ -5554,7 +5556,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             vec![epoch],
             vec![state],
-            CelestialFrame::EME2000.into(),
+            CelestialFrame::EME2000,
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![cov_eme2000]),
@@ -5600,7 +5602,7 @@ mod tests {
         let mut traj = SOrbitTrajectory::from_orbital_data(
             vec![epoch],
             vec![state],
-            CelestialFrame::ECI.into(),
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![cov]),
@@ -5649,7 +5651,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             vec![epoch1, epoch2, epoch3],
             vec![state1, state2, state3],
-            CelestialFrame::ECI.into(),
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![cov1, cov2, cov3]),
@@ -5701,7 +5703,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             vec![epoch1, epoch2, epoch3],
             vec![state1, state2, state3],
-            CelestialFrame::ECI.into(),
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![cov1, cov2, cov3]),
@@ -5751,7 +5753,7 @@ mod tests {
         let traj_wasserstein = SOrbitTrajectory::from_orbital_data(
             vec![epoch1, epoch2],
             vec![state1, state2],
-            CelestialFrame::ECI.into(),
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![cov1, cov2]),
@@ -5762,7 +5764,7 @@ mod tests {
         let traj_matrix_sqrt = SOrbitTrajectory::from_orbital_data(
             vec![epoch1, epoch2],
             vec![state1, state2],
-            CelestialFrame::ECI.into(),
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![cov1, cov2]),
@@ -5818,7 +5820,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             vec![epoch],
             vec![state],
-            CelestialFrame::ECI.into(),
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![cov]),
@@ -5862,7 +5864,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             vec![epoch],
             vec![state],
-            CelestialFrame::ECI.into(),
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![cov]),
@@ -6009,7 +6011,7 @@ mod tests {
         let mut traj = SOrbitTrajectory::from_orbital_data(
             vec![t0, t1],
             vec![state1, state2],
-            CelestialFrame::ECI.into(),
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![cov1, cov2]),
@@ -6054,7 +6056,7 @@ mod tests {
         let mut traj = SOrbitTrajectory::from_orbital_data(
             vec![t0, t1],
             vec![state1, state2],
-            CelestialFrame::ECI.into(),
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![cov1, cov2]),
@@ -7611,7 +7613,7 @@ mod tests {
         let mut traj = SOrbitTrajectory::from_orbital_data(
             vec![t0 - 60.0],
             vec![initial_state],
-            CelestialFrame::ECI.into(),
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![initial_cov]),
@@ -7674,7 +7676,7 @@ mod tests {
         let mut traj = SOrbitTrajectory::from_orbital_data(
             vec![t0],
             vec![initial_state],
-            CelestialFrame::ECI.into(),
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![initial_cov]),
@@ -7706,7 +7708,7 @@ mod tests {
         let traj = SOrbitTrajectory::from_orbital_data(
             vec![t0],
             vec![initial_state],
-            CelestialFrame::ECI.into(),
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![initial_cov]),
@@ -7729,7 +7731,7 @@ mod tests {
         let mut traj = SOrbitTrajectory::from_orbital_data(
             vec![t0],
             vec![initial_state],
-            CelestialFrame::ECI.into(),
+            CelestialFrame::ECI,
             OrbitRepresentation::Cartesian,
             None,
             Some(vec![initial_cov]),
@@ -7774,7 +7776,7 @@ mod tests {
         let result = SOrbitTrajectory::from_orbital_data(
             vec![epoch],
             vec![Vector6::zeros()],
-            CelestialFrame::ECEF.into(),
+            CelestialFrame::ECEF,
             OrbitRepresentation::Keplerian,
             Some(AngleFormat::Degrees),
             None,

--- a/src/trajectories/traits.rs
+++ b/src/trajectories/traits.rs
@@ -6,6 +6,9 @@
  */
 
 use crate::constants::AngleFormat;
+use crate::frames::{
+    CelestialFrame, ReferenceFrame, iau_rotation_model_ids, icrf_aligned_inertial,
+};
 use crate::time::Epoch;
 use crate::utils::BraheError;
 use nalgebra::{DMatrix, SMatrix};
@@ -29,12 +32,16 @@ pub enum TrajectoryEvictionPolicy {
     KeepWithinDuration,
 }
 
-/// Reference-frame-router frame with ICRF-aligned axes centered on `center`,
-/// used to convert `OrbitFrame::BodyCenteredInertial(center)` trajectory
-/// samples (named frames for the bodies that have them, generic
-/// `BodyCenteredICRF` otherwise).
-pub(crate) fn bci_reference_frame(center: i32) -> crate::frames::CelestialFrame {
-    use crate::frames::CelestialFrame;
+/// Reference-frame-router frame with ICRF-aligned axes centered on `center`
+/// (named frames for the bodies that have them, generic `BodyCenteredICRF`
+/// otherwise).
+///
+/// # Arguments
+/// * `center` - NAIF ID of the frame's center
+///
+/// # Returns
+/// * `CelestialFrame`: ICRF-aligned frame centered on `center`
+pub(crate) fn bci_reference_frame(center: i32) -> CelestialFrame {
     match center {
         399 => CelestialFrame::GCRF,
         301 => CelestialFrame::LCI,
@@ -49,68 +56,57 @@ pub(crate) fn bci_reference_frame(center: i32) -> crate::frames::CelestialFrame 
 /// (mirrors `CentralBody::fixed_frame`): `ITRF` for Earth, `LFPA` for the
 /// Moon, `MCMF` for Mars, the compiled-in IAU/WGCCRE frame for bodies in the
 /// embedded rotation table, and `None` for barycenters and unknown bodies.
-pub(crate) fn bci_fixed_frame(center: i32) -> Option<crate::frames::CelestialFrame> {
-    use crate::frames::CelestialFrame;
+///
+/// # Arguments
+/// * `center` - NAIF ID of the body
+///
+/// # Returns
+/// * `Option<CelestialFrame>`: The body-fixed frame, if one is defined
+pub(crate) fn bci_fixed_frame(center: i32) -> Option<CelestialFrame> {
     match center {
         399 => Some(CelestialFrame::ITRF),
         301 => Some(CelestialFrame::LFPA),
         499 => Some(CelestialFrame::MCMF),
-        id if crate::frames::iau_rotation_model_ids().contains(&id) => {
-            Some(CelestialFrame::BodyFixedIAU(id))
-        }
+        id if iau_rotation_model_ids().contains(&id) => Some(CelestialFrame::BodyFixedIAU(id)),
         _ => None,
     }
 }
 
-/// Enumeration of orbit reference frames
-#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub enum OrbitFrame {
-    /// Earth-Centered Inertial (legacy, ambiguous - prefer GCRF or EME2000)
-    ECI,
-    /// Earth-Centered Earth-Fixed (legacy, ambiguous - prefer ITRF)
-    ECEF,
-    /// Geocentric Celestial Reference Frame (IAU 2006/2000A)
-    GCRF,
-    /// International Terrestrial Reference Frame
-    ITRF,
-    /// Earth Mean Equator and Equinox of J2000.0
-    EME2000,
-    /// Body-centered inertial: ICRF-aligned axes centered on the non-Earth
-    /// body with the given NAIF ID (e.g. `BodyCenteredInertial(301)` for
-    /// LCI samples from a Moon-centered propagator, `499` for MCI, `3` for
-    /// EMBI). Earth-frame conversions resolve the center offset through the
-    /// loaded SPK kernels via the reference frame router.
-    BodyCenteredInertial(i32),
-}
-
-impl fmt::Display for OrbitFrame {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            OrbitFrame::ECI => write!(f, "ECI"),
-            OrbitFrame::ECEF => write!(f, "ECEF"),
-            OrbitFrame::GCRF => write!(f, "GCRF"),
-            OrbitFrame::ITRF => write!(f, "ITRF"),
-            OrbitFrame::EME2000 => write!(f, "EME2000"),
-            OrbitFrame::BodyCenteredInertial(center) => write!(f, "BCI({})", center),
+/// Celestial center about which Keplerian elements declared in `frame` are
+/// defined.
+///
+/// Elements are accepted in ICRF-aligned inertial celestial frames and in
+/// `EME2000`. Every other frame (Earth-fixed, of-date, orbit-relative, body)
+/// is rejected.
+///
+/// # Arguments
+/// * `frame` - Frame the elements are declared in
+///
+/// # Returns
+/// * `Ok(i32)`: NAIF ID of the center the elements orbit
+/// * `Err(BraheError)`: If `frame` is not an inertial celestial frame
+pub(crate) fn keplerian_center(frame: &ReferenceFrame) -> Result<i32, BraheError> {
+    match frame {
+        ReferenceFrame::Celestial(c)
+            if *c == CelestialFrame::EME2000 || icrf_aligned_inertial(*c) == *c =>
+        {
+            Ok(c.center_naif_id())
         }
+        _ => Err(BraheError::Error(
+            "Keplerian element trajectories should be in an inertial frame".to_string(),
+        )),
     }
 }
 
-impl fmt::Debug for OrbitFrame {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            OrbitFrame::ECI => write!(f, "OrbitFrame(Earth-Centered Inertial)"),
-            OrbitFrame::ECEF => write!(f, "OrbitFrame(Earth-Centered Earth-Fixed)"),
-            OrbitFrame::GCRF => write!(f, "OrbitFrame(Geocentric Celestial Reference Frame)"),
-            OrbitFrame::ITRF => write!(f, "OrbitFrame(International Terrestrial Reference Frame)"),
-            OrbitFrame::EME2000 => {
-                write!(f, "OrbitFrame(Earth Mean Equator and Equinox of J2000.0)")
-            }
-            OrbitFrame::BodyCenteredInertial(center) => {
-                write!(f, "OrbitFrame(Body-Centered Inertial, NAIF ID {})", center)
-            }
-        }
-    }
+/// Whether covariances may be attached to a trajectory declared in `frame`.
+///
+/// # Arguments
+/// * `frame` - Frame the trajectory is declared in
+///
+/// # Returns
+/// * `bool`: `true` for `GCRF` (equivalently `ECI`) and `EME2000`
+pub(crate) fn covariance_frame_allowed(frame: &ReferenceFrame) -> bool {
+    *frame == CelestialFrame::GCRF || *frame == CelestialFrame::EME2000
 }
 
 /// Enumeration of orbit state representations
@@ -626,7 +622,7 @@ pub trait InterpolatableTrajectory: Trajectory + InterpolationConfig {
 /// Trait for orbital-specific functionality on 6-dimensional trajectories.
 ///
 /// This trait provides methods for working with orbital state trajectories, including
-/// conversions between reference frames (ECI/ECEF), state representations (Cartesian/Keplerian),
+/// conversions between reference frames, state representations (Cartesian/Keplerian),
 /// and angle formats (radians/degrees). It also provides convenient accessors for position
 /// and velocity components.
 ///
@@ -635,8 +631,9 @@ pub trait InterpolatableTrajectory: Trajectory + InterpolationConfig {
 /// interpolation configuration, and state interpolation.
 ///
 /// # Reference Frames
-/// - **ECI (Earth-Centered Inertial)**: GCRF inertial reference frame
-/// - **ECEF (Earth-Centered Earth-Fixed)**: Earth-fixed rotating frame
+/// Any [`crate::frames::ReferenceFrame`]: celestial frames such as `GCRF`,
+/// `ITRF`, `EME2000`, `TOD`, and `LCI`, as well as orbit-relative and body
+/// frames bound to a registered object.
 ///
 /// # State Representations
 /// - **Cartesian**: Position and velocity vectors [x, y, z, vx, vy, vz] in meters and m/s
@@ -650,14 +647,15 @@ pub trait InterpolatableTrajectory: Trajectory + InterpolationConfig {
 /// # Examples
 /// ```rust
 /// use brahe::trajectories::SOrbitTrajectory;
-/// use brahe::traits::{OrbitalTrajectory, OrbitFrame, OrbitRepresentation, Trajectory};
+/// use brahe::traits::{OrbitalTrajectory, OrbitRepresentation, Trajectory};
+/// use brahe::frames::CelestialFrame;
 /// use brahe::AngleFormat;
 /// use brahe::time::{Epoch, TimeSystem};
 /// use nalgebra::Vector6;
 ///
 /// // Create orbital trajectory in ECI Cartesian coordinates
 /// let mut traj = SOrbitTrajectory::new(
-///     OrbitFrame::ECI,
+///     CelestialFrame::ECI,
 ///     OrbitRepresentation::Cartesian,
 ///     None,
 /// )
@@ -677,24 +675,41 @@ pub trait OrbitalTrajectory: InterpolatableTrajectory {
     /// # Arguments
     /// * `epochs` - Vector of epochs
     /// * `states` - Vector of state vectors
-    /// * `frame` - Reference frame (ECI or ECEF)
+    /// * `frame` - Reference frame the states are declared in
     /// * `representation` - State representation (Cartesian or Keplerian)
     /// * `angle_format` - Angle format (None for Cartesian, Radians/Degrees for Keplerian)
     /// * `covariances` - Optional vector of 6x6 covariance matrices corresponding to states
     ///
     /// # Returns
     /// New orbital trajectory with data, or an error if parameters are
-    /// invalid (e.g., None angle_format with Keplerian, Keplerian with ECEF,
-    /// covariances provided for a non-inertial frame, or a covariances length
-    /// that does not match the states length).
+    /// invalid (e.g., None angle_format with Keplerian, Keplerian outside an
+    /// inertial frame, covariances provided for a frame other than GCRF or
+    /// EME2000, or a covariances length that does not match the states
+    /// length).
     fn from_orbital_data(
         epochs: Vec<Epoch>,
         states: Vec<Self::StateVector>,
-        frame: OrbitFrame,
+        frame: ReferenceFrame,
         representation: OrbitRepresentation,
         angle_format: Option<AngleFormat>,
         covariances: Option<Vec<SMatrix<f64, 6, 6>>>,
     ) -> Result<Self, BraheError>
+    where
+        Self: Sized;
+
+    /// Converts every sample to Cartesian coordinates in `frame`, routing
+    /// through the reference frame router. Covariances, state transition
+    /// matrices, sensitivities, and accelerations are dropped.
+    ///
+    /// # Arguments
+    /// * `frame` - Target frame
+    ///
+    /// # Returns
+    /// * `Ok(Self)` - New Cartesian trajectory in `frame`
+    /// * `Err(BraheError)` - If a sample cannot be converted (unbound or
+    ///   unregistered frame, missing ephemeris, or Keplerian elements about
+    ///   a barycenter)
+    fn to_frame(&self, frame: ReferenceFrame) -> Result<Self, BraheError>
     where
         Self: Sized;
 
@@ -907,6 +922,7 @@ pub trait SensitivityStorage: Trajectory {
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
+    use crate::spice::NAIFId;
     use serial_test::parallel;
 
     // =========================================================================
@@ -935,92 +951,68 @@ mod tests {
     }
 
     // =========================================================================
-    // OrbitFrame Display/Debug Tests
+    // Frame Helper Tests
     // =========================================================================
 
     #[test]
     #[parallel]
-    fn test_orbit_frame_display_eci() {
-        let frame = OrbitFrame::ECI;
-        assert_eq!(format!("{}", frame), "ECI");
-    }
-
-    #[test]
-    #[parallel]
-    fn test_orbit_frame_display_ecef() {
-        let frame = OrbitFrame::ECEF;
-        assert_eq!(format!("{}", frame), "ECEF");
-    }
-
-    #[test]
-    #[parallel]
-    fn test_orbit_frame_display_gcrf() {
-        let frame = OrbitFrame::GCRF;
-        assert_eq!(format!("{}", frame), "GCRF");
-    }
-
-    #[test]
-    #[parallel]
-    fn test_orbit_frame_display_itrf() {
-        let frame = OrbitFrame::ITRF;
-        assert_eq!(format!("{}", frame), "ITRF");
-    }
-
-    #[test]
-    #[parallel]
-    fn test_orbit_frame_display_eme2000() {
-        let frame = OrbitFrame::EME2000;
-        assert_eq!(format!("{}", frame), "EME2000");
-    }
-
-    #[test]
-    #[parallel]
-    fn test_orbit_frame_debug_eci() {
-        let frame = OrbitFrame::ECI;
+    fn test_bci_reference_frame_names_known_centers() {
+        assert_eq!(bci_reference_frame(399), CelestialFrame::GCRF);
+        assert_eq!(bci_reference_frame(301), CelestialFrame::LCI);
+        assert_eq!(bci_reference_frame(499), CelestialFrame::MCI);
+        assert_eq!(bci_reference_frame(3), CelestialFrame::EMBI);
+        assert_eq!(bci_reference_frame(0), CelestialFrame::SSBI);
         assert_eq!(
-            format!("{:?}", frame),
-            "OrbitFrame(Earth-Centered Inertial)"
+            bci_reference_frame(599),
+            CelestialFrame::BodyCenteredICRF(599)
         );
     }
 
     #[test]
     #[parallel]
-    fn test_orbit_frame_debug_ecef() {
-        let frame = OrbitFrame::ECEF;
+    fn test_bci_fixed_frame_known_and_unknown_centers() {
+        assert_eq!(bci_fixed_frame(399), Some(CelestialFrame::ITRF));
+        assert_eq!(bci_fixed_frame(301), Some(CelestialFrame::LFPA));
+        assert_eq!(bci_fixed_frame(499), Some(CelestialFrame::MCMF));
         assert_eq!(
-            format!("{:?}", frame),
-            "OrbitFrame(Earth-Centered Earth-Fixed)"
+            bci_fixed_frame(599),
+            Some(CelestialFrame::BodyFixedIAU(599))
         );
+        assert_eq!(bci_fixed_frame(3), None);
+        assert_eq!(bci_fixed_frame(-20001), None);
     }
 
     #[test]
     #[parallel]
-    fn test_orbit_frame_debug_gcrf() {
-        let frame = OrbitFrame::GCRF;
+    fn test_keplerian_center_accepts_only_inertial_frames() {
         assert_eq!(
-            format!("{:?}", frame),
-            "OrbitFrame(Geocentric Celestial Reference Frame)"
+            keplerian_center(&CelestialFrame::GCRF.into()).unwrap(),
+            NAIFId::Earth.id()
         );
+        assert_eq!(
+            keplerian_center(&CelestialFrame::EME2000.into()).unwrap(),
+            NAIFId::Earth.id()
+        );
+        assert_eq!(
+            keplerian_center(&CelestialFrame::LCI.into()).unwrap(),
+            NAIFId::Moon.id()
+        );
+        assert_eq!(keplerian_center(&CelestialFrame::EMBI.into()).unwrap(), 3);
+        assert!(keplerian_center(&CelestialFrame::ITRF.into()).is_err());
+        assert!(keplerian_center(&CelestialFrame::TOD.into()).is_err());
+        assert!(keplerian_center(&CelestialFrame::LFPA.into()).is_err());
+        assert!(keplerian_center(&ReferenceFrame::RTN("SC")).is_err());
     }
 
     #[test]
     #[parallel]
-    fn test_orbit_frame_debug_itrf() {
-        let frame = OrbitFrame::ITRF;
-        assert_eq!(
-            format!("{:?}", frame),
-            "OrbitFrame(International Terrestrial Reference Frame)"
-        );
-    }
-
-    #[test]
-    #[parallel]
-    fn test_orbit_frame_debug_eme2000() {
-        let frame = OrbitFrame::EME2000;
-        assert_eq!(
-            format!("{:?}", frame),
-            "OrbitFrame(Earth Mean Equator and Equinox of J2000.0)"
-        );
+    fn test_covariance_frame_allowed_only_gcrf_and_eme2000() {
+        assert!(covariance_frame_allowed(&CelestialFrame::GCRF.into()));
+        assert!(covariance_frame_allowed(&CelestialFrame::ECI.into()));
+        assert!(covariance_frame_allowed(&CelestialFrame::EME2000.into()));
+        assert!(!covariance_frame_allowed(&CelestialFrame::ITRF.into()));
+        assert!(!covariance_frame_allowed(&CelestialFrame::LCI.into()));
+        assert!(!covariance_frame_allowed(&ReferenceFrame::RTN("SC")));
     }
 
     // =========================================================================

--- a/src/trajectories/traits.rs
+++ b/src/trajectories/traits.rs
@@ -709,6 +709,32 @@ pub trait OrbitalTrajectory: InterpolatableTrajectory {
     /// * `Err(BraheError)` - If a sample cannot be converted (unbound or
     ///   unregistered frame, missing ephemeris, or Keplerian elements about
     ///   a barycenter)
+    ///
+    /// # Examples
+    /// ```rust
+    /// use brahe::eop::*;
+    /// use brahe::trajectories::SOrbitTrajectory;
+    /// use brahe::traits::{OrbitalTrajectory, OrbitRepresentation, Trajectory};
+    /// use brahe::frames::CelestialFrame;
+    /// use brahe::time::{Epoch, TimeSystem};
+    /// use nalgebra::Vector6;
+    ///
+    /// let eop = FileEOPProvider::from_default_file(EOPType::StandardBulletinA, true, EOPExtrapolation::Zero).unwrap();
+    /// set_global_eop_provider(eop);
+    ///
+    /// let mut traj = SOrbitTrajectory::new(
+    ///     CelestialFrame::GCRF,
+    ///     OrbitRepresentation::Cartesian,
+    ///     None,
+    /// )
+    /// .unwrap();
+    ///
+    /// let epoch = Epoch::from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
+    /// traj.add(epoch, Vector6::new(6.678e6, 0.0, 0.0, 0.0, 7.726e3, 0.0)).unwrap();
+    ///
+    /// let itrf = OrbitalTrajectory::to_frame(&traj, CelestialFrame::ITRF.into()).unwrap();
+    /// assert_eq!(itrf.frame, CelestialFrame::ITRF);
+    /// ```
     fn to_frame(&self, frame: ReferenceFrame) -> Result<Self, BraheError>
     where
         Self: Sized;

--- a/src/trajectories/traits.rs
+++ b/src/trajectories/traits.rs
@@ -770,14 +770,20 @@ pub trait OrbitalTrajectory: InterpolatableTrajectory {
 
     /// Convert to Keplerian elements with specified angle format.
     ///
-    /// Returns a new trajectory in Keplerian representation.
+    /// Cartesian samples are converted with a two-body conversion about the
+    /// center of the trajectory's frame, using that body's gravitational
+    /// parameter. Keplerian samples only have their angular elements rescaled.
     ///
     /// # Arguments
     /// * `angle_format` - Format for angular elements (Radians or Degrees, cannot be None)
     ///
     /// # Returns
-    /// * `Ok(Self)` - New trajectory in Keplerian representation
-    /// * `Err(BraheError)` - If the frame is unsupported or conversion fails
+    /// * `Ok(Self)` - New trajectory of Keplerian elements referenced to the
+    ///   trajectory's own frame
+    /// * `Err(BraheError)` - If the frame does not admit Keplerian elements
+    ///   (Earth-fixed, of-date, or orbit-relative frames), if the frame's center
+    ///   is an unknown body or a massless barycenter, or if a Keplerian
+    ///   trajectory is missing its angle format
     fn to_keplerian(&self, angle_format: AngleFormat) -> Result<Self, BraheError>
     where
         Self: Sized;

--- a/src/trajectories/traits.rs
+++ b/src/trajectories/traits.rs
@@ -689,7 +689,7 @@ pub trait OrbitalTrajectory: InterpolatableTrajectory {
     fn from_orbital_data(
         epochs: Vec<Epoch>,
         states: Vec<Self::StateVector>,
-        frame: ReferenceFrame,
+        frame: impl Into<ReferenceFrame>,
         representation: OrbitRepresentation,
         angle_format: Option<AngleFormat>,
         covariances: Option<Vec<SMatrix<f64, 6, 6>>>,

--- a/src/utils/state_providers/combined.rs
+++ b/src/utils/state_providers/combined.rs
@@ -98,10 +98,11 @@ impl<P: DIdentifiableStateProvider> ToPropagatorRefs<P> for [&P] {
 mod tests {
     use super::*;
     use crate::constants::DEGREES;
+    use crate::frames::CelestialFrame;
     use crate::propagators::KeplerianPropagator;
     use crate::propagators::traits::SStatePropagator;
     use crate::time::{Epoch, TimeSystem};
-    use crate::traits::{OrbitFrame, OrbitRepresentation};
+    use crate::traits::OrbitRepresentation;
     use nalgebra::Vector6;
 
     use serial_test::parallel;
@@ -113,7 +114,7 @@ mod tests {
         KeplerianPropagator::new(
             epoch,
             elements,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Keplerian,
             Some(DEGREES),
             60.0,

--- a/src/utils/state_providers/orbit_state.rs
+++ b/src/utils/state_providers/orbit_state.rs
@@ -649,9 +649,10 @@ pub trait DOrbitStateProvider: DStateProvider {
 mod tests {
     use super::*;
     use crate::constants::DEGREES;
+    use crate::frames::CelestialFrame;
     use crate::propagators::KeplerianPropagator;
     use crate::time::{Epoch, TimeSystem};
-    use crate::traits::{OrbitFrame, OrbitRepresentation};
+    use crate::traits::OrbitRepresentation;
     use approx::assert_abs_diff_eq;
     use nalgebra::Vector6;
 
@@ -663,7 +664,7 @@ mod tests {
         KeplerianPropagator::new(
             epoch,
             elements,
-            OrbitFrame::ECI,
+            CelestialFrame::ECI,
             OrbitRepresentation::Keplerian,
             Some(DEGREES),
             60.0,

--- a/tests/access/test_access_window.py
+++ b/tests/access/test_access_window.py
@@ -23,7 +23,7 @@ def create_test_window():
     propagator = bh.KeplerianPropagator(
         epoch,
         oe,
-        frame=bh.OrbitFrame.ECI,
+        frame=bh.CelestialFrame.ECI,
         representation=bh.OrbitRepresentation.KEPLERIAN,
         angle_format=bh.AngleFormat.RADIANS,
         step_size=60.0,
@@ -122,7 +122,7 @@ def test_auto_naming_with_named_location_and_satellite():
     propagator = bh.KeplerianPropagator(
         epoch,
         oe,
-        frame=bh.OrbitFrame.ECI,
+        frame=bh.CelestialFrame.ECI,
         representation=bh.OrbitRepresentation.KEPLERIAN,
         angle_format=bh.AngleFormat.RADIANS,
         step_size=60.0,
@@ -156,7 +156,7 @@ def test_auto_naming_without_names():
     propagator = bh.KeplerianPropagator(
         epoch,
         oe,
-        frame=bh.OrbitFrame.ECI,
+        frame=bh.CelestialFrame.ECI,
         representation=bh.OrbitRepresentation.KEPLERIAN,
         angle_format=bh.AngleFormat.RADIANS,
         step_size=60.0,
@@ -193,7 +193,7 @@ def test_location_satellite_identification():
     propagator = bh.KeplerianPropagator(
         epoch,
         oe,
-        frame=bh.OrbitFrame.ECI,
+        frame=bh.CelestialFrame.ECI,
         representation=bh.OrbitRepresentation.KEPLERIAN,
         angle_format=bh.AngleFormat.RADIANS,
         step_size=60.0,
@@ -293,7 +293,7 @@ def test_counter_increments():
     propagator = bh.KeplerianPropagator(
         epoch,
         oe,
-        frame=bh.OrbitFrame.ECI,
+        frame=bh.CelestialFrame.ECI,
         representation=bh.OrbitRepresentation.KEPLERIAN,
         angle_format=bh.AngleFormat.RADIANS,
         step_size=60.0,

--- a/tests/access/test_compute.py
+++ b/tests/access/test_compute.py
@@ -17,7 +17,7 @@ def create_test_propagator(epoch):
     return bh.KeplerianPropagator(
         epoch,
         oe,
-        frame=bh.OrbitFrame.ECI,
+        frame=bh.CelestialFrame.ECI,
         representation=bh.OrbitRepresentation.KEPLERIAN,
         angle_format=bh.AngleFormat.DEGREES,
         step_size=60.0,
@@ -78,7 +78,7 @@ def test_location_accesses_multiple_sats():
                     0.0,
                 ]
             ),
-            frame=bh.OrbitFrame.ECI,
+            frame=bh.CelestialFrame.ECI,
             representation=bh.OrbitRepresentation.KEPLERIAN,
             angle_format=bh.AngleFormat.DEGREES,
             step_size=60.0,
@@ -95,7 +95,7 @@ def test_location_accesses_multiple_sats():
                     0.0,
                 ]
             ),
-            frame=bh.OrbitFrame.ECI,
+            frame=bh.CelestialFrame.ECI,
             representation=bh.OrbitRepresentation.KEPLERIAN,
             angle_format=bh.AngleFormat.DEGREES,
             step_size=60.0,
@@ -191,7 +191,7 @@ def test_location_accesses_multiple():
                     0.0,
                 ]
             ),
-            frame=bh.OrbitFrame.ECI,
+            frame=bh.CelestialFrame.ECI,
             representation=bh.OrbitRepresentation.KEPLERIAN,
             angle_format=bh.AngleFormat.DEGREES,
             step_size=60.0,
@@ -252,7 +252,7 @@ def test_elevation_boundary_precision():
     propagator = bh.KeplerianPropagator(
         epoch,
         oe,
-        frame=bh.OrbitFrame.ECI,
+        frame=bh.CelestialFrame.ECI,
         representation=bh.OrbitRepresentation.KEPLERIAN,
         angle_format=bh.AngleFormat.DEGREES,
         step_size=60.0,
@@ -1069,7 +1069,7 @@ def test_access_default_uuid_traceability():
     prop2 = bh.KeplerianPropagator(
         epoch,
         np.array([bh.R_EARTH + 500e3, 0.0, 45.0, 60.0, 0.0, 0.0]),
-        frame=bh.OrbitFrame.ECI,
+        frame=bh.CelestialFrame.ECI,
         representation=bh.OrbitRepresentation.KEPLERIAN,
         angle_format=bh.AngleFormat.DEGREES,
         step_size=60.0,

--- a/tests/access/test_custom_constraint_computer_integration.py
+++ b/tests/access/test_custom_constraint_computer_integration.py
@@ -130,7 +130,7 @@ def test_custom_constraint_computer_polar_orbit():
     prop = bh.KeplerianPropagator(
         epoch,
         oe,
-        frame=bh.OrbitFrame.ECI,
+        frame=bh.CelestialFrame.ECI,
         representation=bh.OrbitRepresentation.KEPLERIAN,
         angle_format=bh.AngleFormat.RADIANS,
         step_size=60.0,
@@ -184,7 +184,7 @@ def test_constraint_computer_error_handling():
     propagator = bh.KeplerianPropagator(
         epoch,
         oe,
-        frame=bh.OrbitFrame.ECI,
+        frame=bh.CelestialFrame.ECI,
         representation=bh.OrbitRepresentation.KEPLERIAN,
         angle_format=bh.AngleFormat.RADIANS,
         step_size=60.0,
@@ -242,7 +242,7 @@ def test_constraint_computer_with_stateful_logic():
     propagator = bh.KeplerianPropagator(
         epoch,
         oe,
-        frame=bh.OrbitFrame.ECI,
+        frame=bh.CelestialFrame.ECI,
         representation=bh.OrbitRepresentation.KEPLERIAN,
         angle_format=bh.AngleFormat.RADIANS,
         step_size=60.0,
@@ -298,7 +298,7 @@ def test_constraint_computer_hemisphere_detection():
     prop = bh.KeplerianPropagator(
         epoch,
         oe,
-        frame=bh.OrbitFrame.ECI,
+        frame=bh.CelestialFrame.ECI,
         representation=bh.OrbitRepresentation.KEPLERIAN,
         angle_format=bh.AngleFormat.RADIANS,
         step_size=60.0,
@@ -337,7 +337,7 @@ def test_constraint_computer_hemisphere_detection():
     prop_south = bh.KeplerianPropagator(
         epoch,
         oe_south,
-        frame=bh.OrbitFrame.ECI,
+        frame=bh.CelestialFrame.ECI,
         representation=bh.OrbitRepresentation.KEPLERIAN,
         angle_format=bh.AngleFormat.RADIANS,
         step_size=60.0,

--- a/tests/access/test_custom_property_computer_integration.py
+++ b/tests/access/test_custom_property_computer_integration.py
@@ -89,7 +89,7 @@ def test_custom_property_computer_polar_orbit():
         prop = bh.KeplerianPropagator(
             epoch,
             oe,
-            frame=bh.OrbitFrame.ECI,
+            frame=bh.CelestialFrame.ECI,
             representation=bh.OrbitRepresentation.KEPLERIAN,
             angle_format=bh.AngleFormat.RADIANS,
             step_size=60.0,
@@ -211,7 +211,7 @@ def test_property_computer_error_handling():
     propagator = bh.KeplerianPropagator(
         epoch,
         oe,
-        frame=bh.OrbitFrame.ECI,
+        frame=bh.CelestialFrame.ECI,
         representation=bh.OrbitRepresentation.KEPLERIAN,
         angle_format=bh.AngleFormat.RADIANS,
         step_size=60.0,
@@ -285,7 +285,7 @@ def test_property_computer_is_called():
     propagator = bh.KeplerianPropagator(
         epoch,
         oe,
-        frame=bh.OrbitFrame.ECI,
+        frame=bh.CelestialFrame.ECI,
         representation=bh.OrbitRepresentation.KEPLERIAN,
         angle_format=bh.AngleFormat.RADIANS,
         step_size=60.0,
@@ -368,7 +368,7 @@ def test_property_computer_wrong_signature_raises_error():
     propagator = bh.KeplerianPropagator(
         epoch,
         oe,
-        frame=bh.OrbitFrame.ECI,
+        frame=bh.CelestialFrame.ECI,
         representation=bh.OrbitRepresentation.KEPLERIAN,
         angle_format=bh.AngleFormat.RADIANS,
         step_size=60.0,

--- a/tests/ccsds/test_oem.py
+++ b/tests/ccsds/test_oem.py
@@ -1024,6 +1024,41 @@ def test_OEMSegment_add_trajectory_gcrf_frame(keplerian_trajectory):
     assert states[0].velocity == pytest.approx(list(expected[3:6]), abs=0.001)
 
 
+def test_OEMSegment_add_trajectory_itrf_frame(eop):
+    """An ITRF trajectory written to an ITRF segment takes the same-frame
+    shortcut, so the written states are the stored samples exactly."""
+    epoch = Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, brahe.UTC)
+    traj = brahe.OrbitTrajectory(
+        6,
+        brahe.CelestialFrame.ITRF,
+        brahe.OrbitRepresentation.CARTESIAN,
+        None,
+    )
+    samples = [
+        np.array([brahe.R_EARTH + 500e3, 1.0e5, -2.0e5, 10.0, 7.6e3, -5.0]),
+        np.array([brahe.R_EARTH + 501e3, 1.1e5, -2.1e5, 11.0, 7.5e3, -6.0]),
+        np.array([brahe.R_EARTH + 502e3, 1.2e5, -2.2e5, 12.0, 7.4e3, -7.0]),
+    ]
+    for i, sample in enumerate(samples):
+        traj.add(epoch + i * 60.0, sample)
+
+    seg = OEMSegment(
+        object_name="SAT",
+        object_id="2024-100A",
+        center_name="EARTH",
+        ref_frame="ITRF2000",
+        time_system="UTC",
+        start_time=epoch,
+        stop_time=epoch + 120.0,
+    )
+    seg.add_trajectory(traj)
+
+    assert seg.num_states == len(samples)
+    for written, sample in zip(seg.states, samples):
+        np.testing.assert_array_equal(written.position, sample[:3])
+        np.testing.assert_array_equal(written.velocity, sample[3:6])
+
+
 def test_OEM_trajectory_round_trip(keplerian_trajectory):
     """Test full pipeline: trajectory → OEM → file → load → compare states."""
     epoch, prop = keplerian_trajectory

--- a/tests/orbits/test_mean_elements.py
+++ b/tests/orbits/test_mean_elements.py
@@ -595,7 +595,7 @@ class TestStateKoeMeanOnProviders:
         """Test OrbitTrajectory.state_koe_mean returns different values from osculating."""
         traj = brahe.OrbitTrajectory(
             6,
-            brahe.OrbitFrame.ECI,
+            brahe.CelestialFrame.ECI,
             brahe.OrbitRepresentation.CARTESIAN,
             None,
         )

--- a/tests/plots/test_estimation_state.py
+++ b/tests/plots/test_estimation_state.py
@@ -703,7 +703,7 @@ def solved_bls():
 
     traj = bh.OrbitTrajectory(
         6,
-        bh.OrbitFrame.ECI,
+        bh.CelestialFrame.ECI,
         bh.OrbitRepresentation.CARTESIAN,
         None,
     )

--- a/tests/plots/test_trajectory_3d.py
+++ b/tests/plots/test_trajectory_3d.py
@@ -6,6 +6,8 @@ import plotly.graph_objects as go
 import pytest
 
 import brahe as bh
+from brahe.plots.bodies import resolve_body
+from brahe.plots.trajectory_3d import _coerce_trajectory_frame
 
 
 @pytest.fixture
@@ -49,7 +51,7 @@ def lunar_trajectory():
     return bh.OrbitTrajectory.from_orbital_data(
         epochs,
         states,
-        bh.OrbitFrame.BodyCenteredInertial(301),
+        bh.CelestialFrame.LCI,
         bh.OrbitRepresentation.CARTESIAN,
         None,
         None,
@@ -265,26 +267,37 @@ def test_plot_trajectory_3d_moon_centered(lunar_trajectory):
     plt.close(fig)
 
 
-def test_plot_trajectory_3d_moon_centered_keplerian_rejected():
-    """A Keplerian-representation trajectory in the right frame must be
-    rejected rather than silently plotted as bogus Cartesian data."""
+def test_plot_trajectory_3d_moon_centered_keplerian_converted():
+    """A Keplerian-representation trajectory about a body with a NAIF ID is
+    converted to that body's centered-inertial Cartesian frame rather than
+    being plotted as bogus Cartesian data."""
     epoch = bh.Epoch.from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     traj = bh.OrbitTrajectory(
         6,
-        bh.OrbitFrame.BodyCenteredInertial(301),
+        bh.CelestialFrame.LCI,
         bh.OrbitRepresentation.KEPLERIAN,
         bh.AngleFormat.DEGREES,
     )
     oe = np.array([bh.R_MOON + 100e3, 0.01, 45.0, 0.0, 0.0, 0.0])
-    traj.add(epoch, oe)
+    for i in range(10):
+        oe_i = oe.copy()
+        oe_i[5] = 10.0 * i
+        traj.add(epoch + i * 60.0, oe_i)
 
-    with pytest.raises(ValueError, match="CARTESIAN"):
-        bh.plot_trajectory_3d(
-            [{"trajectory": traj, "label": "LLO"}],
-            central_body="moon",
-            texture="simple",
-            backend="matplotlib",
-        )
+    converted = _coerce_trajectory_frame(traj, resolve_body("moon"))
+    assert converted.frame == bh.CelestialFrame.LCI
+    assert converted.representation == bh.OrbitRepresentation.CARTESIAN
+    radius = np.linalg.norm(converted.to_matrix()[0, 0:3])
+    assert radius == pytest.approx(oe[0] * (1.0 - oe[1]), rel=1e-9)
+
+    fig = bh.plot_trajectory_3d(
+        [{"trajectory": traj, "label": "LLO"}],
+        central_body="moon",
+        texture="simple",
+        backend="matplotlib",
+    )
+    assert fig is not None
+    plt.close(fig)
 
 
 def test_plot_trajectory_3d_custom_body_keplerian_rejected():
@@ -295,7 +308,7 @@ def test_plot_trajectory_3d_custom_body_keplerian_rejected():
     epoch = bh.Epoch.from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, bh.TimeSystem.UTC)
     traj = bh.OrbitTrajectory(
         6,
-        bh.OrbitFrame.BodyCenteredInertial(301),
+        bh.CelestialFrame.LCI,
         bh.OrbitRepresentation.KEPLERIAN,
         bh.AngleFormat.DEGREES,
     )

--- a/tests/plots/test_trajectory_3d.py
+++ b/tests/plots/test_trajectory_3d.py
@@ -7,7 +7,7 @@ import pytest
 
 import brahe as bh
 from brahe.plots.bodies import resolve_body
-from brahe.plots.trajectory_3d import _coerce_trajectory_frame
+from brahe.plots.trajectory_3d import _body_inertial_frame, _coerce_trajectory_frame
 
 
 @pytest.fixture
@@ -353,3 +353,23 @@ def test_plot_trajectory_3d_rejects_removed_kwargs(eci_trajectory):
         bh.plot_trajectory_3d(
             [{"trajectory": eci_trajectory}], None, "km", False, "earth"
         )
+
+
+def test_coerce_trajectory_frame_custom_body_centered_icrf():
+    """A body without a named centered-inertial frame falls back to
+    BodyCenteredICRF on its NAIF ID, and a trajectory already declared there is
+    passed through unchanged."""
+    ceres_naif_id = 2000001
+    frame = _body_inertial_frame(ceres_naif_id)
+    assert frame == bh.CelestialFrame.BodyCenteredICRF(ceres_naif_id)
+
+    epoch = bh.Epoch.from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, bh.TimeSystem.UTC)
+    traj = bh.OrbitTrajectory(6, frame, bh.OrbitRepresentation.CARTESIAN, None)
+    state = np.array([5.0e5, 0.0, 0.0, 0.0, 3.0e2, 0.0])
+    traj.add(epoch, state)
+
+    converted = _coerce_trajectory_frame(
+        traj, {"naif_id": ceres_naif_id, "name": "ceres"}
+    )
+    assert converted.frame == frame
+    np.testing.assert_array_equal(converted.to_matrix()[0, 0:6], state)

--- a/tests/propagators/test_keplerian_propagator.py
+++ b/tests/propagators/test_keplerian_propagator.py
@@ -178,6 +178,48 @@ def test_keplerianpropagator_keplerian_elements_in_eme2000(eop):
     np.testing.assert_allclose(prop.state_gcrf(epoch), x_gcrf, atol=1e-6)
 
 
+def test_keplerianpropagator_propagate_keplerian_elements_in_eme2000(eop):
+    """Rust: test_keplerianpropagator_propagate_keplerian_elements_in_eme2000"""
+    epoch = Epoch.from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, TimeSystem.UTC)
+    x_gcrf = create_cartesian_state()
+    oe_eme2000 = state_eci_to_koe(state_gcrf_to_eme2000(x_gcrf), AngleFormat.DEGREES)
+
+    prop = KeplerianPropagator(
+        epoch,
+        oe_eme2000,
+        CelestialFrame.EME2000,
+        OrbitRepresentation.KEPLERIAN,
+        AngleFormat.DEGREES,
+        60.0,
+    )
+
+    # Independent oracle: the same orbit propagated as a GCRF Cartesian state,
+    # then rotated into EME2000 and converted to elements.
+    oracle = KeplerianPropagator(
+        epoch,
+        x_gcrf,
+        CelestialFrame.GCRF,
+        OrbitRepresentation.CARTESIAN,
+        None,
+        60.0,
+    )
+
+    target = epoch + 3600.0
+    prop.propagate_to(target)
+    oracle.propagate_to(target)
+
+    assert prop.current_epoch() == target
+
+    expected = state_eci_to_koe(
+        state_gcrf_to_eme2000(oracle.current_state()), AngleFormat.DEGREES
+    )
+    elements = prop.current_state()
+    # Semi-major axis is in meters, the remaining elements are dimensionless or
+    # in degrees.
+    assert elements[0] == pytest.approx(expected[0], abs=1e-6)
+    np.testing.assert_allclose(elements[1:], expected[1:], atol=1e-8)
+
+
 def test_keplerianpropagator_new_invalid_angle_format():
     """Test that new() raises when angle_format is None for Keplerian elements"""
     epoch = Epoch.from_jd(TEST_EPOCH_JD, TimeSystem.UTC)

--- a/tests/propagators/test_keplerian_propagator.py
+++ b/tests/propagators/test_keplerian_propagator.py
@@ -10,10 +10,11 @@ import pytest
 from brahe import (
     AngleFormat,
     BraheError,
+    CelestialFrame,
     Epoch,
     KeplerianPropagator,
-    OrbitFrame,
     OrbitRepresentation,
+    ReferenceFrame,
     TimeSystem,
     mean_motion,
     orbital_period,
@@ -64,7 +65,7 @@ def test_keplerianpropagator_new():
     propagator = KeplerianPropagator(
         epoch,
         elements,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.KEPLERIAN,
         AngleFormat.RADIANS,
         60.0,
@@ -77,6 +78,41 @@ def test_keplerianpropagator_new():
     assert abs(state[1] - 0.01) < 1e-10
 
 
+def test_keplerianpropagator_accepts_reference_frame():
+    """The frame argument accepts a CelestialFrame or a ReferenceFrame."""
+    epoch = Epoch.from_jd(TEST_EPOCH_JD, TimeSystem.UTC)
+    elements = create_test_elements()
+
+    propagator = KeplerianPropagator(
+        epoch,
+        elements,
+        ReferenceFrame.celestial(CelestialFrame.GCRF),
+        OrbitRepresentation.KEPLERIAN,
+        AngleFormat.RADIANS,
+        60.0,
+    )
+    assert propagator.trajectory.frame == CelestialFrame.GCRF
+
+    propagator.set_initial_conditions(
+        epoch,
+        elements,
+        ReferenceFrame.celestial(CelestialFrame.EME2000),
+        OrbitRepresentation.KEPLERIAN,
+        AngleFormat.RADIANS,
+    )
+    assert propagator.trajectory.frame == CelestialFrame.EME2000
+
+    with pytest.raises(TypeError):
+        KeplerianPropagator(
+            epoch,
+            elements,
+            "GCRF",
+            OrbitRepresentation.KEPLERIAN,
+            AngleFormat.RADIANS,
+            60.0,
+        )
+
+
 def test_keplerianpropagator_new_invalid_angle_format():
     """Test that new() raises TypeError when angle_format is None for Keplerian elements"""
     epoch = Epoch.from_jd(TEST_EPOCH_JD, TimeSystem.UTC)
@@ -87,7 +123,7 @@ def test_keplerianpropagator_new_invalid_angle_format():
         KeplerianPropagator(
             epoch,
             elements,
-            OrbitFrame.ECI,
+            CelestialFrame.ECI,
             OrbitRepresentation.KEPLERIAN,
             None,  # Invalid: angle_format must be specified for Keplerian
             60.0,
@@ -104,7 +140,7 @@ def test_keplerianpropagator_new_invalid_frame():
         KeplerianPropagator(
             epoch,
             elements,
-            OrbitFrame.ECEF,
+            CelestialFrame.ECEF,
             OrbitRepresentation.KEPLERIAN,
             AngleFormat.RADIANS,
             60.0,
@@ -121,7 +157,7 @@ def test_keplerianpropagator_new_invalid_cartesian_angle_format():
         KeplerianPropagator(
             epoch,
             state,
-            OrbitFrame.ECI,
+            CelestialFrame.ECI,
             OrbitRepresentation.CARTESIAN,
             AngleFormat.RADIANS,
             60.0,
@@ -138,7 +174,7 @@ def test_keplerianpropagator_new_invalid_step_size_negative():
         KeplerianPropagator(
             epoch,
             elements,
-            OrbitFrame.ECI,
+            CelestialFrame.ECI,
             OrbitRepresentation.KEPLERIAN,
             AngleFormat.RADIANS,
             -10.0,
@@ -155,7 +191,7 @@ def test_keplerianpropagator_new_invalid_step_size_zero():
         KeplerianPropagator(
             epoch,
             elements,
-            OrbitFrame.ECI,
+            CelestialFrame.ECI,
             OrbitRepresentation.KEPLERIAN,
             AngleFormat.RADIANS,
             0.0,
@@ -531,7 +567,7 @@ def test_keplerianpropagator_orbitpropagator_set_initial_conditions():
     propagator.set_initial_conditions(
         new_epoch,
         new_elements,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.KEPLERIAN,
         AngleFormat.RADIANS,
     )
@@ -1005,7 +1041,7 @@ def test_orbit_propagator_step():
     prop = KeplerianPropagator(
         epoch,
         elements,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.KEPLERIAN,
         AngleFormat.DEGREES,
         60.0,
@@ -1029,7 +1065,7 @@ def test_orbit_propagator_step_past():
     prop = KeplerianPropagator(
         epoch,
         elements,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.KEPLERIAN,
         AngleFormat.DEGREES,
         60.0,
@@ -1052,7 +1088,7 @@ def test_orbit_propagator_step_past_already_past():
     prop = KeplerianPropagator(
         epoch,
         elements,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.KEPLERIAN,
         AngleFormat.DEGREES,
         60.0,
@@ -1078,7 +1114,7 @@ def test_orbit_propagator_propagate_steps():
     prop = KeplerianPropagator(
         epoch,
         elements,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.KEPLERIAN,
         AngleFormat.DEGREES,
         60.0,
@@ -1104,7 +1140,7 @@ def test_orbit_propagator_propagate_to():
     prop = KeplerianPropagator(
         epoch,
         elements,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.KEPLERIAN,
         AngleFormat.DEGREES,
         60.0,
@@ -1128,7 +1164,7 @@ def test_orbit_propagator_propagate_to_past_epoch():
     prop = KeplerianPropagator(
         epoch,
         elements,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.KEPLERIAN,
         AngleFormat.DEGREES,
         60.0,
@@ -1159,7 +1195,7 @@ def test_state_provider_states():
     prop = KeplerianPropagator(
         epoch,
         elements,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.KEPLERIAN,
         AngleFormat.DEGREES,
         60.0,
@@ -1205,7 +1241,7 @@ def test_state_provider_states_eci():
     prop = KeplerianPropagator(
         epoch,
         elements,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.KEPLERIAN,
         AngleFormat.DEGREES,
         60.0,
@@ -1229,7 +1265,7 @@ def test_state_provider_states_ecef():
     prop = KeplerianPropagator(
         epoch,
         elements,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.KEPLERIAN,
         AngleFormat.DEGREES,
         60.0,
@@ -1253,7 +1289,7 @@ def test_state_provider_states_gcrf():
     prop = KeplerianPropagator(
         epoch,
         elements,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.KEPLERIAN,
         AngleFormat.DEGREES,
         60.0,
@@ -1277,7 +1313,7 @@ def test_state_provider_states_itrf():
     prop = KeplerianPropagator(
         epoch,
         elements,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.KEPLERIAN,
         AngleFormat.DEGREES,
         60.0,
@@ -1304,7 +1340,7 @@ def test_state_provider_states_bci_bcbf_in_frame():
     prop = KeplerianPropagator(
         epoch,
         elements,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.KEPLERIAN,
         AngleFormat.DEGREES,
         60.0,

--- a/tests/propagators/test_keplerian_propagator.py
+++ b/tests/propagators/test_keplerian_propagator.py
@@ -22,6 +22,8 @@ from brahe import (
     state_eci_to_ecef,
     state_eci_to_koe,
     state_eme2000_to_gcrf,
+    state_gcrf_to_eme2000,
+    state_gcrf_to_tod,
     state_itrf_to_gcrf,
     state_koe_to_eci,
 )
@@ -113,13 +115,76 @@ def test_keplerianpropagator_accepts_reference_frame():
         )
 
 
+def test_keplerianpropagator_output_in_tod(eop):
+    """Rust: test_keplerianpropagator_output_in_tod_and_rtn"""
+    epoch = Epoch.from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, TimeSystem.UTC)
+    x_gcrf = create_cartesian_state()
+
+    gcrf_prop = KeplerianPropagator(
+        epoch,
+        x_gcrf,
+        CelestialFrame.GCRF,
+        OrbitRepresentation.CARTESIAN,
+        None,
+        60.0,
+    )
+    tod_prop = KeplerianPropagator(
+        epoch,
+        state_gcrf_to_tod(epoch, x_gcrf),
+        CelestialFrame.TOD,
+        OrbitRepresentation.CARTESIAN,
+        None,
+        60.0,
+    )
+    assert tod_prop.trajectory.frame == CelestialFrame.TOD
+
+    # A true-of-date output frame matches the direct GCRF -> TOD rotation, both
+    # at the initial epoch and after propagation.
+    for dt in (0.0, 600.0):
+        epc = epoch + dt
+        np.testing.assert_allclose(
+            tod_prop.state(epc),
+            state_gcrf_to_tod(epc, gcrf_prop.state(epc)),
+            atol=1e-6,
+        )
+
+    # The inertial accessors are independent of the output frame.
+    np.testing.assert_allclose(tod_prop.state_gcrf(epoch), x_gcrf, atol=1e-6)
+
+
+def test_keplerianpropagator_keplerian_elements_in_eme2000(eop):
+    """Rust: test_keplerianpropagator_keplerian_elements_in_eme2000"""
+    epoch = Epoch.from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, TimeSystem.UTC)
+    x_gcrf = create_cartesian_state()
+
+    # Keplerian output is allowed in any inertial Earth-centered frame, and the
+    # elements are about the Earth in that frame's own axes.
+    x_eme2000 = state_gcrf_to_eme2000(x_gcrf)
+    oe_eme2000 = state_eci_to_koe(x_eme2000, AngleFormat.DEGREES)
+
+    prop = KeplerianPropagator(
+        epoch,
+        oe_eme2000,
+        CelestialFrame.EME2000,
+        OrbitRepresentation.KEPLERIAN,
+        AngleFormat.DEGREES,
+        60.0,
+    )
+    assert prop.trajectory.frame == CelestialFrame.EME2000
+
+    # The elements are realized as Cartesian in EME2000, not treated as GCRF
+    # elements, so the original GCRF state comes back.
+    np.testing.assert_allclose(prop.state_eme2000(epoch), x_eme2000, atol=1e-6)
+    np.testing.assert_allclose(prop.state_gcrf(epoch), x_gcrf, atol=1e-6)
+
+
 def test_keplerianpropagator_new_invalid_angle_format():
-    """Test that new() raises TypeError when angle_format is None for Keplerian elements"""
+    """Test that new() raises when angle_format is None for Keplerian elements"""
     epoch = Epoch.from_jd(TEST_EPOCH_JD, TimeSystem.UTC)
     elements = create_test_elements()
 
-    # This should raise TypeError because angle format cannot be None
-    with pytest.raises(TypeError):
+    # Keplerian elements require an angle format
+    with pytest.raises(BraheError, match="Angle format must be specified"):
         KeplerianPropagator(
             epoch,
             elements,

--- a/tests/propagators/test_numerical_orbit_propagator.py
+++ b/tests/propagators/test_numerical_orbit_propagator.py
@@ -23,7 +23,6 @@ from brahe import (
     IntegratorConfig,
     NumericalOrbitPropagator,
     NumericalPropagationConfig,
-    OrbitFrame,
     TimeSystem,
     VariationalConfig,
     orbital_period,
@@ -6145,7 +6144,7 @@ class TestNumericalOrbitPropagatorCentralBodyStateAccessors:
         prop.propagate_to(epoch + 60.0)
 
         traj = prop.trajectory
-        assert traj.frame == OrbitFrame.BodyCenteredInertial(301)
+        assert traj.frame == CelestialFrame.LCI
         # Earth-frame conversions re-center through SPK: the trajectory's
         # state_eci matches the propagator's own state_eci.
         np.testing.assert_allclose(
@@ -6168,7 +6167,7 @@ class TestNumericalOrbitPropagatorCentralBodyStateAccessors:
             None,
         )
         earth_prop.propagate_to(epoch + 60.0)
-        assert earth_prop.trajectory.frame == OrbitFrame.ECI
+        assert earth_prop.trajectory.frame == CelestialFrame.ECI
         assert np.all(np.isfinite(earth_prop.trajectory.state_eci(epoch)))
 
     def test_lunar_propagation_state_eci_adds_moon_offset(self, naif_cache_setup):

--- a/tests/propagators/test_sgp_propagator.py
+++ b/tests/propagators/test_sgp_propagator.py
@@ -224,19 +224,35 @@ class TestSGPPropagatorMethods:
         prop = brahe.SGPPropagator.from_tle(iss_tle[0], iss_tle[1], 60.0)
 
         prop.set_output_format(
-            brahe.OrbitFrame.ECI, brahe.OrbitRepresentation.CARTESIAN, None
+            brahe.CelestialFrame.ECI, brahe.OrbitRepresentation.CARTESIAN, None
         )
         prop.step()
 
         # Verify it doesn't error and trajectory stores states
         assert prop.trajectory.length > 0
 
+    def test_sgppropagator_set_output_format_reference_frame(self, iss_tle):
+        """set_output_format accepts a ReferenceFrame as well as a CelestialFrame."""
+        prop = brahe.SGPPropagator.from_tle(iss_tle[0], iss_tle[1], 60.0)
+
+        prop.set_output_format(
+            brahe.ReferenceFrame.celestial(brahe.CelestialFrame.ITRF),
+            brahe.OrbitRepresentation.CARTESIAN,
+            None,
+        )
+        prop.step()
+
+        assert prop.trajectory.frame == brahe.CelestialFrame.ITRF
+
+        with pytest.raises(TypeError):
+            prop.set_output_format("ITRF", brahe.OrbitRepresentation.CARTESIAN, None)
+
     def test_sgppropagator_set_output_format_keplerian(self, iss_tle):
         """Test setting output format to ECI Keplerian."""
         prop = brahe.SGPPropagator.from_tle(iss_tle[0], iss_tle[1], 60.0)
 
         prop.set_output_format(
-            brahe.OrbitFrame.ECI,
+            brahe.CelestialFrame.ECI,
             brahe.OrbitRepresentation.KEPLERIAN,
             brahe.AngleFormat.RADIANS,
         )
@@ -250,7 +266,7 @@ class TestSGPPropagatorMethods:
         prop = brahe.SGPPropagator.from_tle(iss_tle[0], iss_tle[1], 60.0)
 
         prop.set_output_format(
-            brahe.OrbitFrame.ECEF, brahe.OrbitRepresentation.CARTESIAN, None
+            brahe.CelestialFrame.ECEF, brahe.OrbitRepresentation.CARTESIAN, None
         )
         prop.step()
 
@@ -262,7 +278,7 @@ class TestSGPPropagatorMethods:
         prop = brahe.SGPPropagator.from_tle(iss_tle[0], iss_tle[1], 60.0)
 
         prop.set_output_format(
-            brahe.OrbitFrame.ECI,
+            brahe.CelestialFrame.ECI,
             brahe.OrbitRepresentation.KEPLERIAN,
             brahe.AngleFormat.DEGREES,
         )
@@ -1923,7 +1939,26 @@ class TestSGPPropagatorBuilder:
         angle_format) must raise RuntimeError from build() rather than
         crashing the interpreter with an unrecoverable Rust panic."""
         builder = brahe.SGPPropagator.builder(*self._omm_args()).output_format(
-            brahe.OrbitFrame.ECI, brahe.OrbitRepresentation.KEPLERIAN, None
+            brahe.CelestialFrame.ECI, brahe.OrbitRepresentation.KEPLERIAN, None
         )
         with pytest.raises(RuntimeError):
             builder.build()
+
+    def test_sgppropagator_builder_output_format_reference_frame(self):
+        """The builder's output_format accepts either frame type and rejects others."""
+        prop = (
+            brahe.SGPPropagator.builder(*self._omm_args())
+            .output_format(
+                brahe.ReferenceFrame.celestial(brahe.CelestialFrame.ITRF),
+                brahe.OrbitRepresentation.CARTESIAN,
+                None,
+            )
+            .build()
+        )
+        prop.step()
+        assert prop.trajectory.frame == brahe.CelestialFrame.ITRF
+
+        with pytest.raises(TypeError):
+            brahe.SGPPropagator.builder(*self._omm_args()).output_format(
+                "ITRF", brahe.OrbitRepresentation.CARTESIAN, None
+            )

--- a/tests/propagators/test_sgp_propagator.py
+++ b/tests/propagators/test_sgp_propagator.py
@@ -261,6 +261,32 @@ class TestSGPPropagatorMethods:
         # Verify it doesn't error and trajectory stores states
         assert prop.trajectory.length > 0
 
+    def test_sgppropagator_output_format_tod(self, iss_tle):
+        """Rust: test_sgppropagator_output_format_tod"""
+        prop = brahe.SGPPropagator.from_tle(iss_tle[0], iss_tle[1], 60.0)
+        epc = prop.epoch
+        expected = brahe.state_itrf_to_tod(epc, prop.state_ecef(epc))
+
+        prop.set_output_format(
+            brahe.CelestialFrame.TOD, brahe.OrbitRepresentation.CARTESIAN, None
+        )
+        assert prop.trajectory.frame == brahe.CelestialFrame.TOD
+        np.testing.assert_allclose(prop.current_state(), expected, atol=1e-6)
+
+        # Non-Earth frames are rejected: Earth-only propagator.
+        with pytest.raises(brahe.BraheError):
+            prop.set_output_format(
+                brahe.CelestialFrame.LCI, brahe.OrbitRepresentation.CARTESIAN, None
+            )
+
+        # Keplerian output requires an inertial frame.
+        with pytest.raises(brahe.BraheError):
+            prop.set_output_format(
+                brahe.CelestialFrame.ITRF,
+                brahe.OrbitRepresentation.KEPLERIAN,
+                brahe.AngleFormat.DEGREES,
+            )
+
     def test_sgppropagator_set_output_format_ecef(self, iss_tle):
         """Test setting output format to ECEF Cartesian."""
         prop = brahe.SGPPropagator.from_tle(iss_tle[0], iss_tle[1], 60.0)

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -287,7 +287,7 @@ def test_register_object_orbit_trajectory_extra_dimensions(clear_frame_registrie
     epc0 = bh.Epoch.from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, bh.UTC)
     x = np.array([bh.R_EARTH + 500e3, 0.0, 0.0, 0.0, 7600.0, 0.0, 1.0, 2.0, 3.0])
     traj = bh.OrbitTrajectory(
-        9, bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None
+        9, bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None
     )
     traj.add(epc0, x)
     bh.register_object("SC", traj, bh.CelestialFrame.GCRF)
@@ -305,7 +305,7 @@ def test_register_object_orbit_trajectory_keplerian_representation_rejected(
     traj = bh.OrbitTrajectory.from_orbital_data(
         [epc0],
         oe,
-        bh.OrbitFrame.ECI,
+        bh.CelestialFrame.ECI,
         bh.OrbitRepresentation.KEPLERIAN,
         bh.AngleFormat.DEGREES,
         None,
@@ -319,7 +319,7 @@ def test_register_object_orbit_trajectory(clear_frame_registries):
     epochs = [epc0]
     x = np.array([[bh.R_EARTH + 500e3, 0.0, 0.0, 0.0, 7600.0, 0.0]])
     traj = bh.OrbitTrajectory.from_orbital_data(
-        epochs, x, bh.OrbitFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None, None
+        epochs, x, bh.CelestialFrame.ECI, bh.OrbitRepresentation.CARTESIAN, None, None
     )
     bh.register_object("SC", traj, bh.CelestialFrame.GCRF)
     # The object's own position expressed in its own RTN frame is the origin.

--- a/tests/trajectories/test_orbit_trajectory.py
+++ b/tests/trajectories/test_orbit_trajectory.py
@@ -13,9 +13,9 @@ from brahe import (
     R_EARTH,
     AngleFormat,
     BraheError,
+    CelestialFrame,
     Epoch,
     InterpolationMethod,
-    OrbitFrame,
     OrbitRepresentation,
     OrbitTrajectory,
     TimeSystem,
@@ -34,7 +34,7 @@ def create_test_trajectory():
     """Helper function to create a test trajectory (mirrors Rust helper)."""
     traj = OrbitTrajectory(
         6,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.KEPLERIAN,
         AngleFormat.DEGREES,
     )
@@ -54,17 +54,95 @@ def create_test_trajectory():
     return traj
 
 
+@pytest.fixture
+def leo_trajectory(eop):
+    """Ten GCRF Cartesian samples of a 500 km circular orbit, 60 s apart."""
+    epoch = Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, brahe.UTC)
+    oe = np.array([R_EARTH + 500e3, 0.001, 97.8, 15.0, 30.0, 45.0])
+    period = brahe.orbital_period(oe[0])
+
+    traj = OrbitTrajectory(6, CelestialFrame.GCRF, OrbitRepresentation.CARTESIAN, None)
+    for i in range(10):
+        oe_i = oe.copy()
+        oe_i[5] = (oe[5] + 360.0 * (i * 60.0) / period) % 360.0
+        traj.add(epoch + i * 60.0, state_koe_to_eci(oe_i, AngleFormat.DEGREES))
+
+    return traj
+
+
+def test_trajectory_frame_is_reference_frame(eop):
+    traj = OrbitTrajectory(6, CelestialFrame.ECI, OrbitRepresentation.CARTESIAN, None)
+    assert traj.frame == CelestialFrame.GCRF
+    assert CelestialFrame.GCRF == traj.frame
+    assert traj.frame == brahe.ReferenceFrame.celestial(CelestialFrame.GCRF)
+    assert traj.frame != CelestialFrame.ITRF
+    assert str(traj.frame) == "GCRF"
+
+
+def test_trajectory_frame_equality_with_other_types(eop):
+    traj = OrbitTrajectory(6, CelestialFrame.ECI, OrbitRepresentation.CARTESIAN, None)
+    assert traj.frame != "GCRF"
+    assert traj.frame != 7
+    assert traj.frame.__eq__("GCRF") is NotImplemented
+    assert traj.frame.__eq__(None) is NotImplemented
+
+
+def test_trajectory_to_frame_matches_wrappers(eop, leo_trajectory):
+    itrf = leo_trajectory.to_frame(CelestialFrame.ITRF)
+    assert itrf.frame == CelestialFrame.ITRF
+    np.testing.assert_array_equal(
+        itrf.to_matrix(), leo_trajectory.to_itrf().to_matrix()
+    )
+
+    tod = leo_trajectory.to_frame(CelestialFrame.TOD)
+    back = tod.to_frame(CelestialFrame.GCRF)
+    np.testing.assert_allclose(
+        back.to_matrix()[:, 0:3], leo_trajectory.to_matrix()[:, 0:3], atol=1e-6
+    )
+
+
+def test_trajectory_to_frame_orbit_relative(eop, leo_trajectory):
+    brahe.clear_object_registry()
+    try:
+        brahe.register_object("CHIEF", leo_trajectory, CelestialFrame.GCRF)
+        rtn = leo_trajectory.to_frame(brahe.ReferenceFrame.RTN("CHIEF"))
+        assert rtn.frame == brahe.ReferenceFrame.RTN("CHIEF")
+        np.testing.assert_allclose(rtn.to_matrix()[:, 0:3], 0.0, atol=1e-6)
+    finally:
+        brahe.clear_object_registry()
+
+
+def test_keplerian_frame_rule():
+    with pytest.raises(BraheError, match="inertial frame"):
+        OrbitTrajectory(
+            6,
+            CelestialFrame.ITRF,
+            OrbitRepresentation.KEPLERIAN,
+            AngleFormat.DEGREES,
+        )
+    OrbitTrajectory(
+        6,
+        CelestialFrame.EME2000,
+        OrbitRepresentation.KEPLERIAN,
+        AngleFormat.DEGREES,
+    )
+
+
+def test_orbit_frame_is_removed():
+    assert not hasattr(brahe, "OrbitFrame")
+
+
 def test_orbittrajectory_new():
     """Rust: test_orbittrajectory_new"""
     traj = OrbitTrajectory(
         6,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.CARTESIAN,
         None,
     )
 
     assert len(traj) == 0
-    assert traj.frame == OrbitFrame.ECI
+    assert traj.frame == CelestialFrame.ECI
     assert traj.representation == OrbitRepresentation.CARTESIAN
     assert traj.angle_format is None
 
@@ -76,7 +154,7 @@ def test_orbittrajectory_new_invalid_keplerian_none():
     ):
         OrbitTrajectory(
             6,
-            OrbitFrame.ECI,
+            CelestialFrame.ECI,
             OrbitRepresentation.KEPLERIAN,
         )
 
@@ -86,7 +164,7 @@ def test_orbittrajectory_new_invalid_cartesian_degrees():
     with pytest.raises(ValueError, match="Angle format must be None for Cartesian"):
         OrbitTrajectory(
             6,
-            OrbitFrame.ECI,
+            CelestialFrame.ECI,
             OrbitRepresentation.CARTESIAN,
             AngleFormat.DEGREES,
         )
@@ -97,7 +175,7 @@ def test_orbittrajectory_new_invalid_cartesian_radians():
     with pytest.raises(ValueError, match="Angle format must be None for Cartesian"):
         OrbitTrajectory(
             6,
-            OrbitFrame.ECI,
+            CelestialFrame.ECI,
             OrbitRepresentation.CARTESIAN,
             AngleFormat.RADIANS,
         )
@@ -105,10 +183,13 @@ def test_orbittrajectory_new_invalid_cartesian_radians():
 
 def test_orbittrajectory_new_invalid_keplerian_ecef_degrees():
     """Rust: test_orbittrajectory_new_invalid_keplerian_ecef_degrees"""
-    with pytest.raises(BraheError, match="Keplerian elements should be in ECI frame"):
+    with pytest.raises(
+        BraheError,
+        match="Keplerian element trajectories should be in an inertial frame",
+    ):
         OrbitTrajectory(
             6,
-            OrbitFrame.ECEF,
+            CelestialFrame.ECEF,
             OrbitRepresentation.KEPLERIAN,
             AngleFormat.DEGREES,
         )
@@ -116,10 +197,13 @@ def test_orbittrajectory_new_invalid_keplerian_ecef_degrees():
 
 def test_orbittrajectory_new_invalid_keplerian_ecef_radians():
     """Rust: test_orbittrajectory_new_invalid_keplerian_ecef_radians"""
-    with pytest.raises(BraheError, match="Keplerian elements should be in ECI frame"):
+    with pytest.raises(
+        BraheError,
+        match="Keplerian element trajectories should be in an inertial frame",
+    ):
         OrbitTrajectory(
             6,
-            OrbitFrame.ECEF,
+            CelestialFrame.ECEF,
             OrbitRepresentation.KEPLERIAN,
             AngleFormat.RADIANS,
         )
@@ -132,7 +216,7 @@ def test_orbittrajectory_new_invalid_keplerian_ecef_none():
     ):
         OrbitTrajectory(
             6,
-            OrbitFrame.ECEF,
+            CelestialFrame.ECEF,
             OrbitRepresentation.KEPLERIAN,
         )
 
@@ -160,7 +244,7 @@ def test_orbittrajectory_to_matrix():
     traj = OrbitTrajectory.from_orbital_data(
         epochs,
         states,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.CARTESIAN,
         None,
     )
@@ -206,7 +290,7 @@ def test_orbittrajectory_trajectory_add():
     """Rust: test_orbittrajectory_trajectory_add"""
     traj = OrbitTrajectory(
         6,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.CARTESIAN,
         None,
     )
@@ -248,7 +332,7 @@ def test_orbittrajectory_trajectory_state():
     traj = OrbitTrajectory.from_orbital_data(
         epochs,
         states,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.CARTESIAN,
         None,
     )
@@ -285,7 +369,7 @@ def test_orbittrajectory_trajectory_epoch():
     traj = OrbitTrajectory.from_orbital_data(
         epochs,
         states,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.CARTESIAN,
         None,
     )
@@ -322,7 +406,7 @@ def test_orbittrajectory_trajectory_nearest_state():
     traj = OrbitTrajectory.from_orbital_data(
         epochs,
         states,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.CARTESIAN,
         None,
     )
@@ -362,7 +446,7 @@ def test_orbittrajectory_trajectory_len():
     """Rust: test_orbittrajectory_trajectory_len"""
     traj = OrbitTrajectory(
         6,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.CARTESIAN,
         None,
     )
@@ -382,7 +466,7 @@ def test_orbittrajectory_trajectory_is_empty():
     """Rust: test_orbittrajectory_trajectory_is_empty"""
     traj = OrbitTrajectory(
         6,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.CARTESIAN,
         None,
     )
@@ -400,7 +484,7 @@ def test_orbittrajectory_trajectory_start_epoch():
     """Rust: test_orbittrajectory_trajectory_start_epoch"""
     traj = OrbitTrajectory(
         6,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.CARTESIAN,
         None,
     )
@@ -418,7 +502,7 @@ def test_orbittrajectory_trajectory_end_epoch():
     """Rust: test_orbittrajectory_trajectory_end_epoch"""
     traj = OrbitTrajectory(
         6,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.CARTESIAN,
         None,
     )
@@ -449,7 +533,7 @@ def test_orbittrajectory_trajectory_timespan():
     traj = OrbitTrajectory.from_orbital_data(
         epochs,
         states,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.CARTESIAN,
         None,
     )
@@ -473,7 +557,7 @@ def test_orbittrajectory_trajectory_first():
     traj = OrbitTrajectory.from_orbital_data(
         epochs,
         states,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.CARTESIAN,
         None,
     )
@@ -498,7 +582,7 @@ def test_orbittrajectory_trajectory_last():
     traj = OrbitTrajectory.from_orbital_data(
         epochs,
         states,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.CARTESIAN,
         None,
     )
@@ -514,7 +598,7 @@ def test_orbittrajectory_trajectory_clear():
     """Rust: test_orbittrajectory_trajectory_clear"""
     traj = OrbitTrajectory(
         6,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.CARTESIAN,
         None,
     )
@@ -543,7 +627,7 @@ def test_orbittrajectory_trajectory_remove_epoch():
     traj = OrbitTrajectory.from_orbital_data(
         epochs,
         states,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.CARTESIAN,
         None,
     )
@@ -568,7 +652,7 @@ def test_orbittrajectory_trajectory_remove():
     traj = OrbitTrajectory.from_orbital_data(
         epochs,
         states,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.CARTESIAN,
         None,
     )
@@ -594,7 +678,7 @@ def test_orbittrajectory_trajectory_get():
     traj = OrbitTrajectory.from_orbital_data(
         epochs,
         states,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.CARTESIAN,
         None,
     )
@@ -622,7 +706,7 @@ def test_orbittrajectory_trajectory_index_before_epoch():
     traj = OrbitTrajectory.from_orbital_data(
         epochs,
         states,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.CARTESIAN,
         None,
     )
@@ -669,7 +753,7 @@ def test_orbittrajectory_trajectory_index_after_epoch():
     traj = OrbitTrajectory.from_orbital_data(
         epochs,
         states,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.CARTESIAN,
         None,
     )
@@ -719,7 +803,7 @@ def test_orbittrajectory_trajectory_state_before_epoch():
     traj = OrbitTrajectory.from_orbital_data(
         epochs,
         states,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.CARTESIAN,
         None,
     )
@@ -764,7 +848,7 @@ def test_orbittrajectory_trajectory_state_after_epoch():
     traj = OrbitTrajectory.from_orbital_data(
         epochs,
         states,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.CARTESIAN,
         None,
     )
@@ -795,7 +879,7 @@ def test_orbittrajectory_trajectory_set_eviction_policy_max_size():
     """Rust: test_orbittrajectory_trajectory_set_eviction_policy_max_size"""
     traj = OrbitTrajectory(
         6,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.CARTESIAN,
         None,
     )
@@ -835,7 +919,7 @@ def test_orbittrajectory_trajectory_set_eviction_policy_max_age():
     """Rust: test_orbittrajectory_trajectory_set_eviction_policy_max_age"""
     traj = OrbitTrajectory(
         6,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.CARTESIAN,
         None,
     )
@@ -875,7 +959,7 @@ def test_orbittrajectory_default():
     traj = OrbitTrajectory.default()
     assert len(traj) == 0
     assert traj.is_empty()
-    assert traj.frame == OrbitFrame.ECI
+    assert traj.frame == CelestialFrame.ECI
     assert traj.representation == OrbitRepresentation.CARTESIAN
     assert traj.angle_format is None
 
@@ -897,7 +981,7 @@ def test_orbittrajectory_index_index():
     traj = OrbitTrajectory.from_orbital_data(
         epochs,
         states,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.CARTESIAN,
         None,
     )
@@ -920,7 +1004,7 @@ def test_orbittrajectory_index_index_out_of_bounds():
     traj = OrbitTrajectory.from_orbital_data(
         epochs,
         states,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.CARTESIAN,
         None,
     )
@@ -946,7 +1030,7 @@ def test_orbittrajectory_intoiterator_into_iter():
     traj = OrbitTrajectory.from_orbital_data(
         epochs,
         states,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.CARTESIAN,
         None,
     )
@@ -972,7 +1056,7 @@ def test_orbittrajectory_intoiterator_into_iter_empty():
     """Rust: test_orbittrajectory_intoiterator_into_iter_empty"""
     traj = OrbitTrajectory(
         6,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.CARTESIAN,
         None,
     )
@@ -1000,7 +1084,7 @@ def test_orbittrajectory_iterator_iterator_len():
     traj = OrbitTrajectory.from_orbital_data(
         epochs,
         states,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.CARTESIAN,
         None,
     )
@@ -1013,7 +1097,7 @@ def test_orbittrajectory_interpolatable_set_interpolation_method():
     """Rust: test_orbittrajectory_interpolatable_set_interpolation_method"""
     traj = OrbitTrajectory(
         6,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.CARTESIAN,
         None,
     )
@@ -1029,7 +1113,7 @@ def test_orbittrajectory_interpolatable_get_interpolation_method():
     """Rust: test_orbittrajectory_interpolatable_get_interpolation_method"""
     traj = OrbitTrajectory(
         6,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.CARTESIAN,
         None,
     )
@@ -1060,7 +1144,7 @@ def test_orbittrajectory_interpolatable_interpolate_linear():
     traj = OrbitTrajectory.from_orbital_data(
         epochs,
         states,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.CARTESIAN,
         None,
     )
@@ -1098,7 +1182,7 @@ def test_orbittrajectory_interpolatable_interpolate_linear():
     single_traj = OrbitTrajectory.from_orbital_data(
         single_epoch,
         single_state,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.CARTESIAN,
         None,
     )
@@ -1126,7 +1210,7 @@ def test_orbittrajectory_interpolatable_interpolate():
     traj = OrbitTrajectory.from_orbital_data(
         epochs,
         states,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.CARTESIAN,
         None,
     )
@@ -1163,7 +1247,7 @@ def test_orbittrajectory_interpolate_before_start():
     traj = OrbitTrajectory.from_orbital_data(
         epochs,
         states,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.CARTESIAN,
         None,
     )
@@ -1196,7 +1280,7 @@ def test_orbittrajectory_interpolate_after_end():
     traj = OrbitTrajectory.from_orbital_data(
         epochs,
         states,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.CARTESIAN,
         None,
     )
@@ -1227,13 +1311,13 @@ def test_orbittrajectory_orbitaltrajectory_from_orbital_data():
     traj = OrbitTrajectory.from_orbital_data(
         epochs,
         states,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.CARTESIAN,
         None,
     )
 
     assert len(traj) == 2
-    assert traj.frame == OrbitFrame.ECI
+    assert traj.frame == CelestialFrame.ECI
     assert traj.representation == OrbitRepresentation.CARTESIAN
 
 
@@ -1249,7 +1333,7 @@ def test_orbittrajectory_orbitaltrajectory_to_eci():
     # No transformation needed if already in ECI
     traj = OrbitTrajectory(
         6,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.CARTESIAN,
         None,
     )
@@ -1258,7 +1342,7 @@ def test_orbittrajectory_orbitaltrajectory_to_eci():
     traj.add(epoch, state_base)
 
     eci_traj = traj.to_eci()
-    assert eci_traj.frame == OrbitFrame.ECI
+    assert eci_traj.frame == CelestialFrame.ECI
     assert eci_traj.representation == OrbitRepresentation.CARTESIAN
     assert len(eci_traj) == 1
     epoch_out, state_out = eci_traj.get(0)
@@ -1269,7 +1353,7 @@ def test_orbittrajectory_orbitaltrajectory_to_eci():
     # Convert Keplerian to ECI - Radians
     kep_traj = OrbitTrajectory(
         6,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.KEPLERIAN,
         AngleFormat.RADIANS,
     )
@@ -1277,7 +1361,7 @@ def test_orbittrajectory_orbitaltrajectory_to_eci():
     kep_traj.add(epoch, kep_state_rad)
 
     eci_from_kep_rad = kep_traj.to_eci()
-    assert eci_from_kep_rad.frame == OrbitFrame.ECI
+    assert eci_from_kep_rad.frame == CelestialFrame.ECI
     assert eci_from_kep_rad.representation == OrbitRepresentation.CARTESIAN
     assert len(eci_from_kep_rad) == 1
     epoch_out, state_out = eci_from_kep_rad.get(0)
@@ -1288,14 +1372,14 @@ def test_orbittrajectory_orbitaltrajectory_to_eci():
     # Convert Keplerian to ECI - Degrees
     kep_traj_deg = OrbitTrajectory(
         6,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.KEPLERIAN,
         AngleFormat.DEGREES,
     )
     kep_state_deg = state_eci_to_koe(state_base, AngleFormat.DEGREES)
     kep_traj_deg.add(epoch, kep_state_deg)
     eci_from_kep_deg = kep_traj_deg.to_eci()
-    assert eci_from_kep_deg.frame == OrbitFrame.ECI
+    assert eci_from_kep_deg.frame == CelestialFrame.ECI
     assert eci_from_kep_deg.representation == OrbitRepresentation.CARTESIAN
     assert len(eci_from_kep_deg) == 1
     epoch_out, state_out = eci_from_kep_deg.get(0)
@@ -1306,14 +1390,14 @@ def test_orbittrajectory_orbitaltrajectory_to_eci():
     # Convert ECEF to ECI
     ecef_traj = OrbitTrajectory(
         6,
-        OrbitFrame.ECEF,
+        CelestialFrame.ECEF,
         OrbitRepresentation.CARTESIAN,
         None,
     )
     ecef_state = state_eci_to_ecef(epoch, state_base)
     ecef_traj.add(epoch, ecef_state)
     eci_from_ecef = ecef_traj.to_eci()
-    assert eci_from_ecef.frame == OrbitFrame.ECI
+    assert eci_from_ecef.frame == CelestialFrame.ECI
     assert eci_from_ecef.representation == OrbitRepresentation.CARTESIAN
     assert len(eci_from_ecef) == 1
     epoch_out, state_out = eci_from_ecef.get(0)
@@ -1338,14 +1422,14 @@ def test_orbittrajectory_orbitaltrajectory_to_ecef():
     # No transformation needed if already in ECEF
     traj = OrbitTrajectory(
         6,
-        OrbitFrame.ECEF,
+        CelestialFrame.ECEF,
         OrbitRepresentation.CARTESIAN,
         None,
     )
 
     traj.add(epoch, state_base)
     ecef_traj = traj.to_ecef()
-    assert ecef_traj.frame == OrbitFrame.ECEF
+    assert ecef_traj.frame == CelestialFrame.ECEF
     assert ecef_traj.representation == OrbitRepresentation.CARTESIAN
     assert len(ecef_traj) == 1
     epoch_out, state_out = ecef_traj.get(0)
@@ -1356,14 +1440,14 @@ def test_orbittrajectory_orbitaltrajectory_to_ecef():
     # Convert ECI to ECEF
     eci_traj = OrbitTrajectory(
         6,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.CARTESIAN,
         None,
     )
     eci_state = state_ecef_to_eci(epoch, state_base)
     eci_traj.add(epoch, eci_state)
     ecef_from_eci = eci_traj.to_ecef()
-    assert ecef_from_eci.frame == OrbitFrame.ECEF
+    assert ecef_from_eci.frame == CelestialFrame.ECEF
     assert ecef_from_eci.representation == OrbitRepresentation.CARTESIAN
     assert len(ecef_from_eci) == 1
     epoch_out, state_out = ecef_from_eci.get(0)
@@ -1374,14 +1458,14 @@ def test_orbittrajectory_orbitaltrajectory_to_ecef():
     # Convert Keplerian to ECEF - Radians
     kep_traj = OrbitTrajectory(
         6,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.KEPLERIAN,
         AngleFormat.RADIANS,
     )
     kep_state_rad = state_eci_to_koe(eci_state, AngleFormat.RADIANS)
     kep_traj.add(epoch, kep_state_rad)
     ecef_from_kep_rad = kep_traj.to_ecef()
-    assert ecef_from_kep_rad.frame == OrbitFrame.ECEF
+    assert ecef_from_kep_rad.frame == CelestialFrame.ECEF
     assert ecef_from_kep_rad.representation == OrbitRepresentation.CARTESIAN
     assert len(ecef_from_kep_rad) == 1
     epoch_out, state_out = ecef_from_kep_rad.get(0)
@@ -1392,14 +1476,14 @@ def test_orbittrajectory_orbitaltrajectory_to_ecef():
     # Convert Keplerian to ECEF - Degrees
     kep_traj_deg = OrbitTrajectory(
         6,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.KEPLERIAN,
         AngleFormat.DEGREES,
     )
     kep_state_deg = state_eci_to_koe(eci_state, AngleFormat.DEGREES)
     kep_traj_deg.add(epoch, kep_state_deg)
     ecef_from_kep_deg = kep_traj_deg.to_ecef()
-    assert ecef_from_kep_deg.frame == OrbitFrame.ECEF
+    assert ecef_from_kep_deg.frame == CelestialFrame.ECEF
     assert ecef_from_kep_deg.representation == OrbitRepresentation.CARTESIAN
     assert len(ecef_from_kep_deg) == 1
     epoch_out, state_out = ecef_from_kep_deg.get(0)
@@ -1424,14 +1508,14 @@ def test_orbittrajectory_orbitaltrajectory_to_itrf():
     # No transformation needed if already in ITRF
     traj = OrbitTrajectory(
         6,
-        OrbitFrame.ITRF,
+        CelestialFrame.ITRF,
         OrbitRepresentation.CARTESIAN,
         None,
     )
 
     traj.add(epoch, state_base)
     itrf_traj = traj.to_itrf()
-    assert itrf_traj.frame == OrbitFrame.ITRF
+    assert itrf_traj.frame == CelestialFrame.ITRF
     assert itrf_traj.representation == OrbitRepresentation.CARTESIAN
     assert len(itrf_traj) == 1
     epoch_out, state_out = itrf_traj.get(0)
@@ -1442,14 +1526,14 @@ def test_orbittrajectory_orbitaltrajectory_to_itrf():
     # Convert GCRF to ITRF
     gcrf_traj = OrbitTrajectory(
         6,
-        OrbitFrame.GCRF,
+        CelestialFrame.GCRF,
         OrbitRepresentation.CARTESIAN,
         None,
     )
     gcrf_state = state_itrf_to_gcrf(epoch, state_base)
     gcrf_traj.add(epoch, gcrf_state)
     itrf_from_gcrf = gcrf_traj.to_itrf()
-    assert itrf_from_gcrf.frame == OrbitFrame.ITRF
+    assert itrf_from_gcrf.frame == CelestialFrame.ITRF
     assert itrf_from_gcrf.representation == OrbitRepresentation.CARTESIAN
     assert len(itrf_from_gcrf) == 1
     epoch_out, state_out = itrf_from_gcrf.get(0)
@@ -1460,14 +1544,14 @@ def test_orbittrajectory_orbitaltrajectory_to_itrf():
     # Convert EME2000 to ITRF
     eme2000_traj = OrbitTrajectory(
         6,
-        OrbitFrame.EME2000,
+        CelestialFrame.EME2000,
         OrbitRepresentation.CARTESIAN,
         None,
     )
     eme2000_state = state_gcrf_to_eme2000(gcrf_state)
     eme2000_traj.add(epoch, eme2000_state)
     itrf_from_eme2000 = eme2000_traj.to_itrf()
-    assert itrf_from_eme2000.frame == OrbitFrame.ITRF
+    assert itrf_from_eme2000.frame == CelestialFrame.ITRF
     assert itrf_from_eme2000.representation == OrbitRepresentation.CARTESIAN
     assert len(itrf_from_eme2000) == 1
     epoch_out, state_out = itrf_from_eme2000.get(0)
@@ -1478,14 +1562,14 @@ def test_orbittrajectory_orbitaltrajectory_to_itrf():
     # Convert Keplerian to ITRF - Radians
     kep_traj = OrbitTrajectory(
         6,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.KEPLERIAN,
         AngleFormat.RADIANS,
     )
     kep_state_rad = state_eci_to_koe(gcrf_state, AngleFormat.RADIANS)
     kep_traj.add(epoch, kep_state_rad)
     itrf_from_kep_rad = kep_traj.to_itrf()
-    assert itrf_from_kep_rad.frame == OrbitFrame.ITRF
+    assert itrf_from_kep_rad.frame == CelestialFrame.ITRF
     assert itrf_from_kep_rad.representation == OrbitRepresentation.CARTESIAN
     assert len(itrf_from_kep_rad) == 1
     epoch_out, state_out = itrf_from_kep_rad.get(0)
@@ -1496,14 +1580,14 @@ def test_orbittrajectory_orbitaltrajectory_to_itrf():
     # Convert Keplerian to ITRF - Degrees
     kep_traj_deg = OrbitTrajectory(
         6,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.KEPLERIAN,
         AngleFormat.DEGREES,
     )
     kep_state_deg = state_eci_to_koe(gcrf_state, AngleFormat.DEGREES)
     kep_traj_deg.add(epoch, kep_state_deg)
     itrf_from_kep_deg = kep_traj_deg.to_itrf()
-    assert itrf_from_kep_deg.frame == OrbitFrame.ITRF
+    assert itrf_from_kep_deg.frame == CelestialFrame.ITRF
     assert itrf_from_kep_deg.representation == OrbitRepresentation.CARTESIAN
     assert len(itrf_from_kep_deg) == 1
     epoch_out, state_out = itrf_from_kep_deg.get(0)
@@ -1525,14 +1609,14 @@ def test_orbittrajectory_orbitaltrajectory_to_gcrf():
     # No transformation needed if already in GCRF
     traj = OrbitTrajectory(
         6,
-        OrbitFrame.GCRF,
+        CelestialFrame.GCRF,
         OrbitRepresentation.CARTESIAN,
         None,
     )
 
     traj.add(epoch, state_base)
     gcrf_traj = traj.to_gcrf()
-    assert gcrf_traj.frame == OrbitFrame.GCRF
+    assert gcrf_traj.frame == CelestialFrame.GCRF
     assert gcrf_traj.representation == OrbitRepresentation.CARTESIAN
     assert len(gcrf_traj) == 1
     epoch_out, state_out = gcrf_traj.get(0)
@@ -1543,14 +1627,14 @@ def test_orbittrajectory_orbitaltrajectory_to_gcrf():
     # Convert ITRF to GCRF
     itrf_traj = OrbitTrajectory(
         6,
-        OrbitFrame.ITRF,
+        CelestialFrame.ITRF,
         OrbitRepresentation.CARTESIAN,
         None,
     )
     itrf_state = state_gcrf_to_itrf(epoch, state_base)
     itrf_traj.add(epoch, itrf_state)
     gcrf_from_itrf = itrf_traj.to_gcrf()
-    assert gcrf_from_itrf.frame == OrbitFrame.GCRF
+    assert gcrf_from_itrf.frame == CelestialFrame.GCRF
     assert gcrf_from_itrf.representation == OrbitRepresentation.CARTESIAN
     assert len(gcrf_from_itrf) == 1
     epoch_out, state_out = gcrf_from_itrf.get(0)
@@ -1561,14 +1645,14 @@ def test_orbittrajectory_orbitaltrajectory_to_gcrf():
     # Convert EME2000 to GCRF
     eme2000_traj = OrbitTrajectory(
         6,
-        OrbitFrame.EME2000,
+        CelestialFrame.EME2000,
         OrbitRepresentation.CARTESIAN,
         None,
     )
     eme2000_state = state_gcrf_to_eme2000(state_base)
     eme2000_traj.add(epoch, eme2000_state)
     gcrf_from_eme2000 = eme2000_traj.to_gcrf()
-    assert gcrf_from_eme2000.frame == OrbitFrame.GCRF
+    assert gcrf_from_eme2000.frame == CelestialFrame.GCRF
     assert gcrf_from_eme2000.representation == OrbitRepresentation.CARTESIAN
     assert len(gcrf_from_eme2000) == 1
     epoch_out, state_out = gcrf_from_eme2000.get(0)
@@ -1579,14 +1663,14 @@ def test_orbittrajectory_orbitaltrajectory_to_gcrf():
     # Convert Keplerian to GCRF - Radians
     kep_traj = OrbitTrajectory(
         6,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.KEPLERIAN,
         AngleFormat.RADIANS,
     )
     kep_state_rad = state_eci_to_koe(state_base, AngleFormat.RADIANS)
     kep_traj.add(epoch, kep_state_rad)
     gcrf_from_kep_rad = kep_traj.to_gcrf()
-    assert gcrf_from_kep_rad.frame == OrbitFrame.GCRF
+    assert gcrf_from_kep_rad.frame == CelestialFrame.GCRF
     assert gcrf_from_kep_rad.representation == OrbitRepresentation.CARTESIAN
     assert len(gcrf_from_kep_rad) == 1
     epoch_out, state_out = gcrf_from_kep_rad.get(0)
@@ -1597,14 +1681,14 @@ def test_orbittrajectory_orbitaltrajectory_to_gcrf():
     # Convert Keplerian to GCRF - Degrees
     kep_traj_deg = OrbitTrajectory(
         6,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.KEPLERIAN,
         AngleFormat.DEGREES,
     )
     kep_state_deg = state_eci_to_koe(state_base, AngleFormat.DEGREES)
     kep_traj_deg.add(epoch, kep_state_deg)
     gcrf_from_kep_deg = kep_traj_deg.to_gcrf()
-    assert gcrf_from_kep_deg.frame == OrbitFrame.GCRF
+    assert gcrf_from_kep_deg.frame == CelestialFrame.GCRF
     assert gcrf_from_kep_deg.representation == OrbitRepresentation.CARTESIAN
     assert len(gcrf_from_kep_deg) == 1
     epoch_out, state_out = gcrf_from_kep_deg.get(0)
@@ -1628,14 +1712,14 @@ def test_orbittrajectory_orbitaltrajectory_to_eme2000():
     # No transformation needed if already in EME2000
     traj = OrbitTrajectory(
         6,
-        OrbitFrame.EME2000,
+        CelestialFrame.EME2000,
         OrbitRepresentation.CARTESIAN,
         None,
     )
 
     traj.add(epoch, state_base)
     eme2000_traj = traj.to_eme2000()
-    assert eme2000_traj.frame == OrbitFrame.EME2000
+    assert eme2000_traj.frame == CelestialFrame.EME2000
     assert eme2000_traj.representation == OrbitRepresentation.CARTESIAN
     assert len(eme2000_traj) == 1
     epoch_out, state_out = eme2000_traj.get(0)
@@ -1646,14 +1730,14 @@ def test_orbittrajectory_orbitaltrajectory_to_eme2000():
     # Convert GCRF to EME2000
     gcrf_traj = OrbitTrajectory(
         6,
-        OrbitFrame.GCRF,
+        CelestialFrame.GCRF,
         OrbitRepresentation.CARTESIAN,
         None,
     )
     gcrf_state = state_eme2000_to_gcrf(state_base)
     gcrf_traj.add(epoch, gcrf_state)
     eme2000_from_gcrf = gcrf_traj.to_eme2000()
-    assert eme2000_from_gcrf.frame == OrbitFrame.EME2000
+    assert eme2000_from_gcrf.frame == CelestialFrame.EME2000
     assert eme2000_from_gcrf.representation == OrbitRepresentation.CARTESIAN
     assert len(eme2000_from_gcrf) == 1
     epoch_out, state_out = eme2000_from_gcrf.get(0)
@@ -1664,14 +1748,14 @@ def test_orbittrajectory_orbitaltrajectory_to_eme2000():
     # Convert ITRF to EME2000
     itrf_traj = OrbitTrajectory(
         6,
-        OrbitFrame.ITRF,
+        CelestialFrame.ITRF,
         OrbitRepresentation.CARTESIAN,
         None,
     )
     itrf_state = state_gcrf_to_itrf(epoch, gcrf_state)
     itrf_traj.add(epoch, itrf_state)
     eme2000_from_itrf = itrf_traj.to_eme2000()
-    assert eme2000_from_itrf.frame == OrbitFrame.EME2000
+    assert eme2000_from_itrf.frame == CelestialFrame.EME2000
     assert eme2000_from_itrf.representation == OrbitRepresentation.CARTESIAN
     assert len(eme2000_from_itrf) == 1
     epoch_out, state_out = eme2000_from_itrf.get(0)
@@ -1682,14 +1766,14 @@ def test_orbittrajectory_orbitaltrajectory_to_eme2000():
     # Convert Keplerian to EME2000 - Radians
     kep_traj = OrbitTrajectory(
         6,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.KEPLERIAN,
         AngleFormat.RADIANS,
     )
     kep_state_rad = state_eci_to_koe(gcrf_state, AngleFormat.RADIANS)
     kep_traj.add(epoch, kep_state_rad)
     eme2000_from_kep_rad = kep_traj.to_eme2000()
-    assert eme2000_from_kep_rad.frame == OrbitFrame.EME2000
+    assert eme2000_from_kep_rad.frame == CelestialFrame.EME2000
     assert eme2000_from_kep_rad.representation == OrbitRepresentation.CARTESIAN
     assert len(eme2000_from_kep_rad) == 1
     epoch_out, state_out = eme2000_from_kep_rad.get(0)
@@ -1700,14 +1784,14 @@ def test_orbittrajectory_orbitaltrajectory_to_eme2000():
     # Convert Keplerian to EME2000 - Degrees
     kep_traj_deg = OrbitTrajectory(
         6,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.KEPLERIAN,
         AngleFormat.DEGREES,
     )
     kep_state_deg = state_eci_to_koe(gcrf_state, AngleFormat.DEGREES)
     kep_traj_deg.add(epoch, kep_state_deg)
     eme2000_from_kep_deg = kep_traj_deg.to_eme2000()
-    assert eme2000_from_kep_deg.frame == OrbitFrame.EME2000
+    assert eme2000_from_kep_deg.frame == CelestialFrame.EME2000
     assert eme2000_from_kep_deg.representation == OrbitRepresentation.CARTESIAN
     assert len(eme2000_from_kep_deg) == 1
     epoch_out, state_out = eme2000_from_kep_deg.get(0)
@@ -1727,13 +1811,13 @@ def test_orbittrajectory_orbitaltrajectory_to_keplerian_deg():
     # No transformation needed if already in Keplerian Degrees
     traj = OrbitTrajectory(
         6,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.KEPLERIAN,
         AngleFormat.DEGREES,
     )
     traj.add(epoch, state_kep_deg)
     kep_traj = traj.to_keplerian(AngleFormat.DEGREES)
-    assert kep_traj.frame == OrbitFrame.ECI
+    assert kep_traj.frame == CelestialFrame.ECI
     assert kep_traj.representation == OrbitRepresentation.KEPLERIAN
     assert kep_traj.angle_format == AngleFormat.DEGREES
     assert len(kep_traj) == 1
@@ -1745,7 +1829,7 @@ def test_orbittrajectory_orbitaltrajectory_to_keplerian_deg():
     # Convert Keplerian Radians to Keplerian Degrees
     kep_rad_traj = OrbitTrajectory(
         6,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.KEPLERIAN,
         AngleFormat.RADIANS,
     )
@@ -1754,7 +1838,7 @@ def test_orbittrajectory_orbitaltrajectory_to_keplerian_deg():
         state_kep_rad[i] = state_kep_deg[i] * DEG2RAD
     kep_rad_traj.add(epoch, state_kep_rad)
     kep_from_rad = kep_rad_traj.to_keplerian(AngleFormat.DEGREES)
-    assert kep_from_rad.frame == OrbitFrame.ECI
+    assert kep_from_rad.frame == CelestialFrame.ECI
     assert kep_from_rad.representation == OrbitRepresentation.KEPLERIAN
     assert kep_from_rad.angle_format == AngleFormat.DEGREES
     assert len(kep_from_rad) == 1
@@ -1766,14 +1850,14 @@ def test_orbittrajectory_orbitaltrajectory_to_keplerian_deg():
     # Convert ECI to Keplerian Degrees
     cart_traj = OrbitTrajectory(
         6,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.CARTESIAN,
         None,
     )
     cart_state = state_koe_to_eci(state_kep_deg, AngleFormat.DEGREES)
     cart_traj.add(epoch, cart_state)
     kep_from_cart = cart_traj.to_keplerian(AngleFormat.DEGREES)
-    assert kep_from_cart.frame == OrbitFrame.ECI
+    assert kep_from_cart.frame == CelestialFrame.ECI
     assert kep_from_cart.representation == OrbitRepresentation.KEPLERIAN
     assert kep_from_cart.angle_format == AngleFormat.DEGREES
     assert len(kep_from_cart) == 1
@@ -1785,14 +1869,14 @@ def test_orbittrajectory_orbitaltrajectory_to_keplerian_deg():
     # Convert ECEF to Keplerian Degrees
     ecef_traj = OrbitTrajectory(
         6,
-        OrbitFrame.ECEF,
+        CelestialFrame.ECEF,
         OrbitRepresentation.CARTESIAN,
         None,
     )
     ecef_state = state_eci_to_ecef(epoch, cart_state)
     ecef_traj.add(epoch, ecef_state)
     kep_from_ecef = ecef_traj.to_keplerian(AngleFormat.DEGREES)
-    assert kep_from_ecef.frame == OrbitFrame.ECI
+    assert kep_from_ecef.frame == CelestialFrame.ECI
     assert kep_from_ecef.representation == OrbitRepresentation.KEPLERIAN
     assert kep_from_ecef.angle_format == AngleFormat.DEGREES
     assert len(kep_from_ecef) == 1
@@ -1816,13 +1900,13 @@ def test_orbittrajectory_orbitaltrajectory_to_keplerian_rad():
     # No transformation needed if already in Keplerian Radians
     traj = OrbitTrajectory(
         6,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.KEPLERIAN,
         AngleFormat.RADIANS,
     )
     traj.add(epoch, state_kep_rad)
     kep_traj = traj.to_keplerian(AngleFormat.RADIANS)
-    assert kep_traj.frame == OrbitFrame.ECI
+    assert kep_traj.frame == CelestialFrame.ECI
     assert kep_traj.representation == OrbitRepresentation.KEPLERIAN
     assert kep_traj.angle_format == AngleFormat.RADIANS
     assert len(kep_traj) == 1
@@ -1834,13 +1918,13 @@ def test_orbittrajectory_orbitaltrajectory_to_keplerian_rad():
     # Convert Keplerian Degrees to Keplerian Radians
     kep_deg_traj = OrbitTrajectory(
         6,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.KEPLERIAN,
         AngleFormat.DEGREES,
     )
     kep_deg_traj.add(epoch, state_kep_deg)
     kep_from_deg = kep_deg_traj.to_keplerian(AngleFormat.RADIANS)
-    assert kep_from_deg.frame == OrbitFrame.ECI
+    assert kep_from_deg.frame == CelestialFrame.ECI
     assert kep_from_deg.representation == OrbitRepresentation.KEPLERIAN
     assert kep_from_deg.angle_format == AngleFormat.RADIANS
     assert len(kep_from_deg) == 1
@@ -1852,14 +1936,14 @@ def test_orbittrajectory_orbitaltrajectory_to_keplerian_rad():
     # Convert ECI to Keplerian Radians
     cart_traj = OrbitTrajectory(
         6,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.CARTESIAN,
         None,
     )
     cart_state = state_koe_to_eci(state_kep_deg, AngleFormat.DEGREES)
     cart_traj.add(epoch, cart_state)
     kep_from_cart = cart_traj.to_keplerian(AngleFormat.RADIANS)
-    assert kep_from_cart.frame == OrbitFrame.ECI
+    assert kep_from_cart.frame == CelestialFrame.ECI
     assert kep_from_cart.representation == OrbitRepresentation.KEPLERIAN
     assert kep_from_cart.angle_format == AngleFormat.RADIANS
     assert len(kep_from_cart) == 1
@@ -1871,14 +1955,14 @@ def test_orbittrajectory_orbitaltrajectory_to_keplerian_rad():
     # Convert ECEF to Keplerian Radians
     ecef_traj = OrbitTrajectory(
         6,
-        OrbitFrame.ECEF,
+        CelestialFrame.ECEF,
         OrbitRepresentation.CARTESIAN,
         None,
     )
     ecef_state = state_eci_to_ecef(epoch, cart_state)
     ecef_traj.add(epoch, ecef_state)
     kep_from_ecef = ecef_traj.to_keplerian(AngleFormat.RADIANS)
-    assert kep_from_ecef.frame == OrbitFrame.ECI
+    assert kep_from_ecef.frame == CelestialFrame.ECI
     assert kep_from_ecef.representation == OrbitRepresentation.KEPLERIAN
     assert kep_from_ecef.angle_format == AngleFormat.RADIANS
     assert len(kep_from_ecef) == 1
@@ -1893,7 +1977,7 @@ def test_orbittrajectory_orbitaltrajectory_to_keplerian_rad():
 
 def test_orbittrajectory_stateprovider_state_eci_cartesian():
     """Test state() for ECI Cartesian trajectory"""
-    traj = OrbitTrajectory(6, OrbitFrame.ECI, OrbitRepresentation.CARTESIAN, None)
+    traj = OrbitTrajectory(6, CelestialFrame.ECI, OrbitRepresentation.CARTESIAN, None)
     # Sparse points half a day apart: HermiteCubic (the new default) overshoots
     # wildly, so request Linear for this midpoint-bracket check.
     traj.set_interpolation_method(InterpolationMethod.LINEAR)
@@ -1920,7 +2004,7 @@ def test_orbittrajectory_stateprovider_state_eci_cartesian():
 
 def test_orbittrajectory_stateprovider_state_eci():
     """Test state_eci() for ECI Cartesian trajectory"""
-    traj = OrbitTrajectory(6, OrbitFrame.ECI, OrbitRepresentation.CARTESIAN, None)
+    traj = OrbitTrajectory(6, CelestialFrame.ECI, OrbitRepresentation.CARTESIAN, None)
 
     epoch = Epoch.from_jd(2451545.0, TimeSystem.UTC)
     state_eci = np.array([7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0])
@@ -1935,7 +2019,7 @@ def test_orbittrajectory_stateprovider_state_eci():
 def test_orbittrajectory_stateprovider_state_eci_from_keplerian():
     """Test state_eci() for Keplerian trajectory"""
     traj = OrbitTrajectory(
-        6, OrbitFrame.ECI, OrbitRepresentation.KEPLERIAN, AngleFormat.DEGREES
+        6, CelestialFrame.ECI, OrbitRepresentation.KEPLERIAN, AngleFormat.DEGREES
     )
 
     epoch = Epoch.from_jd(2451545.0, TimeSystem.UTC)
@@ -1954,7 +2038,7 @@ def test_orbittrajectory_stateprovider_state_eci_from_keplerian():
 
 def test_orbittrajectory_stateprovider_state_eci_from_ecef():
     """Test state_eci() for ECEF Cartesian trajectory"""
-    traj = OrbitTrajectory(6, OrbitFrame.ECEF, OrbitRepresentation.CARTESIAN, None)
+    traj = OrbitTrajectory(6, CelestialFrame.ECEF, OrbitRepresentation.CARTESIAN, None)
 
     epoch = Epoch.from_jd(2451545.0, TimeSystem.UTC)
     state_ecef = np.array([7000e3, 0.0, 0.0, 0.0, 0.0, 7.5e3])
@@ -1972,7 +2056,7 @@ def test_orbittrajectory_stateprovider_state_eci_from_ecef():
 
 def test_orbittrajectory_stateprovider_state_ecef():
     """Test state_ecef() for ECEF Cartesian trajectory"""
-    traj = OrbitTrajectory(6, OrbitFrame.ECEF, OrbitRepresentation.CARTESIAN, None)
+    traj = OrbitTrajectory(6, CelestialFrame.ECEF, OrbitRepresentation.CARTESIAN, None)
 
     epoch = Epoch.from_jd(2451545.0, TimeSystem.UTC)
     state_ecef = np.array([7000e3, 0.0, 0.0, 0.0, 0.0, 7.5e3])
@@ -1987,7 +2071,7 @@ def test_orbittrajectory_stateprovider_state_ecef():
 
 def test_orbittrajectory_stateprovider_state_ecef_from_eci():
     """Test state_ecef() for ECI Cartesian trajectory"""
-    traj = OrbitTrajectory(6, OrbitFrame.ECI, OrbitRepresentation.CARTESIAN, None)
+    traj = OrbitTrajectory(6, CelestialFrame.ECI, OrbitRepresentation.CARTESIAN, None)
 
     epoch = Epoch.from_jd(2451545.0, TimeSystem.UTC)
     state_eci = np.array([7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0])
@@ -2006,7 +2090,7 @@ def test_orbittrajectory_stateprovider_state_ecef_from_eci():
 def test_orbittrajectory_stateprovider_state_ecef_from_keplerian():
     """Test state_ecef() for Keplerian trajectory"""
     traj = OrbitTrajectory(
-        6, OrbitFrame.ECI, OrbitRepresentation.KEPLERIAN, AngleFormat.DEGREES
+        6, CelestialFrame.ECI, OrbitRepresentation.KEPLERIAN, AngleFormat.DEGREES
     )
 
     epoch = Epoch.from_jd(2451545.0, TimeSystem.UTC)
@@ -2026,7 +2110,7 @@ def test_orbittrajectory_stateprovider_state_ecef_from_keplerian():
 
 def test_orbittrajectory_stateprovider_state_gcrf():
     """Test state_gcrf() for GCRF Cartesian trajectory"""
-    traj = OrbitTrajectory(6, OrbitFrame.GCRF, OrbitRepresentation.CARTESIAN, None)
+    traj = OrbitTrajectory(6, CelestialFrame.GCRF, OrbitRepresentation.CARTESIAN, None)
 
     epoch = Epoch.from_jd(2451545.0, TimeSystem.UTC)
     state_gcrf = np.array([7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0])
@@ -2041,7 +2125,7 @@ def test_orbittrajectory_stateprovider_state_gcrf():
 def test_orbittrajectory_stateprovider_state_gcrf_from_keplerian():
     """Test state_gcrf() for Keplerian trajectory"""
     traj = OrbitTrajectory(
-        6, OrbitFrame.ECI, OrbitRepresentation.KEPLERIAN, AngleFormat.DEGREES
+        6, CelestialFrame.ECI, OrbitRepresentation.KEPLERIAN, AngleFormat.DEGREES
     )
 
     epoch = Epoch.from_jd(2451545.0, TimeSystem.UTC)
@@ -2060,7 +2144,7 @@ def test_orbittrajectory_stateprovider_state_gcrf_from_keplerian():
 
 def test_orbittrajectory_stateprovider_state_gcrf_from_itrf():
     """Test state_gcrf() for ITRF Cartesian trajectory"""
-    traj = OrbitTrajectory(6, OrbitFrame.ITRF, OrbitRepresentation.CARTESIAN, None)
+    traj = OrbitTrajectory(6, CelestialFrame.ITRF, OrbitRepresentation.CARTESIAN, None)
 
     epoch = Epoch.from_jd(2451545.0, TimeSystem.UTC)
     state_itrf = np.array([7000e3, 0.0, 0.0, 0.0, 0.0, 7.5e3])
@@ -2078,7 +2162,9 @@ def test_orbittrajectory_stateprovider_state_gcrf_from_itrf():
 
 def test_orbittrajectory_stateprovider_state_gcrf_from_eme2000():
     """Test state_gcrf() for EME2000 Cartesian trajectory"""
-    traj = OrbitTrajectory(6, OrbitFrame.EME2000, OrbitRepresentation.CARTESIAN, None)
+    traj = OrbitTrajectory(
+        6, CelestialFrame.EME2000, OrbitRepresentation.CARTESIAN, None
+    )
 
     epoch = Epoch.from_jd(2451545.0, TimeSystem.UTC)
     state_eme2000 = np.array([7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0])
@@ -2096,7 +2182,7 @@ def test_orbittrajectory_stateprovider_state_gcrf_from_eme2000():
 
 def test_orbittrajectory_stateprovider_state_itrf():
     """Test state_itrf() for ITRF Cartesian trajectory"""
-    traj = OrbitTrajectory(6, OrbitFrame.ITRF, OrbitRepresentation.CARTESIAN, None)
+    traj = OrbitTrajectory(6, CelestialFrame.ITRF, OrbitRepresentation.CARTESIAN, None)
 
     epoch = Epoch.from_jd(2451545.0, TimeSystem.UTC)
     state_itrf = np.array([7000e3, 0.0, 0.0, 0.0, 0.0, 7.5e3])
@@ -2112,7 +2198,7 @@ def test_orbittrajectory_stateprovider_state_itrf():
 def test_orbittrajectory_stateprovider_state_itrf_from_keplerian():
     """Test state_itrf() for Keplerian trajectory"""
     traj = OrbitTrajectory(
-        6, OrbitFrame.ECI, OrbitRepresentation.KEPLERIAN, AngleFormat.DEGREES
+        6, CelestialFrame.ECI, OrbitRepresentation.KEPLERIAN, AngleFormat.DEGREES
     )
 
     epoch = Epoch.from_jd(2451545.0, TimeSystem.UTC)
@@ -2132,7 +2218,7 @@ def test_orbittrajectory_stateprovider_state_itrf_from_keplerian():
 
 def test_orbittrajectory_stateprovider_state_itrf_from_gcrf():
     """Test state_itrf() for GCRF Cartesian trajectory"""
-    traj = OrbitTrajectory(6, OrbitFrame.GCRF, OrbitRepresentation.CARTESIAN, None)
+    traj = OrbitTrajectory(6, CelestialFrame.GCRF, OrbitRepresentation.CARTESIAN, None)
 
     epoch = Epoch.from_jd(2451545.0, TimeSystem.UTC)
     state_gcrf = np.array([7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0])
@@ -2150,7 +2236,9 @@ def test_orbittrajectory_stateprovider_state_itrf_from_gcrf():
 
 def test_orbittrajectory_stateprovider_state_itrf_from_eme2000():
     """Test state_itrf() for EME2000 Cartesian trajectory"""
-    traj = OrbitTrajectory(6, OrbitFrame.EME2000, OrbitRepresentation.CARTESIAN, None)
+    traj = OrbitTrajectory(
+        6, CelestialFrame.EME2000, OrbitRepresentation.CARTESIAN, None
+    )
 
     epoch = Epoch.from_jd(2451545.0, TimeSystem.UTC)
     state_eme2000 = np.array([7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0])
@@ -2169,7 +2257,9 @@ def test_orbittrajectory_stateprovider_state_itrf_from_eme2000():
 
 def test_orbittrajectory_stateprovider_state_eme2000():
     """Test state_eme2000() for EME2000 Cartesian trajectory"""
-    traj = OrbitTrajectory(6, OrbitFrame.EME2000, OrbitRepresentation.CARTESIAN, None)
+    traj = OrbitTrajectory(
+        6, CelestialFrame.EME2000, OrbitRepresentation.CARTESIAN, None
+    )
 
     epoch = Epoch.from_jd(2451545.0, TimeSystem.UTC)
     state_eme2000 = np.array([7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0])
@@ -2185,7 +2275,7 @@ def test_orbittrajectory_stateprovider_state_eme2000():
 def test_orbittrajectory_stateprovider_state_eme2000_from_keplerian():
     """Test state_eme2000() for Keplerian trajectory"""
     traj = OrbitTrajectory(
-        6, OrbitFrame.ECI, OrbitRepresentation.KEPLERIAN, AngleFormat.DEGREES
+        6, CelestialFrame.ECI, OrbitRepresentation.KEPLERIAN, AngleFormat.DEGREES
     )
 
     epoch = Epoch.from_jd(2451545.0, TimeSystem.UTC)
@@ -2205,7 +2295,7 @@ def test_orbittrajectory_stateprovider_state_eme2000_from_keplerian():
 
 def test_orbittrajectory_stateprovider_state_eme2000_from_gcrf():
     """Test state_eme2000() for GCRF Cartesian trajectory"""
-    traj = OrbitTrajectory(6, OrbitFrame.GCRF, OrbitRepresentation.CARTESIAN, None)
+    traj = OrbitTrajectory(6, CelestialFrame.GCRF, OrbitRepresentation.CARTESIAN, None)
 
     epoch = Epoch.from_jd(2451545.0, TimeSystem.UTC)
     state_gcrf = np.array([7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0])
@@ -2223,7 +2313,7 @@ def test_orbittrajectory_stateprovider_state_eme2000_from_gcrf():
 
 def test_orbittrajectory_stateprovider_state_eme2000_from_itrf():
     """Test state_eme2000() for ITRF Cartesian trajectory"""
-    traj = OrbitTrajectory(6, OrbitFrame.ITRF, OrbitRepresentation.CARTESIAN, None)
+    traj = OrbitTrajectory(6, CelestialFrame.ITRF, OrbitRepresentation.CARTESIAN, None)
 
     epoch = Epoch.from_jd(2451545.0, TimeSystem.UTC)
     state_itrf = np.array([7000e3, 0.0, 0.0, 0.0, 0.0, 7.5e3])
@@ -2242,7 +2332,7 @@ def test_orbittrajectory_stateprovider_state_eme2000_from_itrf():
 
 def test_orbittrajectory_stateprovider_state_koe_from_cartesian():
     """Test state_koe_osc() for ECI Cartesian trajectory"""
-    traj = OrbitTrajectory(6, OrbitFrame.ECI, OrbitRepresentation.CARTESIAN, None)
+    traj = OrbitTrajectory(6, CelestialFrame.ECI, OrbitRepresentation.CARTESIAN, None)
 
     epoch = Epoch.from_jd(2451545.0, TimeSystem.UTC)
     state_cart = np.array([7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0])
@@ -2268,7 +2358,7 @@ def test_orbittrajectory_stateprovider_state_koe_from_cartesian():
 def test_orbittrajectory_stateprovider_state_koe_from_keplerian():
     """Test state_koe_osc() for Keplerian trajectory"""
     traj = OrbitTrajectory(
-        6, OrbitFrame.ECI, OrbitRepresentation.KEPLERIAN, AngleFormat.DEGREES
+        6, CelestialFrame.ECI, OrbitRepresentation.KEPLERIAN, AngleFormat.DEGREES
     )
 
     epoch = Epoch.from_jd(2451545.0, TimeSystem.UTC)
@@ -2297,7 +2387,7 @@ def test_orbittrajectory_stateprovider_state_koe_from_keplerian():
 
 def test_orbittrajectory_stateprovider_state_koe_from_ecef():
     """Test state_koe_osc() for ECEF Cartesian trajectory"""
-    traj = OrbitTrajectory(6, OrbitFrame.ECEF, OrbitRepresentation.CARTESIAN, None)
+    traj = OrbitTrajectory(6, CelestialFrame.ECEF, OrbitRepresentation.CARTESIAN, None)
 
     epoch = Epoch.from_jd(2451545.0, TimeSystem.UTC)
     state_ecef = np.array([7000e3, 0.0, 0.0, 0.0, 0.0, 7.5e3])
@@ -2332,7 +2422,7 @@ def test_orbittrajectory_epochs():
     traj = OrbitTrajectory.from_orbital_data(
         epochs,
         states,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.CARTESIAN,
         None,
     )
@@ -2352,7 +2442,9 @@ def test_orbittrajectory_epochs():
         assert epoch.jd() == pytest.approx(epochs[i].jd(), abs=1e-10)
 
     # Test empty trajectory
-    empty_traj = OrbitTrajectory(6, OrbitFrame.ECI, OrbitRepresentation.CARTESIAN, None)
+    empty_traj = OrbitTrajectory(
+        6, CelestialFrame.ECI, OrbitRepresentation.CARTESIAN, None
+    )
     empty_epochs = empty_traj.epochs()
     assert isinstance(empty_epochs, list)
     assert len(empty_epochs) == 0
@@ -2360,7 +2452,7 @@ def test_orbittrajectory_epochs():
 
 def test_orbittrajectory_epochs_with_frame_transformations():
     """Test epochs() works with epoch objects in frame transformations"""
-    traj = OrbitTrajectory(6, OrbitFrame.ECI, OrbitRepresentation.CARTESIAN, None)
+    traj = OrbitTrajectory(6, CelestialFrame.ECI, OrbitRepresentation.CARTESIAN, None)
 
     epoch1 = Epoch.from_datetime(2024, 1, 1, 0, 0, 0.0, 0.0, brahe.UTC)
     state1 = np.array([R_EARTH + 500e3, 0.0, 0.0, 0.0, 7600.0, 0.0])
@@ -2403,7 +2495,7 @@ def test_orbittrajectory_states():
     traj = OrbitTrajectory.from_orbital_data(
         epochs,
         states,
-        OrbitFrame.ECI,
+        CelestialFrame.ECI,
         OrbitRepresentation.CARTESIAN,
         None,
     )
@@ -2423,7 +2515,9 @@ def test_orbittrajectory_states():
             assert states_array[i, j] == pytest.approx(states[i, j], abs=1e-10)
 
     # Test empty trajectory - should raise error
-    empty_traj = OrbitTrajectory(6, OrbitFrame.ECI, OrbitRepresentation.CARTESIAN, None)
+    empty_traj = OrbitTrajectory(
+        6, CelestialFrame.ECI, OrbitRepresentation.CARTESIAN, None
+    )
     with pytest.raises(RuntimeError, match="Cannot convert empty trajectory to matrix"):
         empty_traj.states()
 
@@ -2435,7 +2529,7 @@ def test_orbittrajectory_states():
 
 def test_orbittrajectory_identifiable_with_name():
     """Test OrbitTrajectory.with_name() method (mirrors Rust test)."""
-    traj = OrbitTrajectory(6, OrbitFrame.ECI, OrbitRepresentation.CARTESIAN, None)
+    traj = OrbitTrajectory(6, CelestialFrame.ECI, OrbitRepresentation.CARTESIAN, None)
     traj = traj.with_name("Test Trajectory")
 
     assert traj.get_name() == "Test Trajectory"
@@ -2443,7 +2537,7 @@ def test_orbittrajectory_identifiable_with_name():
 
 def test_orbittrajectory_identifiable_with_id():
     """Test OrbitTrajectory.with_id() method (mirrors Rust test)."""
-    traj = OrbitTrajectory(6, OrbitFrame.ECI, OrbitRepresentation.CARTESIAN, None)
+    traj = OrbitTrajectory(6, CelestialFrame.ECI, OrbitRepresentation.CARTESIAN, None)
     traj = traj.with_id(12345)
 
     assert traj.get_id() == 12345
@@ -2451,7 +2545,7 @@ def test_orbittrajectory_identifiable_with_id():
 
 def test_orbittrajectory_identifiable_with_uuid():
     """Test OrbitTrajectory.with_new_uuid() method (mirrors Rust test)."""
-    traj = OrbitTrajectory(6, OrbitFrame.ECI, OrbitRepresentation.CARTESIAN, None)
+    traj = OrbitTrajectory(6, CelestialFrame.ECI, OrbitRepresentation.CARTESIAN, None)
     traj = traj.with_new_uuid()
 
     uuid_str = traj.get_uuid()
@@ -2464,7 +2558,7 @@ def test_orbittrajectory_identifiable_with_uuid():
 def test_orbittrajectory_identifiable_get_methods():
     """Test OrbitTrajectory Identifiable getter methods."""
     # Test that getters return None when not set
-    traj = OrbitTrajectory(6, OrbitFrame.ECI, OrbitRepresentation.CARTESIAN, None)
+    traj = OrbitTrajectory(6, CelestialFrame.ECI, OrbitRepresentation.CARTESIAN, None)
 
     assert traj.get_name() is None
     assert traj.get_id() is None
@@ -2483,7 +2577,7 @@ def test_orbittrajectory_identifiable_get_methods():
 
 def test_orbittrajectory_identifiable_builder_chain():
     """Test chaining multiple Identifiable builder methods."""
-    traj = OrbitTrajectory(6, OrbitFrame.ECI, OrbitRepresentation.CARTESIAN, None)
+    traj = OrbitTrajectory(6, CelestialFrame.ECI, OrbitRepresentation.CARTESIAN, None)
 
     # Chain multiple builder methods
     traj = traj.with_name("Chained Trajectory").with_id(777).with_new_uuid()
@@ -2496,7 +2590,7 @@ def test_orbittrajectory_identifiable_builder_chain():
 def test_orbittrajectory_identifiable_preserved_through_conversions():
     """Test that identity is preserved through frame/representation conversions."""
     # Create trajectory with identity
-    traj = OrbitTrajectory(6, OrbitFrame.ECI, OrbitRepresentation.CARTESIAN, None)
+    traj = OrbitTrajectory(6, CelestialFrame.ECI, OrbitRepresentation.CARTESIAN, None)
     traj = traj.with_name("Conversion Test").with_id(456)
 
     # Add a state
@@ -2622,7 +2716,7 @@ def test_from_orbital_data_with_covariances(eop):
     traj = brahe.OrbitTrajectory.from_orbital_data(
         [epoch1, epoch2],
         np.array([state1, state2]),
-        brahe.OrbitFrame.ECI,
+        brahe.CelestialFrame.ECI,
         brahe.OrbitRepresentation.CARTESIAN,
         covariances=np.array([cov1, cov2]),
     )
@@ -2655,7 +2749,7 @@ def test_from_orbital_data_covariances_length_mismatch(eop):
         brahe.OrbitTrajectory.from_orbital_data(
             [epoch1, epoch2],
             np.array([state1, state2]),
-            brahe.OrbitFrame.ECI,
+            brahe.CelestialFrame.ECI,
             brahe.OrbitRepresentation.CARTESIAN,
             covariances=np.array([cov1]),  # Length mismatch!
         )
@@ -2674,7 +2768,7 @@ def test_from_orbital_data_covariances_invalid_frame_ecef(eop):
         brahe.OrbitTrajectory.from_orbital_data(
             [epoch1],
             np.array([state1]),
-            brahe.OrbitFrame.ECEF,  # Invalid frame for covariances!
+            brahe.CelestialFrame.ECEF,  # Invalid frame for covariances!
             brahe.OrbitRepresentation.CARTESIAN,
             covariances=np.array([cov1]),
         )
@@ -2696,7 +2790,7 @@ def test_from_orbital_data_covariances_invalid_frame_itrf(eop):
         brahe.OrbitTrajectory.from_orbital_data(
             [epoch1],
             np.array([state1]),
-            brahe.OrbitFrame.ITRF,  # Invalid frame for covariances!
+            brahe.CelestialFrame.ITRF,  # Invalid frame for covariances!
             brahe.OrbitRepresentation.CARTESIAN,
             covariances=np.array([cov1]),
         )
@@ -2717,7 +2811,7 @@ def test_add_state_and_covariance(eop):
     traj = brahe.OrbitTrajectory.from_orbital_data(
         [epoch1],
         np.array([state1]),
-        brahe.OrbitFrame.ECI,
+        brahe.CelestialFrame.ECI,
         brahe.OrbitRepresentation.CARTESIAN,
         covariances=np.array([cov1]),
     )
@@ -2756,7 +2850,7 @@ def test_covariance_provider_basic(eop):
     traj = brahe.OrbitTrajectory.from_orbital_data(
         [epoch1, epoch2],
         np.array([state1, state2]),
-        brahe.OrbitFrame.ECI,
+        brahe.CelestialFrame.ECI,
         brahe.OrbitRepresentation.CARTESIAN,
         covariances=np.array([cov1, cov2]),
     )
@@ -2802,7 +2896,7 @@ def test_covariance_rtn(eop):
     traj = brahe.OrbitTrajectory.from_orbital_data(
         [epoch],
         np.array([state]),
-        brahe.OrbitFrame.ECI,
+        brahe.CelestialFrame.ECI,
         brahe.OrbitRepresentation.CARTESIAN,
         covariances=np.array([cov_eci]),
     )
@@ -2830,7 +2924,7 @@ def test_covariance_error_for_trajectory_without_covariances(eop):
     traj = brahe.OrbitTrajectory.from_orbital_data(
         [epoch],
         np.array([state]),
-        brahe.OrbitFrame.ECI,
+        brahe.CelestialFrame.ECI,
         brahe.OrbitRepresentation.CARTESIAN,
         # No covariances parameter
     )
@@ -2861,7 +2955,7 @@ def test_covariance_interpolation_method_two_wasserstein(eop):
     traj = brahe.OrbitTrajectory.from_orbital_data(
         [epoch1, epoch2],
         np.array([state1, state2]),
-        brahe.OrbitFrame.ECI,
+        brahe.CelestialFrame.ECI,
         brahe.OrbitRepresentation.CARTESIAN,
         covariances=np.array([cov1, cov2]),
     )
@@ -2900,7 +2994,7 @@ def test_covariance_interpolation_method_matrix_square_root(eop):
     traj = brahe.OrbitTrajectory.from_orbital_data(
         [epoch1, epoch2],
         np.array([state1, state2]),
-        brahe.OrbitFrame.ECI,
+        brahe.CelestialFrame.ECI,
         brahe.OrbitRepresentation.CARTESIAN,
         covariances=np.array([cov1, cov2]),
     )
@@ -2933,7 +3027,7 @@ def test_with_covariance_interpolation_method_builder(eop):
     traj = brahe.OrbitTrajectory.from_orbital_data(
         [epoch],
         np.array([state]),
-        brahe.OrbitFrame.ECI,
+        brahe.CelestialFrame.ECI,
         brahe.OrbitRepresentation.CARTESIAN,
         covariances=np.array([cov]),
     ).with_covariance_interpolation_method(
@@ -2954,7 +3048,7 @@ def test_covariance_eci(eop):
     traj = brahe.OrbitTrajectory.from_orbital_data(
         [epoch],
         np.array([state]),
-        brahe.OrbitFrame.ECI,
+        brahe.CelestialFrame.ECI,
         brahe.OrbitRepresentation.CARTESIAN,
         covariances=np.array([cov]),
     )
@@ -2977,7 +3071,7 @@ def test_covariance_gcrf(eop):
     traj = brahe.OrbitTrajectory.from_orbital_data(
         [epoch],
         np.array([state]),
-        brahe.OrbitFrame.GCRF,
+        brahe.CelestialFrame.GCRF,
         brahe.OrbitRepresentation.CARTESIAN,
         covariances=np.array([cov]),
     )
@@ -3002,7 +3096,7 @@ def test_covariance_eci_from_eme2000_frame(eop):
     traj = brahe.OrbitTrajectory.from_orbital_data(
         [epoch],
         np.array([state]),
-        brahe.OrbitFrame.EME2000,
+        brahe.CelestialFrame.EME2000,
         brahe.OrbitRepresentation.CARTESIAN,
         covariances=np.array([cov_eme2000]),
     )
@@ -3036,7 +3130,7 @@ def test_covariance_gcrf_from_eme2000_frame(eop):
     traj = brahe.OrbitTrajectory.from_orbital_data(
         [epoch],
         np.array([state]),
-        brahe.OrbitFrame.EME2000,
+        brahe.CelestialFrame.EME2000,
         brahe.OrbitRepresentation.CARTESIAN,
         covariances=np.array([cov_eme2000]),
     )
@@ -3063,7 +3157,7 @@ def test_covariance_rtn_from_eme2000_frame(eop):
     traj = brahe.OrbitTrajectory.from_orbital_data(
         [epoch],
         np.array([state]),
-        brahe.OrbitFrame.EME2000,
+        brahe.CelestialFrame.EME2000,
         brahe.OrbitRepresentation.CARTESIAN,
         covariances=np.array([cov_eme2000]),
     )
@@ -3100,7 +3194,7 @@ def test_covariance_interpolatable_trait_methods(eop):
     traj = brahe.OrbitTrajectory.from_orbital_data(
         [epoch],
         np.array([state]),
-        brahe.OrbitFrame.ECI,
+        brahe.CelestialFrame.ECI,
         brahe.OrbitRepresentation.CARTESIAN,
         covariances=np.array([cov]),
     )
@@ -3141,7 +3235,7 @@ def test_covariance_interpolation_edge_cases_matrix_square_root(eop):
     traj = brahe.OrbitTrajectory.from_orbital_data(
         [epoch1, epoch2, epoch3],
         np.array([state1, state2, state3]),
-        brahe.OrbitFrame.ECI,
+        brahe.CelestialFrame.ECI,
         brahe.OrbitRepresentation.CARTESIAN,
         covariances=np.array([cov1, cov2, cov3]),
     ).with_covariance_interpolation_method(
@@ -3190,7 +3284,7 @@ def test_covariance_interpolation_edge_cases_two_wasserstein(eop):
     traj = brahe.OrbitTrajectory.from_orbital_data(
         [epoch1, epoch2, epoch3],
         np.array([state1, state2, state3]),
-        brahe.OrbitFrame.ECI,
+        brahe.CelestialFrame.ECI,
         brahe.OrbitRepresentation.CARTESIAN,
         covariances=np.array([cov1, cov2, cov3]),
     ).with_covariance_interpolation_method(
@@ -3237,7 +3331,7 @@ def test_covariance_interpolation_methods_comparison(eop):
     traj_wasserstein = brahe.OrbitTrajectory.from_orbital_data(
         [epoch1, epoch2],
         np.array([state1, state2]),
-        brahe.OrbitFrame.ECI,
+        brahe.CelestialFrame.ECI,
         brahe.OrbitRepresentation.CARTESIAN,
         covariances=np.array([cov1, cov2]),
     ).with_covariance_interpolation_method(
@@ -3247,7 +3341,7 @@ def test_covariance_interpolation_methods_comparison(eop):
     traj_matrix_sqrt = brahe.OrbitTrajectory.from_orbital_data(
         [epoch1, epoch2],
         np.array([state1, state2]),
-        brahe.OrbitFrame.ECI,
+        brahe.CelestialFrame.ECI,
         brahe.OrbitRepresentation.CARTESIAN,
         covariances=np.array([cov1, cov2]),
     ).with_covariance_interpolation_method(
@@ -3292,7 +3386,7 @@ def test_covariance_single_point_trajectory(eop):
     traj = brahe.OrbitTrajectory.from_orbital_data(
         [epoch],
         np.array([state]),
-        brahe.OrbitFrame.ECI,
+        brahe.CelestialFrame.ECI,
         brahe.OrbitRepresentation.CARTESIAN,
         covariances=np.array([cov]),
     )
@@ -3331,7 +3425,7 @@ def test_covariance_rtn_elliptical_orbit(eop):
     traj = brahe.OrbitTrajectory.from_orbital_data(
         [epoch],
         np.array([state]),
-        brahe.OrbitFrame.ECI,
+        brahe.CelestialFrame.ECI,
         brahe.OrbitRepresentation.CARTESIAN,
         covariances=np.array([cov]),
     )
@@ -3368,7 +3462,7 @@ def test_orbittrajectory_interpolation_linear():
     t0 = Epoch.from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, brahe.UTC)
     t1 = t0 + 60.0
 
-    traj = OrbitTrajectory(6, OrbitFrame.ECI, OrbitRepresentation.CARTESIAN, None)
+    traj = OrbitTrajectory(6, CelestialFrame.ECI, OrbitRepresentation.CARTESIAN, None)
     traj.set_interpolation_method(InterpolationMethod.LINEAR)
     traj.add(t0, np.array([7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]))
     traj.add(t1, np.array([7060e3, 0.0, 0.0, 0.0, 7.5e3, 0.0]))
@@ -3385,7 +3479,7 @@ def test_orbittrajectory_interpolation_lagrange_degree2():
     """Test Lagrange degree 2 interpolation on OrbitTrajectory."""
     t0 = Epoch.from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, brahe.UTC)
 
-    traj = OrbitTrajectory(6, OrbitFrame.ECI, OrbitRepresentation.CARTESIAN, None)
+    traj = OrbitTrajectory(6, CelestialFrame.ECI, OrbitRepresentation.CARTESIAN, None)
     traj.set_interpolation_method(InterpolationMethod.lagrange(2))
 
     # Add 3 points with quadratic position profile: x = 7000e3 + 1000*t + 0.5*t^2
@@ -3407,7 +3501,7 @@ def test_orbittrajectory_interpolation_lagrange_degree3():
     """Test Lagrange degree 3 interpolation on OrbitTrajectory."""
     t0 = Epoch.from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, brahe.UTC)
 
-    traj = OrbitTrajectory(6, OrbitFrame.ECI, OrbitRepresentation.CARTESIAN, None)
+    traj = OrbitTrajectory(6, CelestialFrame.ECI, OrbitRepresentation.CARTESIAN, None)
     traj.set_interpolation_method(InterpolationMethod.lagrange(3))
 
     # Add 4 points with cubic profile
@@ -3429,7 +3523,7 @@ def test_orbittrajectory_interpolation_hermite_cubic():
     t0 = Epoch.from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, brahe.UTC)
     t1 = t0 + 60.0
 
-    traj = OrbitTrajectory(6, OrbitFrame.ECI, OrbitRepresentation.CARTESIAN, None)
+    traj = OrbitTrajectory(6, CelestialFrame.ECI, OrbitRepresentation.CARTESIAN, None)
     traj.set_interpolation_method(InterpolationMethod.HERMITE_CUBIC)
 
     # State 0: position = (7000e3, 0, 0), velocity = (100, 7500, 0)
@@ -3452,10 +3546,10 @@ def test_orbittrajectory_interpolation_lagrange_vs_linear_different():
 
     # Create two trajectories with the same quadratic data
     traj_linear = OrbitTrajectory(
-        6, OrbitFrame.ECI, OrbitRepresentation.CARTESIAN, None
+        6, CelestialFrame.ECI, OrbitRepresentation.CARTESIAN, None
     )
     traj_lagrange = OrbitTrajectory(
-        6, OrbitFrame.ECI, OrbitRepresentation.CARTESIAN, None
+        6, CelestialFrame.ECI, OrbitRepresentation.CARTESIAN, None
     )
 
     traj_linear.set_interpolation_method(InterpolationMethod.LINEAR)
@@ -3492,13 +3586,13 @@ def test_orbittrajectory_interpolation_lagrange_vs_linear_different():
 
 def test_orbittrajectory_acceleration_storage_disabled_by_default():
     """Test that acceleration storage is disabled by default."""
-    traj = OrbitTrajectory(6, OrbitFrame.ECI, OrbitRepresentation.CARTESIAN, None)
+    traj = OrbitTrajectory(6, CelestialFrame.ECI, OrbitRepresentation.CARTESIAN, None)
     assert not traj.has_accelerations()
 
 
 def test_orbittrajectory_enable_acceleration_storage():
     """Test enabling acceleration storage."""
-    traj = OrbitTrajectory(6, OrbitFrame.ECI, OrbitRepresentation.CARTESIAN, None)
+    traj = OrbitTrajectory(6, CelestialFrame.ECI, OrbitRepresentation.CARTESIAN, None)
     traj.enable_acceleration_storage(3)
     assert traj.has_accelerations()
 
@@ -3507,7 +3601,7 @@ def test_orbittrajectory_add_with_acceleration():
     """Test adding states with accelerations."""
     t0 = Epoch.from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, brahe.UTC)
 
-    traj = OrbitTrajectory(6, OrbitFrame.ECI, OrbitRepresentation.CARTESIAN, None)
+    traj = OrbitTrajectory(6, CelestialFrame.ECI, OrbitRepresentation.CARTESIAN, None)
     traj.enable_acceleration_storage(3)
 
     state = np.array([7000e3, 0.0, 0.0, 0.0, 7500.0, 0.0])
@@ -3526,7 +3620,7 @@ def test_orbittrajectory_set_acceleration_at():
     """Test setting acceleration at a specific index."""
     t0 = Epoch.from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, brahe.UTC)
 
-    traj = OrbitTrajectory(6, OrbitFrame.ECI, OrbitRepresentation.CARTESIAN, None)
+    traj = OrbitTrajectory(6, CelestialFrame.ECI, OrbitRepresentation.CARTESIAN, None)
     traj.enable_acceleration_storage(3)
 
     state = np.array([7000e3, 0.0, 0.0, 0.0, 7500.0, 0.0])
@@ -3550,7 +3644,7 @@ def test_orbittrajectory_acceleration_at_idx_no_storage():
     """Test that acceleration_at_idx returns None when storage is not enabled."""
     t0 = Epoch.from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, brahe.UTC)
 
-    traj = OrbitTrajectory(6, OrbitFrame.ECI, OrbitRepresentation.CARTESIAN, None)
+    traj = OrbitTrajectory(6, CelestialFrame.ECI, OrbitRepresentation.CARTESIAN, None)
     # Acceleration storage NOT enabled
     traj.add(t0, np.array([7000e3, 0.0, 0.0, 0.0, 7500.0, 0.0]))
 
@@ -3563,7 +3657,7 @@ def test_orbittrajectory_hermite_quintic_with_accelerations():
     t0 = Epoch.from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, brahe.UTC)
     t1 = t0 + 60.0
 
-    traj = OrbitTrajectory(6, OrbitFrame.ECI, OrbitRepresentation.CARTESIAN, None)
+    traj = OrbitTrajectory(6, CelestialFrame.ECI, OrbitRepresentation.CARTESIAN, None)
     traj.enable_acceleration_storage(3)
     traj.set_interpolation_method(InterpolationMethod.HERMITE_QUINTIC)
 
@@ -3588,7 +3682,7 @@ def test_orbittrajectory_hermite_quintic_without_accelerations_errors():
     """HermiteQuintic must error if acceleration storage is not enabled."""
     t0 = Epoch.from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, brahe.UTC)
 
-    traj = OrbitTrajectory(6, OrbitFrame.ECI, OrbitRepresentation.CARTESIAN, None)
+    traj = OrbitTrajectory(6, CelestialFrame.ECI, OrbitRepresentation.CARTESIAN, None)
     # Acceleration storage NOT enabled
     traj.set_interpolation_method(InterpolationMethod.HERMITE_QUINTIC)
 
@@ -3607,7 +3701,7 @@ def test_orbittrajectory_add_with_acceleration_requires_enabled():
     """Test that add_with_acceleration raises error if storage not enabled."""
     t0 = Epoch.from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, brahe.UTC)
 
-    traj = OrbitTrajectory(6, OrbitFrame.ECI, OrbitRepresentation.CARTESIAN, None)
+    traj = OrbitTrajectory(6, CelestialFrame.ECI, OrbitRepresentation.CARTESIAN, None)
     # Storage NOT enabled
 
     state = np.array([7000e3, 0.0, 0.0, 0.0, 7500.0, 0.0])
@@ -3621,7 +3715,7 @@ def test_orbittrajectory_set_acceleration_requires_enabled():
     """Test that set_acceleration_at raises error if storage not enabled."""
     t0 = Epoch.from_datetime(2023, 1, 1, 12, 0, 0.0, 0.0, brahe.UTC)
 
-    traj = OrbitTrajectory(6, OrbitFrame.ECI, OrbitRepresentation.CARTESIAN, None)
+    traj = OrbitTrajectory(6, CelestialFrame.ECI, OrbitRepresentation.CARTESIAN, None)
     # Storage NOT enabled
     traj.add(t0, np.array([7000e3, 0.0, 0.0, 0.0, 7500.0, 0.0]))
 
@@ -3638,17 +3732,17 @@ def test_orbittrajectory_set_acceleration_requires_enabled():
 
 def test_orbittrajectory_repr_and_str():
     """Test OrbitTrajectory __repr__ and __str__ methods."""
-    traj = OrbitTrajectory(6, OrbitFrame.ECI, OrbitRepresentation.CARTESIAN, None)
+    traj = OrbitTrajectory(6, CelestialFrame.ECI, OrbitRepresentation.CARTESIAN, None)
     repr_str = repr(traj)
     str_str = str(traj)
 
     assert "DOrbitTrajectory" in repr_str
-    assert "ECI" in repr_str or "Earth-Centered Inertial" in repr_str
+    assert "GCRF" in repr_str
     assert "Cartesian" in repr_str
     assert "states=0" in repr_str
 
     assert "DOrbitTrajectory" in str_str
-    assert "ECI" in str_str
+    assert "GCRF" in str_str
     assert "Cartesian" in str_str
 
     # Add a state and verify count changes
@@ -3658,28 +3752,24 @@ def test_orbittrajectory_repr_and_str():
     assert "states=1" in repr(traj)
 
 
-def test_orbitframe_repr_str_name():
-    """Test OrbitFrame __repr__, __str__, and name() methods."""
-    # Test ECI
-    assert str(OrbitFrame.ECI) == "ECI"
-    assert "OrbitFrame" in repr(OrbitFrame.ECI)
-    assert OrbitFrame.ECI.name() == "Earth-Centered Inertial"
+def test_trajectory_frame_repr_str_name():
+    """Frames carried by a trajectory render through CelestialFrame."""
+    # ECI and ECEF are aliases of GCRF and ITRF respectively
+    assert str(CelestialFrame.ECI) == "GCRF"
+    assert repr(CelestialFrame.ECI) == "CelestialFrame.GCRF"
+    assert CelestialFrame.ECI == CelestialFrame.GCRF
 
-    # Test ECEF
-    assert str(OrbitFrame.ECEF) == "ECEF"
-    assert OrbitFrame.ECEF.name() == "Earth-Centered Earth-Fixed"
+    assert str(CelestialFrame.ECEF) == "ITRF"
+    assert CelestialFrame.ECEF == CelestialFrame.ITRF
 
-    # Test GCRF
-    assert str(OrbitFrame.GCRF) == "GCRF"
-    assert OrbitFrame.GCRF.name() == "Geocentric Celestial Reference Frame"
+    assert str(CelestialFrame.GCRF) == "GCRF"
+    assert str(CelestialFrame.EME2000) == "EME2000"
+    assert str(CelestialFrame.ITRF) == "ITRF"
 
-    # Test EME2000
-    assert str(OrbitFrame.EME2000) == "EME2000"
-    assert OrbitFrame.EME2000.name() == "Earth Mean Equator and Equinox of J2000.0"
-
-    # Test ITRF
-    assert str(OrbitFrame.ITRF) == "ITRF"
-    assert OrbitFrame.ITRF.name() == "International Terrestrial Reference Frame"
+    # A trajectory reports the wrapping ReferenceFrame
+    traj = OrbitTrajectory(6, CelestialFrame.ITRF, OrbitRepresentation.CARTESIAN, None)
+    assert str(traj.frame) == "ITRF"
+    assert repr(traj.frame) == 'ReferenceFrame("ITRF")'
 
 
 def test_orbitrepresentation_repr_str():
@@ -3784,31 +3874,33 @@ def test_covarianceinterpolationmethod_repr_str():
 
 def test_orbittrajectory_orbital_dimension():
     """Test orbital_dimension() method."""
-    traj6 = OrbitTrajectory(6, OrbitFrame.ECI, OrbitRepresentation.CARTESIAN, None)
+    traj6 = OrbitTrajectory(6, CelestialFrame.ECI, OrbitRepresentation.CARTESIAN, None)
     assert traj6.orbital_dimension() == 6
 
-    traj9 = OrbitTrajectory(9, OrbitFrame.ECI, OrbitRepresentation.CARTESIAN, None)
+    traj9 = OrbitTrajectory(9, CelestialFrame.ECI, OrbitRepresentation.CARTESIAN, None)
     assert traj9.orbital_dimension() == 6  # Always 6
 
 
 def test_orbittrajectory_additional_dimension():
     """Test additional_dimension() method."""
-    traj6 = OrbitTrajectory(6, OrbitFrame.ECI, OrbitRepresentation.CARTESIAN, None)
+    traj6 = OrbitTrajectory(6, CelestialFrame.ECI, OrbitRepresentation.CARTESIAN, None)
     assert traj6.additional_dimension() == 0
 
-    traj9 = OrbitTrajectory(9, OrbitFrame.ECI, OrbitRepresentation.CARTESIAN, None)
+    traj9 = OrbitTrajectory(9, CelestialFrame.ECI, OrbitRepresentation.CARTESIAN, None)
     assert traj9.additional_dimension() == 3
 
-    traj12 = OrbitTrajectory(12, OrbitFrame.ECI, OrbitRepresentation.CARTESIAN, None)
+    traj12 = OrbitTrajectory(
+        12, CelestialFrame.ECI, OrbitRepresentation.CARTESIAN, None
+    )
     assert traj12.additional_dimension() == 6
 
 
 def test_orbittrajectory_dimension_too_small():
     """Test that dimension < 6 raises error."""
     with pytest.raises(ValueError, match="at least 6"):
-        OrbitTrajectory(5, OrbitFrame.ECI, OrbitRepresentation.CARTESIAN, None)
+        OrbitTrajectory(5, CelestialFrame.ECI, OrbitRepresentation.CARTESIAN, None)
     with pytest.raises(ValueError, match="at least 6"):
-        OrbitTrajectory(3, OrbitFrame.ECI, OrbitRepresentation.CARTESIAN, None)
+        OrbitTrajectory(3, CelestialFrame.ECI, OrbitRepresentation.CARTESIAN, None)
 
 
 # ========================
@@ -3818,7 +3910,7 @@ def test_orbittrajectory_dimension_too_small():
 
 def test_orbittrajectory_set_name():
     """Test OrbitTrajectory.set_name() method."""
-    traj = OrbitTrajectory(6, OrbitFrame.ECI, OrbitRepresentation.CARTESIAN, None)
+    traj = OrbitTrajectory(6, CelestialFrame.ECI, OrbitRepresentation.CARTESIAN, None)
     assert traj.get_name() is None
 
     traj.set_name("My Satellite")
@@ -3831,7 +3923,7 @@ def test_orbittrajectory_set_name():
 
 def test_orbittrajectory_set_id():
     """Test OrbitTrajectory.set_id() method."""
-    traj = OrbitTrajectory(6, OrbitFrame.ECI, OrbitRepresentation.CARTESIAN, None)
+    traj = OrbitTrajectory(6, CelestialFrame.ECI, OrbitRepresentation.CARTESIAN, None)
     assert traj.get_id() is None
 
     traj.set_id(42)
@@ -3849,7 +3941,7 @@ def test_orbittrajectory_set_id():
 
 def test_orbittrajectory_states_koe_osc_multi_epoch():
     """Test states_koe_osc() with multiple epochs."""
-    traj = OrbitTrajectory(6, OrbitFrame.ECI, OrbitRepresentation.CARTESIAN, None)
+    traj = OrbitTrajectory(6, CelestialFrame.ECI, OrbitRepresentation.CARTESIAN, None)
 
     epoch1 = Epoch.from_jd(2451545.0, TimeSystem.UTC)
     state1 = np.array([7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0])
@@ -3877,7 +3969,7 @@ def test_orbittrajectory_states_koe_osc_multi_epoch():
 
 def test_orbittrajectory_states_koe_mean_multi_epoch():
     """Test states_koe_mean() with multiple epochs."""
-    traj = OrbitTrajectory(6, OrbitFrame.ECI, OrbitRepresentation.CARTESIAN, None)
+    traj = OrbitTrajectory(6, CelestialFrame.ECI, OrbitRepresentation.CARTESIAN, None)
 
     # Use realistic inclined orbit to avoid mean element conversion issues
     oe1 = np.array([R_EARTH + 500e3, 0.01, 51.6, 15.0, 30.0, 45.0])
@@ -3906,7 +3998,7 @@ def test_orbittrajectory_states_koe_mean_multi_epoch():
 
 def test_orbittrajectory_state_koe_mean():
     """Test state_koe_mean() returns mean Keplerian elements."""
-    traj = OrbitTrajectory(6, OrbitFrame.ECI, OrbitRepresentation.CARTESIAN, None)
+    traj = OrbitTrajectory(6, CelestialFrame.ECI, OrbitRepresentation.CARTESIAN, None)
 
     # Use realistic inclined orbit to avoid mean element conversion issues
     oe = np.array([R_EARTH + 500e3, 0.01, 51.6, 15.0, 30.0, 45.0])
@@ -3936,9 +4028,7 @@ def test_orbittrajectory_body_centered_inertial_providers(naif_cache_setup):
     through SPK. Mirrors test_dorbittrajectory_body_centered_inertial_providers."""
     import brahe as bh
 
-    traj = OrbitTrajectory(
-        6, OrbitFrame.BodyCenteredInertial(301), OrbitRepresentation.CARTESIAN, None
-    )
+    traj = OrbitTrajectory(6, CelestialFrame.LCI, OrbitRepresentation.CARTESIAN, None)
     epoch = Epoch.from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem.UTC)
     state = np.array([2.0e6, 1.0e5, -3.0e5, 10.0, 1.6e3, -5.0])
     traj.add(epoch, state)
@@ -3953,7 +4043,7 @@ def test_orbittrajectory_body_centered_inertial_providers(naif_cache_setup):
 
     # Batch conversion matches the per-epoch provider result.
     traj_eci = traj.to_eci()
-    assert traj_eci.frame == OrbitFrame.ECI
+    assert traj_eci.frame == CelestialFrame.ECI
     np.testing.assert_allclose(
         traj_eci.state_eci(epoch), traj.state_eci(epoch), atol=1e-6
     )
@@ -3996,7 +4086,9 @@ def test_orbittrajectory_body_centered_inertial_providers(naif_cache_setup):
     assert abs(np.linalg.norm(bcbf[:3]) - np.linalg.norm(state[:3])) < 1e-6
 
     # Earth-frame trajectory: state_bci == state_gcrf.
-    traj_e = OrbitTrajectory(6, OrbitFrame.GCRF, OrbitRepresentation.CARTESIAN, None)
+    traj_e = OrbitTrajectory(
+        6, CelestialFrame.GCRF, OrbitRepresentation.CARTESIAN, None
+    )
     state_e = np.array([7000e3, 0.0, 0.0, 0.0, 7.5e3, 0.0])
     traj_e.add(epoch, state_e)
     np.testing.assert_array_equal(traj_e.state_bci(epoch), traj_e.state_gcrf(epoch))
@@ -4012,7 +4104,7 @@ def test_orbittrajectory_body_centered_inertial_error_branches():
     epoch = Epoch.from_datetime(2024, 3, 1, 0, 0, 0.0, 0.0, TimeSystem.UTC)
 
     traj_emb = OrbitTrajectory(
-        6, OrbitFrame.BodyCenteredInertial(3), OrbitRepresentation.CARTESIAN, None
+        6, CelestialFrame.EMBI, OrbitRepresentation.CARTESIAN, None
     )
     traj_emb.add(epoch, np.array([1e8, 0.0, 0.0, 0.0, 1e3, 0.0]))
     with pytest.raises(bh.BraheError, match="barycenter"):
@@ -4021,7 +4113,7 @@ def test_orbittrajectory_body_centered_inertial_error_branches():
         traj_emb.state_bcbf(epoch)
 
     traj_unknown = OrbitTrajectory(
-        6, OrbitFrame.BodyCenteredInertial(-20001), OrbitRepresentation.CARTESIAN, None
+        6, CelestialFrame.BodyCenteredICRF(-20001), OrbitRepresentation.CARTESIAN, None
     )
     traj_unknown.add(epoch, np.array([1e5, 0.0, 0.0, 0.0, 1.0, 0.0]))
     with pytest.raises(bh.BraheError):
@@ -4044,7 +4136,7 @@ def test_hermite_interpolation_at_a_repeated_epoch(eop):
         InterpolationMethod.HERMITE_CUBIC,
         InterpolationMethod.HERMITE_QUINTIC,
     ]:
-        traj = OrbitTrajectory(6, OrbitFrame.ECI, OrbitRepresentation.CARTESIAN)
+        traj = OrbitTrajectory(6, CelestialFrame.ECI, OrbitRepresentation.CARTESIAN)
         traj.enable_acceleration_storage(3)
         zero = np.zeros(3)
         traj.add_with_acceleration(start, state(0.0), zero)

--- a/tests/trajectories/test_orbit_trajectory.py
+++ b/tests/trajectories/test_orbit_trajectory.py
@@ -107,7 +107,15 @@ def test_trajectory_to_frame_orbit_relative(eop, leo_trajectory):
         brahe.register_object("CHIEF", leo_trajectory, CelestialFrame.GCRF)
         rtn = leo_trajectory.to_frame(brahe.ReferenceFrame.RTN("CHIEF"))
         assert rtn.frame == brahe.ReferenceFrame.RTN("CHIEF")
-        np.testing.assert_allclose(rtn.to_matrix()[:, 0:3], 0.0, atol=1e-6)
+        # The trajectory is its own chief, so position and the transported
+        # velocity are both zero.
+        np.testing.assert_allclose(rtn.to_matrix()[:, 0:6], 0.0, atol=1e-6)
+
+        epc = leo_trajectory.epochs()[3]
+        bci = rtn.state_bci(epc)
+        expected = leo_trajectory.state_gcrf(epc)
+        np.testing.assert_allclose(bci[0:3], expected[0:3], atol=1e-3)
+        np.testing.assert_allclose(bci[3:6], expected[3:6], atol=1e-6)
     finally:
         brahe.clear_object_registry()
 
@@ -126,6 +134,45 @@ def test_keplerian_frame_rule():
         OrbitRepresentation.KEPLERIAN,
         AngleFormat.DEGREES,
     )
+
+
+def test_trajectory_to_keplerian_uses_the_frame_center(eop):
+    """Rust: test_dorbittrajectory_to_keplerian_uses_the_frame_center"""
+    epoch = Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, brahe.UTC)
+
+    # A circular lunar orbit declared in LCI: elements are taken about the Moon
+    # and keep the trajectory's own frame.
+    r_moon = brahe.R_MOON + 100e3
+    v_moon = np.sqrt(brahe.GM_MOON / r_moon)
+    lci = OrbitTrajectory(6, CelestialFrame.LCI, OrbitRepresentation.CARTESIAN, None)
+    lci.add(epoch, np.array([r_moon, 0.0, 0.0, 0.0, v_moon, 0.0]))
+
+    lci_kep = lci.to_keplerian(AngleFormat.DEGREES)
+    assert lci_kep.frame == CelestialFrame.LCI
+    assert lci_kep.representation == OrbitRepresentation.KEPLERIAN
+    _, elements = lci_kep.get(0)
+    assert elements[0] == pytest.approx(r_moon, abs=1e-6)
+    assert elements[1] == pytest.approx(0.0, abs=1e-9)
+
+    # Earth-centered Cartesian input matches the pairwise Earth conversion
+    # exactly and keeps its GCRF label.
+    x_gcrf = np.array([R_EARTH + 500e3, 0.0, 0.0, 0.0, 7.6e3, 10.0])
+    gcrf = OrbitTrajectory(6, CelestialFrame.GCRF, OrbitRepresentation.CARTESIAN, None)
+    gcrf.add(epoch, x_gcrf)
+
+    gcrf_kep = gcrf.to_keplerian(AngleFormat.DEGREES)
+    assert gcrf_kep.frame == CelestialFrame.GCRF
+    _, elements = gcrf_kep.get(0)
+    np.testing.assert_array_equal(
+        elements, state_eci_to_koe(x_gcrf, AngleFormat.DEGREES)
+    )
+
+    # Earth-fixed and of-date frames admit no Keplerian elements.
+    for frame in (CelestialFrame.ITRF, CelestialFrame.TOD):
+        traj = OrbitTrajectory(6, frame, OrbitRepresentation.CARTESIAN, None)
+        traj.add(epoch, x_gcrf)
+        with pytest.raises(BraheError, match="inertial frame"):
+            traj.to_keplerian(AngleFormat.DEGREES)
 
 
 def test_orbit_frame_is_removed():
@@ -1866,7 +1913,7 @@ def test_orbittrajectory_orbitaltrajectory_to_keplerian_deg():
     for i in range(6):
         assert state_out[i] == pytest.approx(state_kep_deg[i], abs=tol)
 
-    # Convert ECEF to Keplerian Degrees
+    # ECEF is Earth-fixed, so it admits no Keplerian elements.
     ecef_traj = OrbitTrajectory(
         6,
         CelestialFrame.ECEF,
@@ -1875,15 +1922,8 @@ def test_orbittrajectory_orbitaltrajectory_to_keplerian_deg():
     )
     ecef_state = state_eci_to_ecef(epoch, cart_state)
     ecef_traj.add(epoch, ecef_state)
-    kep_from_ecef = ecef_traj.to_keplerian(AngleFormat.DEGREES)
-    assert kep_from_ecef.frame == CelestialFrame.ECI
-    assert kep_from_ecef.representation == OrbitRepresentation.KEPLERIAN
-    assert kep_from_ecef.angle_format == AngleFormat.DEGREES
-    assert len(kep_from_ecef) == 1
-    epoch_out, state_out = kep_from_ecef.get(0)
-    assert epoch_out.jd() == epoch.jd()
-    for i in range(6):
-        assert state_out[i] == pytest.approx(state_kep_deg[i], abs=tol)
+    with pytest.raises(BraheError, match="inertial frame"):
+        ecef_traj.to_keplerian(AngleFormat.DEGREES)
 
 
 def test_orbittrajectory_orbitaltrajectory_to_keplerian_rad():
@@ -1952,7 +1992,7 @@ def test_orbittrajectory_orbitaltrajectory_to_keplerian_rad():
     for i in range(6):
         assert state_out[i] == pytest.approx(state_kep_rad[i], abs=tol)
 
-    # Convert ECEF to Keplerian Radians
+    # ECEF is Earth-fixed, so it admits no Keplerian elements.
     ecef_traj = OrbitTrajectory(
         6,
         CelestialFrame.ECEF,
@@ -1961,15 +2001,8 @@ def test_orbittrajectory_orbitaltrajectory_to_keplerian_rad():
     )
     ecef_state = state_eci_to_ecef(epoch, cart_state)
     ecef_traj.add(epoch, ecef_state)
-    kep_from_ecef = ecef_traj.to_keplerian(AngleFormat.RADIANS)
-    assert kep_from_ecef.frame == CelestialFrame.ECI
-    assert kep_from_ecef.representation == OrbitRepresentation.KEPLERIAN
-    assert kep_from_ecef.angle_format == AngleFormat.RADIANS
-    assert len(kep_from_ecef) == 1
-    epoch_out, state_out = kep_from_ecef.get(0)
-    assert epoch_out.jd() == epoch.jd()
-    for i in range(6):
-        assert state_out[i] == pytest.approx(state_kep_rad[i], abs=tol)
+    with pytest.raises(BraheError, match="inertial frame"):
+        ecef_traj.to_keplerian(AngleFormat.RADIANS)
 
 
 # StateProvider Tests


### PR DESCRIPTION
## Description

Replaces the trajectory-level `OrbitFrame` tag with the router's `ReferenceFrame`, so a trajectory, a propagator output, or a CCSDS ephemeris can be declared in any frame the reference frame router evaluates: every `CelestialFrame` (GCRF, ITRF, EME2000, MOD, TOD, the lunar and Mars frames, ...) and any bound orbit-relative or body frame. Frame conversion collapses onto one `to_frame` method that converts Keplerian samples to Cartesian with the GM of the frame's center and routes every sample through `state_frame_to_frame`; the named `to_eci`/`to_gcrf`/`to_ecef`/`to_itrf`/`to_eme2000` methods remain as wrappers, and the state-provider accessors delegate to `state_in_frame`. A crate-internal `celestial_root` resolves any bound frame to its celestial root without evaluating rotations, so `state_bci`/`state_bcbf` work for orbit-relative trajectories. `ReferenceFrame` compares equal to the `CelestialFrame` it wraps in both Rust and Python. Second PR of the equinox-frames stack (on #526); the CCSDS TOD/MOD token mapping that closes #520 follows in the next PR.

## Changelog

### Added
- `OrbitTrajectory.to_frame(frame)` (Rust `DOrbitTrajectory::to_frame` / `SOrbitTrajectory::to_frame`) converting a trajectory to any `ReferenceFrame` through the reference frame router, including orbit-relative frames of registered objects.
- `ReferenceFrame == CelestialFrame` comparisons in Rust (`PartialEq` both directions) and Python (`ReferenceFrame.__eq__` accepts a `CelestialFrame`).
- `KeplerianPropagator` and `SGPPropagator` accept any Earth-rooted `ReferenceFrame` as output frame (for example `CelestialFrame.TOD` or a bound `RTN` frame), and Keplerian output is accepted in EME2000 as well as GCRF.

### Changed
- Trajectory, propagator, and CCSDS interop frame fields and arguments are `ReferenceFrame`; constructors accept a `CelestialFrame` or `ReferenceFrame` (`bh.CelestialFrame.ECI` where `bh.OrbitFrame.ECI` was used; `bh.CelestialFrame.LCI` for the former `BodyCenteredInertial(301)`).
- `OrbitTrajectory.frame` returns a `ReferenceFrame` whose string form is the celestial name (`GCRF`, `ITRF`, `LCI`) rather than the former `ECI`/`ECEF`/`BCI(301)` labels.
- Keplerian element trajectories and propagator outputs are valid in ICRF-aligned inertial celestial frames and EME2000; `CelestialFrame.GCRF` is accepted wherever `ECI` was (they are the same frame).
- `plot_trajectory_3d` converts trajectories around any central body into that body's inertial frame with `to_frame` instead of rejecting a mismatched frame.
- `OEM.register_for` accepts any celestial trajectory frame; the Python OEM-from-trajectory path converts through the router, so a non-Earth body-centered trajectory is re-centered instead of rejected.
- `to_keplerian` keeps the trajectory's own frame for element input and, for Cartesian input, produces elements about the frame's center (accepted for ICRF-aligned inertial frames and EME2000; rejected for Earth-fixed, of-date, orbit-relative, and body frames, where it previously converted through GCRF and labeled the result ECI). `state_koe_osc` short-circuits exactly for Keplerian trajectories in any ICRF-aligned frame.
- `covariance_eci`/`covariance_gcrf` error, naming the frame, for trajectory frames without a covariance representation; propagator error messages for the Keplerian-frame and Earth-only rules changed.
- `OrbitalTrajectory` gains a required `to_frame` method (breaking for external implementors). Propagator constructors, `with_output_format`, and stepping can return router errors for frames that cannot be evaluated; `KeplerianPropagator::reset` panics if the output frame can no longer be resolved; `set_initial_conditions` leaves the propagator unchanged when a conversion fails.
- Python `KeplerianPropagator(...)` and `set_initial_conditions` accept `angle_format=None` for Cartesian input, mirroring the Rust `Option<AngleFormat>`; passing `None` with a Keplerian representation now raises `BraheError` instead of `TypeError`.
- `ccsds_ref_frame_to_orbit_frame` is renamed `ccsds_ref_frame_to_reference_frame` and returns a `ReferenceFrame`; the token mapping itself lives in the new `ccsds_ref_frame_to_celestial_frame`, which `OEM::register_for` uses directly.

### Removed
- `OrbitFrame` (Rust `brahe::trajectories::OrbitFrame`, Python `brahe.OrbitFrame`).

### Fixed
- `KeplerianPropagator` with an EME2000 output frame no longer applies a spurious frame rotation in `state_gcrf`, and its ECEF/ITRF output arms no longer disagree.
- Frame conversion of a Keplerian trajectory declared in EME2000 now converts the elements about the correct frame instead of treating them as GCRF elements, matching the point-query accessors.

## Related Issue
Related to #520 (closed by the next PR of this stack).

## Note to Reviewers
Keplerian element trajectories in EME2000 were accepted before this change and remain accepted (elements are realized as Cartesian and rotated); the design spec's D9 row records this allowance. The four patch lines codecov still reports as missing are the `?` early-return regions of infallible calls (`SOrbitTrajectory::new` for Cartesian input, `convert_state_from_spg4_frame` for ECI Cartesian output, and the EME2000 bias rotation), which no input can reach.
The trajectory conversion paths for GCRF, ITRF, and EME2000 are bit-identical to the previous pairwise implementation because the router calls the same functions; tests assert exact equality. Behavior changes are listed above; the largest is the `plot_trajectory_3d` conversion (the former rejection test is rewritten to assert the conversion). The pre-existing `SOrbitTrajectory::from_orbital_data` trait method takes a `ReferenceFrame` directly, so Rust call sites pass `CelestialFrame::ECI.into()`.

