### PR TITLE
Fix cookbook EOP fixture scale and add CIP offset oracle

### DIFF
--- a/src/frames/gcrf_itrf.rs
+++ b/src/frames/gcrf_itrf.rs
@@ -816,8 +816,8 @@ mod tests {
         let pm_x = 0.0349282 * AS2RAD;
         let pm_y = 0.4833163 * AS2RAD;
         let ut1_utc = -0.072073685;
-        let dX = 0.0001750 * AS2RAD * 1.0e-3;
-        let dY = -0.0002259 * AS2RAD * 1.0e-3;
+        let dX = 0.0001750 * AS2RAD;
+        let dY = -0.0002259 * AS2RAD;
         let eop = StaticEOPProvider::from_values((pm_x, pm_y, ut1_utc, dX, dY, 0.0));
         set_global_eop_provider(eop);
     }
@@ -847,6 +847,29 @@ mod tests {
         assert_abs_diff_eq!(rc2i[(2, 0)], 0.000712264729599, epsilon = tol);
         assert_abs_diff_eq!(rc2i[(2, 1)], 0.000044385250426, epsilon = tol);
         assert_abs_diff_eq!(rc2i[(2, 2)], 0.999999745354420, epsilon = tol);
+    }
+
+    #[test]
+    #[serial]
+    fn test_bias_precession_nutation_applies_cip_offsets() {
+        let epc = Epoch::from_datetime(2007, 4, 5, 12, 0, 0.0, 0.0, TimeSystem::UTC);
+        let dx = 0.0001750 * AS2RAD;
+        let dy = -0.0002259 * AS2RAD;
+
+        set_test_static_eop();
+        let rc2i = bias_precession_nutation(epc);
+        set_global_eop_provider(StaticEOPProvider::from_values((
+            0.0349282 * AS2RAD,
+            0.4833163 * AS2RAD,
+            -0.072073685,
+            0.0,
+            0.0,
+            0.0,
+        )));
+        let rc2i_zero = bias_precession_nutation(epc);
+
+        assert_abs_diff_eq!(rc2i[(2, 0)] - rc2i_zero[(2, 0)], dx, epsilon = 1.0e-12);
+        assert_abs_diff_eq!(rc2i[(2, 1)] - rc2i_zero[(2, 1)], dy, epsilon = 1.0e-12);
     }
 
     #[test]

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -10,21 +10,32 @@ def static_eop():
     pm_x = 0.0349282 * brahe.AS2RAD
     pm_y = 0.4833163 * brahe.AS2RAD
     ut1_utc = -0.072073685
-    dX = 0.0001750 * brahe.AS2RAD * 1.0e-3
-    dY = -0.0002259 * brahe.AS2RAD * 1.0e-3
-    eop = brahe.StaticEOPProvider.from_values(pm_x, pm_y, ut1_utc, dX, dY, 0.0)
-    brahe.set_global_eop_provider(eop)
-
-
-@pytest.fixture()
-def cookbook_eop():
-    pm_x = 0.0349282 * brahe.AS2RAD
-    pm_y = 0.4833163 * brahe.AS2RAD
-    ut1_utc = -0.072073685
     dX = 0.0001750 * brahe.AS2RAD
     dY = -0.0002259 * brahe.AS2RAD
     eop = brahe.StaticEOPProvider.from_values(pm_x, pm_y, ut1_utc, dX, dY, 0.0)
     brahe.set_global_eop_provider(eop)
+
+
+def test_bias_precession_nutation_applies_cip_offsets(static_eop):
+    epc = brahe.Epoch.from_datetime(2007, 4, 5, 12, 0, 0, 0.0, brahe.UTC)
+    dX = 0.0001750 * brahe.AS2RAD
+    dY = -0.0002259 * brahe.AS2RAD
+
+    rc2i = brahe.bias_precession_nutation(epc)
+    brahe.set_global_eop_provider(
+        brahe.StaticEOPProvider.from_values(
+            0.0349282 * brahe.AS2RAD,
+            0.4833163 * brahe.AS2RAD,
+            -0.072073685,
+            0.0,
+            0.0,
+            0.0,
+        )
+    )
+    rc2i_zero = brahe.bias_precession_nutation(epc)
+
+    assert rc2i[2, 0] - rc2i_zero[2, 0] == pytest.approx(dX, abs=1e-12)
+    assert rc2i[2, 1] - rc2i_zero[2, 1] == pytest.approx(dY, abs=1e-12)
 
 
 def test_bias_precession_nutation(static_eop):
@@ -1624,7 +1635,7 @@ def test_celestial_frame_mod_tod_attrs():
     assert str(brahe.CelestialFrame.TOD) == "TOD"
 
 
-def test_rotation_gcrf_to_tod_cookbook(cookbook_eop):
+def test_rotation_gcrf_to_tod_cookbook(static_eop):
     """Equinox chain GCRF -> TOD -> ITRF against SOFA cookbook 5.4 (2000B vs 2000A)."""
     epc = brahe.Epoch.from_datetime(2007, 4, 5, 12, 0, 0.0, 0.0, brahe.UTC)
 
@@ -1644,7 +1655,7 @@ def test_rotation_gcrf_to_tod_cookbook(cookbook_eop):
     np.testing.assert_allclose(r, brahe.rotation_gcrf_to_itrf(epc), atol=1e-10)
 
 
-def test_equinox_building_blocks(cookbook_eop):
+def test_equinox_building_blocks(static_eop):
     epc = brahe.Epoch.from_datetime(2007, 4, 5, 12, 0, 0.0, 0.0, brahe.UTC)
     np.testing.assert_array_equal(
         brahe.bias_precession_iau2000(epc), brahe.rotation_gcrf_to_mod(epc)
@@ -1664,7 +1675,7 @@ def test_equinox_building_blocks(cookbook_eop):
     )
 
 
-def test_equinox_rotation_inverses(cookbook_eop):
+def test_equinox_rotation_inverses(static_eop):
     epc = brahe.Epoch.from_datetime(2007, 4, 5, 12, 0, 0.0, 0.0, brahe.UTC)
     for fwd, inv in [
         (brahe.rotation_gcrf_to_mod, brahe.rotation_mod_to_gcrf),


### PR DESCRIPTION
## Description

Removes the extra `1.0e-3` factor that two test fixtures applied to the SOFA cookbook celestial pole offsets, so the GCRF/ITRF cookbook tests now exercise the real dX/dY correction (0.1750 mas and -0.2259 mas) instead of a value one thousand times too small. Adds a corrected-CIP oracle test in Rust and Python that asserts the correction shifts the bias-precession-nutation matrix by exactly dX and dY, so a dropped or sign-flipped correction fails the test rather than passing inside the 1e-8 cookbook tolerance. The Python `cookbook_eop` fixture added by #526 duplicated the corrected `static_eop` fixture and is folded into it.

## Changelog

### Fixed
- Test fixtures `set_test_static_eop` (`src/frames/gcrf_itrf.rs`) and `static_eop` (`tests/test_frames.py`) apply the SOFA cookbook dX/dY celestial pole offsets at their true scale; new `test_bias_precession_nutation_applies_cip_offsets` tests assert the offsets enter the CIP with the correct sign and magnitude.

## Related Issue
Closes #525

## Note to Reviewers
The cookbook matrix assertions keep their 1e-8 tolerance because the cookbook values come from the full IAU 2006/2000A series while brahe evaluates the truncated IAU 2000B series (about 5e-9 rad apart at the cookbook epoch); the new oracle test is what detects a wrong correction.
