### PR TITLE
Unify state kinematics across frame modules

### DIFF
--- a/src/frames/eme_2000.rs
+++ b/src/frames/eme_2000.rs
@@ -5,6 +5,7 @@
 use nalgebra::{Vector3, matrix};
 
 use crate::constants::AS2RAD;
+use crate::frames::kinematics::rotate_state;
 use crate::math::{SMatrix3, SVector6};
 use crate::utils::batch::batch_map;
 
@@ -182,15 +183,7 @@ pub fn position_eme2000_to_gcrf(x_eme2000: Vector3<f64>) -> Vector3<f64> {
 /// let x_eme2000 = state_gcrf_to_eme2000(x_gcrf);
 /// ```
 pub fn state_gcrf_to_eme2000(x_gcrf: SVector6) -> SVector6 {
-    let r = rotation_gcrf_to_eme2000();
-
-    let r_gcrf = x_gcrf.fixed_rows::<3>(0);
-    let v_gcrf = x_gcrf.fixed_rows::<3>(3);
-
-    let p: Vector3<f64> = Vector3::from(r * r_gcrf);
-    let v: Vector3<f64> = Vector3::from(r * v_gcrf);
-
-    SVector6::new(p[0], p[1], p[2], v[0], v[1], v[2])
+    rotate_state(&rotation_gcrf_to_eme2000(), &x_gcrf)
 }
 
 /// Transforms a Cartesian state in EME 2000 (Earth Mean Equator and Equinox of J2000.0)
@@ -223,15 +216,7 @@ pub fn state_gcrf_to_eme2000(x_gcrf: SVector6) -> SVector6 {
 /// let x_gcrf = state_eme2000_to_gcrf(x_eme2000);
 /// ```
 pub fn state_eme2000_to_gcrf(x_eme2000: SVector6) -> SVector6 {
-    let r = rotation_eme2000_to_gcrf();
-
-    let r_eme2000 = x_eme2000.fixed_rows::<3>(0);
-    let v_eme2000 = x_eme2000.fixed_rows::<3>(3);
-
-    let p: Vector3<f64> = Vector3::from(r * r_eme2000);
-    let v: Vector3<f64> = Vector3::from(r * v_eme2000);
-
-    SVector6::new(p[0], p[1], p[2], v[0], v[1], v[2])
+    rotate_state(&rotation_eme2000_to_gcrf(), &x_eme2000)
 }
 
 /// Transforms a batch of Cartesian positions from GCRF to EME2000.

--- a/src/frames/equinox.rs
+++ b/src/frames/equinox.rs
@@ -21,6 +21,9 @@ use crate::constants;
 use crate::constants::MJD_ZERO;
 use crate::eop;
 use crate::frames::gcrf_itrf::polar_motion;
+use crate::frames::kinematics::{
+    rotate_state, state_inertial_to_rotating, state_rotating_to_inertial,
+};
 use crate::frames::precession_nutation::{PrecessionNutationModel, get_precession_nutation_model};
 use crate::math::{SMatrix3, SVector6, matrix3_from_array};
 use crate::time::{Epoch, TimeSystem};
@@ -605,74 +608,34 @@ pub fn rotation_itrf_to_tod(epc: Epoch) -> SMatrix3 {
     rotation_tod_to_itrf(epc).transpose()
 }
 
-/// Applies a rotation to both the position and velocity halves of a state.
-///
-/// # Arguments
-/// - `r`: Rotation matrix applied to both halves of the state
-/// - `x`: Cartesian state (position, velocity). Units: (*m*; *m/s*)
-///
-/// # Returns
-/// - Rotated Cartesian state (position, velocity). Units: (*m*; *m/s*)
-fn rotate_state(r: &SMatrix3, x: &SVector6) -> SVector6 {
-    let p: Vector3<f64> = r * x.fixed_rows::<3>(0);
-    let v: Vector3<f64> = r * x.fixed_rows::<3>(3);
-    SVector6::new(p[0], p[1], p[2], v[0], v[1], v[2])
-}
-
-/// Rotation and polar-motion matrices for the TOD <-> ITRF state transforms.
+/// TOD -> ITRF rotation and the ITRF axes' angular velocity for one epoch.
 struct TodItrfContext {
-    r: SMatrix3,
-    pm: SMatrix3,
+    /// TOD -> ITRF rotation, `W R3(GAST)`.
+    r_mat: SMatrix3,
+    /// Angular velocity of the ITRF axes, expressed in the ITRF. Units: (*rad/s*)
+    omega_b: Vector3<f64>,
 }
 
-/// Computes the sidereal-rotation and polar-motion matrices for `epc`.
+/// Computes the TOD -> ITRF rotation and the ITRF angular velocity for `epc`.
+///
+/// The ITRF axes rotate about the true celestial pole at
+/// [`constants::OMEGA_EARTH`]; polar motion carries that vector from the
+/// terrestrial intermediate axes into the ITRF, so the angular velocity
+/// expressed in the ITRF is `W (0, 0, OMEGA_EARTH)`.
 ///
 /// # Arguments
-/// - `epc`: Epoch instant for computation of the transformation matrices
+/// - `epc`: Epoch instant for computation of the transformation
 ///
 /// # Returns
-/// - Context holding the `R3(GAST)` and polar-motion matrices
+/// - Context holding the `W R3(GAST)` rotation (dimensionless) and the ITRF
+///   axes' angular velocity. Units: (*rad/s*)
 fn tod_itrf_context(epc: Epoch) -> TodItrfContext {
+    let r = EquinoxContext::new(epc, get_precession_nutation_model()).sidereal_rotation();
+    let pm = polar_motion(epc);
     TodItrfContext {
-        r: EquinoxContext::new(epc, get_precession_nutation_model()).sidereal_rotation(),
-        pm: polar_motion(epc),
+        r_mat: pm * r,
+        omega_b: pm * Vector3::new(0.0, 0.0, constants::OMEGA_EARTH),
     }
-}
-
-/// Apply a precomputed TOD-to-ITRF context to one Cartesian TOD state.
-///
-/// # Arguments
-/// - `c`: Transformation matrices for the epoch
-/// - `x_tod`: Cartesian TOD state (position, velocity). Units: (*m*; *m/s*)
-///
-/// # Returns
-/// - Cartesian ITRF state (position, velocity). Units: (*m*; *m/s*)
-fn apply_state_tod_to_itrf(c: &TodItrfContext, x_tod: &SVector6) -> SVector6 {
-    let omega_vec = Vector3::new(0.0, 0.0, constants::OMEGA_EARTH);
-    let r_tod = x_tod.fixed_rows::<3>(0);
-    let v_tod = x_tod.fixed_rows::<3>(3);
-    let p: Vector3<f64> = c.pm * c.r * r_tod;
-    let v: Vector3<f64> = c.pm * (c.r * v_tod - omega_vec.cross(&(c.r * r_tod)));
-    SVector6::new(p[0], p[1], p[2], v[0], v[1], v[2])
-}
-
-/// Apply a precomputed TOD-to-ITRF context to one Cartesian ITRF state,
-/// producing the TOD state.
-///
-/// # Arguments
-/// - `c`: Transformation matrices for the epoch
-/// - `x_itrf`: Cartesian ITRF state (position, velocity). Units: (*m*; *m/s*)
-///
-/// # Returns
-/// - Cartesian TOD state (position, velocity). Units: (*m*; *m/s*)
-fn apply_state_itrf_to_tod(c: &TodItrfContext, x_itrf: &SVector6) -> SVector6 {
-    let omega_vec = Vector3::new(0.0, 0.0, constants::OMEGA_EARTH);
-    let r_itrf = x_itrf.fixed_rows::<3>(0);
-    let v_itrf = x_itrf.fixed_rows::<3>(3);
-    let p: Vector3<f64> = (c.pm * c.r).transpose() * r_itrf;
-    let v: Vector3<f64> = c.r.transpose()
-        * (c.pm.transpose() * v_itrf + omega_vec.cross(&(c.pm.transpose() * r_itrf)));
-    SVector6::new(p[0], p[1], p[2], v[0], v[1], v[2])
 }
 
 /// Transforms a Cartesian position in the GCRF to the equivalent position
@@ -2122,7 +2085,8 @@ pub fn position_itrf_to_tod(epc: Epoch, x: Vector3<f64>) -> Vector3<f64> {
 /// - SOFA `c2teqx` note 2; SOFA cookbook Section 3.5 (polar motion) and
 ///   Appendix p. A4 (`R3(GAST)`, `W` rows)
 pub fn state_tod_to_itrf(epc: Epoch, x_tod: SVector6) -> SVector6 {
-    apply_state_tod_to_itrf(&tod_itrf_context(epc), &x_tod)
+    let c = tod_itrf_context(epc);
+    state_inertial_to_rotating(&c.r_mat, &c.omega_b, &x_tod)
 }
 
 /// Transforms a Cartesian state in the ITRF to the equivalent state in the
@@ -2166,7 +2130,8 @@ pub fn state_tod_to_itrf(epc: Epoch, x_tod: SVector6) -> SVector6 {
 /// - SOFA `c2teqx` note 2; SOFA cookbook Section 3.5 (polar motion) and
 ///   Appendix p. A4 (`R3(GAST)`, `W` rows)
 pub fn state_itrf_to_tod(epc: Epoch, x_itrf: SVector6) -> SVector6 {
-    apply_state_itrf_to_tod(&tod_itrf_context(epc), &x_itrf)
+    let c = tod_itrf_context(epc);
+    state_rotating_to_inertial(&c.r_mat, &c.omega_b, &x_itrf)
 }
 
 /// Computes the TOD-to-ITRF rotation matrix for each epoch in `epochs`.
@@ -2404,7 +2369,12 @@ pub fn states_tod_to_itrf(
     epochs: &[Epoch],
     x_tod: &[SVector6],
 ) -> Result<Vec<SVector6>, BraheError> {
-    batch_map_epochs(tod_itrf_context, apply_state_tod_to_itrf, epochs, x_tod)
+    batch_map_epochs(
+        tod_itrf_context,
+        |c, x| state_inertial_to_rotating(&c.r_mat, &c.omega_b, x),
+        epochs,
+        x_tod,
+    )
 }
 
 /// Transforms a batch of Cartesian states from ITRF to TOD.
@@ -2458,7 +2428,12 @@ pub fn states_itrf_to_tod(
     epochs: &[Epoch],
     x_itrf: &[SVector6],
 ) -> Result<Vec<SVector6>, BraheError> {
-    batch_map_epochs(tod_itrf_context, apply_state_itrf_to_tod, epochs, x_itrf)
+    batch_map_epochs(
+        tod_itrf_context,
+        |c, x| state_rotating_to_inertial(&c.r_mat, &c.omega_b, x),
+        epochs,
+        x_itrf,
+    )
 }
 
 #[cfg(test)]

--- a/src/frames/gcrf_itrf.rs
+++ b/src/frames/gcrf_itrf.rs
@@ -8,6 +8,7 @@ use crate::math::{SMatrix3, SVector6};
 use crate::constants;
 use crate::constants::MJD_ZERO;
 use crate::eop;
+use crate::frames::kinematics::{state_inertial_to_rotating, state_rotating_to_inertial};
 use crate::frames::precession_nutation::{PrecessionNutationModel, get_precession_nutation_model};
 use crate::math::matrix3_from_array;
 use crate::time::{Epoch, TimeSystem};
@@ -434,6 +435,25 @@ fn gcrf_itrf_context(epc: Epoch) -> GcrfItrfContext {
     }
 }
 
+/// Assembles the GCRF-to-ITRF rotation and the ITRF-frame angular velocity
+/// from a precomputed context.
+///
+/// The ITRF axes rotate about the Celestial Intermediate Pole at
+/// [`constants::OMEGA_EARTH`]; polar motion carries that vector from the
+/// terrestrial intermediate axes into the ITRF, so the angular velocity in
+/// ITRF axes is `pm * (0, 0, OMEGA_EARTH)`.
+///
+/// # Arguments
+/// - `c`: Transformation matrices for the epoch
+///
+/// # Returns
+/// - GCRF -> ITRF rotation matrix (dimensionless) and the ITRF axes' angular
+///   velocity expressed in the ITRF. Units: (*rad/s*)
+fn gcrf_itrf_rotating_axes(c: &GcrfItrfContext) -> (SMatrix3, Vector3<f64>) {
+    let omega_cip = Vector3::new(0.0, 0.0, constants::OMEGA_EARTH);
+    (c.pm * c.r * c.bpn, c.pm * omega_cip)
+}
+
 /// Apply a precomputed GCRF-to-ITRF context to one Cartesian GCRF state.
 ///
 /// # Arguments
@@ -456,18 +476,8 @@ fn gcrf_itrf_context(epc: Epoch) -> GcrfItrfContext {
 /// let x_itrf = apply_state_gcrf_to_itrf(&c, &x_gcrf);
 /// ```
 fn apply_state_gcrf_to_itrf(c: &GcrfItrfContext, x_gcrf: &SVector6) -> SVector6 {
-    let (bpn, r, pm) = (c.bpn, c.r, c.pm);
-
-    // Create Earth's Angular Rotation Vector
-    let omega_vec = Vector3::new(0.0, 0.0, constants::OMEGA_EARTH);
-
-    let r_gcrf = x_gcrf.fixed_rows::<3>(0);
-    let v_gcrf = x_gcrf.fixed_rows::<3>(3);
-
-    let p: Vector3<f64> = Vector3::from(pm * r * bpn * r_gcrf);
-    let v: Vector3<f64> = pm * (r * bpn * v_gcrf - omega_vec.cross(&(r * bpn * r_gcrf)));
-
-    SVector6::new(p[0], p[1], p[2], v[0], v[1], v[2])
+    let (r_mat, omega_b) = gcrf_itrf_rotating_axes(c);
+    state_inertial_to_rotating(&r_mat, &omega_b, x_gcrf)
 }
 
 /// Apply a precomputed GCRF-to-ITRF context to one Cartesian ITRF state,
@@ -492,19 +502,8 @@ fn apply_state_gcrf_to_itrf(c: &GcrfItrfContext, x_gcrf: &SVector6) -> SVector6 
 /// let x_gcrf = apply_state_itrf_to_gcrf(&c, &x_itrf);
 /// ```
 fn apply_state_itrf_to_gcrf(c: &GcrfItrfContext, x_itrf: &SVector6) -> SVector6 {
-    let (bpn, r, pm) = (c.bpn, c.r, c.pm);
-
-    // Create Earth's Angular Rotation Vector
-    let omega_vec = Vector3::new(0.0, 0.0, constants::OMEGA_EARTH);
-
-    let r_itrf = x_itrf.fixed_rows::<3>(0);
-    let v_itrf = x_itrf.fixed_rows::<3>(3);
-
-    let p: Vector3<f64> = Vector3::from((pm * r * bpn).transpose() * r_itrf);
-    let v: Vector3<f64> = (r * bpn).transpose()
-        * (pm.transpose() * v_itrf + omega_vec.cross(&(pm.transpose() * r_itrf)));
-
-    SVector6::new(p[0], p[1], p[2], v[0], v[1], v[2])
+    let (r_mat, omega_b) = gcrf_itrf_rotating_axes(c);
+    state_rotating_to_inertial(&r_mat, &omega_b, x_itrf)
 }
 
 /// Transforms a Cartesian state in GCRF (Geocentric Celestial Reference Frame)

--- a/src/frames/graph.rs
+++ b/src/frames/graph.rs
@@ -26,6 +26,7 @@
 
 use nalgebra::Vector3;
 
+use crate::frames::kinematics::{state_inertial_to_rotating, state_rotating_to_inertial};
 use crate::frames::object_registry::object_state;
 use crate::frames::registry::{FrameKey, frame_entry};
 use crate::frames::{
@@ -173,14 +174,7 @@ pub(crate) fn resolve_state(
     let omega_to = chain_rate(to, &resolved_to)?;
     let offset = origin_offset_state(&from.origin()?, &to.origin()?, epc)?;
 
-    let dcm_from = resolved_from.dcm.transpose();
-    let p: Vector3<f64> = x.fixed_rows::<3>(0).into_owned();
-    let v: Vector3<f64> = x.fixed_rows::<3>(3).into_owned();
-    let p_root = dcm_from * p;
-    let v_root = dcm_from * (v + omega_from.cross(&p));
-    let x_root = SVector6::new(
-        p_root[0], p_root[1], p_root[2], v_root[0], v_root[1], v_root[2],
-    );
+    let x_root = state_rotating_to_inertial(&resolved_from.dcm, &omega_from, &x);
 
     // Both celestial legs share their frame's center, so they rotate only;
     // the whole translation is carried by `offset`.
@@ -197,10 +191,10 @@ pub(crate) fn resolve_state(
         x_icrf,
     )?;
 
-    let p_to: Vector3<f64> = resolved_to.dcm * x_root_to.fixed_rows::<3>(0);
-    let v_to: Vector3<f64> = resolved_to.dcm * x_root_to.fixed_rows::<3>(3) - omega_to.cross(&p_to);
-    Ok(SVector6::new(
-        p_to[0], p_to[1], p_to[2], v_to[0], v_to[1], v_to[2],
+    Ok(state_inertial_to_rotating(
+        &resolved_to.dcm,
+        &omega_to,
+        &x_root_to,
     ))
 }
 

--- a/src/frames/kinematics.rs
+++ b/src/frames/kinematics.rs
@@ -1,0 +1,208 @@
+/*!
+ * Cartesian state kinematics shared by every reference frame transformation.
+ *
+ * A frame pair either differs by a rotation alone, in which case position and
+ * velocity rotate identically, or the target axes turn relative to the source
+ * axes, in which case the velocity picks up a transport term. This module
+ * holds one implementation of each case, together with the extraction of a
+ * frame's angular velocity from a rotation matrix and its time derivative.
+ *
+ * Throughout, `R` is the rotation matrix taking a vector expressed in the
+ * inertial (non-rotating) axes into the rotating axes, and `omega_b` is the
+ * angular velocity of the rotating axes with respect to the inertial axes,
+ * itself expressed in the rotating axes. The two are related by
+ * `Ṙ = -[omega_b]× R`, where `[a]×` is the skew-symmetric matrix satisfying
+ * `[a]× b = a × b`.
+ */
+
+use nalgebra::Vector3;
+
+use crate::math::{SMatrix3, SVector6};
+
+/// Rotates a Cartesian state between two axis sets that have no relative
+/// angular velocity: `p' = R p` and `v' = R v`.
+///
+/// # Arguments
+/// - `r`: Rotation matrix from the source axes to the target axes (dimensionless)
+/// - `x`: Cartesian state (position, velocity) in the source axes. Units: (*m*; *m/s*)
+///
+/// # Returns
+/// - Cartesian state (position, velocity) in the target axes. Units: (*m*; *m/s*)
+pub(crate) fn rotate_state(r: &SMatrix3, x: &SVector6) -> SVector6 {
+    let p: Vector3<f64> = r * x.fixed_rows::<3>(0);
+    let v: Vector3<f64> = r * x.fixed_rows::<3>(3);
+    SVector6::new(p[0], p[1], p[2], v[0], v[1], v[2])
+}
+
+/// Maps a Cartesian state from inertial axes into rotating axes:
+/// `p' = R p` and `v' = R v - omega_b × p'`.
+///
+/// The transport term `omega_b × p'` removes the velocity that a point fixed
+/// in the rotating axes acquires purely from the rotation of those axes.
+///
+/// # Arguments
+/// - `r`: Rotation matrix from the inertial axes to the rotating axes (dimensionless)
+/// - `omega_b`: Angular velocity of the rotating axes, expressed in the rotating axes. Units: (*rad/s*)
+/// - `x`: Cartesian state (position, velocity) in the inertial axes. Units: (*m*; *m/s*)
+///
+/// # Returns
+/// - Cartesian state (position, velocity) in the rotating axes. Units: (*m*; *m/s*)
+pub(crate) fn state_inertial_to_rotating(
+    r: &SMatrix3,
+    omega_b: &Vector3<f64>,
+    x: &SVector6,
+) -> SVector6 {
+    let p: Vector3<f64> = r * x.fixed_rows::<3>(0);
+    let v: Vector3<f64> = r * x.fixed_rows::<3>(3) - omega_b.cross(&p);
+    SVector6::new(p[0], p[1], p[2], v[0], v[1], v[2])
+}
+
+/// Inverse of [`state_inertial_to_rotating`]: `p = Rᵀ p'` and
+/// `v = Rᵀ (v' + omega_b × p')`.
+///
+/// # Arguments
+/// - `r`: Rotation matrix from the inertial axes to the rotating axes (dimensionless)
+/// - `omega_b`: Angular velocity of the rotating axes, expressed in the rotating axes. Units: (*rad/s*)
+/// - `x`: Cartesian state (position, velocity) in the rotating axes. Units: (*m*; *m/s*)
+///
+/// # Returns
+/// - Cartesian state (position, velocity) in the inertial axes. Units: (*m*; *m/s*)
+pub(crate) fn state_rotating_to_inertial(
+    r: &SMatrix3,
+    omega_b: &Vector3<f64>,
+    x: &SVector6,
+) -> SVector6 {
+    let p_rot: Vector3<f64> = x.fixed_rows::<3>(0).into_owned();
+    let v_rot: Vector3<f64> = x.fixed_rows::<3>(3).into_owned();
+    let p: Vector3<f64> = r.transpose() * p_rot;
+    let v: Vector3<f64> = r.transpose() * (v_rot + omega_b.cross(&p_rot));
+    SVector6::new(p[0], p[1], p[2], v[0], v[1], v[2])
+}
+
+/// Extracts the angular velocity of a rotating axis set from its rotation
+/// matrix and that matrix's time derivative, through `[omega_b]× = -Ṙ Rᵀ`.
+///
+/// The product is skew-symmetric for an exactly orthonormal `R`; the
+/// skew-symmetric part is taken so that a matrix orthonormal only to within
+/// floating-point round-off still yields the angular velocity that best fits
+/// it.
+///
+/// # Arguments
+/// - `r`: Rotation matrix from the inertial axes to the rotating axes (dimensionless)
+/// - `r_dot`: Time derivative of `r`. Units: (*1/s*)
+///
+/// # Returns
+/// - Angular velocity of the rotating axes, expressed in the rotating axes. Units: (*rad/s*)
+pub(crate) fn angular_velocity_from_rotation_rate(r: &SMatrix3, r_dot: &SMatrix3) -> Vector3<f64> {
+    let m = -(r_dot * r.transpose());
+    Vector3::new(
+        0.5 * (m[(2, 1)] - m[(1, 2)]),
+        0.5 * (m[(0, 2)] - m[(2, 0)]),
+        0.5 * (m[(1, 0)] - m[(0, 1)]),
+    )
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use approx::assert_abs_diff_eq;
+    use serial_test::parallel;
+
+    use super::*;
+    use crate::attitude::Rz;
+    use crate::constants::AngleFormat;
+
+    /// `R(t) = Rz(rate t)` and its analytic derivative, for a frame turning
+    /// about the inertial z-axis at `rate` rad/s.
+    fn spinning_axes(rate: f64, t: f64) -> (SMatrix3, SMatrix3) {
+        let theta = rate * t;
+        let (s, c) = theta.sin_cos();
+        let r = Rz(theta, AngleFormat::Radians);
+        let r_dot = rate * SMatrix3::new(-s, c, 0.0, -c, -s, 0.0, 0.0, 0.0, 0.0);
+        (r, r_dot)
+    }
+
+    #[test]
+    #[parallel]
+    fn test_rotate_state() {
+        // Quarter turn about z: x̂ -> -ŷ and ŷ -> x̂ in the rotated axes.
+        let r = Rz(std::f64::consts::FRAC_PI_2, AngleFormat::Radians);
+        let x = SVector6::new(7.0e6, 0.0, 1.0e5, 0.0, 7.5e3, -1.0);
+        let out = rotate_state(&r, &x);
+
+        assert_abs_diff_eq!(out[0], 0.0, epsilon = 1e-8);
+        assert_abs_diff_eq!(out[1], -7.0e6, epsilon = 1e-8);
+        assert_abs_diff_eq!(out[2], 1.0e5, epsilon = 1e-12);
+        assert_abs_diff_eq!(out[3], 7.5e3, epsilon = 1e-9);
+        assert_abs_diff_eq!(out[4], 0.0, epsilon = 1e-9);
+        assert_abs_diff_eq!(out[5], -1.0, epsilon = 1e-12);
+    }
+
+    #[test]
+    #[parallel]
+    fn test_rotating_state_round_trip() {
+        let (r, _) = spinning_axes(7.2921150e-5, 3.6e3);
+        let omega_b = Vector3::new(1.0e-6, -2.0e-6, 7.2921150e-5);
+        let x = SVector6::new(7.0e6, -1.2e6, 3.4e5, -1.1e3, 7.4e3, 2.0e2);
+
+        let x_rot = state_inertial_to_rotating(&r, &omega_b, &x);
+        let x_back = state_rotating_to_inertial(&r, &omega_b, &x_rot);
+
+        // Relative tolerance: the round trip is exact to a few units in the
+        // last place of each component.
+        for i in 0..6 {
+            assert_abs_diff_eq!(x_back[i], x[i], epsilon = 1e-12 * x[i].abs());
+        }
+    }
+
+    #[test]
+    #[parallel]
+    fn test_state_inertial_to_rotating_removes_transport_velocity() {
+        // A point fixed in the rotating axes has zero velocity there.
+        let rate = 7.2921150e-5;
+        let (r, _) = spinning_axes(rate, 1.234e4);
+        let omega_b = Vector3::new(0.0, 0.0, rate);
+        let omega_inertial = Vector3::new(0.0, 0.0, rate);
+
+        let p = Vector3::new(6.378e6, 1.0e6, -2.0e6);
+        let v = omega_inertial.cross(&p);
+        let x = SVector6::new(p[0], p[1], p[2], v[0], v[1], v[2]);
+
+        let x_rot = state_inertial_to_rotating(&r, &omega_b, &x);
+        for i in 3..6 {
+            assert_abs_diff_eq!(x_rot[i], 0.0, epsilon = 1e-9);
+        }
+    }
+
+    #[test]
+    #[parallel]
+    fn test_angular_velocity_from_rotation_rate() {
+        let rate = 2.5e-4;
+        for t in [0.0, 1.0e3, 5.5e3] {
+            let (r, r_dot) = spinning_axes(rate, t);
+            let omega_b = angular_velocity_from_rotation_rate(&r, &r_dot);
+            assert_abs_diff_eq!(omega_b[0], 0.0, epsilon = 1e-18);
+            assert_abs_diff_eq!(omega_b[1], 0.0, epsilon = 1e-18);
+            assert_abs_diff_eq!(omega_b[2], rate, epsilon = 1e-18);
+        }
+    }
+
+    #[test]
+    #[parallel]
+    fn test_transport_term_matches_rotation_rate_form() {
+        // `-omega_b × (R p)` and `Ṙ p` are the same transport term.
+        let rate = 2.5e-4;
+        let (r, r_dot) = spinning_axes(rate, 7.7e3);
+        let omega_b = angular_velocity_from_rotation_rate(&r, &r_dot);
+        let x = SVector6::new(2.5e8, -1.2e8, 0.9e8, 3.0e2, 8.0e2, -1.5e2);
+
+        let out = state_inertial_to_rotating(&r, &omega_b, &x);
+        let p: Vector3<f64> = x.fixed_rows::<3>(0).into_owned();
+        let v: Vector3<f64> = x.fixed_rows::<3>(3).into_owned();
+        let v_expected: Vector3<f64> = r * v + r_dot * p;
+
+        for i in 0..3 {
+            assert_abs_diff_eq!(out[i + 3], v_expected[i], epsilon = 1e-9);
+        }
+    }
+}

--- a/src/frames/mod.rs
+++ b/src/frames/mod.rs
@@ -20,6 +20,8 @@ pub mod gcrf_itrf;
 // Not `pub`: chain resolution is internal machinery.
 mod graph;
 pub mod iau_rotation;
+// Not `pub`: shared state-kinematics algebra used by the pairwise modules.
+mod kinematics;
 pub mod lunar;
 pub mod mars;
 pub mod object_registry;

--- a/src/frames/synodic.rs
+++ b/src/frames/synodic.rs
@@ -14,6 +14,9 @@ use crate::constants::{
     GM_NEPTUNE, GM_NEPTUNE_SYSTEM, GM_PLUTO, GM_PLUTO_SYSTEM, GM_SATURN, GM_SATURN_SYSTEM, GM_SUN,
     GM_URANUS, GM_URANUS_SYSTEM, GM_VENUS,
 };
+use crate::frames::kinematics::{
+    angular_velocity_from_rotation_rate, state_inertial_to_rotating, state_rotating_to_inertial,
+};
 use crate::math::{SMatrix3, SVector6};
 use crate::spice::{NAIFId, spk_acceleration, spk_position, spk_state};
 use crate::time::Epoch;
@@ -110,6 +113,10 @@ pub(crate) fn synodic_axes(
 /// frame's origin) into synodic axes: `r_s = R r`, `v_s = R v + Ṙ r`
 /// (NASA TP-20220014814 Eq. 67/70, translation handled by the caller).
 ///
+/// The transport term is evaluated as `−ω_b × r_s`, with `ω_b` the synodic
+/// axes' angular velocity recovered from `Ṙ` by
+/// [`angular_velocity_from_rotation_rate`].
+///
 /// # Arguments
 /// - `r_mat`: Inertial→synodic rotation matrix from [`synodic_axes`]
 /// - `r_dot_mat`: Its time derivative. Units: [1/s]
@@ -122,16 +129,13 @@ pub(crate) fn state_inertial_to_synodic(
     r_dot_mat: &SMatrix3,
     x: SVector6,
 ) -> SVector6 {
-    let r = x.fixed_rows::<3>(0).into_owned();
-    let v = x.fixed_rows::<3>(3).into_owned();
-    let r_s: Vector3<f64> = r_mat * r;
-    let v_s: Vector3<f64> = r_mat * v + r_dot_mat * r;
-    SVector6::new(r_s[0], r_s[1], r_s[2], v_s[0], v_s[1], v_s[2])
+    let omega_b = angular_velocity_from_rotation_rate(r_mat, r_dot_mat);
+    state_inertial_to_rotating(r_mat, &omega_b, &x)
 }
 
 /// Inverse of [`state_inertial_to_synodic`]: `r = Rᵀ r_s`,
-/// `v = Rᵀ v_s + Ṙᵀ r_s` (using Ṙᵀ = −RᵀṘRᵀ from d/dt(RᵀR) = 0, which
-/// reduces TP Eq. 68/71 to this form).
+/// `v = Rᵀ (v_s + ω_b × r_s)` (TP Eq. 68/71, with `Ṙᵀ = Rᵀ [ω_b]×` from
+/// d/dt(RᵀR) = 0).
 ///
 /// # Arguments
 /// - `r_mat`: Inertial→synodic rotation matrix from [`synodic_axes`]
@@ -145,11 +149,8 @@ pub(crate) fn state_synodic_to_inertial(
     r_dot_mat: &SMatrix3,
     x: SVector6,
 ) -> SVector6 {
-    let r_s = x.fixed_rows::<3>(0).into_owned();
-    let v_s = x.fixed_rows::<3>(3).into_owned();
-    let r: Vector3<f64> = r_mat.transpose() * r_s;
-    let v: Vector3<f64> = r_mat.transpose() * v_s + r_dot_mat.transpose() * r_s;
-    SVector6::new(r[0], r[1], r[2], v[0], v[1], v[2])
+    let omega_b = angular_velocity_from_rotation_rate(r_mat, r_dot_mat);
+    state_rotating_to_inertial(r_mat, &omega_b, &x)
 }
 
 /// Gravitational parameter for the NAIF IDs supported as generic synodic
@@ -267,11 +268,13 @@ struct SynodicPositionContext {
     offset: Vector3<f64>,
 }
 
-/// Synodic rotation matrix, its time derivative, and origin offset state
-/// (ICRF axes, from Earth) for a state transformation at one epoch.
+/// Synodic rotation matrix, the synodic axes' angular velocity, and origin
+/// offset state (ICRF axes, from Earth) for a state transformation at one
+/// epoch.
 struct SynodicStateContext {
     r_mat: SMatrix3,
-    r_dot_mat: SMatrix3,
+    /// Angular velocity of the synodic axes, expressed in them. Units: [rad/s]
+    omega_b: Vector3<f64>,
     offset: SVector6,
 }
 
@@ -350,7 +353,7 @@ fn apply_position_synodic_to_inertial(
 /// let x_emr = apply_state_inertial_to_synodic(&c, &vector6_from_array([1.0e8, -2.0e8, 5.0e7, 1.0e3, -2.0e3, 0.5e3]));
 /// ```
 fn apply_state_inertial_to_synodic(c: &SynodicStateContext, x: &SVector6) -> SVector6 {
-    state_inertial_to_synodic(&c.r_mat, &c.r_dot_mat, x - c.offset)
+    state_inertial_to_rotating(&c.r_mat, &c.omega_b, &(x - c.offset))
 }
 
 /// Apply a synodic state context in the inverse direction.
@@ -373,7 +376,7 @@ fn apply_state_inertial_to_synodic(c: &SynodicStateContext, x: &SVector6) -> SVe
 /// let x_gcrf = apply_state_synodic_to_inertial(&c, &vector6_from_array([3.8e8, 0.0, 0.0, 0.0, 0.0, 0.0]));
 /// ```
 fn apply_state_synodic_to_inertial(c: &SynodicStateContext, x: &SVector6) -> SVector6 {
-    state_synodic_to_inertial(&c.r_mat, &c.r_dot_mat, *x) + c.offset
+    state_rotating_to_inertial(&c.r_mat, &c.omega_b, x) + c.offset
 }
 
 /// EMR position context: rotation from [`emr_axes`] and the Earth -> EMB
@@ -424,7 +427,7 @@ fn emr_state_context(epc: Epoch) -> Result<SynodicStateContext, BraheError> {
     let offset = spk_state(NAIFId::EarthMoonBarycenter, NAIFId::Earth, epc)?;
     Ok(SynodicStateContext {
         r_mat,
-        r_dot_mat,
+        omega_b: angular_velocity_from_rotation_rate(&r_mat, &r_dot_mat),
         offset,
     })
 }
@@ -730,7 +733,7 @@ fn ser_state_context(epc: Epoch) -> Result<SynodicStateContext, BraheError> {
     let offset = seb_offset_from_earth(epc)?;
     Ok(SynodicStateContext {
         r_mat,
-        r_dot_mat,
+        omega_b: angular_velocity_from_rotation_rate(&r_mat, &r_dot_mat),
         offset,
     })
 }
@@ -1046,6 +1049,26 @@ pub fn position_gse_to_gcrf(epc: Epoch, x_gse: Vector3<f64>) -> Result<Vector3<f
     Ok(gse_axes(epc)?.0.transpose() * x_gse)
 }
 
+/// GSE rotation matrix and the GSE axes' angular velocity for one epoch.
+///
+/// GSE is Earth-centered, so a state transformation needs no origin offset
+/// and this pair is the whole context.
+///
+/// # Arguments
+/// - `epc`: Epoch instant
+///
+/// # Returns
+/// - GCRF -> GSE rotation matrix (dimensionless) and the GSE axes' angular
+///   velocity expressed in the GSE. Units: [rad/s]
+/// - Error if the ephemeris cannot be evaluated
+fn gse_rotating_axes(epc: Epoch) -> Result<(SMatrix3, Vector3<f64>), BraheError> {
+    let (r_mat, r_dot_mat) = gse_axes(epc)?;
+    Ok((
+        r_mat,
+        angular_velocity_from_rotation_rate(&r_mat, &r_dot_mat),
+    ))
+}
+
 /// Transforms a Cartesian GCRF state (position and velocity) into the
 /// equivalent Cartesian Geocentric Solar Ecliptic (GSE) state.
 ///
@@ -1075,8 +1098,8 @@ pub fn position_gse_to_gcrf(epc: Epoch, x_gse: Vector3<f64>) -> Result<Vector3<f
 /// let x_gse = state_gcrf_to_gse(epc, x_gcrf).unwrap();
 /// ```
 pub fn state_gcrf_to_gse(epc: Epoch, x_gcrf: SVector6) -> Result<SVector6, BraheError> {
-    let (r_mat, r_dot_mat) = gse_axes(epc)?;
-    Ok(state_inertial_to_synodic(&r_mat, &r_dot_mat, x_gcrf))
+    let (r_mat, omega_b) = gse_rotating_axes(epc)?;
+    Ok(state_inertial_to_rotating(&r_mat, &omega_b, &x_gcrf))
 }
 
 /// Transforms a Cartesian Geocentric Solar Ecliptic (GSE) state (position
@@ -1107,8 +1130,8 @@ pub fn state_gcrf_to_gse(epc: Epoch, x_gcrf: SVector6) -> Result<SVector6, Brahe
 /// let x_gcrf2 = state_gse_to_gcrf(epc, x_gse).unwrap();
 /// ```
 pub fn state_gse_to_gcrf(epc: Epoch, x_gse: SVector6) -> Result<SVector6, BraheError> {
-    let (r_mat, r_dot_mat) = gse_axes(epc)?;
-    Ok(state_synodic_to_inertial(&r_mat, &r_dot_mat, x_gse))
+    let (r_mat, omega_b) = gse_rotating_axes(epc)?;
+    Ok(state_rotating_to_inertial(&r_mat, &omega_b, &x_gse))
 }
 
 /// Computes the GCRF to Earth-Moon Rotating (EMR) rotation matrix for each epoch in `epochs`.
@@ -1689,8 +1712,8 @@ pub fn states_gcrf_to_gse(
     x_gcrf: &[SVector6],
 ) -> Result<Vec<SVector6>, BraheError> {
     try_batch_map_epochs(
-        gse_axes,
-        |(r_mat, r_dot_mat), x| Ok(state_inertial_to_synodic(r_mat, r_dot_mat, *x)),
+        gse_rotating_axes,
+        |(r_mat, omega_b), x| Ok(state_inertial_to_rotating(r_mat, omega_b, x)),
         epochs,
         x_gcrf,
     )
@@ -1729,8 +1752,8 @@ pub fn states_gse_to_gcrf(
     x_gse: &[SVector6],
 ) -> Result<Vec<SVector6>, BraheError> {
     try_batch_map_epochs(
-        gse_axes,
-        |(r_mat, r_dot_mat), x| Ok(state_synodic_to_inertial(r_mat, r_dot_mat, *x)),
+        gse_rotating_axes,
+        |(r_mat, omega_b), x| Ok(state_rotating_to_inertial(r_mat, omega_b, x)),
         epochs,
         x_gse,
     )

--- a/src/frames/transform.rs
+++ b/src/frames/transform.rs
@@ -82,6 +82,7 @@ use super::gcrf_itrf::rotation_gcrf_to_itrf;
 use super::iau_rotation::{
     body_fixed_iau_angles_and_rates, euler313_omega_body, rotation_icrf_to_body_fixed_iau,
 };
+use super::kinematics::{state_inertial_to_rotating, state_rotating_to_inertial};
 use super::lunar::{rotation_lci_to_lfme, rotation_lci_to_lfpa};
 use super::mars::rotation_mci_to_mcmf;
 
@@ -379,7 +380,7 @@ impl CelestialFrame {
             }
             CelestialFrame::BodyFixedCustom { key, .. } => {
                 let (r_mat, omega) = super::custom::custom_frame_rotation_and_omega(*key, epc)?;
-                Ok(state_rotating_to_icrf(r_mat, omega, x))
+                Ok(state_rotating_to_inertial(&r_mat, &omega, &x))
             }
             CelestialFrame::Synodic {
                 primary, secondary, ..
@@ -432,7 +433,7 @@ impl CelestialFrame {
             }
             CelestialFrame::BodyFixedCustom { key, .. } => {
                 let (r_mat, omega) = super::custom::custom_frame_rotation_and_omega(*key, epc)?;
-                Ok(state_icrf_to_rotating(r_mat, omega, x_icrf))
+                Ok(state_inertial_to_rotating(&r_mat, &omega, &x_icrf))
             }
             CelestialFrame::Synodic {
                 primary, secondary, ..
@@ -524,34 +525,6 @@ impl FromStr for CelestialFrame {
     }
 }
 
-/// Applies the rigid-rotation state transform from ICRF axes into a rotating
-/// body-fixed frame, given the ICRF-to-body DCM `r_mat` and the frame's
-/// angular velocity `omega_b` (rad/s, expressed in the body-fixed frame):
-/// `r_b = R r`, `v_b = R v - omega_b x r_b`. Single shared implementation of
-/// the transport-term algebra used by the IAU and PCK body-fixed helpers
-/// below (and identical to the pairwise forms in `mars.rs`/`lunar.rs`).
-fn state_icrf_to_rotating(r_mat: SMatrix3, omega_b: Vector3<f64>, x_icrf: SVector6) -> SVector6 {
-    let r = x_icrf.fixed_rows::<3>(0);
-    let v = x_icrf.fixed_rows::<3>(3);
-
-    let r_b: Vector3<f64> = r_mat * r;
-    let v_b: Vector3<f64> = r_mat * v - omega_b.cross(&r_b);
-
-    SVector6::new(r_b[0], r_b[1], r_b[2], v_b[0], v_b[1], v_b[2])
-}
-
-/// Inverse of [`state_icrf_to_rotating`]: `r = R^T r_b`,
-/// `v = R^T (v_b + omega_b x r_b)`.
-fn state_rotating_to_icrf(r_mat: SMatrix3, omega_b: Vector3<f64>, x_body: SVector6) -> SVector6 {
-    let r_b: Vector3<f64> = x_body.fixed_rows::<3>(0).into_owned();
-    let v_b: Vector3<f64> = x_body.fixed_rows::<3>(3).into_owned();
-
-    let r: Vector3<f64> = r_mat.transpose() * r_b;
-    let v: Vector3<f64> = r_mat.transpose() * (v_b + omega_b.cross(&r_b));
-
-    SVector6::new(r[0], r[1], r[2], v[0], v[1], v[2])
-}
-
 /// ICRF-to-body-fixed rotation matrix and body-frame angular velocity of a
 /// rotating frame at one epoch, shared by the lunar and Mars body-fixed
 /// transformations and their batch forms.
@@ -583,7 +556,7 @@ pub(crate) fn apply_state_icrf_to_rotating(
     c: &RotatingFrameContext,
     x_icrf: &SVector6,
 ) -> SVector6 {
-    state_icrf_to_rotating(c.r_mat, c.omega_b, *x_icrf)
+    state_inertial_to_rotating(&c.r_mat, &c.omega_b, x_icrf)
 }
 
 /// Apply a precomputed rotating-frame context to one body-fixed state,
@@ -610,7 +583,7 @@ pub(crate) fn apply_state_rotating_to_icrf(
     c: &RotatingFrameContext,
     x_body: &SVector6,
 ) -> SVector6 {
-    state_rotating_to_icrf(c.r_mat, c.omega_b, *x_body)
+    state_rotating_to_inertial(&c.r_mat, &c.omega_b, x_body)
 }
 
 /// Rotates an ICRF-axis state into the IAU/WGCCRE body-fixed frame of
@@ -624,10 +597,10 @@ fn state_icrf_to_iau_body(
 ) -> Result<SVector6, BraheError> {
     let (angles, rates) = body_fixed_iau_angles_and_rates(naif_id, epc)?;
     let r_mat = rotation_icrf_to_body_fixed_iau(naif_id, epc)?;
-    Ok(state_icrf_to_rotating(
-        r_mat,
-        euler313_omega_body(angles, rates),
-        x_icrf,
+    Ok(state_inertial_to_rotating(
+        &r_mat,
+        &euler313_omega_body(angles, rates),
+        &x_icrf,
     ))
 }
 
@@ -640,10 +613,10 @@ fn state_iau_body_to_icrf(
 ) -> Result<SVector6, BraheError> {
     let (angles, rates) = body_fixed_iau_angles_and_rates(naif_id, epc)?;
     let r_mat = rotation_icrf_to_body_fixed_iau(naif_id, epc)?;
-    Ok(state_rotating_to_icrf(
-        r_mat,
-        euler313_omega_body(angles, rates),
-        x_body,
+    Ok(state_rotating_to_inertial(
+        &r_mat,
+        &euler313_omega_body(angles, rates),
+        &x_body,
     ))
 }
 
@@ -662,10 +635,10 @@ fn state_icrf_to_pck_body(
 ) -> Result<SVector6, BraheError> {
     let (angles, rates) = crate::spice::pck_euler_angles(frame_id, epc)?;
     let r_mat = crate::spice::pck_rotation_matrix(frame_id, epc)?.to_matrix();
-    Ok(state_icrf_to_rotating(
-        r_mat,
-        euler313_omega_body(angles, rates),
-        x_icrf,
+    Ok(state_inertial_to_rotating(
+        &r_mat,
+        &euler313_omega_body(angles, rates),
+        &x_icrf,
     ))
 }
 
@@ -678,10 +651,10 @@ fn state_pck_body_to_icrf(
 ) -> Result<SVector6, BraheError> {
     let (angles, rates) = crate::spice::pck_euler_angles(frame_id, epc)?;
     let r_mat = crate::spice::pck_rotation_matrix(frame_id, epc)?.to_matrix();
-    Ok(state_rotating_to_icrf(
-        r_mat,
-        euler313_omega_body(angles, rates),
-        x_body,
+    Ok(state_rotating_to_inertial(
+        &r_mat,
+        &euler313_omega_body(angles, rates),
+        &x_body,
     ))
 }
 


### PR DESCRIPTION
## Description

Collects the Cartesian state kinematics used by every frame transformation into one crate-internal module, `frames::kinematics`, with a constant-rotation state map, the rotating-axes pair that applies the transport term `omega x r`, and a helper that derives a body-frame angular velocity from a rotation matrix and its time derivative. The GCRF/ITRF, TOD/ITRF, EME2000, lunar, Mars, custom, PCK, synodic, and router state paths call these functions instead of carrying their own copies of the same arithmetic. Public signatures, results, and tests are unchanged; the only numerical effect is floating-point reassociation far below any test tolerance.

## Changelog

### Changed
- Frame modules share one implementation of state rotation and rotating-axes transport in `frames::kinematics`; no user-facing behavior changes.

## Note to Reviewers
The ITRF and TOD/ITRF paths now form `R = W R3 C` and `omega_b = W [0, 0, omega]` and call the shared rotating-axes map, which is the same expression as the previous hand-expanded form because `W` is a rotation. Synodic frames derive `omega_b` from `S` and its derivative through `[omega_b]x = -S_dot S^T`.
