### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,14 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+type: software
+title: "Brahe: A Modern Astrodynamics Library for Research and Engineering Applications"
+authors:
+  - family-names: "Eddy"
+    given-names: "Duncan"
+    orcid: "https://orcid.org/0009-0000-2832-9711"
+  - family-names: "Kochenderfer"
+    given-names: "Mykel"
+    orcid: "https://orcid.org/0000-0002-7238-9663"
+repository-code: "https://github.com/duncaneddy/brahe"
+license: "MIT"
+version: "1.7.0"


### PR DESCRIPTION
JOSS reviewers ask for a `CITATION.cff`, and this repository does not have one yet.

Generated from the author list in `origin:joss/paper.md`: 2 author(s), with given and family names taken from each author's ORCID record rather than split from the display name, because compound surnames do not split reliably.

`license` is `MIT`, read from the LICENSE file. `version` is `1.7.0`, the newest release tag. 

Verified with `cffconvert --validate`: valid against schema 1.2.0.