### PR TITLE
Sync CITATION.cff version with the release process

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -3,25 +3,60 @@ name: PR Tests
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    paths-ignore:
-      - 'CHANGELOG.md'
-      - 'CITATION.cff'
-      - 'profiles/**'
 
 concurrency:
   group: pr-tests-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
+  # Decide whether this PR touches only files that cannot affect the build.
+  # The filter lives here rather than in a workflow-level `paths-ignore` because
+  # a filtered-out workflow never starts, so the `ci-success` job below is never
+  # created — and that job is the required status check on `main`. GitHub would
+  # leave it pending forever and block exactly the trivial PRs a path filter is
+  # meant to speed up. Running the workflow and skipping the expensive jobs
+  # inside it lets `ci-success` report success (it tolerates `skipped`).
   check-skip:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - id: skip_check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # Paths that cannot affect the build, tested against the full path of
+          # every file the PR changes.
+          IGNORED: '^(CHANGELOG\.md|CITATION\.cff)$|^profiles/'
         run: |
-          echo "should_skip=false" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          PR="repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}"
+          CHANGED=$(gh api "$PR" --jq '.changed_files')
+          # `previous_filename` is listed alongside `filename` so a rename is
+          # judged by both its old and its new path. Moving a source file into
+          # an ignored directory reports only the destination otherwise, and
+          # would read as an ignorable change.
+          FILES=$(gh api --paginate "$PR/files" \
+            --jq '.[] | .filename, (.previous_filename // empty)')
+          echo "Changed files ($CHANGED):"
+          echo "$FILES"
+          # Three ways to end up running the full suite:
+          #   - an empty list, meaning the file list could not be determined;
+          #   - a PR at or above the 3000-file cap on the `/files` endpoint,
+          #     where the list is truncated and may omit a relevant file;
+          #   - any listed path that is not build-irrelevant.
+          # A herestring, not a pipe: `grep -q` exits at its first match, and
+          # under `pipefail` the resulting SIGPIPE on `echo` would surface as a
+          # non-zero pipeline status, inverting this test.
+          if [ -n "$FILES" ] && [ "$CHANGED" -lt 3000 ] && ! grep -qvE "$IGNORED" <<< "$FILES"; then
+            echo "should_skip=true" >> "$GITHUB_OUTPUT"
+            echo "Every changed file is build-irrelevant; skipping test jobs."
+          else
+            echo "should_skip=false" >> "$GITHUB_OUTPUT"
+          fi
 
   test-rust:
     needs: [check-skip]

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, synchronize, reopened]
     paths-ignore:
       - 'CHANGELOG.md'
+      - 'CITATION.cff'
       - 'profiles/**'
 
 concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,16 @@ jobs:
           fi
           echo "Cargo.toml version matches: $CARGO_VERSION"
 
+      - name: Validate CITATION.cff version
+        run: |
+          CITATION_VERSION=$(sed -n 's/^version: "\(.*\)"$/\1/p' CITATION.cff | head -1)
+          if [ "$CITATION_VERSION" != "${{ steps.extract.outputs.version }}" ]; then
+            echo "ERROR: Tag version (${{ steps.extract.outputs.version }}) does not match CITATION.cff version ($CITATION_VERSION)"
+            echo "Run 'just set-version ${{ steps.extract.outputs.version }}' locally before tagging, then commit and re-tag."
+            exit 1
+          fi
+          echo "CITATION.cff version matches: $CITATION_VERSION"
+
       - name: Validate CHANGELOG entry for this version
         run: |
           VERSION="${{ steps.extract.outputs.version }}"

--- a/docs/development_guide.md
+++ b/docs/development_guide.md
@@ -468,7 +468,7 @@ CHANGELOG generation and version bumps happen **locally before tagging**, so the
    ```bash
    just set-version 1.2.3
    ```
-   This updates `[workspace.package].version` in `Cargo.toml` (inherited by `brahe` and `brahe-py`) and refreshes `Cargo.lock`.
+   This updates `[workspace.package].version` in `Cargo.toml` (inherited by `brahe` and `brahe-py`), refreshes `Cargo.lock`, and mirrors the version into `CITATION.cff`.
 
 2. **Regenerate the CHANGELOG entry** for this release:
    ```bash
@@ -485,7 +485,7 @@ CHANGELOG generation and version bumps happen **locally before tagging**, so the
 
 4. **Commit and tag**:
    ```bash
-   git add Cargo.toml Cargo.lock CHANGELOG.md
+   git add Cargo.toml Cargo.lock CITATION.cff CHANGELOG.md
    git commit -m "Prepare release v1.2.3"
    git push origin main
    git tag v1.2.3
@@ -496,7 +496,7 @@ CHANGELOG generation and version bumps happen **locally before tagging**, so the
 
 Once the tag is pushed, GitHub Actions automatically:
 
-1. Validates the tag version matches `Cargo.toml` **and** that `CHANGELOG.md` contains a `## [1.2.3]` entry (fails fast if `just generate-changelog` was skipped).
+1. Validates the tag version matches `Cargo.toml` and `CITATION.cff`, **and** that `CHANGELOG.md` contains a `## [1.2.3]` entry (fails fast if `just set-version` or `just generate-changelog` was skipped).
 2. Runs all tests (Rust, Python, examples).
 3. Extracts `release_notes.md` from the committed `CHANGELOG.md` (via `scripts/extract_release_notes.py`) for use as the GitHub Release body — no commits or pushes from CI.
 4. Builds documentation and deploys to GitHub Pages.

--- a/justfile
+++ b/justfile
@@ -633,6 +633,7 @@ stats: _setup
 # ───── Release ─────
 
 # Set the workspace version in Cargo.toml (single source of truth for all crates)
+# and mirror it into CITATION.cff
 set-version version:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -646,20 +647,35 @@ set-version version:
     import re, pathlib
     p = pathlib.Path('Cargo.toml')
     text = p.read_text()
-    new = re.sub(
+    new, count = re.subn(
         r'(\[workspace\.package\][^\[]*?\nversion = )\"[^\"]+\"',
         r'\\g<1>\"{{version}}\"',
         text,
         count=1,
         flags=re.DOTALL,
     )
-    if new == text:
+    if count == 0:
         raise SystemExit('error: could not find [workspace.package] version in Cargo.toml')
     p.write_text(new)
     "
     # Refresh Cargo.lock so the workspace version bump is reflected there too.
     cargo update --workspace --quiet
-    echo "✓ Set workspace version to {{version}}"
+    # Mirror the version into CITATION.cff so citation metadata tracks the release.
+    python3 -c "
+    import re, pathlib
+    p = pathlib.Path('CITATION.cff')
+    text = p.read_text()
+    new, count = re.subn(
+        r'(?m)^version: \".*\"$',
+        'version: \"{{version}}\"',
+        text,
+        count=1,
+    )
+    if count == 0:
+        raise SystemExit('error: could not find version field in CITATION.cff')
+    p.write_text(new)
+    "
+    echo "✓ Set workspace version to {{version}} (Cargo.toml, Cargo.lock, CITATION.cff)"
 
 # Regenerate the CHANGELOG.md entry for an upcoming release.
 # Defaults: version from Cargo.toml, prev-tag from `git describe --tags`.


### PR DESCRIPTION
# Pull Request

## Description

`CITATION.cff` carried a hand-written version that drifted from the `Cargo.toml` single source of truth as soon as a release was cut. `just set-version` now mirrors the version into `CITATION.cff` alongside the `Cargo.toml` and `Cargo.lock` updates, and the release workflow validates `CITATION.cff` against the pushed tag next to the existing `Cargo.toml` check so a missed bump fails fast instead of publishing stale citation metadata. Both rewrites in the recipe key on whether the pattern matched rather than on whether the file text changed, making the recipe idempotent and able to repair an already-drifted `CITATION.cff`.

Keeping CI off version-only pull requests is done inside the PR Tests workflow rather than with a trigger-level `paths-ignore`. A filtered-out workflow is never created, so its `ci-success` job — the enforced required status check on `main` — is never reported, and GitHub leaves the check pending indefinitely, blocking exactly the pull requests the filter was meant to speed up. The pre-existing `check-skip` gate, which previously hardcoded `should_skip=false`, now reads the pull request's changed files and sets that output; every expensive job already keys on it, and `ci-success` still runs and reports because it tolerates `skipped` upstream results. `CHANGELOG.md` and `profiles/**` move from the trigger filter into that same ignore set, so those pull requests now start two lightweight jobs instead of none. The gate falls back to a full test run whenever it cannot prove a pull request is build-irrelevant: an unreadable file list, a pull request at or above the 3000-file cap on the `/files` endpoint where the list may be truncated, or any listed path outside the ignore set. Renames are judged by their previous path as well as their new one.

## Changelog

### Changed
- `just set-version` now also updates the version in `CITATION.cff`, and the release workflow validates that it matches the pushed tag

### Fixed
- PR Tests now filters build-irrelevant pull requests inside the workflow instead of with a trigger-level `paths-ignore`, so the required `ci-success` check is always reported rather than left pending indefinitely

## Related Issue

Closes #543

## Note to Reviewers

The `set-version` recipe was verified against four cases: a normal bump updates all three files, a re-run at the same version is a no-op, a stale `CITATION.cff` is repaired even when `Cargo.toml` already holds the target version, and both a malformed version and a missing `version:` field exit non-zero. The release workflow's extraction was checked against the committed file format.

The `check-skip` predicate was verified by extracting the step body verbatim from the workflow and running it against 19 file lists covering each ignorable path alone and in combination, mixed ignorable/source lists, near-miss names (`docs/CHANGELOG.md`, `CHANGELOG.mdx`, `profiles.md`, `CITATION.cff.bak`), an empty list, renames in both directions across the ignore boundary, and the 2999/3000/5000-file cap boundary. One point worth flagging: the first draft used `echo "$FILES" | grep -qvE ...`, which inverts under `set -o pipefail` once the list exceeds the pipe buffer, because `grep -q` exits at its first match and `echo` then takes SIGPIPE. That reported `should_skip=true` for a 20k-file list containing `src/lib.rs`. The herestring form avoids the pipeline entirely and returns the correct result on the same input.