### PR TITLE
Carry covariance through trajectory frame conversion

### DIFF
--- a/crates/brahe-py/src/trajectories.rs
+++ b/crates/brahe-py/src/trajectories.rs
@@ -1437,8 +1437,11 @@ impl PyOrbitalTrajectory {
     }
 
     /// Convert every sample to Cartesian coordinates in `frame` through the
-    /// reference frame router. Covariances, STMs, sensitivities, and
-    /// accelerations are dropped.
+    /// reference frame router. Covariance is carried through when both
+    /// frames may hold it (GCRF and EME2000) and the trajectory is
+    /// Cartesian, rotated by the frame-bias Jacobian; other targets and
+    /// Keplerian sources drop it. STMs, sensitivities, and accelerations
+    /// are dropped.
     ///
     /// Args:
     ///     frame (CelestialFrame or ReferenceFrame): Target frame.

--- a/src/trajectories/dorbit_trajectory.rs
+++ b/src/trajectories/dorbit_trajectory.rs
@@ -142,8 +142,8 @@ fn smat66_to_dmat(sm: SMatrix<f64, 6, 6>) -> DMatrix<f64> {
 use super::traits::{
     CovarianceInterpolationMethod, InterpolatableTrajectory, InterpolationConfig,
     InterpolationMethod, OrbitRepresentation, STMStorage, SensitivityStorage, Trajectory,
-    TrajectoryEvictionPolicy, bci_fixed_frame, covariance_frame_allowed, is_eme2000_axes_frame,
-    is_icrf_axes_frame, keplerian_center,
+    TrajectoryEvictionPolicy, bci_fixed_frame, covariance_frame_allowed, frame_covariance_jacobian,
+    is_eme2000_axes_frame, is_icrf_axes_frame, keplerian_center,
 };
 
 /// Dynamic (runtime-sized) orbital trajectory container.
@@ -1985,8 +1985,12 @@ impl DOrbitTrajectory {
     /// their own frame's center, using that body's gravitational parameter.
     /// The result is then routed to `frame` by the reference frame router,
     /// which resolves any center offset through the loaded SPK kernels.
-    /// Covariances, state transition matrices, sensitivities, and
-    /// accelerations are dropped.
+    /// Covariance is carried through the conversion when both frames may
+    /// hold it (GCRF and EME2000) and the trajectory is Cartesian: each
+    /// matrix is rotated by the block-diagonal frame-bias Jacobian, with an
+    /// identity block for state elements beyond the orbital six. Any other
+    /// target frame, or a Keplerian source, drops the covariance. State
+    /// transition matrices, sensitivities, and accelerations are dropped.
     ///
     /// For extended states (dimension > 6), only the first 6 elements
     /// (orbital state) are converted. Additional elements (6+) are preserved
@@ -2041,10 +2045,33 @@ impl DOrbitTrajectory {
             states_converted.push(converted);
         }
 
+        let covariances = match (&self.covariances, self.representation) {
+            (Some(covs), OrbitRepresentation::Cartesian) => {
+                match frame_covariance_jacobian(&self.frame, &frame, self.dimension) {
+                    Some(j)
+                        if covs.iter().all(|p| {
+                            p.nrows() == self.dimension && p.ncols() == self.dimension
+                        }) =>
+                    {
+                        Some(
+                            covs.iter()
+                                .map(|p| {
+                                    let rotated = &j * p * j.transpose();
+                                    (&rotated + rotated.transpose()) * 0.5
+                                })
+                                .collect(),
+                        )
+                    }
+                    _ => None,
+                }
+            }
+            _ => None,
+        };
+
         Ok(Self {
             epochs: self.epochs.clone(),
             states: states_converted,
-            covariances: None,   // Covariances are dropped during frame conversions
+            covariances,
             stms: None,          // STMs are dropped during frame conversions
             sensitivities: None, // Sensitivities are dropped during frame conversions
             sensitivity_dimension: None,
@@ -7333,5 +7360,119 @@ mod tests {
                 assert_eq!(with_gm[k], with_eci[k]);
             }
         }
+    }
+
+    fn covariance_test_trajectory(frame: CelestialFrame, dimension: usize) -> DOrbitTrajectory {
+        let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
+        let mut epochs = Vec::new();
+        let mut states = Vec::new();
+        let mut covs = Vec::new();
+        for i in 0..3 {
+            epochs.push(epoch + 60.0 * i as f64);
+            let mut x = vec![6.878e6, 1.0e5 * i as f64, -2.0e5, 10.0, 7.5e3, 20.0];
+            x.extend(std::iter::repeat_n(1.5, dimension - 6));
+            states.push(DVector::from_vec(x));
+            let mut p = DMatrix::<f64>::zeros(dimension, dimension);
+            for k in 0..dimension {
+                p[(k, k)] = 1.0 + k as f64;
+            }
+            p[(0, 1)] = 0.25;
+            p[(1, 0)] = 0.25;
+            p[(1, 4)] = -0.1;
+            p[(4, 1)] = -0.1;
+            if dimension > 6 {
+                p[(0, 6)] = 0.05;
+                p[(6, 0)] = 0.05;
+            }
+            covs.push(p);
+        }
+        DOrbitTrajectory::from_orbital_data(
+            epochs,
+            states,
+            frame,
+            OrbitRepresentation::Cartesian,
+            None,
+            Some(covs),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    #[parallel]
+    fn test_dorbittrajectory_to_frame_rotates_covariance_between_gcrf_and_eme2000() {
+        setup_global_test_eop();
+        let traj = covariance_test_trajectory(CelestialFrame::GCRF, 6);
+        let eme = traj.to_eme2000().unwrap();
+        let p0 = traj.covariances.as_ref().unwrap()[0].clone();
+        let q0 = eme.covariances.as_ref().unwrap()[0].clone();
+        let r = crate::frames::rotation_gcrf_to_eme2000();
+        for i in 0..3 {
+            for k in 0..3 {
+                let expected: f64 = (0..3)
+                    .map(|a| {
+                        (0..3)
+                            .map(|b| r[(i, a)] * p0[(a, b)] * r[(k, b)])
+                            .sum::<f64>()
+                    })
+                    .sum();
+                assert_abs_diff_eq!(q0[(i, k)], expected, epsilon = 1e-12);
+            }
+        }
+        assert_abs_diff_eq!(q0.trace(), p0.trace(), epsilon = 1e-12);
+        assert!((q0[(0, 1)] - p0[(0, 1)]).abs() > 0.0);
+
+        let back = eme.to_gcrf().unwrap();
+        let b0 = &back.covariances.as_ref().unwrap()[0];
+        for i in 0..6 {
+            for k in 0..6 {
+                assert_abs_diff_eq!(
+                    b0[(i, k)],
+                    p0[(i, k)],
+                    epsilon = 1e-12 * p0[(i, k)].abs().max(1.0)
+                );
+            }
+        }
+        assert_eq!(back.covariances.as_ref().unwrap().len(), 3);
+    }
+
+    #[test]
+    #[parallel]
+    fn test_dorbittrajectory_to_frame_keeps_covariance_for_same_frame_and_extended_state() {
+        setup_global_test_eop();
+        let traj = covariance_test_trajectory(CelestialFrame::EME2000, 7);
+        let same = traj.to_frame(CelestialFrame::EME2000).unwrap();
+        assert_eq!(
+            same.covariances.as_ref().unwrap()[1],
+            traj.covariances.as_ref().unwrap()[1]
+        );
+
+        let gcrf = traj.to_gcrf().unwrap();
+        let q = &gcrf.covariances.as_ref().unwrap()[0];
+        assert_eq!(q.nrows(), 7);
+        assert_eq!(q[(6, 6)], 7.0);
+        let p = &traj.covariances.as_ref().unwrap()[0];
+        let r = crate::frames::rotation_eme2000_to_gcrf();
+        let expected_06: f64 = (0..3).map(|a| r[(0, a)] * p[(a, 6)]).sum();
+        assert_abs_diff_eq!(q[(0, 6)], expected_06, epsilon = 1e-12);
+        assert_abs_diff_eq!(q[(6, 0)], expected_06, epsilon = 1e-12);
+    }
+
+    #[test]
+    #[parallel]
+    fn test_dorbittrajectory_to_frame_drops_covariance_for_unsupported_targets_and_keplerian() {
+        setup_global_test_eop();
+        let traj = covariance_test_trajectory(CelestialFrame::GCRF, 6);
+        assert!(traj.to_itrf().unwrap().covariances.is_none());
+        assert!(
+            traj.to_frame(CelestialFrame::TEME)
+                .unwrap()
+                .covariances
+                .is_none()
+        );
+
+        let mut kep = traj.to_keplerian(AngleFormat::Degrees).unwrap();
+        assert!(kep.covariances.is_none());
+        kep.covariances = traj.covariances.clone();
+        assert!(kep.to_eme2000().unwrap().covariances.is_none());
     }
 }

--- a/src/trajectories/dorbit_trajectory.rs
+++ b/src/trajectories/dorbit_trajectory.rs
@@ -1987,9 +1987,11 @@ impl DOrbitTrajectory {
     /// which resolves any center offset through the loaded SPK kernels.
     /// Covariance is carried through the conversion when both frames may
     /// hold it (GCRF and EME2000) and the trajectory is Cartesian: each
-    /// matrix is rotated by the block-diagonal frame-bias Jacobian, with an
-    /// identity block for state elements beyond the orbital six. Any other
-    /// target frame, or a Keplerian source, drops the covariance. State
+    /// matrix is rotated by the block-diagonal frame-bias Jacobian sized to
+    /// that matrix, with an identity block for any covariance rows beyond the
+    /// orbital six (a 6x6 covariance on an extended state rotates as 6x6).
+    /// Any other target frame, or a Keplerian source, drops the covariance;
+    /// so does a covariance that is not square or is smaller than 6x6. State
     /// transition matrices, sensitivities, and accelerations are dropped.
     ///
     /// For extended states (dimension > 6), only the first 6 elements
@@ -2046,25 +2048,15 @@ impl DOrbitTrajectory {
         }
 
         let covariances = match (&self.covariances, self.representation) {
-            (Some(covs), OrbitRepresentation::Cartesian) => {
-                match frame_covariance_jacobian(&self.frame, &frame, self.dimension) {
-                    Some(j)
-                        if covs.iter().all(|p| {
-                            p.nrows() == self.dimension && p.ncols() == self.dimension
-                        }) =>
-                    {
-                        Some(
-                            covs.iter()
-                                .map(|p| {
-                                    let rotated = &j * p * j.transpose();
-                                    (&rotated + rotated.transpose()) * 0.5
-                                })
-                                .collect(),
-                        )
-                    }
-                    _ => None,
-                }
-            }
+            (Some(covs), OrbitRepresentation::Cartesian) => covs
+                .iter()
+                .map(|p| {
+                    let j = frame_covariance_jacobian(&self.frame, &frame, p.nrows())
+                        .filter(|_| p.nrows() == p.ncols())?;
+                    let rotated = &j * p * j.transpose();
+                    Some((&rotated + rotated.transpose()) * 0.5)
+                })
+                .collect::<Option<Vec<_>>>(),
             _ => None,
         };
 
@@ -7455,6 +7447,56 @@ mod tests {
         let expected_06: f64 = (0..3).map(|a| r[(0, a)] * p[(a, 6)]).sum();
         assert_abs_diff_eq!(q[(0, 6)], expected_06, epsilon = 1e-12);
         assert_abs_diff_eq!(q[(6, 0)], expected_06, epsilon = 1e-12);
+    }
+
+    #[test]
+    #[parallel]
+    fn test_dorbittrajectory_to_frame_rotates_6x6_covariance_on_extended_state() {
+        setup_global_test_eop();
+        let base = covariance_test_trajectory(CelestialFrame::GCRF, 6);
+        let epochs: Vec<Epoch> = (0..base.len()).map(|i| base.epochs[i]).collect();
+        let states: Vec<DVector<f64>> = base
+            .states
+            .iter()
+            .map(|x| {
+                let mut v = x.as_slice().to_vec();
+                v.extend([1.5, 2.5, 3.5]);
+                DVector::from_vec(v)
+            })
+            .collect();
+        let covs = base.covariances.clone().unwrap();
+        let traj = DOrbitTrajectory::from_orbital_data(
+            epochs,
+            states,
+            CelestialFrame::GCRF,
+            OrbitRepresentation::Cartesian,
+            None,
+            Some(covs.clone()),
+        )
+        .unwrap();
+        assert_eq!(traj.dimension(), 9);
+
+        let eme = traj.to_eme2000().unwrap();
+        let q = &eme.covariances.as_ref().unwrap()[0];
+        assert_eq!(q.nrows(), 6);
+        let r = crate::frames::rotation_gcrf_to_eme2000();
+        let expected = r * covs[0].view((0, 0), (3, 3)) * r.transpose();
+        for a in 0..3 {
+            for b in 0..3 {
+                assert_abs_diff_eq!(q[(a, b)], expected[(a, b)], epsilon = 1e-12);
+            }
+        }
+        let back = eme.to_gcrf().unwrap();
+        let round_trip = &back.covariances.as_ref().unwrap()[0];
+        for a in 0..6 {
+            for b in 0..6 {
+                assert_abs_diff_eq!(round_trip[(a, b)], covs[0][(a, b)], epsilon = 1e-12);
+            }
+        }
+
+        let mut malformed = traj.clone();
+        malformed.covariances = Some(vec![DMatrix::<f64>::identity(5, 5); traj.len()]);
+        assert!(malformed.to_eme2000().unwrap().covariances.is_none());
     }
 
     #[test]

--- a/src/trajectories/dorbit_trajectory.rs
+++ b/src/trajectories/dorbit_trajectory.rs
@@ -143,7 +143,7 @@ use super::traits::{
     CovarianceInterpolationMethod, InterpolatableTrajectory, InterpolationConfig,
     InterpolationMethod, OrbitRepresentation, STMStorage, SensitivityStorage, Trajectory,
     TrajectoryEvictionPolicy, bci_fixed_frame, covariance_frame_allowed, frame_covariance_jacobian,
-    is_eme2000_axes_frame, is_icrf_axes_frame, keplerian_center,
+    frame_covariance_jacobian_6, is_eme2000_axes_frame, is_icrf_axes_frame, keplerian_center,
 };
 
 /// Dynamic (runtime-sized) orbital trajectory container.
@@ -2048,15 +2048,20 @@ impl DOrbitTrajectory {
         }
 
         let covariances = match (&self.covariances, self.representation) {
-            (Some(covs), OrbitRepresentation::Cartesian) => covs
-                .iter()
-                .map(|p| {
-                    let j = frame_covariance_jacobian(&self.frame, &frame, p.nrows())
-                        .filter(|_| p.nrows() == p.ncols())?;
-                    let rotated = &j * p * j.transpose();
-                    Some((&rotated + rotated.transpose()) * 0.5)
-                })
-                .collect::<Option<Vec<_>>>(),
+            (Some(covs), OrbitRepresentation::Cartesian)
+                if frame_covariance_jacobian_6(&self.frame, &frame).is_some() =>
+            {
+                covs.iter()
+                    .map(|p| {
+                        if p.nrows() != p.ncols() {
+                            return None;
+                        }
+                        let j = frame_covariance_jacobian(&self.frame, &frame, p.nrows())?;
+                        let rotated = &j * p * j.transpose();
+                        Some((&rotated + rotated.transpose()) * 0.5)
+                    })
+                    .collect::<Option<Vec<_>>>()
+            }
             _ => None,
         };
 
@@ -7497,6 +7502,13 @@ mod tests {
         let mut malformed = traj.clone();
         malformed.covariances = Some(vec![DMatrix::<f64>::identity(5, 5); traj.len()]);
         assert!(malformed.to_eme2000().unwrap().covariances.is_none());
+        malformed.covariances = Some(vec![DMatrix::<f64>::zeros(6, 3); traj.len()]);
+        assert!(malformed.to_eme2000().unwrap().covariances.is_none());
+
+        let mut empty = traj.clone();
+        empty.covariances = Some(Vec::new());
+        assert!(empty.to_itrf().unwrap().covariances.is_none());
+        assert_eq!(empty.to_eme2000().unwrap().covariances, Some(Vec::new()));
     }
 
     #[test]

--- a/src/trajectories/sorbit_trajectory.rs
+++ b/src/trajectories/sorbit_trajectory.rs
@@ -68,8 +68,8 @@ use crate::utils::{BraheError, Identifiable};
 use super::traits::{
     CovarianceInterpolationMethod, InterpolatableTrajectory, InterpolationConfig,
     InterpolationMethod, OrbitRepresentation, OrbitalTrajectory, Trajectory,
-    TrajectoryEvictionPolicy, bci_fixed_frame, covariance_frame_allowed, is_eme2000_axes_frame,
-    is_icrf_axes_frame, keplerian_center,
+    TrajectoryEvictionPolicy, bci_fixed_frame, covariance_frame_allowed,
+    frame_covariance_jacobian_6, is_eme2000_axes_frame, is_icrf_axes_frame, keplerian_center,
 };
 
 /// Static (compile-time sized) orbital trajectory container.
@@ -1621,8 +1621,12 @@ impl SOrbitTrajectory {
     /// their own frame's center, using that body's gravitational parameter.
     /// The result is then routed to `frame` by the reference frame router,
     /// which resolves any center offset through the loaded SPK kernels.
-    /// Covariances, state transition matrices, sensitivities, and
-    /// accelerations are dropped.
+    /// Covariance is carried through the conversion when both frames may
+    /// hold it (GCRF and EME2000) and the trajectory is Cartesian: each
+    /// matrix is rotated by the block-diagonal frame-bias Jacobian. Any
+    /// other target frame, or a Keplerian source, drops the covariance.
+    /// State transition matrices, sensitivities, and accelerations are
+    /// dropped.
     ///
     /// # Arguments
     /// * `frame` - Target reference frame
@@ -1753,10 +1757,24 @@ impl OrbitalTrajectory for SOrbitTrajectory {
             states_converted.push(converted);
         }
 
+        let covariances = match (&self.covariances, self.representation) {
+            (Some(covs), OrbitRepresentation::Cartesian) => {
+                frame_covariance_jacobian_6(&self.frame, &frame).map(|j| {
+                    covs.iter()
+                        .map(|p| {
+                            let rotated = j * p * j.transpose();
+                            (rotated + rotated.transpose()) * 0.5
+                        })
+                        .collect()
+                })
+            }
+            _ => None,
+        };
+
         Ok(Self {
             epochs: self.epochs.clone(),
             states: states_converted,
-            covariances: None,   // Covariances are dropped during frame conversions
+            covariances,
             stms: None,          // STMs are dropped during frame conversions
             sensitivities: None, // Sensitivities are dropped during frame conversions
             sensitivity_param_dim: None,
@@ -8133,5 +8151,96 @@ mod tests {
             .unwrap();
         assert_eq!(traj.frame.to_string(), "GCRF");
         assert!(traj.frame == CelestialFrame::GCRF);
+    }
+
+    fn covariance_test_strajectory(frame: CelestialFrame) -> SOrbitTrajectory {
+        let epoch = Epoch::from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, TimeSystem::UTC);
+        let mut epochs = Vec::new();
+        let mut states = Vec::new();
+        let mut covs = Vec::new();
+        for i in 0..3 {
+            epochs.push(epoch + 60.0 * i as f64);
+            states.push(Vector6::new(
+                6.878e6,
+                1.0e5 * i as f64,
+                -2.0e5,
+                10.0,
+                7.5e3,
+                20.0,
+            ));
+            let mut p = SMatrix::<f64, 6, 6>::zeros();
+            for k in 0..6 {
+                p[(k, k)] = 1.0 + k as f64;
+            }
+            p[(0, 1)] = 0.25;
+            p[(1, 0)] = 0.25;
+            p[(1, 4)] = -0.1;
+            p[(4, 1)] = -0.1;
+            covs.push(p);
+        }
+        SOrbitTrajectory::from_orbital_data(
+            epochs,
+            states,
+            frame,
+            OrbitRepresentation::Cartesian,
+            None,
+            Some(covs),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    #[parallel]
+    fn test_sorbittrajectory_to_frame_rotates_covariance_between_gcrf_and_eme2000() {
+        setup_global_test_eop();
+        let traj = covariance_test_strajectory(CelestialFrame::GCRF);
+        let eme = traj.to_eme2000().unwrap();
+        let p0 = traj.covariances.as_ref().unwrap()[0];
+        let q0 = eme.covariances.as_ref().unwrap()[0];
+        let r = crate::frames::rotation_gcrf_to_eme2000();
+        let expected = r * p0.fixed_view::<3, 3>(0, 0) * r.transpose();
+        for i in 0..3 {
+            for k in 0..3 {
+                assert_abs_diff_eq!(q0[(i, k)], expected[(i, k)], epsilon = 1e-12);
+            }
+        }
+        assert_abs_diff_eq!(q0.trace(), p0.trace(), epsilon = 1e-12);
+        let back = eme.to_gcrf().unwrap();
+        let b0 = back.covariances.as_ref().unwrap()[0];
+        for i in 0..6 {
+            for k in 0..6 {
+                assert_abs_diff_eq!(
+                    b0[(i, k)],
+                    p0[(i, k)],
+                    epsilon = 1e-12 * p0[(i, k)].abs().max(1.0)
+                );
+            }
+        }
+        assert_eq!(back.covariances.as_ref().unwrap().len(), 3);
+    }
+
+    #[test]
+    #[parallel]
+    fn test_sorbittrajectory_to_frame_drops_covariance_for_unsupported_targets_and_keplerian() {
+        setup_global_test_eop();
+        let traj = covariance_test_strajectory(CelestialFrame::GCRF);
+        assert_eq!(
+            traj.to_frame(CelestialFrame::GCRF)
+                .unwrap()
+                .covariances
+                .as_ref()
+                .unwrap()[2],
+            traj.covariances.as_ref().unwrap()[2]
+        );
+        assert!(traj.to_itrf().unwrap().covariances.is_none());
+        assert!(
+            traj.to_frame(CelestialFrame::TEME)
+                .unwrap()
+                .covariances
+                .is_none()
+        );
+        let mut kep = traj.to_keplerian(AngleFormat::Degrees).unwrap();
+        kep.covariances = traj.covariances.clone();
+        assert!(kep.to_eme2000().unwrap().covariances.is_none());
     }
 }

--- a/src/trajectories/traits.rs
+++ b/src/trajectories/traits.rs
@@ -10,7 +10,7 @@ use crate::frames::{
     CelestialFrame, FrameAxes, ReferenceFrame, iau_rotation_model_ids, rotation_eme2000_to_gcrf,
     rotation_gcrf_to_eme2000,
 };
-use crate::math::linalg::SMatrix3;
+use crate::math::linalg::{SMatrix3, SMatrix6};
 use crate::time::Epoch;
 use crate::utils::BraheError;
 use nalgebra::{DMatrix, SMatrix};
@@ -189,6 +189,62 @@ pub(crate) fn inertial_covariance_rotation(
             _ => SMatrix3::identity(),
         },
     )
+}
+
+/// Jacobian that carries an `n x n` trajectory covariance from `from` to `to`.
+///
+/// Covariance is stored only in GCRF or EME2000 frames, whose axes differ by
+/// the constant frame bias. The Jacobian is `blockdiag(R, R, I)` with `R` the
+/// bias rotation (identity when the axes match) and `I` covering any state
+/// elements beyond the six orbital components.
+///
+/// # Arguments
+/// * `from` - Frame the covariance is expressed in
+/// * `to` - Frame to rotate it into
+/// * `dimension` - Covariance size; must be at least 6
+///
+/// # Returns
+/// * `Some(DMatrix<f64>)`: The `dimension x dimension` Jacobian when both frames may carry covariance
+/// * `None`: When either frame cannot carry covariance or `dimension < 6`
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) fn frame_covariance_jacobian(
+    from: &ReferenceFrame,
+    to: &ReferenceFrame,
+    dimension: usize,
+) -> Option<DMatrix<f64>> {
+    if dimension < 6 {
+        return None;
+    }
+    let r = inertial_covariance_rotation(from, to).ok()?;
+    let mut j = DMatrix::<f64>::identity(dimension, dimension);
+    for i in 0..3 {
+        for k in 0..3 {
+            j[(i, k)] = r[(i, k)];
+            j[(i + 3, k + 3)] = r[(i, k)];
+        }
+    }
+    Some(j)
+}
+
+/// Six-dimensional form of [`frame_covariance_jacobian`] for static trajectories.
+///
+/// # Arguments
+/// * `from` - Frame the covariance is expressed in
+/// * `to` - Frame to rotate it into
+///
+/// # Returns
+/// * `Some(SMatrix6)`: `blockdiag(R, R)` when both frames may carry covariance
+/// * `None`: When either frame cannot carry covariance
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) fn frame_covariance_jacobian_6(
+    from: &ReferenceFrame,
+    to: &ReferenceFrame,
+) -> Option<SMatrix6> {
+    let r = inertial_covariance_rotation(from, to).ok()?;
+    let mut j = SMatrix6::identity();
+    j.fixed_view_mut::<3, 3>(0, 0).copy_from(&r);
+    j.fixed_view_mut::<3, 3>(3, 3).copy_from(&r);
+    Some(j)
 }
 
 /// Enumeration of orbit state representations
@@ -1299,5 +1355,43 @@ mod tests {
         );
         assert!(inertial_covariance_rotation(&CelestialFrame::ITRF.into(), &eme).is_err());
         assert!(inertial_covariance_rotation(&eme, &CelestialFrame::TEME.into()).is_err());
+    }
+
+    #[test]
+    #[parallel]
+    fn test_frame_covariance_jacobian() {
+        use crate::frames::rotation_gcrf_to_eme2000;
+        let gcrf: ReferenceFrame = CelestialFrame::GCRF.into();
+        let eme: ReferenceFrame = CelestialFrame::EME2000.into();
+        let itrf: ReferenceFrame = CelestialFrame::ITRF.into();
+
+        let j = frame_covariance_jacobian(&gcrf, &eme, 7).unwrap();
+        assert_eq!(j.nrows(), 7);
+        let r = rotation_gcrf_to_eme2000();
+        for i in 0..3 {
+            for k in 0..3 {
+                assert_eq!(j[(i, k)], r[(i, k)]);
+                assert_eq!(j[(i + 3, k + 3)], r[(i, k)]);
+                assert_eq!(j[(i, k + 3)], 0.0);
+                assert_eq!(j[(i + 3, k)], 0.0);
+            }
+        }
+        assert_eq!(j[(6, 6)], 1.0);
+        for i in 0..6 {
+            assert_eq!(j[(6, i)], 0.0);
+            assert_eq!(j[(i, 6)], 0.0);
+        }
+
+        let same = frame_covariance_jacobian(&gcrf, &gcrf, 6).unwrap();
+        assert_eq!(same, DMatrix::identity(6, 6));
+        assert!(frame_covariance_jacobian(&gcrf, &itrf, 6).is_none());
+        assert!(frame_covariance_jacobian(&itrf, &eme, 6).is_none());
+        assert!(frame_covariance_jacobian(&gcrf, &eme, 5).is_none());
+
+        let j6 = frame_covariance_jacobian_6(&eme, &gcrf).unwrap();
+        let r6 = crate::frames::rotation_eme2000_to_gcrf();
+        assert_eq!(j6.fixed_view::<3, 3>(0, 0).clone_owned(), r6);
+        assert_eq!(j6.fixed_view::<3, 3>(3, 3).clone_owned(), r6);
+        assert!(frame_covariance_jacobian_6(&gcrf, &itrf).is_none());
     }
 }

--- a/src/trajectories/traits.rs
+++ b/src/trajectories/traits.rs
@@ -206,6 +206,22 @@ pub(crate) fn inertial_covariance_rotation(
 /// # Returns
 /// * `Some(DMatrix<f64>)`: The `dimension x dimension` Jacobian when both frames may carry covariance
 /// * `None`: When either frame cannot carry covariance or `dimension < 6`
+///
+/// # Examples
+///
+/// ```ignore
+/// use brahe::frames::{CelestialFrame, ReferenceFrame, rotation_gcrf_to_eme2000};
+/// use brahe::trajectories::traits::frame_covariance_jacobian;
+///
+/// let gcrf: ReferenceFrame = CelestialFrame::GCRF.into();
+/// let eme2000: ReferenceFrame = CelestialFrame::EME2000.into();
+/// let j = frame_covariance_jacobian(&gcrf, &eme2000, 7).unwrap();
+/// let r = rotation_gcrf_to_eme2000();
+/// assert_eq!(j[(0, 0)], r[(0, 0)]);
+/// assert_eq!(j[(3, 3)], r[(0, 0)]);
+/// assert_eq!(j[(6, 6)], 1.0);
+/// assert!(frame_covariance_jacobian(&gcrf, &CelestialFrame::ITRF.into(), 6).is_none());
+/// ```
 pub(crate) fn frame_covariance_jacobian(
     from: &ReferenceFrame,
     to: &ReferenceFrame,
@@ -234,6 +250,21 @@ pub(crate) fn frame_covariance_jacobian(
 /// # Returns
 /// * `Some(SMatrix6)`: `blockdiag(R, R)` when both frames may carry covariance
 /// * `None`: When either frame cannot carry covariance
+///
+/// # Examples
+///
+/// ```ignore
+/// use brahe::frames::{CelestialFrame, ReferenceFrame, rotation_gcrf_to_eme2000};
+/// use brahe::trajectories::traits::frame_covariance_jacobian_6;
+///
+/// let gcrf: ReferenceFrame = CelestialFrame::GCRF.into();
+/// let eme2000: ReferenceFrame = CelestialFrame::EME2000.into();
+/// let j = frame_covariance_jacobian_6(&gcrf, &eme2000).unwrap();
+/// let r = rotation_gcrf_to_eme2000();
+/// assert_eq!(j.fixed_view::<3, 3>(0, 0), r);
+/// assert_eq!(j.fixed_view::<3, 3>(3, 3), r);
+/// assert!(frame_covariance_jacobian_6(&gcrf, &CelestialFrame::ITRF.into()).is_none());
+/// ```
 pub(crate) fn frame_covariance_jacobian_6(
     from: &ReferenceFrame,
     to: &ReferenceFrame,

--- a/src/trajectories/traits.rs
+++ b/src/trajectories/traits.rs
@@ -206,7 +206,6 @@ pub(crate) fn inertial_covariance_rotation(
 /// # Returns
 /// * `Some(DMatrix<f64>)`: The `dimension x dimension` Jacobian when both frames may carry covariance
 /// * `None`: When either frame cannot carry covariance or `dimension < 6`
-#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn frame_covariance_jacobian(
     from: &ReferenceFrame,
     to: &ReferenceFrame,

--- a/src/trajectories/traits.rs
+++ b/src/trajectories/traits.rs
@@ -1362,7 +1362,6 @@ mod tests {
     #[test]
     #[parallel]
     fn test_frame_covariance_jacobian() {
-        use crate::frames::rotation_gcrf_to_eme2000;
         let gcrf: ReferenceFrame = CelestialFrame::GCRF.into();
         let eme: ReferenceFrame = CelestialFrame::EME2000.into();
         let itrf: ReferenceFrame = CelestialFrame::ITRF.into();

--- a/src/trajectories/traits.rs
+++ b/src/trajectories/traits.rs
@@ -234,7 +234,6 @@ pub(crate) fn frame_covariance_jacobian(
 /// # Returns
 /// * `Some(SMatrix6)`: `blockdiag(R, R)` when both frames may carry covariance
 /// * `None`: When either frame cannot carry covariance
-#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn frame_covariance_jacobian_6(
     from: &ReferenceFrame,
     to: &ReferenceFrame,
@@ -835,8 +834,12 @@ pub trait OrbitalTrajectory: InterpolatableTrajectory {
         Self: Sized;
 
     /// Converts every sample to Cartesian coordinates in `frame`, routing
-    /// through the reference frame router. Covariances, state transition
-    /// matrices, sensitivities, and accelerations are dropped.
+    /// through the reference frame router. Covariance is carried through the
+    /// conversion when both frames may hold it (GCRF and EME2000) and the
+    /// trajectory is Cartesian: each matrix is rotated by the block-diagonal
+    /// frame-bias Jacobian. Any other target frame, or a Keplerian source,
+    /// drops the covariance. State transition matrices, sensitivities, and
+    /// accelerations are dropped.
     ///
     /// # Arguments
     /// * `frame` - Target frame

--- a/tests/trajectories/test_orbit_trajectory.py
+++ b/tests/trajectories/test_orbit_trajectory.py
@@ -4353,3 +4353,17 @@ def test_orbittrajectory_to_frame_drops_covariance_for_unsupported_targets(eop):
     )
     assert _covariance_or_none(traj.to_itrf(), epochs[0]) is None
     assert _covariance_or_none(traj.to_frame(CelestialFrame.TEME), epochs[0]) is None
+
+    kep_states = np.array(
+        [state_eci_to_koe(s, AngleFormat.DEGREES) for s in traj.states()]
+    )
+    kep = OrbitTrajectory.from_orbital_data(
+        epochs,
+        kep_states,
+        CelestialFrame.GCRF,
+        OrbitRepresentation.KEPLERIAN,
+        AngleFormat.DEGREES,
+        np.stack([cov, cov, cov]),
+    )
+    np.testing.assert_array_equal(kep.covariance(epochs[0]), cov)
+    assert _covariance_or_none(kep.to_eme2000(), epochs[0]) is None

--- a/tests/trajectories/test_orbit_trajectory.py
+++ b/tests/trajectories/test_orbit_trajectory.py
@@ -19,6 +19,7 @@ from brahe import (
     OrbitRepresentation,
     OrbitTrajectory,
     TimeSystem,
+    rotation_gcrf_to_eme2000,
     state_ecef_to_eci,
     state_eci_to_ecef,
     state_eci_to_koe,
@@ -4306,3 +4307,49 @@ def test_orbittrajectory_state_koe_osc_fast_path_for_icrf_axes_frames(eop):
 
         koe = traj.state_koe_osc(epoch, AngleFormat.RADIANS)
         np.testing.assert_array_equal(koe, state, err_msg=str(frame))
+
+
+def _covariance_or_none(traj, epoch):
+    try:
+        return traj.covariance(epoch)
+    except BraheError:
+        return None
+
+
+def _covariance_trajectory(frame):
+    epoch = Epoch.from_datetime(2024, 1, 1, 12, 0, 0.0, 0.0, brahe.UTC)
+    epochs = [epoch + 60.0 * i for i in range(3)]
+    states = np.array(
+        [[6.878e6, 1.0e5 * i, -2.0e5, 10.0, 7.5e3, 20.0] for i in range(3)]
+    )
+    cov = np.diag([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+    cov[0, 1] = cov[1, 0] = 0.25
+    cov[1, 4] = cov[4, 1] = -0.1
+    covariances = np.stack([cov, cov, cov])
+    traj = OrbitTrajectory.from_orbital_data(
+        epochs, states, frame, OrbitRepresentation.CARTESIAN, None, covariances
+    )
+    return traj, epochs, cov
+
+
+def test_orbittrajectory_to_frame_rotates_covariance_between_gcrf_and_eme2000(eop):
+    """Rust: test_dorbittrajectory_to_frame_rotates_covariance_between_gcrf_and_eme2000"""
+    traj, epochs, cov = _covariance_trajectory(CelestialFrame.GCRF)
+    eme = traj.to_eme2000()
+    q = eme.covariance(epochs[0])
+    r = rotation_gcrf_to_eme2000()
+    np.testing.assert_allclose(q[:3, :3], r @ cov[:3, :3] @ r.T, rtol=0, atol=1e-12)
+    assert np.trace(q) == pytest.approx(np.trace(cov), abs=1e-12)
+    assert abs(q[0, 1] - cov[0, 1]) > 0.0
+    back = eme.to_gcrf()
+    np.testing.assert_allclose(back.covariance(epochs[0]), cov, rtol=1e-12, atol=1e-12)
+
+
+def test_orbittrajectory_to_frame_drops_covariance_for_unsupported_targets(eop):
+    """Rust: test_dorbittrajectory_to_frame_drops_covariance_for_unsupported_targets_and_keplerian"""
+    traj, epochs, cov = _covariance_trajectory(CelestialFrame.GCRF)
+    np.testing.assert_array_equal(
+        traj.to_frame(CelestialFrame.GCRF).covariance(epochs[1]), cov
+    )
+    assert _covariance_or_none(traj.to_itrf(), epochs[0]) is None
+    assert _covariance_or_none(traj.to_frame(CelestialFrame.TEME), epochs[0]) is None


### PR DESCRIPTION
# Pull Request

## Description

`OrbitTrajectory.to_frame` and its wrappers now carry stored covariance through conversions between frames that may hold it (GCRF and EME2000), rotating each matrix by the constant frame-bias Jacobian sized to that matrix, with an identity block for covariance rows beyond the orbital six. Targets that cannot carry covariance, and Keplerian-representation sources, drop it as before. Applies to both the dynamic and the static Rust trajectory types. Fourth PR of the Starlink ephemeris client stack; it lets an ITC-derived EME2000 trajectory keep its covariance after `to_eci()`.

## Changelog

### Changed
- `DOrbitTrajectory::to_frame` and `SOrbitTrajectory::to_frame` (and `to_eci`, `to_gcrf`, `to_eme2000`) rotate covariance between GCRF and EME2000 instead of dropping it; other target frames and Keplerian sources still drop covariance

## Note to Reviewers
State transition matrices, sensitivities and accelerations are still dropped on frame conversion; only covariance changes here.
