### PR TITLE
chore(justfile): Update lint commands to lint all crates in workspace

### DIFF
--- a/justfile
+++ b/justfile
@@ -553,13 +553,13 @@ format-check: _setup
 
 # Run linters (clippy + ruff + test labels)
 lint: _setup
-    cargo clippy --all-targets --all-features -- -D warnings
+    cargo clippy --workspace --all-targets --all-features -- -D warnings
     uv run ruff check
     uv run scripts/check_test_labels.py
 
 # Run linters with auto-fix
 lint-fix: _setup
-    cargo clippy --all-targets --all-features --fix --allow-dirty -- -D warnings
+    cargo clippy --workspace --all-targets --all-features --fix --allow-dirty -- -D warnings
     uv run ruff check --fix
     uv run scripts/check_test_labels.py
 


### PR DESCRIPTION
# Pull Request

## Description

Justfile commands `lint` and `lint-fix` were missing the `--workspace` argument so they only ran for the base crate and not the python bindings. This change adds the argument to address the gap.

## Changelog

### Changed
- Add `--workspace` argument to `just lint` and `just lint-fix` so that python bindings are linted as well.