### PR TITLE
Add DOIs to paper.bib entries that have one registered

### DIFF
--- a/joss/paper.bib
+++ b/joss/paper.bib
@@ -4,6 +4,7 @@
   title={{Optimal Ground Station Selection for Low-Earth Orbiting Satellites}}, 
   year={2025},
   url={https://arxiv.org/abs/2410.16282},
+  doi={10.1109/aero63441.2025.11068558},
 }
 
 @inproceedings{eddyMarkov2020,
@@ -11,6 +12,7 @@
 	Booktitle = {IEEE Aerospace Conference},
 	Title = {Markov Decision Processes for multi-objective satellite task planning},
 	Year = {2020},
+	doi = {10.1109/aero47225.2020.9172258},
 }
 
 @inproceedings{stringham2019capella,
@@ -18,7 +20,8 @@
   author={Stringham, Craig and Farquharson, Gordon and Castelletti, Davide and Quist, Eric and Riggi, Lucas and Eddy, Duncan and Soenen, Scott},
   booktitle={IEEE International Geoscience and Remote Sensing Symposium},
   year={2019},
-  organization={IEEE}
+  organization={IEEE},
+  doi={10.1109/igarss.2019.8900410},
 }
 
 
@@ -30,7 +33,8 @@
   number={5},
   pages={1416--1429},
   year={2021},
-  publisher={American Institute of Aeronautics and Astronautics}
+  publisher={American Institute of Aeronautics and Astronautics},
+  doi={10.2514/1.a34931},
 }
 
 @misc{celestrak,
@@ -68,7 +72,8 @@
   title={{Optimal Scheduling of a Constellation of Earth-Imaging Satellites for Maximal Data Throughput and Efficient Human Management}},
   author={Augenstein, Sean and Estanislao, Alejandra and Guere, Emmanuel and Blaes, Sean},
   booktitle=icaps,
-  year={2016}
+  year={2016},
+  doi={10.1609/icaps.v26i1.13784},
 }
 
 @book{newton1833philosophiae,
@@ -95,7 +100,8 @@
   title     = {{Satellite Orbits: Models, Methods and Applications}},
   publisher = {Springer},
   address   = {Berlin / Heidelberg},
-  year      = {2000}
+  year      = {2000},
+  doi       = {10.1007/978-3-642-58351-3},
 }
 
 @inproceedings{maisonobe2010orekit,
@@ -110,7 +116,8 @@
   title={{Verification and Validation of the General Mission Analysis Tool (GMAT)}},
   author={Hughes, Steven P and Qureshi, Rizwan H and Cooley, Steven D and Parker, Joel J},
   booktitle={AIAA/AAS Astrodynamics Specialist Conference},
-  year={2014}
+  year={2014},
+  doi={10.2514/6.2014-4151},
 }
 
 @article{basilisk2020,
@@ -153,7 +160,8 @@
   author={Hohenkerk, Catherine},
   booktitle={{The Science of Time 2016: Time in Astronomy \& Society, Past, Present and Future}},
   year={2017},
-  publisher={Springer}
+  publisher={Springer},
+  doi={10.1007/978-3-319-59909-0_21},
 }
 
 @incollection{peters2004zen,
@@ -161,7 +169,8 @@
   author={Peters, Tim},
   booktitle={{Pro Python}},
   year={2004},
-  publisher={Springer}
+  publisher={Springer},
+  doi={10.1007/978-1-4302-2758-8_14},
 }
 
 @inproceedings{rodriguez2016poliastro,
@@ -185,7 +194,8 @@ year = {2022}
   title={{Revisiting Spacetrack Report \#3}},
   author={Vallado, David and Crawford, Paul and Hujsak, Ricahrd and Kelso, Thomas Sean},
   booktitle={AIAA/AAS Astrodynamics Specialist Conference and Exhibit},
-  year={2006}
+  year={2006},
+  doi={10.2514/6.2006-6753},
 }
 
 @article{kim2025scalable,
@@ -200,7 +210,8 @@ year = {2022}
   title={{Satellite Navigation for the Age of Autonomy}},
   author={Reid, Tyler GR and Chan, Bryan and Goel, Ashish and Gunning, Kazuma and Manning, Brian and Martin, Jerami and Neish, Andrew and Perkins, Adrien and Tarantino, Paul},
   booktitle={2020 IEEE/ION Position, Location and Navigation Symposium (PLANS)},
-  year={2020}
+  year={2020},
+  doi={10.1109/plans46316.2020.9109938},
 }
 
 @book{kepler1953epitome,


### PR DESCRIPTION
## Description

Adds `doi` to the 11 `joss/paper.bib` entries I could confirm on Crossref by exact title and first-author match.

## Changelog

### Changed
- `joss/paper.bib` references now carry a `doi` field where one is registered on Crossref (11 entries)

## Related Issue

Part of #547

## Note to Reviewers

I said 13 in #547 and can only stand up 11. I left out `kim2025scalable` and `newton1833philosophiae` as i couldn't find the right DOIs.

